### PR TITLE
Derive Default for FluentBuilders

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/FluentClientGenerator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/FluentClientGenerator.kt
@@ -135,6 +135,7 @@ class FluentClientGenerator(protocolConfig: ProtocolConfig) {
 
                 rust(
                     """
+                ##[derive(std::fmt::Debug)]
                 pub struct $name {
                     handle: std::sync::Arc<super::Handle>,
                     inner: #T

--- a/aws/sdk/examples/dynamo-add-item/src/main.rs
+++ b/aws/sdk/examples/dynamo-add-item/src/main.rs
@@ -114,17 +114,18 @@ async fn main() {
     let first_av = AttributeValue::S(String::from(&first));
     let last_av = AttributeValue::S(String::from(&last));
 
-    match client
+    let request = client
         .put_item()
         .table_name(table)
         .item("username", user_av)
         .item("account_type", type_av)
         .item("age", age_av)
         .item("first_name", first_av)
-        .item("last_name", last_av)
-        .send()
-        .await
-    {
+        .item("last_name", last_av);
+
+    println!("Executing request [{:?}] to add item...", request);
+
+    match request.send().await {
         Ok(_) => println!(
             "Added user {}, {} {}, age {} as {} user",
             username, first, last, age, p_type

--- a/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
+++ b/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
@@ -30,6 +30,7 @@ fn validate_sensitive_trait() {
 
 fn assert_send_sync<T: Send + Sync + 'static>() {}
 fn assert_send_fut<T: Send + 'static>(_: T) {}
+fn assert_debug<T: std::fmt::Debug>() {}
 
 #[test]
 fn types_are_send_sync() {
@@ -52,6 +53,13 @@ fn client_is_debug() {
 fn client_is_clone() {
     let client = kms::Client::from_env();
     let _ = client.clone();
+}
+
+#[test]
+fn types_are_debug() {
+    assert_debug::<kms::Client>();
+    assert_debug::<kms::client::fluent_builders::GenerateRandom>();
+    assert_debug::<kms::client::fluent_builders::CreateAlias>();
 }
 
 fn create_alias_op() -> Parts<CreateAlias, AwsErrorRetryPolicy> {


### PR DESCRIPTION
*Issue #, if available:*
Closes #363 

*Description of changes:*
Update the `fluent_builder` codegen to derive `std::fmt::Default` on the structure.

I wasn't sure what the right place for testing this was, I could add some print outs to the [`aws/sdk/examples`](https://github.com/awslabs/smithy-rs/tree/main/aws/sdk/examples) crates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
