### PR TITLE
Fix support of primitive headers with a default

### DIFF
--- a/codegen-test/model/rest-json-extras.smithy
+++ b/codegen-test/model/rest-json-extras.smithy
@@ -84,6 +84,13 @@ structure StringPayloadInput {
         code: 200,
         headers: { "x-field": "123" },
         params: { field: 123 }
+    },
+    {
+        id: "DeserPrimitiveHeaderMissing",
+        protocol: "aws.protocols#restJson1",
+        code: 200,
+        headers: { },
+        params: { field: 0 }
     }
 ])
 @http(uri: "/primitive", method: "POST")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -38,8 +38,6 @@ import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.HttpLabelTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustType
-import software.amazon.smithy.rust.codegen.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.smithy.traits.InputBodyTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.OutputBodyTrait
@@ -315,15 +313,6 @@ sealed class Default {
      * This symbol should use the Rust `std::default::Default` when unset
      */
     object RustDefault : Default()
-
-    /**
-     * This symbol has a custom default implementation. This will be written into the block of `or_default(|| <block>)`
-     */
-    class Custom(val default: Writable) : Default() {
-        fun render(writer: RustWriter) {
-            default(writer)
-        }
-    }
 }
 
 /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -219,9 +219,6 @@ class BuilderGenerator(
                             ".ok_or(",
                             ")?"
                         ) { missingRequiredField(memberName) }
-                        memberSymbol.isOptional() && default is Default.Custom -> {
-                            withBlock(".or_else(||Some(", "))") { default.render(this) }
-                        }
                     }
                 }
             }


### PR DESCRIPTION
*Description of changes:* Discovered during testing S3, we are not properly filling in a default value when a required value  is unset and a default is available. This also simplifies the code by removing an unused `Default.Custom` variant that enabled writing any renderable.

Adds protocol test to verify.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
