### PR TITLE
Escape enum variants to avoid collision with generated Unknown variant

### DIFF
--- a/codegen-test/model/naming-obstacle-course.smithy
+++ b/codegen-test/model/naming-obstacle-course.smithy
@@ -92,3 +92,10 @@ structure CollidingException {
 // Fixing this is more refactoring than I want to get into right now
 // @error("client")
 // structure ErrCollisionsException { }
+
+// The "Unknown" value on this enum collides with the code generated "Unknown" variant used for backwards compatibility
+@enum([
+    { name: "Known", value: "Known" },
+    { name: "Unknown", value: "Unknown" },
+])
+string UnknownVariantCollidingEnum

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
@@ -118,7 +118,7 @@ class CodegenVisitor(context: PluginContext, private val codegenDecorator: RustC
     override fun stringShape(shape: StringShape) {
         shape.getTrait<EnumTrait>()?.also { enum ->
             rustCrate.useShapeWriter(shape) { writer ->
-                EnumGenerator(symbolProvider, writer, shape, enum).render()
+                EnumGenerator(model, symbolProvider, writer, shape, enum).render()
             }
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -66,6 +66,7 @@ internal class EnumMemberModel(private val definition: EnumDefinition) {
 private fun RustWriter.docWithNote(doc: String?, note: String?) {
     doc?.also { docs(it) }
     note?.also {
+        // Add a blank line between the docs and the note to visually differentiate
         doc?.also { write("///") }
         docs("**NOTE:** $it")
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -6,10 +6,14 @@
 package software.amazon.smithy.rust.codegen.smithy.generators
 
 import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.docs
+import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
@@ -17,21 +21,77 @@ import software.amazon.smithy.rust.codegen.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.expectRustMetadata
 import software.amazon.smithy.rust.codegen.util.doubleQuote
+import software.amazon.smithy.rust.codegen.util.getTrait
+import software.amazon.smithy.rust.codegen.util.orNull
 import software.amazon.smithy.rust.codegen.util.toPascalCase
-import java.lang.IllegalStateException
+
+/** Model that wraps [EnumDefinition] to calculate and cache values required to generate the Rust enum source. */
+internal class EnumMemberModel(private val definition: EnumDefinition) {
+    // Because enum variants always start with an upper case letter, they will never
+    // conflict with reserved words (which are always lower case), therefore, we never need
+    // to fall back to raw identifiers
+    private val unescapedName: String? = definition.name.orNull()?.toPascalCase()
+
+    val collidesWithUnknown: Boolean = unescapedName == EnumGenerator.UnknownVariant
+
+    /** Enum name with correct case format and collision resolution */
+    fun derivedName(): String = when (collidesWithUnknown) {
+        // If there is a variant named "Unknown", then rename it to "UnknownValue" so that it
+        // doesn't conflict with the code generator's "Unknown" variant that exists for backwards compatibility.
+        true -> "UnknownValue"
+        else -> checkNotNull(unescapedName) { "Enum variants must be named to derive a name. This is a bug." }
+    }
+
+    val value: String get() = definition.value
+
+    private fun renderDocumentation(writer: RustWriter) {
+        writer.docWithNote(
+            definition.documentation.orNull(),
+            when (collidesWithUnknown) {
+                true ->
+                    "`::${EnumGenerator.UnknownVariant}` has been renamed to `::${EnumGenerator.EscapedUnknownVariant}`. " +
+                        "`::${EnumGenerator.UnknownVariant}` refers to additional values that may have been added since " +
+                        "this enum was generated."
+                else -> null
+            }
+        )
+    }
+
+    fun render(writer: RustWriter) {
+        renderDocumentation(writer)
+        writer.write("${derivedName()},")
+    }
+}
+
+private fun RustWriter.docWithNote(doc: String?, note: String?) {
+    doc?.also { docs(it) }
+    note?.also {
+        doc?.also { write("///") }
+        docs("**NOTE:** $it")
+    }
+}
 
 class EnumGenerator(
+    private val model: Model,
     symbolProvider: SymbolProvider,
     private val writer: RustWriter,
-    shape: StringShape,
+    private val shape: StringShape,
     private val enumTrait: EnumTrait
 ) {
-    private val sortedMembers: List<EnumDefinition> = enumTrait.values.sortedBy { it.value }
     private val symbol = symbolProvider.toSymbol(shape)
     private val enumName = symbol.name
     private val meta = symbol.expectRustMetadata()
+    private val sortedMembers: List<EnumMemberModel> = enumTrait.values.sortedBy { it.value }.map(::EnumMemberModel)
 
     companion object {
+        /**
+         * For enums with named members, variants with names that collide with the generated unknown enum
+         * member get renamed to this [EscapedUnknownVariant] value.
+         */
+        const val EscapedUnknownVariant = "UnknownValue"
+        /** Name of the generated unknown enum member name for enums with named members. */
+        const val UnknownVariant = "Unknown"
+        /** Name of the function on the enum impl to get a vec of value names */
         const val Values = "values"
     }
 
@@ -57,6 +117,7 @@ class EnumGenerator(
     }
 
     private fun renderUnamedEnum() {
+        writer.documentShape(shape, model)
         meta.render(writer)
         writer.write("struct $enumName(String);")
         writer.rustBlock("impl $enumName") {
@@ -79,29 +140,22 @@ class EnumGenerator(
         }
     }
 
-    private fun EnumDefinition.derivedName(): String {
-        // Because enum variants always start with an upper case letter, they will never
-        // conflict with reserved words (which are always lower case), therefore, we never need
-        // to fall back to raw identifiers
-        val unescapedName = name.orElse(null)?.toPascalCase()
-            ?: throw IllegalStateException("Enum variants must be named to derive a name. This is a bug.")
-        return when (unescapedName) {
-            // If there is a variant named "Unknown", then rename it to "UnknownValue" so that it
-            // doesn't conflict with the code generator's "Unknown" variant that exists for backwards compatibility.
-            "Unknown" -> "UnknownValue"
-            else -> unescapedName
-        }
-    }
-
     private fun renderEnum() {
+        writer.docWithNote(
+            shape.getTrait<DocumentationTrait>()?.value,
+            when (sortedMembers.any { it.collidesWithUnknown }) {
+                true ->
+                    "`$enumName::$UnknownVariant` has been renamed to `::$EscapedUnknownVariant`. " +
+                        "`$enumName::$UnknownVariant` refers to additional values that may have been added since " +
+                        "this enum was generated."
+                else -> null
+            }
+        )
+
         meta.render(writer)
         writer.rustBlock("enum $enumName") {
-            sortedMembers.forEach { member ->
-                member.documentation.map { setNewlinePrefix("/// ").write(it).setNewlinePrefix("") }
-                // use the name, or escape the value
-                write("${member.derivedName()},")
-            }
-            write("Unknown(String)")
+            sortedMembers.forEach { member -> member.render(writer) }
+            write("$UnknownVariant(String)")
         }
     }
 
@@ -113,7 +167,7 @@ class EnumGenerator(
                     sortedMembers.forEach { member ->
                         write("""$enumName::${member.derivedName()} => "${member.value}",""")
                     }
-                    write("$enumName::Unknown(s) => s.as_ref()")
+                    write("$enumName::$UnknownVariant(s) => s.as_ref()")
                 }
             }
         }
@@ -149,7 +203,7 @@ class EnumGenerator(
                     sortedMembers.forEach { member ->
                         write(""""${member.value}" => $enumName::${member.derivedName()},""")
                     }
-                    write("other => $enumName::Unknown(other.to_owned())")
+                    write("other => $enumName::$UnknownVariant(other.to_owned())")
                 }
             }
         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -83,8 +83,14 @@ class EnumGenerator(
         // Because enum variants always start with an upper case letter, they will never
         // conflict with reserved words (which are always lower case), therefore, we never need
         // to fall back to raw identifiers
-        return name.orElse(null)?.toPascalCase()
+        val unescapedName = name.orElse(null)?.toPascalCase()
             ?: throw IllegalStateException("Enum variants must be named to derive a name. This is a bug.")
+        return when (unescapedName) {
+            // If there is a variant named "Unknown", then rename it to "UnknownValue" so that it
+            // doesn't conflict with the code generator's "Unknown" variant that exists for backwards compatibility.
+            "Unknown" -> "UnknownValue"
+            else -> unescapedName
+        }
     }
 
     private fun renderEnum() {
@@ -157,8 +163,7 @@ class EnumGenerator(
                     Ok($enumName::from(s))
                 }
             }
-
-        """
+            """
         )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
@@ -5,93 +5,157 @@
 
 package software.amazon.smithy.rust.codegen.generators
 
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.codegen.core.SymbolProvider
-import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.smithy.generators.EnumGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.EnumMemberModel
 import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.lookup
+import software.amazon.smithy.rust.codegen.util.orNull
 
 class EnumGeneratorTest {
-    @Test
-    fun `it generates named enums`() {
-        val model = """
-        namespace test
-        @enum([
-            {
-                value: "t2.nano",
-                name: "T2_NANO",
-                documentation: "T2 instances are Burstable Performance Instances.",
-                tags: ["ebsOnly"]
-            },
-            {
-                value: "t2.micro",
-                name: "T2_MICRO",
-                documentation: "T2 instances are Burstable Performance Instances.",
-                tags: ["ebsOnly"]
-            },
-        ])
-        string InstanceType
-        """.asSmithyModel()
-        val provider: SymbolProvider = testSymbolProvider(model)
-        val writer = RustWriter.forModule("model")
-        val shape = model.lookup<StringShape>("test#InstanceType")
-        val generator = EnumGenerator(provider, writer, shape, shape.expectTrait<EnumTrait>())
-        generator.render()
-        writer.compileAndTest(
-            """
-            let instance = InstanceType::T2Micro;
-            assert_eq!(instance.as_str(), "t2.micro");
-            assert_eq!(InstanceType::from("t2.nano"), InstanceType::T2Nano);
-            assert_eq!(InstanceType::from("other"), InstanceType::Unknown("other".to_owned()));
-            // round trip unknown variants:
-            assert_eq!(InstanceType::from("other").as_str(), "other");
-            """
-        )
-
-        writer.toString() shouldContain "#[non_exhaustive]"
-    }
-
-    @Test
-    fun `named enums are implement eq and hash`() {
-        val model = """
+    @Nested
+    inner class EnumMemberModelTests {
+        private val testModel = """
             namespace test
             @enum([
-            {
-                value: "Foo",
-                name: "Foo",
-            },
-            {
-                value: "Bar",
-                name: "Bar"
-            }])
-            string FooEnum
+                { value: "some-value-1",
+                  name: "some_name_1",
+                  documentation: "Some documentation." },
+                { value: "some-value-2",
+                  name: "someName2",
+                  documentation: "More documentation" },
+                { value: "unknown",
+                  name: "unknown",
+                  documentation: "It has some docs" }
+            ])
+            string EnumWithUnknown
+        """.asSmithyModel()
+
+        private val enumTrait = testModel.lookup<StringShape>("test#EnumWithUnknown").expectTrait<EnumTrait>()
+
+        private fun model(name: String): EnumMemberModel =
+            EnumMemberModel(enumTrait.values.first { it.name.orNull() == name })
+
+        @Test
+        fun `it converts enum names to PascalCase and renames any named Unknown to UnknownValue`() {
+            model("some_name_1").derivedName() shouldBe "SomeName1"
+            model("someName2").also { someName2 ->
+                someName2.derivedName() shouldBe "SomeName2"
+                someName2.collidesWithUnknown shouldBe false
+            }
+            model("unknown").also { unknown ->
+                unknown.derivedName() shouldBe "UnknownValue"
+                unknown.collidesWithUnknown shouldBe true
+            }
+        }
+
+        @Test
+        fun `it should render documentation`() {
+            val rendered = RustWriter.forModule("model").also { model("some_name_1").render(it) }.toString()
+            rendered shouldContain
+                """
+                /// Some documentation.
+                SomeName1,
+                """.trimIndent()
+        }
+
+        @Test
+        fun `it adds a documentation note when renaming an enum named Unknown`() {
+            val rendered = RustWriter.forModule("model").also { model("unknown").render(it) }.toString()
+            rendered shouldContain
+                """
+                /// It has some docs
+                ///
+                /// **NOTE:** `::Unknown` has been renamed to `::UnknownValue`. `::Unknown` refers to additional values that may have been added since this enum was generated.
+                UnknownValue,
+                """.trimIndent()
+        }
+    }
+
+    @Nested
+    inner class EnumGeneratorTests {
+        @Test
+        fun `it generates named enums`() {
+            val model = """
+                namespace test
+                @enum([
+                    {
+                        value: "t2.nano",
+                        name: "T2_NANO",
+                        documentation: "T2 instances are Burstable Performance Instances.",
+                        tags: ["ebsOnly"]
+                    },
+                    {
+                        value: "t2.micro",
+                        name: "T2_MICRO",
+                        documentation: "T2 instances are Burstable Performance Instances.",
+                        tags: ["ebsOnly"]
+                    },
+                ])
+                string InstanceType
             """.asSmithyModel()
-        val shape: StringShape = model.lookup("test#FooEnum")
-        val trait = shape.expectTrait<EnumTrait>()
-        val writer = RustWriter.forModule("model")
-        val generator = EnumGenerator(testSymbolProvider(model), writer, shape, trait)
-        generator.render()
-        writer.compileAndTest(
-            """
+            val provider: SymbolProvider = testSymbolProvider(model)
+            val writer = RustWriter.forModule("model")
+            val shape = model.lookup<StringShape>("test#InstanceType")
+            val generator = EnumGenerator(model, provider, writer, shape, shape.expectTrait<EnumTrait>())
+            generator.render()
+            writer.compileAndTest(
+                """
+                let instance = InstanceType::T2Micro;
+                assert_eq!(instance.as_str(), "t2.micro");
+                assert_eq!(InstanceType::from("t2.nano"), InstanceType::T2Nano);
+                assert_eq!(InstanceType::from("other"), InstanceType::Unknown("other".to_owned()));
+                // round trip unknown variants:
+                assert_eq!(InstanceType::from("other").as_str(), "other");
+                """
+            )
+
+            writer.toString() shouldContain "#[non_exhaustive]"
+        }
+
+        @Test
+        fun `named enums are implement eq and hash`() {
+            val model = """
+                namespace test
+                @enum([
+                {
+                    value: "Foo",
+                    name: "Foo",
+                },
+                {
+                    value: "Bar",
+                    name: "Bar"
+                }])
+                string FooEnum
+            """.asSmithyModel()
+            val shape: StringShape = model.lookup("test#FooEnum")
+            val trait = shape.expectTrait<EnumTrait>()
+            val writer = RustWriter.forModule("model")
+            val generator = EnumGenerator(model, testSymbolProvider(model), writer, shape, trait)
+            generator.render()
+            writer.compileAndTest(
+                """
                 assert_eq!(FooEnum::Foo, FooEnum::Foo);
                 assert_ne!(FooEnum::Bar, FooEnum::Foo);
                 let mut hash_of_enums = std::collections::HashSet::new();
                 hash_of_enums.insert(FooEnum::Foo);
-            """.trimIndent()
-        )
-    }
+                """.trimIndent()
+            )
+        }
 
-    @Test
-    fun `unnamed enums are implement eq and hash`() {
-        val model = """
+        @Test
+        fun `unnamed enums are implement eq and hash`() {
+            val model = """
             namespace test
             @enum([
             {
@@ -102,80 +166,131 @@ class EnumGeneratorTest {
             }])
             string FooEnum
             """.asSmithyModel()
-        val shape: StringShape = model.lookup("test#FooEnum")
-        val trait = shape.expectTrait<EnumTrait>()
-        val writer = RustWriter.forModule("model")
-        val generator = EnumGenerator(testSymbolProvider(model), writer, shape, trait)
-        generator.render()
-        writer.compileAndTest(
-            """
+            val shape: StringShape = model.lookup("test#FooEnum")
+            val trait = shape.expectTrait<EnumTrait>()
+            val writer = RustWriter.forModule("model")
+            val generator = EnumGenerator(model, testSymbolProvider(model), writer, shape, trait)
+            generator.render()
+            writer.compileAndTest(
+                """
                 assert_eq!(FooEnum::from("Foo"), FooEnum::from("Foo"));
                 assert_ne!(FooEnum::from("Bar"), FooEnum::from("Foo"));
                 let mut hash_of_enums = std::collections::HashSet::new();
                 hash_of_enums.insert(FooEnum::from("Foo"));
-            """
-        )
-    }
+                """
+            )
+        }
 
-    @Test
-    fun `it generates unamed enums`() {
-        val model = """
+        @Test
+        fun `it generates unamed enums`() {
+            val model = """
             namespace test
             @enum([
-            {
-                value: "Foo",
-            },
-            {
-                value: "Baz",
-            },
-            {
-                value: "Bar",
-            },
-            {
-                value: "1",
-            },
-            {
-                value: "0",
-            },
-        ])
-        string FooEnum
-        """.asSmithyModel()
-        val shape = model.expectShape(ShapeId.from("test#FooEnum"), StringShape::class.java)
-        val trait = shape.expectTrait<EnumTrait>()
-        val provider: SymbolProvider = testSymbolProvider(model)
-        val writer = RustWriter.forModule("model")
-        val generator = EnumGenerator(provider, writer, shape, trait)
-        generator.render()
-        writer.compileAndTest(
-            """
-            // Values should be sorted
-            assert_eq!(FooEnum::${EnumGenerator.Values}(), ["0", "1", "Bar", "Baz", "Foo"]);
-        """
-        )
-    }
-
-    @Test
-    fun `it escapes the Unknown variant if the enum has an unknown value in the model`() {
-        val model = """
-            namespace test
-            @enum([
-                { name: "Known", value: "Known" },
-                { name: "Unknown", value: "Unknown" },
+                {
+                    value: "Foo",
+                },
+                {
+                    value: "Baz",
+                },
+                {
+                    value: "Bar",
+                },
+                {
+                    value: "1",
+                },
+                {
+                    value: "0",
+                },
             ])
-            string SomeEnum
-        """.asSmithyModel()
+            string FooEnum
+            """.asSmithyModel()
+            val shape: StringShape = model.lookup("test#FooEnum")
+            val trait = shape.expectTrait<EnumTrait>()
+            val provider: SymbolProvider = testSymbolProvider(model)
+            val writer = RustWriter.forModule("model")
+            val generator = EnumGenerator(model, provider, writer, shape, trait)
+            generator.render()
+            writer.compileAndTest(
+                """
+                // Values should be sorted
+                assert_eq!(FooEnum::${EnumGenerator.Values}(), ["0", "1", "Bar", "Baz", "Foo"]);
+                """
+            )
+        }
 
-        val shape = model.expectShape(ShapeId.from("test#SomeEnum"), StringShape::class.java)
-        val trait = shape.expectTrait(EnumTrait::class.java)
-        val provider = testSymbolProvider(model)
-        val writer = RustWriter.forModule("model")
-        EnumGenerator(provider, writer, shape, trait).render()
+        @Test
+        fun `it escapes the Unknown variant if the enum has an unknown value in the model`() {
+            val model = """
+                namespace test
+                @enum([
+                    { name: "Known", value: "Known" },
+                    { name: "Unknown", value: "Unknown" },
+                ])
+                string SomeEnum
+            """.asSmithyModel()
 
-        writer.compileAndTest(
-            """
-            assert_eq!(SomeEnum::from("Unknown"), SomeEnum::UnknownValue);
-            assert_eq!(SomeEnum::from("SomethingNew"), SomeEnum::Unknown("SomethingNew".into()));
-            """
-        )
+            val shape: StringShape = model.lookup("test#SomeEnum")
+            val trait = shape.expectTrait<EnumTrait>()
+            val provider = testSymbolProvider(model)
+            val writer = RustWriter.forModule("model")
+            EnumGenerator(model, provider, writer, shape, trait).render()
+
+            writer.compileAndTest(
+                """
+                assert_eq!(SomeEnum::from("Unknown"), SomeEnum::UnknownValue);
+                assert_eq!(SomeEnum::from("SomethingNew"), SomeEnum::Unknown("SomethingNew".into()));
+                """
+            )
+        }
+
+        @Test
+        fun `it should generate documentation for enums`() {
+            val model = """
+                namespace test
+                
+                /// Some top-level documentation.
+                @enum([
+                    { name: "Known", value: "Known" },
+                    { name: "Unknown", value: "Unknown" },
+                ])
+                string SomeEnum
+            """.asSmithyModel()
+
+            val shape: StringShape = model.lookup("test#SomeEnum")
+            val trait = shape.expectTrait<EnumTrait>()
+            val provider = testSymbolProvider(model)
+            val rendered = RustWriter.forModule("model").also { EnumGenerator(model, provider, it, shape, trait).render() }.toString()
+
+            rendered shouldContain
+                """
+                    /// Some top-level documentation.
+                    ///
+                    /// **NOTE:** `SomeEnum::Unknown` has been renamed to `::UnknownValue`. `SomeEnum::Unknown` refers to additional values that may have been added since this enum was generated.
+                """.trimIndent()
+        }
+
+        @Test
+        fun `it should generate documentation for unnamed enums`() {
+            val model = """
+                namespace test
+                
+                /// Some top-level documentation.
+                @enum([
+                    { value: "One" },
+                    { value: "Two" },
+                ])
+                string SomeEnum
+            """.asSmithyModel()
+
+            val shape: StringShape = model.lookup("test#SomeEnum")
+            val trait = shape.expectTrait<EnumTrait>()
+            val provider = testSymbolProvider(model)
+            val rendered = RustWriter.forModule("model").also { EnumGenerator(model, provider, it, shape, trait).render() }.toString()
+
+            rendered shouldContain
+                """
+                    /// Some top-level documentation.
+                """.trimIndent()
+        }
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlBindingTraitParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlBindingTraitParserGeneratorTest.kt
@@ -175,7 +175,7 @@ internal class XmlBindingTraitParserGeneratorTest {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, it)
             UnionGenerator(model, symbolProvider, it, model.lookup("test#Choice")).render()
             val enum = model.lookup<StringShape>("test#FooEnum")
-            EnumGenerator(symbolProvider, it, enum, enum.expectTrait()).render()
+            EnumGenerator(model, symbolProvider, it, enum, enum.expectTrait()).render()
         }
 
         project.withModule(RustModule.default("output", public = true)) {


### PR DESCRIPTION
This fixes enum variant collisions in #386.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
