### PR TITLE
Add comments and rename synthetic shape ID extension functions

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -60,13 +60,17 @@ class StructureGenerator(
     }
 
     companion object {
-        fun fallibleBuilder(structureShape: StructureShape, symbolProvider: SymbolProvider): Boolean = structureShape
-            .allMembers
-            .values.map { symbolProvider.toSymbol(it) }.any {
-                // If any members are not optional && we can't use a default, we need to
-                // generate a fallible builder
-                !it.isOptional() && !it.canUseDefault()
-            } || structureShape.hasTrait(SyntheticInputTrait::class.java)
+        /** Returns whether or not a structure shape requires a fallible builder to be generated. */
+        fun fallibleBuilder(structureShape: StructureShape, symbolProvider: SymbolProvider): Boolean =
+            // All inputs should have fallible builders in case a new required field is added in the future
+            structureShape.hasTrait(SyntheticInputTrait::class.java) ||
+                    structureShape
+                        .allMembers
+                        .values.map { symbolProvider.toSymbol(it) }.any {
+                            // If any members are not optional && we can't use a default, we need to
+                            // generate a fallible builder
+                            !it.isOptional() && !it.canUseDefault()
+                        }
     }
 
     /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -64,13 +64,13 @@ class StructureGenerator(
         fun fallibleBuilder(structureShape: StructureShape, symbolProvider: SymbolProvider): Boolean =
             // All inputs should have fallible builders in case a new required field is added in the future
             structureShape.hasTrait(SyntheticInputTrait::class.java) ||
-                    structureShape
-                        .allMembers
-                        .values.map { symbolProvider.toSymbol(it) }.any {
-                            // If any members are not optional && we can't use a default, we need to
-                            // generate a fallible builder
-                            !it.isOptional() && !it.canUseDefault()
-                        }
+                structureShape
+                    .allMembers
+                    .values.map { symbolProvider.toSymbol(it) }.any {
+                        // If any members are not optional && we can't use a default, we need to
+                        // generate a fallible builder
+                        !it.isOptional() && !it.canUseDefault()
+                    }
     }
 
     /**


### PR DESCRIPTION
These are some minor renames and comment updates to clarify the code in `OperationNormalizer` and `StructureGenerator`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
