### PR TITLE
Http protocol refactor

### DIFF
--- a/aws/sdk-codegen-test/build.gradle.kts
+++ b/aws/sdk-codegen-test/build.gradle.kts
@@ -9,7 +9,7 @@ extra["moduleName"] = "software.amazon.smithy.kotlin.codegen.test"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 val smithyVersion: String by project

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -13,7 +13,7 @@ extra["moduleName"] = "software.amazon.smithy.rust.awssdk"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 val smithyVersion: String by project

--- a/codegen-test/build.gradle.kts
+++ b/codegen-test/build.gradle.kts
@@ -9,7 +9,7 @@ extra["moduleName"] = "software.amazon.smithy.kotlin.codegen.test"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.2")
+    id("software.amazon.smithy").version("0.5.3")
 }
 
 val smithyVersion: String by project

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/StreamingTraitSymbolProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/StreamingTraitSymbolProvider.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
+import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
 import software.amazon.smithy.rust.codegen.util.hasStreamingMember
 import software.amazon.smithy.rust.codegen.util.isStreaming
@@ -33,7 +34,7 @@ class StreamingShapeSymbolProvider(private val base: RustSymbolProvider, private
         val container = model.expectShape(shape.container)
 
         // We are only targeting output shapes
-        if (!container.hasTrait(SyntheticOutputTrait::class.java)) {
+        if (!(container.hasTrait(SyntheticOutputTrait::class.java) || container.hasTrait(SyntheticInputTrait::class.java))) {
             return initial
         }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
@@ -41,7 +41,6 @@ import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.isOptional
 import software.amazon.smithy.rust.codegen.smithy.letIf
 import software.amazon.smithy.rust.codegen.smithy.rustType
-import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
 import software.amazon.smithy.rust.codegen.util.isStreaming
@@ -152,8 +151,7 @@ class Instantiator(
                         ctx.letIf(shape.getMemberTrait(model, HttpPrefixHeadersTrait::class.java).isPresent) {
                             it.copy(lowercaseMapKeys = true)
                         }.letIf(
-                            shape.isStreaming(model) &&
-                                model.expectShape(shape.container).hasTrait(SyntheticOutputTrait::class.java)
+                            shape.isStreaming(model)
                         ) {
                             it.copy(streaming = true)
                         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.knowledge.HttpBinding
 import software.amazon.smithy.model.knowledge.HttpBindingIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.DocumentShape
+import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StringShape
@@ -40,16 +41,20 @@ import software.amazon.smithy.rust.codegen.smithy.generators.builderSymbol
 import software.amazon.smithy.rust.codegen.smithy.generators.error.errorSymbol
 import software.amazon.smithy.rust.codegen.smithy.generators.http.RequestBindingGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.http.ResponseBindingGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.operationBuildError
 import software.amazon.smithy.rust.codegen.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.smithy.isOptional
+import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.smithy.transformers.RemoveEventStreamOperations
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
 import software.amazon.smithy.rust.codegen.util.hasStreamingMember
+import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.isStreaming
 import software.amazon.smithy.rust.codegen.util.outputShape
+import software.amazon.smithy.rust.codegen.util.toSnakeCase
 import java.util.logging.Logger
 
 class AwsRestJsonFactory : ProtocolGeneratorFactory<AwsRestJsonGenerator> {
@@ -421,93 +426,142 @@ class AwsRestJsonGenerator(
         }
     }
 
-    private fun serializeViaSyntheticBody(
-        implBlockWriter: RustWriter,
+    private fun RustWriter.serializeViaSyntheticBody(
+        self: String,
+        inputShape: StructureShape,
         inputBody: StructureShape
     ) {
-        val bodySymbol = protocolConfig.symbolProvider.toSymbol(inputBody)
-        implBlockWriter.rustBlock("fn body(&self) -> #T", bodySymbol) {
-            rustBlock("#T", bodySymbol) {
-                for (member in inputBody.members()) {
-                    val name = protocolConfig.symbolProvider.toMemberName(member)
-                    write("$name: &self.$name,")
+        val fnName = "synth_body_${inputBody.id.name.toSnakeCase()}"
+        val bodySer = RuntimeType.forInlineFun(fnName, "operation_ser") {
+            it.rustBlock(
+                "pub fn $fnName(input: &#T) -> Result<#T, #T>",
+                symbolProvider.toSymbol(inputShape),
+                RuntimeType.sdkBody(runtimeConfig),
+                runtimeConfig.operationBuildError()
+            ) {
+                withBlock("let body = ", ";") {
+                    rustBlock("#T", symbolProvider.toSymbol(inputBody)) {
+                        for (member in inputBody.members()) {
+                            val name = protocolConfig.symbolProvider.toMemberName(member)
+                            write("$name: &input.$name,")
+                        }
+                    }
                 }
+                rustTemplate(
+                    """#{serde_json}::to_vec(&body)
+                                  .map(#{SdkBody}::from)
+                                  .map_err(|err|#{BuildError}::SerializationError(err.into()))""",
+                    "serde_json" to CargoDependency.SerdeJson.asType(),
+                    "BuildError" to runtimeConfig.operationBuildError(),
+                    "SdkBody" to sdkBody
+                )
             }
         }
-        bodyBuilderFun(implBlockWriter) {
-            write("""#T(&self.body()).expect("serialization should succeed")""", RuntimeType.SerdeJson("to_vec"))
+        rust("#T(&$self)?", bodySer)
+    }
+
+    override fun RustWriter.body(self: String, operationShape: OperationShape): BodyMetadata {
+        val inputShape = operationShape.inputShape(model)
+        val inputBody = inputShape.expectTrait(SyntheticInputTrait::class.java).body?.let {
+            model.expectShape(
+                it,
+                StructureShape::class.java
+            )
+        }
+        if (inputBody != null) {
+            serializeViaSyntheticBody(self, inputShape, inputBody)
+            return BodyMetadata(takesOwnership = false)
+        }
+        val bindings = httpIndex.getRequestBindings(operationShape).toList()
+        val payloadMemberName: String? =
+            bindings.firstOrNull { (_, binding) -> binding.location == HttpBinding.Location.PAYLOAD }?.first
+        if (payloadMemberName == null) {
+            rustTemplate("""#{SdkBody}::from("")""", "SdkBody" to sdkBody)
+            return BodyMetadata(takesOwnership = false)
+        } else {
+            val member = inputShape.expectMember(payloadMemberName)
+            return serializeViaPayload(member)
         }
     }
 
-    override fun toBodyImpl(
-        implBlockWriter: RustWriter,
-        inputShape: StructureShape,
-        inputBody: StructureShape?,
-        operationShape: OperationShape
-    ) {
-        // If we created a synthetic input body, serialize that
-        if (inputBody != null) {
-            return serializeViaSyntheticBody(implBlockWriter, inputBody)
+    private fun RustWriter.serializeViaPayload(member: MemberShape): BodyMetadata {
+        val fnName = "ser_payload_${member.container.name.toSnakeCase()}"
+        val targetShape = model.expectShape(member.target)
+        val bodyMetadata: BodyMetadata = RustWriter.root().renderPayload(targetShape, "payload")
+        val ref = when (bodyMetadata.takesOwnership) {
+            true -> ""
+            false -> "&"
         }
-
-        // Otherwise, we need to serialize via the HTTP payload trait
-        val bindings = httpIndex.getRequestBindings(operationShape).toList()
-        val payload: Pair<String, HttpBinding>? =
-            bindings.firstOrNull { (_, binding) -> binding.location == HttpBinding.Location.PAYLOAD }
-        val payloadSerde = payload?.let { (payloadMemberName, _) ->
-            val member = inputShape.expectMember(payloadMemberName)
-            val rustMemberName = "self.${symbolProvider.toMemberName(member)}"
-            val targetShape = model.expectShape(member.target)
-            writable {
-                val payloadName = safeName()
-                rust("let $payloadName = &$rustMemberName;")
+        val serializer = RuntimeType.forInlineFun(fnName, "operation_ser") {
+            it.rustBlock(
+                "pub fn $fnName(payload: $ref#T) -> Result<#T, #T>",
+                symbolProvider.toSymbol(member),
+                sdkBody,
+                runtimeConfig.operationBuildError()
+            ) {
                 // If this targets a member & the member is None, return an empty vec
+                val ref = when (bodyMetadata.takesOwnership) {
+                    false -> ".as_ref()"
+                    true -> ""
+                }
+
                 if (symbolProvider.toSymbol(member).isOptional()) {
-                    rust(
+                    rustTemplate(
                         """
-                        let $payloadName = match $payloadName.as_ref() {
+                        let payload = match payload$ref {
                             Some(t) => t,
-                            None => return vec![]
-                        };"""
+                            None => return Ok(#{SdkBody}::from(""))
+                        };""",
+                        "SdkBody" to sdkBody
                     )
                 }
-                renderPayload(targetShape, payloadName)
+                withBlock("Ok(#T::from(", "))", sdkBody) {
+                    renderPayload(targetShape, "payload")
+                }
             }
-            // body is null, no payload set, so this is empty
-        } ?: writable { rust("vec![]") }
-        bodyBuilderFun(implBlockWriter) {
-            payloadSerde(this)
         }
+        rust("#T($ref self.${symbolProvider.toMemberName(member)})?", serializer)
+        return bodyMetadata
     }
 
     private fun RustWriter.renderPayload(
         targetShape: Shape,
         payloadName: String,
-    ) {
+    ): BodyMetadata {
         val serdeToVec = RuntimeType.SerdeJson("to_vec")
-        when (targetShape) {
+        return when (targetShape) {
             // Write the raw string to the payload
-            is StringShape ->
+            is StringShape -> {
                 if (targetShape.hasTrait(EnumTrait::class.java)) {
-                    rust("$payloadName.as_str().into()")
+                    rust("$payloadName.as_str()")
                 } else {
-                    rust("""$payloadName.to_string().into()""")
+                    rust("""$payloadName.to_string()""")
                 }
-            is BlobShape ->
+                BodyMetadata(takesOwnership = false)
+            }
+
+            is BlobShape -> {
                 // Write the raw blob to the payload
-                rust("$payloadName.as_ref().into()")
-            is StructureShape, is UnionShape ->
+                rust("$payloadName.into_inner()")
+                BodyMetadata(takesOwnership = true)
+            }
+            is StructureShape, is UnionShape -> {
                 // JSON serialize the structure or union targetted
                 rust(
-                    """#T(&$payloadName).expect("serialization should succeed")""",
-                    serdeToVec
+                    """#T(&$payloadName).map_err(|err|#T::SerializationError(err.into()))?""",
+                    serdeToVec, runtimeConfig.operationBuildError()
                 )
-            is DocumentShape ->
+                BodyMetadata(takesOwnership = false)
+            }
+            is DocumentShape -> {
                 rustTemplate(
-                    """#{to_vec}(&#{doc_json}::SerDoc(&$payloadName)).expect("serialization should succeed")""",
+                    """#{to_vec}(&#{doc_json}::SerDoc(&$payloadName)).map_err(|err|#{BuildError}::SerializationError(err.into()))?""",
                     "to_vec" to serdeToVec,
-                    "doc_json" to RuntimeType.DocJson
+                    "doc_json" to RuntimeType.DocJson,
+                    "BuildError" to runtimeConfig.operationBuildError()
                 )
+                BodyMetadata(takesOwnership = false)
+            }
             else -> TODO("Unexpected payload target type")
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -540,6 +540,8 @@ class AwsRestJsonGenerator(
                 BodyMetadata(takesOwnership = false)
             }
 
+            // This works for streaming & non streaming blobs because they both have `into_inner()` which
+            // can be converted into an SDK body!
             is BlobShape -> {
                 // Write the raw blob to the payload
                 rust("$payloadName.into_inner()")

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGeneratorTest.kt
@@ -122,6 +122,11 @@ class HttpProtocolTestGeneratorTest {
         // A stubbed test protocol to do enable testing intentionally broken protocols
         class TestProtocol(private val protocolConfig: ProtocolConfig) : HttpProtocolGenerator(protocolConfig) {
             private val symbolProvider = protocolConfig.symbolProvider
+            override fun RustWriter.body(self: String, operationShape: OperationShape): BodyMetadata {
+                writeWithNoFormatting(body)
+                return BodyMetadata(takesOwnership = false)
+            }
+
             override fun traitImplementations(operationWriter: RustWriter, operationShape: OperationShape) {
                 operationWriter.rustTemplate(
                     """
@@ -142,17 +147,6 @@ class HttpProtocolTestGeneratorTest {
             override fun fromResponseImpl(implBlockWriter: RustWriter, operationShape: OperationShape) {
                 fromResponseFun(implBlockWriter, operationShape) {
                     writeWithNoFormatting(correctResponse)
-                }
-            }
-
-            override fun toBodyImpl(
-                implBlockWriter: RustWriter,
-                inputShape: StructureShape,
-                inputBody: StructureShape?,
-                operationShape: OperationShape
-            ) {
-                bodyBuilderFun(implBlockWriter) {
-                    writeWithNoFormatting(body)
                 }
             }
 

--- a/rust-runtime/smithy-http/src/body.rs
+++ b/rust-runtime/smithy-http/src/body.rs
@@ -101,11 +101,15 @@ impl SdkBody {
             _ => None,
         }
     }
+
+    pub fn content_length(&self) -> Option<u64> {
+        self.size_hint().exact()
+    }
 }
 
 impl From<&str> for SdkBody {
     fn from(s: &str) -> Self {
-        SdkBody(Inner::Once(Some(Bytes::copy_from_slice(s.as_bytes()))))
+        Self::from(s.as_bytes())
     }
 }
 
@@ -124,6 +128,18 @@ impl From<hyper::Body> for SdkBody {
 impl From<Vec<u8>> for SdkBody {
     fn from(data: Vec<u8>) -> Self {
         Self::from(Bytes::from(data))
+    }
+}
+
+impl From<String> for SdkBody {
+    fn from(s: String) -> Self {
+        Self::from(s.into_bytes())
+    }
+}
+
+impl From<&[u8]> for SdkBody {
+    fn from(data: &[u8]) -> Self {
+        SdkBody(Inner::Once(Some(Bytes::copy_from_slice(data))))
     }
 }
 

--- a/rust-runtime/smithy-http/src/operation.rs
+++ b/rust-runtime/smithy-http/src/operation.rs
@@ -6,6 +6,7 @@
 use crate::body::SdkBody;
 use crate::property_bag::PropertyBag;
 use std::borrow::Cow;
+use std::error::Error;
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, MutexGuard};
 use thiserror::Error;
@@ -62,6 +63,8 @@ pub enum BuildError {
         field: &'static str,
         details: &'static str,
     },
+    #[error("Failed during serialization: {0}")]
+    SerializationError(#[from] Box<dyn Error + Send + Sync + 'static>),
 }
 
 pub struct Operation<H, R> {

--- a/rust-runtime/smithy-types/src/lib.rs
+++ b/rust-runtime/smithy-types/src/lib.rs
@@ -22,6 +22,9 @@ impl Blob {
     pub fn new<T: Into<Vec<u8>>>(inp: T) -> Self {
         Blob { inner: inp.into() }
     }
+    pub fn into_inner(self) -> Vec<u8> {
+        self.inner
+    }
 }
 
 impl AsRef<[u8]> for Blob {


### PR DESCRIPTION
*Issue #, if available:* Fixes #215 
*Description of changes:* This change, split into two commits:
1. Refactors the code to generate bodies for HTTP based protocols
2. Enables support for streaming request bodies, which via a stroke of luck, worked _without modification_ after the refactor.

These refactors (besides cleaning up the code) improve the performance of serializers by avoiding an unnecessary when serializing `Blob` & `ByteStream` operations. This is facilitated via `BodyMetadata` which allows a body serializer to communicate whether it requires ownership of the request object.

In general, we try to generate operations that _do not_ take ownership of the request object enabling operation reuse.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
