### PR TITLE
Introduce syntax sugar for accessing Smithy shape traits

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -23,6 +23,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.expectTrait
 
 class AwsEndpointDecorator : RustCodegenDecorator {
     override val name: String = "AwsEndpoint"
@@ -56,7 +57,7 @@ class AwsEndpointDecorator : RustCodegenDecorator {
 
 class EndpointConfigCustomization(private val runtimeConfig: RuntimeConfig, serviceShape: ServiceShape) :
     ConfigCustomization() {
-    private val endpointPrefix = serviceShape.expectTrait(ServiceTrait::class.java).endpointPrefix
+    private val endpointPrefix = serviceShape.expectTrait<ServiceTrait>().endpointPrefix
     private val resolveAwsEndpoint = runtimeConfig.awsEndpointDependency().asType().copy(name = "ResolveAwsEndpoint")
     override fun section(section: ServiceConfig): Writable = writable {
         when (section) {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -21,6 +21,8 @@ import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustom
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.smithy.letIf
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.expectTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 /**
  * The SigV4SigningDecorator:
@@ -33,14 +35,14 @@ class SigV4SigningDecorator : RustCodegenDecorator {
     override val name: String = "SigV4Signing"
     override val order: Byte = 0
 
-    private fun applies(protocolConfig: ProtocolConfig): Boolean = protocolConfig.serviceShape.hasTrait(SigV4Trait::class.java)
+    private fun applies(protocolConfig: ProtocolConfig): Boolean = protocolConfig.serviceShape.hasTrait<SigV4Trait>()
 
     override fun configCustomizations(
         protocolConfig: ProtocolConfig,
         baseCustomizations: List<ConfigCustomization>
     ): List<ConfigCustomization> {
         return baseCustomizations.letIf(applies(protocolConfig)) {
-            it + SigV4SigningConfig(protocolConfig.serviceShape.expectTrait(SigV4Trait::class.java))
+            it + SigV4SigningConfig(protocolConfig.serviceShape.expectTrait())
         }
     }
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.expectTrait
 
 /**
  * Inserts a UserAgent configuration into the operation
@@ -33,7 +34,7 @@ class UserAgentDecorator : RustCodegenDecorator {
         baseCustomizations: List<LibRsCustomization>
     ): List<LibRsCustomization> {
         // We are generating an AWS SDK, the service needs to have the AWS service trait
-        val serviceTrait = protocolConfig.serviceShape.expectTrait(ServiceTrait::class.java)
+        val serviceTrait = protocolConfig.serviceShape.expectTrait<ServiceTrait>()
         return baseCustomizations + ApiVersion(protocolConfig.runtimeConfig, serviceTrait)
     }
 

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointConfigCustomizationTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointConfigCustomizationTest.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.testutil.stubConfigProject
 import software.amazon.smithy.rust.codegen.testutil.unitTest
 import software.amazon.smithy.rust.codegen.testutil.validateConfigCustomizations
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.lookup
 
 internal class EndpointConfigCustomizationTest {
@@ -41,7 +42,7 @@ internal class EndpointConfigCustomizationTest {
     fun `generates valid code when no endpoint prefix is provided`() {
         val serviceShape = model.lookup<ServiceShape>("test#NoEndpointPrefix")
         validateConfigCustomizations(EndpointConfigCustomization(AwsTestRuntimeConfig, serviceShape))
-        serviceShape.expectTrait(ServiceTrait::class.java).endpointPrefix shouldBe "noendpointprefix"
+        serviceShape.expectTrait<ServiceTrait>().endpointPrefix shouldBe "noendpointprefix"
     }
 
     @Test

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
@@ -29,6 +29,8 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolLoader
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.util.CommandFailed
+import software.amazon.smithy.rust.codegen.util.getTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.runCommand
 import java.util.logging.Logger
 
@@ -103,7 +105,7 @@ class CodegenVisitor(context: PluginContext, private val codegenDecorator: RustC
         logger.fine("generating a structure...")
         rustCrate.useShapeWriter(shape) { writer ->
             StructureGenerator(model, symbolProvider, writer, shape).render()
-            if (!shape.hasTrait(SyntheticInputTrait::class.java)) {
+            if (!shape.hasTrait<SyntheticInputTrait>()) {
                 val builderGenerator = BuilderGenerator(protocolConfig.model, protocolConfig.symbolProvider, shape)
                 builderGenerator.render(writer)
                 writer.implBlock(shape, symbolProvider) {
@@ -114,7 +116,7 @@ class CodegenVisitor(context: PluginContext, private val codegenDecorator: RustC
     }
 
     override fun stringShape(shape: StringShape) {
-        shape.getTrait(EnumTrait::class.java).map { enum ->
+        shape.getTrait<EnumTrait>()?.also { enum ->
             rustCrate.useShapeWriter(shape) { writer ->
                 EnumGenerator(symbolProvider, writer, shape, enum).render()
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.DocumentationTrait
+import software.amazon.smithy.rust.codegen.util.getTrait
 import software.amazon.smithy.rust.codegen.util.orNull
 import java.util.Optional
 import java.util.logging.Logger
@@ -72,10 +73,7 @@ class RustSettings(
     }
 
     val moduleDescription: String
-        get() {
-            val service = getService(model)
-            return service.getTrait(DocumentationTrait::class.java).map { it.value }.orElse(moduleName)
-        }
+        get() = getService(model).getTrait<DocumentationTrait>()?.value ?: moduleName
 
     companion object {
         private val LOGGER: Logger = Logger.getLogger(RustSettings::class.java.name)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/StreamingTraitSymbolProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/StreamingTraitSymbolProvider.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
 import software.amazon.smithy.rust.codegen.util.hasStreamingMember
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.isStreaming
 
 /**
@@ -34,7 +35,7 @@ class StreamingShapeSymbolProvider(private val base: RustSymbolProvider, private
         val container = model.expectShape(shape.container)
 
         // We are only targeting output shapes
-        if (!(container.hasTrait(SyntheticOutputTrait::class.java) || container.hasTrait(SyntheticInputTrait::class.java))) {
+        if (!(container.hasTrait<SyntheticOutputTrait>() || container.hasTrait<SyntheticInputTrait>())) {
             return initial
         }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolMetadataProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolMetadataProvider.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.Attribute.Companion.NonExhaustive
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.PartialEq
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 /**
  * Default delegator to enable easily decorating another symbol provider.
@@ -47,7 +48,7 @@ abstract class SymbolMetadataProvider(private val base: RustSymbolProvider) : Wr
             is MemberShape -> memberMeta(shape)
             is StructureShape -> structureMeta(shape)
             is UnionShape -> unionMeta(shape)
-            is StringShape -> if (shape.hasTrait(EnumTrait::class.java)) {
+            is StringShape -> if (shape.hasTrait<EnumTrait>()) {
                 enumMeta(shape)
             } else null
             else -> null

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -45,6 +45,7 @@ import software.amazon.smithy.rust.codegen.smithy.traits.InputBodyTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.OutputBodyTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
 import software.amazon.smithy.utils.StringUtils
 import kotlin.reflect.KClass
@@ -152,14 +153,14 @@ class SymbolVisitor(
         // If a field has the httpLabel trait and we are generating
         // an Input shape, then the field is _not optional_.
         val httpLabeledInput =
-            container.hasTrait(SyntheticInputTrait::class.java) && member.hasTrait(HttpLabelTrait::class.java)
+            container.hasTrait<SyntheticInputTrait>() && member.hasTrait<HttpLabelTrait>()
         return if (nullableIndex.isNullable(member) && !httpLabeledInput || model.expectShape(member.target).isDocumentShape) {
             symbol.makeOptional()
         } else symbol
     }
 
     private fun handleRustBoxing(symbol: Symbol, shape: Shape): Symbol {
-        return if (shape.hasTrait(RustBoxTrait::class.java)) {
+        return if (shape.hasTrait<RustBoxTrait>()) {
             val rustType = RustType.Box(symbol.rustType())
             with(Symbol.builder()) {
                 rustType(rustType)
@@ -182,7 +183,7 @@ class SymbolVisitor(
     override fun floatShape(shape: FloatShape): Symbol = simpleShape(shape)
     override fun doubleShape(shape: DoubleShape): Symbol = simpleShape(shape)
     override fun stringShape(shape: StringShape): Symbol {
-        return if (shape.hasTrait(EnumTrait::class.java)) {
+        return if (shape.hasTrait<EnumTrait>()) {
             symbolBuilder(shape, RustType.Opaque(shape.contextName())).locatedIn(Models).build()
         } else {
             simpleShape(shape)
@@ -240,10 +241,10 @@ class SymbolVisitor(
     }
 
     override fun structureShape(shape: StructureShape): Symbol {
-        val isError = shape.hasTrait(ErrorTrait::class.java)
-        val isInput = shape.hasTrait(SyntheticInputTrait::class.java)
-        val isOutput = shape.hasTrait(SyntheticOutputTrait::class.java)
-        val isBody = shape.hasTrait(InputBodyTrait::class.java) || shape.hasTrait(OutputBodyTrait::class.java)
+        val isError = shape.hasTrait<ErrorTrait>()
+        val isInput = shape.hasTrait<SyntheticInputTrait>()
+        val isOutput = shape.hasTrait<SyntheticOutputTrait>()
+        val isBody = shape.hasTrait<InputBodyTrait>() || shape.hasTrait<OutputBodyTrait>()
         val name = StringUtils.capitalize(shape.contextName()).letIf(isError && config.codegenConfig.renameExceptions) {
             // TODO: Do we want to do this?
             // https://github.com/awslabs/smithy-rs/issues/77

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
@@ -26,6 +26,7 @@ import software.amazon.smithy.rust.codegen.smithy.customize.OperationCustomizati
 import software.amazon.smithy.rust.codegen.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.smithy.letIf
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.getTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 
 /**
@@ -63,18 +64,17 @@ abstract class HttpProtocolGenerator(
         operationShape: OperationShape,
         customizations: List<OperationCustomization>
     ) {
-        /* if (operationShape.hasTrait(EndpointTrait::class.java)) {
+        /* if (operationShape.hasTrait<EndpointTrait>()) {
             TODO("https://github.com/awslabs/smithy-rs/issues/197")
         } */
         val inputShape = operationShape.inputShape(model)
         val sdkId =
-            protocolConfig.serviceShape.getTrait(ServiceTrait::class.java)
-                .map { it.sdkId.toLowerCase().replace(" ", "") }
-                .orElse(protocolConfig.serviceShape.id.getName(protocolConfig.serviceShape))
+            protocolConfig.serviceShape.getTrait<ServiceTrait>()?.sdkId?.toLowerCase()?.replace(" ", "")
+                ?: protocolConfig.serviceShape.id.getName(protocolConfig.serviceShape)
         val builderGenerator = BuilderGenerator(model, symbolProvider, operationShape.inputShape(model))
         builderGenerator.render(inputWriter)
-        // impl OperationInputShape { ... }
 
+        // impl OperationInputShape { ... }
         inputWriter.implBlock(inputShape, symbolProvider) {
             buildOperation(this, operationShape, customizations, sdkId)
             toHttpRequestImpl(this, operationShape, inputShape)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/Instantiator.kt
@@ -44,6 +44,7 @@ import software.amazon.smithy.rust.codegen.smithy.letIf
 import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
+import software.amazon.smithy.rust.codegen.util.getTrait
 import software.amazon.smithy.rust.codegen.util.isStreaming
 import software.amazon.smithy.rust.codegen.util.toPascalCase
 
@@ -248,7 +249,7 @@ class Instantiator(
         shape: StringShape,
         arg: StringNode
     ) {
-        val enumTrait = shape.getTrait(EnumTrait::class.java).orElse(null)
+        val enumTrait = shape.getTrait<EnumTrait>()
         val data = writer.escape(arg.value).dq()
         if (enumTrait == null) {
             writer.rust("$data.to_string()")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ServiceGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ServiceGenerator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.error.CombinedError
 import software.amazon.smithy.rust.codegen.smithy.generators.error.TopLevelErrorGenerator
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 
 class ServiceGenerator(
@@ -63,14 +64,14 @@ class ServiceGenerator(
 
     private fun renderBodies(operations: List<OperationShape>) {
         val inputBodies = operations.map { config.model.expectShape(it.input.get()) }.map {
-            it.expectTrait(SyntheticInputTrait::class.java)
+            it.expectTrait<SyntheticInputTrait>()
         }.mapNotNull { // mapNotNull is flatMap but for null `map { it }.filter { it != null }`
             it.body
         }.map { // Lookup the Body structure by its id
             config.model.expectShape(it, StructureShape::class.java)
         }
         val outputBodies = operations.map { config.model.expectShape(it.output.get()) }.map {
-            it.expectTrait(SyntheticOutputTrait::class.java)
+            it.expectTrait<SyntheticOutputTrait>()
         }.mapNotNull { // mapNotNull is flatMap but for null `map { it }.filter { it != null }`
             it.body
         }.map { // Lookup the Body structure by its id

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.smithy.customize.NamedSectionGenerator
 import software.amazon.smithy.rust.codegen.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 /**
  * [ServiceConfig] is the parent type of sections that can be overridden when generating a config for a service.
@@ -68,7 +69,7 @@ sealed class ServiceConfig(name: String) : Section(name) {
 // TODO: if this becomes hot, it may need to be cached in a knowledge index
 fun ServiceShape.needsIdempotencyToken(model: Model): Boolean {
     val operationIndex = OperationIndex.of(model)
-    return this.allOperations.flatMap { operationIndex.getInputMembers(it).values }.any { it.hasTrait(IdempotencyTokenTrait::class.java) }
+    return this.allOperations.flatMap { operationIndex.getInputMembers(it).values }.any { it.hasTrait<IdempotencyTokenTrait>() }
 }
 
 typealias ConfigCustomization = NamedSectionGenerator<ServiceConfig>

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/CombinedErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/CombinedErrorGenerator.kt
@@ -23,6 +23,7 @@ import software.amazon.smithy.rust.codegen.rustlang.writable
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 /**
  * For a given Operation ([this]), return the symbol referring to the unified error? This can be used
@@ -103,7 +104,7 @@ class CombinedErrorGenerator(
             }
 
             rustBlock("fn retryable_error_kind(&self) -> Option<#T>", errorKindT) {
-                val retryableVariants = errors.filter { it.hasTrait(RetryableTrait::class.java) }
+                val retryableVariants = errors.filter { it.hasTrait<RetryableTrait>() }
                 if (retryableVariants.isEmpty()) {
                     rust("None")
                 } else {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/ErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/ErrorGenerator.kt
@@ -21,7 +21,7 @@ import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.stdfmt
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.letIf
 import software.amazon.smithy.rust.codegen.util.dq
-import software.amazon.smithy.rust.codegen.util.orNull
+import software.amazon.smithy.rust.codegen.util.getTrait
 
 sealed class ErrorKind {
     abstract fun writable(runtimeConfig: RuntimeConfig): Writable
@@ -48,7 +48,7 @@ sealed class ErrorKind {
  * This is _only_ non-null in cases where the @retryable trait has been applied.
  */
 fun StructureShape.modeledRetryKind(errorTrait: ErrorTrait): ErrorKind? {
-    val retryableTrait = this.getTrait(RetryableTrait::class.java).orNull() ?: return null
+    val retryableTrait = this.getTrait<RetryableTrait>() ?: return null
     return when {
         retryableTrait.throttling -> ErrorKind.Throttling
         errorTrait.isClientError -> ErrorKind.Client

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
@@ -30,6 +30,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.operationBuildError
 import software.amazon.smithy.rust.codegen.smithy.generators.redactIfNecessary
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 fun HttpTrait.uriFormatString(): String {
     val base = uri.segments.joinToString("/", prefix = "/") {
@@ -207,7 +208,7 @@ class RequestBindingGenerator(
     private fun headerFmtFun(target: Shape, member: MemberShape, targetName: String): String {
         return when {
             target.isStringShape -> {
-                if (target.hasTrait(MediaTypeTrait::class.java)) {
+                if (target.hasTrait<MediaTypeTrait>()) {
                     val func = writer.format(RuntimeType.Base64Encode(runtimeConfig))
                     "$func(&$targetName)"
                 } else {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -34,6 +34,7 @@ import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
 import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.isStreaming
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
 
@@ -186,7 +187,7 @@ class ResponseBindingGenerator(protocolConfig: ProtocolConfig, private val opera
                         "let body_str = std::str::from_utf8(&body).map_err(#{error_symbol}::unhandled)?;",
                         "error_symbol" to errorSymbol
                     )
-                    if (targetShape.hasTrait(EnumTrait::class.java)) {
+                    if (targetShape.hasTrait<EnumTrait>()) {
                         rust(
                             "Ok(#T::from(body_str))",
                             symbolProvider.toSymbol(targetShape)
@@ -235,7 +236,7 @@ class ResponseBindingGenerator(protocolConfig: ProtocolConfig, private val opera
                 "let $parsedValue: Vec<${coreType.render(true)}> = #T::read_many(headers)?;",
                 headerUtil
             )
-            if (coreShape.hasTrait(MediaTypeTrait::class.java)) {
+            if (coreShape.hasTrait<MediaTypeTrait>()) {
                 rustTemplate(
                     """let $parsedValue: Result<Vec<_>, _> = $parsedValue
                         .iter().map(|s|

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
@@ -45,6 +45,7 @@ import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormaliz
 import software.amazon.smithy.rust.codegen.smithy.transformers.RemoveEventStreamOperations
 import software.amazon.smithy.rust.codegen.smithy.transformers.StructureModifier
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.outputShape
 
 sealed class AwsJsonVersion {
@@ -120,9 +121,9 @@ class SyntheticBodySymbolProvider(private val model: Model, private val base: Ru
         val initialSymbol = base.toSymbol(shape)
         val override = when (shape) {
             is StructureShape -> when {
-                shape.hasTrait(InputBodyTrait::class.java) ->
+                shape.hasTrait<InputBodyTrait>() ->
                     initialSymbol.toBuilder().locatedIn(Serializers).build()
-                shape.hasTrait(OutputBodyTrait::class.java) ->
+                shape.hasTrait<OutputBodyTrait>() ->
                     initialSymbol.toBuilder().locatedIn(Serializers).meta(
                         initialSymbol.expectRustMetadata().withDerives(RuntimeType("Default", null, "std::default"))
                     ).build()
@@ -130,7 +131,7 @@ class SyntheticBodySymbolProvider(private val model: Model, private val base: Ru
             }
             is MemberShape -> {
                 val container = model.expectShape(shape.container)
-                if (container.hasTrait(InputBodyTrait::class.java)) {
+                if (container.hasTrait<InputBodyTrait>()) {
                     initialSymbol.toBuilder().rustType(
                         RustType.Reference(
                             lifetime = "a",

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpTraitProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpTraitProtocolGenerator.kt
@@ -42,7 +42,9 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.StructuredDa
 import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.StructuredDataSerializerGenerator
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.hasStreamingMember
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.isStreaming
 import software.amazon.smithy.rust.codegen.util.outputShape
@@ -154,7 +156,7 @@ class HttpTraitProtocolGenerator(
         return when (targetShape) {
             // Write the raw string to the payload
             is StringShape -> {
-                if (targetShape.hasTrait(EnumTrait::class.java)) {
+                if (targetShape.hasTrait<EnumTrait>()) {
                     rust("$payloadName.as_str()")
                 } else {
                     rust("""$payloadName.to_string()""")
@@ -374,7 +376,7 @@ class HttpTraitProtocolGenerator(
         operationShape: OperationShape,
         inputShape: StructureShape
     ) {
-        val httpTrait = operationShape.expectTrait(HttpTrait::class.java)
+        val httpTrait = operationShape.expectTrait<HttpTrait>()
 
         val httpBindingGenerator = RequestBindingGenerator(
             model,
@@ -422,7 +424,7 @@ class HttpTraitProtocolGenerator(
                 )
             }
         } else {
-            check(outputShape.hasTrait(ErrorTrait::class.java)) { "should only be called on outputs or errors $outputShape" }
+            check(outputShape.hasTrait<ErrorTrait>()) { "should only be called on outputs or errors $outputShape" }
             structuredDataParser.errorParser(outputShape)?.also { parser ->
                 rust(
                     "output = #T(response.body().as_ref(), output).map_err(#T::unhandled)?;",

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/JsonSerializerSymbolProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/JsonSerializerSymbolProvider.kt
@@ -29,6 +29,8 @@ import software.amazon.smithy.rust.codegen.smithy.traits.OutputBodyTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.getTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 /**
  * JsonSerializerSymbolProvider annotates shapes and members with `serde` attributes
@@ -42,8 +44,7 @@ class JsonSerializerSymbolProvider(
 
     data class SerdeConfig(val serialize: Boolean, val deserialize: Boolean)
 
-    private fun MemberShape.serializedName() =
-        this.getTrait(JsonNameTrait::class.java).map { it.value }.orElse(this.memberName)
+    private fun MemberShape.serializedName() = this.getTrait<JsonNameTrait>()?.value ?: this.memberName
 
     private val serializerBuilder = CustomSerializerGenerator(base, model, defaultTimestampFormat)
     override fun memberMeta(memberShape: MemberShape): RustMetadata {
@@ -88,12 +89,12 @@ class JsonSerializerSymbolProvider(
 
     private fun serdeRequired(shape: Shape): SerdeConfig {
         return when {
-            shape.hasTrait(InputBodyTrait::class.java) -> SerdeConfig(serialize = true, deserialize = false)
-            shape.hasTrait(OutputBodyTrait::class.java) -> SerdeConfig(serialize = false, deserialize = true)
+            shape.hasTrait<InputBodyTrait>() -> SerdeConfig(serialize = true, deserialize = false)
+            shape.hasTrait<OutputBodyTrait>() -> SerdeConfig(serialize = false, deserialize = true)
 
             // The bodies must be serializable. The top level inputs are _not_
-            shape.hasTrait(SyntheticInputTrait::class.java) -> SerdeConfig(serialize = false, deserialize = false)
-            shape.hasTrait(SyntheticOutputTrait::class.java) -> SerdeConfig(serialize = false, deserialize = false)
+            shape.hasTrait<SyntheticInputTrait>() -> SerdeConfig(serialize = false, deserialize = false)
+            shape.hasTrait<SyntheticOutputTrait>() -> SerdeConfig(serialize = false, deserialize = false)
             else -> SerdeConfig(serialize = true, deserialize = true)
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -27,6 +27,7 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.XmlBindingTr
 import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.smithy.transformers.RemoveEventStreamOperations
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
 
 class RestXmlFactory : ProtocolGeneratorFactory<HttpTraitProtocolGenerator> {
@@ -52,7 +53,7 @@ class RestXmlFactory : ProtocolGeneratorFactory<HttpTraitProtocolGenerator> {
 }
 
 class RestXml(private val protocolConfig: ProtocolConfig) : Protocol {
-    private val restXml = protocolConfig.serviceShape.expectTrait(RestXmlTrait::class.java)
+    private val restXml = protocolConfig.serviceShape.expectTrait<RestXmlTrait>()
     private val runtimeConfig = protocolConfig.runtimeConfig
     private val restXmlErrors: RuntimeType = when (restXml.isNoErrorWrapping) {
         true -> RuntimeType.unwrappedXmlErrors(runtimeConfig)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonParserGenerator.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.builderSymbol
 import software.amazon.smithy.rust.codegen.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.outputShape
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
@@ -54,7 +55,7 @@ class JsonSerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSe
         // Currently, JSON shapes are serialized via a synthetic body structure that gets generated during model
         // transformation
         val inputShape = operationShape.inputShape(model)
-        val inputBody = inputShape.expectTrait(SyntheticInputTrait::class.java).body?.let {
+        val inputBody = inputShape.expectTrait<SyntheticInputTrait>().body?.let {
             model.expectShape(
                 it,
                 StructureShape::class.java
@@ -124,7 +125,7 @@ class JsonParserGenerator(protocolConfig: ProtocolConfig) : StructuredDataParser
     override fun operationParser(operationShape: OperationShape): RuntimeType? {
         val outputShape = operationShape.outputShape(model)
         val fnName = operationShape.id.name.toString().toSnakeCase() + "_deser_operation"
-        val bodyId = outputShape.expectTrait(SyntheticOutputTrait::class.java).body
+        val bodyId = outputShape.expectTrait<SyntheticOutputTrait>().body
         val bodyShape = bodyId?.let { model.expectShape(bodyId, StructureShape::class.java) } ?: return null
         val body = symbolProvider.toSymbol(bodyShape)
         if (bodyShape.members().isEmpty()) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/XmlBindingTraitParserGenerator.kt
@@ -45,7 +45,9 @@ import software.amazon.smithy.rust.codegen.smithy.isOptional
 import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticOutputTrait
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
-import software.amazon.smithy.rust.codegen.util.orNull
+import software.amazon.smithy.rust.codegen.util.expectTrait
+import software.amazon.smithy.rust.codegen.util.getTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.outputShape
 import software.amazon.smithy.rust.codegen.util.toPascalCase
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
@@ -154,8 +156,7 @@ class XmlBindingTraitParserGenerator(protocolConfig: ProtocolConfig, private val
 
     private fun payloadName(member: MemberShape): XmlName {
         val payloadShape = model.expectShape(member.target)
-        val xmlRename = member.getTrait(XmlNameTrait::class.java).orNull()
-            ?: payloadShape.getTrait(XmlNameTrait::class.java).orNull()
+        val xmlRename = member.getTrait<XmlNameTrait>() ?: payloadShape.getTrait()
 
         return xmlRename?.let { XmlName.parse(it.value) } ?: XmlName(local = payloadShape.id.name)
     }
@@ -203,8 +204,8 @@ class XmlBindingTraitParserGenerator(protocolConfig: ProtocolConfig, private val
     }
 
     private fun operationXmlName(outputShape: StructureShape): XmlName? {
-        return outputShape.getTrait(XmlNameTrait::class.java).orNull()?.let { XmlName.parse(it.value) }
-            ?: outputShape.expectTrait(SyntheticOutputTrait::class.java).originalId?.name?.let {
+        return outputShape.getTrait<XmlNameTrait>()?.let { XmlName.parse(it.value) }
+            ?: outputShape.expectTrait<SyntheticOutputTrait>().originalId?.name?.let {
                 XmlName(local = it, prefix = null)
             }
     }
@@ -577,8 +578,7 @@ class XmlBindingTraitParserGenerator(protocolConfig: ProtocolConfig, private val
 
     private fun RustWriter.parseStringInner(shape: StringShape, provider: RustWriter.() -> Unit) {
         withBlock("Result::<#T, #T>::Ok(", ")", symbolProvider.toSymbol(shape), xmlError) {
-            val enumTrait = shape.getTrait(EnumTrait::class.java).orElse(null)
-            if (enumTrait == null) {
+            if (!shape.hasTrait<EnumTrait>()) {
                 provider()
                 // if it's already `Cow::Owned` then `.into()` is free (vs. to_string())
                 rust(".into()")
@@ -592,7 +592,7 @@ class XmlBindingTraitParserGenerator(protocolConfig: ProtocolConfig, private val
     }
 
     private fun MemberShape.xmlName(): XmlName {
-        val override = this.getTrait(XmlNameTrait::class.java).orNull()
+        val override = this.getTrait<XmlNameTrait>()
         return override?.let { XmlName.parse(it.value) } ?: XmlName(local = this.memberName)
     }
 
@@ -606,7 +606,7 @@ class XmlBindingTraitParserGenerator(protocolConfig: ProtocolConfig, private val
     data class XmlMemberIndex(val dataMembers: List<MemberShape>, val attributeMembers: List<MemberShape>) {
         companion object {
             fun fromMembers(members: List<MemberShape>): XmlMemberIndex {
-                val (attribute, data) = members.partition { it.hasTrait(XmlAttributeTrait::class.java) }
+                val (attribute, data) = members.partition { it.hasTrait<XmlAttributeTrait>() }
                 return XmlMemberIndex(data, attribute)
             }
         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxer.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.shapes.SetShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.smithy.RustBoxTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 
 object RecursiveShapeBoxer {
     /**
@@ -85,7 +86,7 @@ object RecursiveShapeBoxer {
                 is ListShape,
                 is MapShape,
                 is SetShape -> true
-                else -> it.hasTrait(RustBoxTrait::class.java)
+                else -> it.hasTrait<RustBoxTrait>()
             }
         } != null
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Smithy.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Smithy.kt
@@ -56,3 +56,12 @@ inline fun <reified T : Trait> StructureShape.findMemberWithTrait(model: Model):
 inline fun <reified T : Trait> UnionShape.findMemberWithTrait(model: Model): MemberShape? {
     return this.members().find { it.getMemberTrait(model, T::class.java).isPresent }
 }
+
+/** Kotlin sugar for hasTrait() check. e.g. shape.hasTrait<EnumTrait>() instead of shape.hasTrait(EnumTrait::class.java) */
+inline fun <reified T : Trait> Shape.hasTrait(): Boolean = hasTrait(T::class.java)
+
+/** Kotlin sugar for expectTrait() check. e.g. shape.expectTrait<EnumTrait>() instead of shape.expectTrait(EnumTrait::class.java) */
+inline fun <reified T : Trait> Shape.expectTrait(): T = expectTrait(T::class.java)
+
+/** Kotlin sugar for getTrait() check. e.g. shape.getTrait<EnumTrait>() instead of shape.getTrait(EnumTrait::class.java) */
+inline fun <reified T : Trait> Shape.getTrait(): T? = getTrait(T::class.java).orNull()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.EnumGenerator
 import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.lookup
 
 class EnumGeneratorTest {
@@ -42,7 +43,7 @@ class EnumGeneratorTest {
         val provider: SymbolProvider = testSymbolProvider(model)
         val writer = RustWriter.forModule("model")
         val shape = model.lookup<StringShape>("test#InstanceType")
-        val generator = EnumGenerator(provider, writer, shape, shape.expectTrait(EnumTrait::class.java))
+        val generator = EnumGenerator(provider, writer, shape, shape.expectTrait<EnumTrait>())
         generator.render()
         writer.compileAndTest(
             """
@@ -74,7 +75,7 @@ class EnumGeneratorTest {
             string FooEnum
             """.asSmithyModel()
         val shape: StringShape = model.lookup("test#FooEnum")
-        val trait = shape.expectTrait(EnumTrait::class.java)
+        val trait = shape.expectTrait<EnumTrait>()
         val writer = RustWriter.forModule("model")
         val generator = EnumGenerator(testSymbolProvider(model), writer, shape, trait)
         generator.render()
@@ -102,7 +103,7 @@ class EnumGeneratorTest {
             string FooEnum
             """.asSmithyModel()
         val shape: StringShape = model.lookup("test#FooEnum")
-        val trait = shape.expectTrait(EnumTrait::class.java)
+        val trait = shape.expectTrait<EnumTrait>()
         val writer = RustWriter.forModule("model")
         val generator = EnumGenerator(testSymbolProvider(model), writer, shape, trait)
         generator.render()
@@ -140,7 +141,7 @@ class EnumGeneratorTest {
         string FooEnum
         """.asSmithyModel()
         val shape = model.expectShape(ShapeId.from("test#FooEnum"), StringShape::class.java)
-        val trait = shape.expectTrait(EnumTrait::class.java)
+        val trait = shape.expectTrait<EnumTrait>()
         val provider: SymbolProvider = testSymbolProvider(model)
         val writer = RustWriter.forModule("model")
         val generator = EnumGenerator(provider, writer, shape, trait)

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/RequestBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/RequestBindingGeneratorTest.kt
@@ -24,6 +24,7 @@ import software.amazon.smithy.rust.codegen.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.expectTrait
 
 class RequestBindingGeneratorTest {
     private val baseModel = """
@@ -106,7 +107,7 @@ class RequestBindingGeneratorTest {
 
     private val operationShape = model.expectShape(ShapeId.from("smithy.example#PutObject"), OperationShape::class.java)
     private val inputShape = model.expectShape(operationShape.input.get(), StructureShape::class.java)
-    private val httpTrait = operationShape.expectTrait(HttpTrait::class.java)
+    private val httpTrait = operationShape.expectTrait<HttpTrait>()
 
     private val symbolProvider = testSymbolProvider(model)
     private fun renderOperation(writer: RustWriter) {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlBindingTraitParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlBindingTraitParserGeneratorTest.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
-import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.generators.EnumGenerator
@@ -25,6 +24,7 @@ import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.testutil.testProtocolConfig
 import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.testutil.unitTest
+import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.lookup
 import software.amazon.smithy.rust.codegen.util.outputShape
 
@@ -175,7 +175,7 @@ internal class XmlBindingTraitParserGeneratorTest {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, it)
             UnionGenerator(model, symbolProvider, it, model.lookup("test#Choice")).render()
             val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(symbolProvider, it, enum, enum.expectTrait(EnumTrait::class.java)).render()
+            EnumGenerator(symbolProvider, it, enum, enum.expectTrait()).render()
         }
 
         project.withModule(RustModule.default("output", public = true)) {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxerTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxerTest.kt
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.rust.codegen.smithy.RustBoxTrait
 import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.util.expectTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.lookup
 import kotlin.streams.toList
 
@@ -43,7 +45,7 @@ internal class RecursiveShapeBoxerTest {
         """.asSmithyModel()
         val transformed = RecursiveShapeBoxer.transform(model)
         val member: MemberShape = transformed.lookup("com.example#Recursive\$RecursiveStruct")
-        member.expectTrait(RustBoxTrait::class.java)
+        member.expectTrait<RustBoxTrait>()
     }
 
     @Test
@@ -69,7 +71,7 @@ internal class RecursiveShapeBoxerTest {
        }
        """.asSmithyModel()
         val transformed = RecursiveShapeBoxer.transform(model)
-        val boxed = transformed.shapes().filter { it.hasTrait(RustBoxTrait::class.java) }.toList()
+        val boxed = transformed.shapes().filter { it.hasTrait<RustBoxTrait>() }.toList()
         boxed.map { it.id.toString().removePrefix("com.example#") }.toSet() shouldBe setOf(
             "Atom\$add",
             "Atom\$sub",


### PR DESCRIPTION
This adds three syntax sugar extension functions for accessing Smithy shape traits and refactors the existing code to use them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
