### PR TITLE
Mark authorization headers as sensitive

### DIFF
--- a/aws/rust-runtime/aws-sig-auth/src/signer.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/signer.rs
@@ -7,6 +7,7 @@ use aws_auth::Credentials;
 use aws_sigv4_poc::{SigningSettings, UriEncoding};
 use aws_types::region::SigningRegion;
 use aws_types::SigningService;
+use http::HeaderValue;
 use std::error::Error;
 use std::time::SystemTime;
 
@@ -120,9 +121,10 @@ impl SigV4Signer {
             },
         };
         for (key, value) in aws_sigv4_poc::sign_core(request, sigv4_config) {
-            request
-                .headers_mut()
-                .append(key.header_name(), value.parse()?);
+            let mut value = HeaderValue::from_str(&value)?;
+            value.set_sensitive(true); // Prevent Debug logging of signing headers in traces
+
+            request.headers_mut().append(key.header_name(), value);
         }
 
         Ok(())


### PR DESCRIPTION
Related to #371 and #397.

This marks the sigv4 headers as sensitive so that they don't appear in directly in the request trace logs. I think when debugging issues with trace logs, knowing these headers are present, and knowing the canonical request (once that's in the trace) should be sufficient to find any issues without any risk of someone unknowingly putting these header values into a bug report.

Example trace log with this change:
```
May 20 16:45:01.037 TRACE smithy_http_tower::dispatch: request=Request { method: POST, uri: https://ssm.us-east-1.amazonaws.com/, version: HTTP/1.1, headers: {"content-type": "application/x-amz-json-1.1", "x-amz-target": "AmazonSSM.PutParameter", "content-length": "117", "host": "ssm.us-east-1.amazonaws.com", "authorization": Sensitive, "x-amz-date": Sensitive, "x-amz-security-token": Sensitive, "user-agent": "aws-sdk-rust/0.1.0 os/linux lang/rust/1.52.1", "x-amz-user-agent": "aws-sdk-rust/0.1.0 api/ssm/0.0.2 os/linux lang/rust/1.52.1"}, body: SdkBody(Once(Some(b"{\"Name\":\"test_parameter_name\",\"Description\":\"some description\",\"Value\":\"some_value\",\"Type\":\"String\",\"Overwrite\":true}"))) }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
