### PR TITLE
Adding an extra bound makes a not great error.

### DIFF
--- a/aws/rust-runtime/aws-hyper/src/retry.rs
+++ b/aws/rust-runtime/aws-hyper/src/retry.rs
@@ -238,7 +238,7 @@ impl<Handler, R, T, E>
     tower::retry::Policy<operation::Operation<Handler, R>, SdkSuccess<T>, SdkError<E>>
     for RetryHandler
 where
-    E: ProvideErrorKind,
+    E: ProvideErrorKind + Clone,
     Handler: Clone,
     R: ClassifyResponse<SdkSuccess<T>, SdkError<E>>,
 {


### PR DESCRIPTION
Ignore, this is a branch for rustc error improvements.

Adds a bound on a layer that isn't satisfied. It tells you the layer that is broken (which is helpful) but not anything about why you can't use the layer.

`cd aws/rust-runtime/aws-hyper/` -> `cargo check``

```
➜  aws-hyper git:(ekuber) ✗ cargo check
    Checking aws-hyper v0.1.0 (/Users/rcoh/code/smithy-rs/aws/rust-runtime/aws-hyper)
error[E0599]: the method `ready` exists for struct `Retry<RetryHandler, ParseResponseService<MapRequestService<MapRequestService<MapRequestService<DispatchService<S>, SigV4SigningStage>, UserAgentStage>, AwsEndpointStage>, O, Retry>>`, but its trait bounds were not satisfied
   --> src/lib.rs:136:13
    |
136 |         svc.ready().await?.call(input).await
    |             ^^^^^ method cannot be called on `Retry<RetryHandler, ParseResponseService<MapRequestService<MapRequestService<MapRequestService<DispatchService<S>, SigV4SigningStage>, UserAgentStage>, AwsEndpointStage>, O, Retry>>` due to unsatisfied trait bounds
    | 
   ::: /Users/rcoh/.cargo/registry/src/github.com-1ecc6299db9ec823/tower-0.4.6/src/retry/mod.rs:21:1
    |
21  | pub struct Retry<P, S> {
    | ----------------------
    | |
    | doesn't satisfy `_: Service<_>`
    | doesn't satisfy `_: ServiceExt<_>`
    |
    = note: the following trait bounds were not satisfied:
            `Retry<RetryHandler, ParseResponseService<MapRequestService<MapRequestService<MapRequestService<DispatchService<S>, SigV4SigningStage>, UserAgentStage>, AwsEndpointStage>, O, Retry>>: Service<_>`
            which is required by `Retry<RetryHandler, ParseResponseService<MapRequestService<MapRequestService<MapRequestService<DispatchService<S>, SigV4SigningStage>, UserAgentStage>, AwsEndpointStage>, O, Retry>>: ServiceExt<_>`
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
