### PR TITLE
Update example code to use write_all_buf method

### DIFF
--- a/aws/sdk/examples/polly-synthesize-speech/src/main.rs
+++ b/aws/sdk/examples/polly-synthesize-speech/src/main.rs
@@ -10,7 +10,6 @@ use polly::{Client, Config, Region};
 
 use aws_types::region::{EnvironmentProvider, ProvideRegion};
 
-use bytes::Buf;
 use structopt::StructOpt;
 use tokio::io::AsyncWriteExt;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -90,9 +89,8 @@ async fn main() {
     let mut file = tokio::fs::File::create(out_file)
         .await
         .expect("failed to create file");
-    while blob.has_remaining() {
-        file.write_buf(&mut blob)
-            .await
-            .expect("failed to write to file");
-    }
+
+    file.write_all_buf(&mut blob)
+        .await
+        .expect("failed to write to file");
 }

--- a/rust-runtime/smithy-http/Cargo.toml
+++ b/rust-runtime/smithy-http/Cargo.toml
@@ -25,5 +25,5 @@ futures-core = "0.3.14"
 [dev-dependencies]
 proptest = "1"
 base64 = "0.13.0"
-tokio = { version = "1", features = ["macros", "rt", "fs", "io-util"]}
+tokio = {version = "1.6", features = ["macros", "rt", "fs", "io-util"]}
 tokio-stream = "0.1.5"

--- a/rust-runtime/smithy-http/src/byte_stream.rs
+++ b/rust-runtime/smithy-http/src/byte_stream.rs
@@ -11,7 +11,6 @@
 //!
 //! ### Writing a ByteStream into a file:
 //! ```rust
-//! use bytes::Buf;
 //! use smithy_http::byte_stream::ByteStream;
 //! use std::error::Error;
 //! use tokio::fs::File;
@@ -25,9 +24,7 @@
 //! ) -> Result<(), Box<dyn Error + Send + Sync>> {
 //!     let mut buf = output.audio_stream.collect().await?;
 //!     let mut file = File::open("audio.mp3").await?;
-//!     while buf.has_remaining() {
-//!         file.write_buf(&mut buf).await?;
-//!     }
+//!     file.write_all_buf(&mut buf).await?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
Small PR, related to #349 
*This PR updated the example code to use the lastest supported method `write_all_buf`from `AsyncWriteExt` trait (https://github.com/tokio-rs/tokio/pull/3737) to make example less verbose *


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Test: `./gradlew :aws:sdk:test` passed locally. 

`BUILD SUCCESSFUL in 8m 41s`

Please let me know if you have any feedbacks. Thanks!