### PR TITLE
Misc encoding fixes

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
@@ -32,6 +32,7 @@ import software.amazon.smithy.model.traits.HttpPrefixHeadersTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.conditionalBlock
+import software.amazon.smithy.rust.codegen.rustlang.escape
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.stripOuter
@@ -248,12 +249,12 @@ class Instantiator(
         arg: StringNode
     ) {
         val enumTrait = shape.getTrait(EnumTrait::class.java).orElse(null)
-        val data = arg.value.dq()
+        val data = writer.escape(arg.value).dq()
         if (enumTrait == null) {
-            writer.write("$data.to_string()")
+            writer.rust("$data.to_string()")
         } else {
             val enumSymbol = symbolProvider.toSymbol(shape)
-            writer.write("#T::from($data)", enumSymbol)
+            writer.rust("#T::from($data)", enumSymbol)
         }
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Strings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Strings.kt
@@ -6,9 +6,9 @@
 package software.amazon.smithy.rust.codegen.util
 
 import software.amazon.smithy.utils.CaseUtils
+import software.amazon.smithy.utils.StringUtils
 
-fun String.doubleQuote(): String = "\"${this.slashEscape('\\').slashEscape('"')}\""
-fun String.slashEscape(char: Char) = this.replace(char.toString(), """\$char""")
+fun String.doubleQuote(): String = StringUtils.escapeJavaString(this, "")
 
 /**
  * Double quote a string, eg. "abc" -> "\"abc\""

--- a/rust-runtime/smithy-http/src/urlencode.rs
+++ b/rust-runtime/smithy-http/src/urlencode.rs
@@ -18,8 +18,7 @@ pub const BASE_SET: &AsciiSet = &CONTROLS
     .add(b'?')
     .add(b'#')
     .add(b'[')
-    .add(b')')
-    .add(b')')
+    .add(b']')
     .add(b'@')
     .add(b'!')
     .add(b'$')
@@ -32,3 +31,22 @@ pub const BASE_SET: &AsciiSet = &CONTROLS
     .add(b';')
     .add(b'=')
     .add(b'%');
+
+#[cfg(test)]
+mod test {
+    use crate::urlencode::BASE_SET;
+    use percent_encoding::utf8_percent_encode;
+
+    #[test]
+    fn set_includes_mandatory_characters() {
+        let chars = ":/?#[]@!$&'()*+,;=%";
+        let escaped = utf8_percent_encode(chars, BASE_SET).to_string();
+        assert_eq!(
+            escaped,
+            "%3A%2F%3F%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D%25"
+        );
+
+        // sanity check that every character is escaped
+        assert_eq!(escaped.len(), chars.len() * 3);
+    }
+}


### PR DESCRIPTION
*Description of changes:*

Found several bugs while adding some more protocol tests:
- whitespace characters were not properly handled by `dq()/doubleQuote()`. I found a proper implementation in Smithy I should have been using all along.
- I erred at some point when I used a Vim macro to setup the new percent encoder. This is been resolved & a test has been added

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
