### PR TITLE
Implement new JsonSerializerGenerator without document/operation support

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -187,6 +187,8 @@ data class CargoDependency(
             "protocol-test-helpers", Local(runtimeConfig.relativePath), scope = DependencyScope.Dev
         )
 
+        fun smithyJson(runtimeConfig: RuntimeConfig): CargoDependency =
+            CargoDependency("${runtimeConfig.cratePrefix}-json", Local(runtimeConfig.relativePath))
         fun smithyXml(runtimeConfig: RuntimeConfig): CargoDependency =
             CargoDependency("${runtimeConfig.cratePrefix}-xml", Local(runtimeConfig.relativePath))
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -128,22 +128,15 @@ fun RustType.render(fullyQualified: Boolean = true): String {
  * Option<Instant>.contains(Instant) would return true.
  * Option<Instant>.contains(Blob) would return false.
  */
-fun <T : RustType> RustType.contains(t: T): Boolean {
-    if (t == this) {
-        return true
-    }
-
-    return when (this) {
-        is RustType.Container -> this.member.contains(t)
-        else -> false
-    }
+fun <T : RustType> RustType.contains(t: T): Boolean = when (this) {
+    t -> true
+    is RustType.Container -> this.member.contains(t)
+    else -> false
 }
 
-inline fun <reified T : RustType.Container> RustType.stripOuter(): RustType {
-    return when (this) {
-        is T -> this.member
-        else -> this
-    }
+inline fun <reified T : RustType.Container> RustType.stripOuter(): RustType = when (this) {
+    is T -> this.member
+    else -> this
 }
 
 /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -74,6 +74,16 @@ fun <T : CodeWriter> T.rust(
 }
 
 /**
+ * Convenience wrapper that tells Intellij that the contents of this block are Rust
+ */
+fun <T : CodeWriter> T.rustInline(
+    @Language("Rust", prefix = "macro_rules! foo { () =>  {{ ", suffix = "}}}") contents: String,
+    vararg args: Any
+) {
+    this.writeInline(contents, *args)
+}
+
+/**
  * Sibling method to [rustBlock] that enables `#{variablename}` style templating
  */
 fun <T : CodeWriter> T.rustBlockTemplate(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -65,16 +65,18 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
             namespace = "${runtimeConfig.cratePrefix}_types::retry"
         )
 
-        val Default: RuntimeType = RuntimeType("Default", dependency = null, namespace = "std::default")
-        val From = RuntimeType("From", dependency = null, namespace = "std::convert")
-        val AsRef = RuntimeType("AsRef", dependency = null, namespace = "std::convert")
         val std = RuntimeType(null, dependency = null, namespace = "std")
         val stdfmt = std.member("fmt")
-        val StdError = RuntimeType("Error", dependency = null, namespace = "std::error")
+
+        val AsRef = RuntimeType("AsRef", dependency = null, namespace = "std::convert")
         val ByteSlab = RuntimeType("Vec<u8>", dependency = null, namespace = "std::vec")
-        val Debug = stdfmt.member("Debug")
-        val PartialEq = std.member("cmp::PartialEq")
         val Clone = std.member("clone::Clone")
+        val Debug = stdfmt.member("Debug")
+        val Default: RuntimeType = RuntimeType("Default", dependency = null, namespace = "std::default")
+        val From = RuntimeType("From", dependency = null, namespace = "std::convert")
+        val PartialEq = std.member("cmp::PartialEq")
+        val StdError = RuntimeType("Error", dependency = null, namespace = "std::error")
+        val String = RuntimeType("String", dependency = null, namespace = "std::string")
 
         fun Instant(runtimeConfig: RuntimeConfig) =
             RuntimeType("Instant", CargoDependency.SmithyTypes(runtimeConfig), "${runtimeConfig.cratePrefix}_types")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson10.kt
@@ -36,8 +36,8 @@ import software.amazon.smithy.rust.codegen.smithy.generators.error.errorSymbol
 import software.amazon.smithy.rust.codegen.smithy.generators.operationBuildError
 import software.amazon.smithy.rust.codegen.smithy.locatedIn
 import software.amazon.smithy.rust.codegen.smithy.meta
-import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.JsonParserGenerator
-import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.JsonSerializerGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.SerdeJsonParserGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.SerdeJsonSerializerGenerator
 import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.smithy.traits.InputBodyTrait
 import software.amazon.smithy.rust.codegen.smithy.traits.OutputBodyTrait
@@ -198,7 +198,7 @@ class BasicAwsJsonGenerator(
     }
 
     override fun RustWriter.body(self: String, operationShape: OperationShape): BodyMetadata {
-        val generator = JsonSerializerGenerator(protocolConfig)
+        val generator = SerdeJsonSerializerGenerator(protocolConfig)
         val serializer = generator.operationSerializer(operationShape)
         serializer?.also { sym ->
             rustTemplate(
@@ -214,7 +214,7 @@ class BasicAwsJsonGenerator(
         val outputShape = operationIndex.getOutput(operationShape).get()
         val errorSymbol = operationShape.errorSymbol(symbolProvider)
         val jsonErrors = RuntimeType.awsJsonErrors(protocolConfig.runtimeConfig)
-        val generator = JsonParserGenerator(protocolConfig)
+        val generator = SerdeJsonParserGenerator(protocolConfig)
 
         fromResponseFun(implBlockWriter, operationShape) {
             rustBlock("if #T::is_error(&response)", jsonErrors) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsRestJson.kt
@@ -18,8 +18,8 @@ import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolGeneratorFactory
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolSupport
-import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.JsonParserGenerator
-import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.JsonSerializerGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.SerdeJsonParserGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.SerdeJsonSerializerGenerator
 import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.StructuredDataParserGenerator
 import software.amazon.smithy.rust.codegen.smithy.protocols.parsers.StructuredDataSerializerGenerator
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
@@ -77,11 +77,11 @@ class AwsRestJsonFactory : ProtocolGeneratorFactory<HttpTraitProtocolGenerator> 
 class RestJson(private val protocolConfig: ProtocolConfig) : Protocol {
     private val runtimeConfig = protocolConfig.runtimeConfig
     override fun structuredDataParser(operationShape: OperationShape): StructuredDataParserGenerator {
-        return JsonParserGenerator(protocolConfig)
+        return SerdeJsonParserGenerator(protocolConfig)
     }
 
     override fun structuredDataSerializer(operationShape: OperationShape): StructuredDataSerializerGenerator {
-        return JsonSerializerGenerator(protocolConfig)
+        return SerdeJsonSerializerGenerator(protocolConfig)
     }
 
     override fun parseGenericError(operationShape: OperationShape): RuntimeType {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlNameIndex.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlNameIndex.kt
@@ -44,9 +44,9 @@ class XmlNameIndex(private val model: Model) : KnowledgeIndex {
     }
 
     fun operationInputShapeName(operationShape: OperationShape): String? {
-        val outputShape = operationShape.inputShape(model)
-        val rename = outputShape.getTrait<XmlNameTrait>()?.value
-        return rename ?: outputShape.expectTrait<SyntheticInputTrait>().originalId?.name
+        val inputShape = operationShape.inputShape(model)
+        val rename = inputShape.getTrait<XmlNameTrait>()?.value
+        return rename ?: inputShape.expectTrait<SyntheticInputTrait>().originalId?.name
     }
 
     fun memberName(member: MemberShape): String {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonSerializerGenerator.kt
@@ -1,0 +1,325 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.protocols.parsers
+
+import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.model.knowledge.HttpBinding
+import software.amazon.smithy.model.knowledge.HttpBindingIndex
+import software.amazon.smithy.model.shapes.BlobShape
+import software.amazon.smithy.model.shapes.BooleanShape
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.DocumentShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.NumberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.TimestampShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.EnumTrait
+import software.amazon.smithy.model.traits.JsonNameTrait
+import software.amazon.smithy.model.traits.TimestampFormatTrait.Format.EPOCH_SECONDS
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.rustlang.rustInline
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.isOptional
+import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.smithy.traits.SyntheticInputTrait
+import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.expectTrait
+import software.amazon.smithy.rust.codegen.util.getTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
+import software.amazon.smithy.rust.codegen.util.inputShape
+import software.amazon.smithy.rust.codegen.util.toPascalCase
+import software.amazon.smithy.rust.codegen.util.toSnakeCase
+
+private data class SimpleContext<T : Shape>(
+    /** Name of the JsonObjectWriter or JsonArrayWriter */
+    val writerName: String,
+    val localName: String,
+    val shape: T,
+)
+
+private data class StructContext(
+    /** Name of the JsonObjectWriter */
+    val objectName: String,
+    val localName: String,
+    val shape: StructureShape,
+    val symbolProvider: RustSymbolProvider,
+) {
+    fun member(member: MemberShape): MemberContext =
+        MemberContext(objectName, "$localName.${symbolProvider.toMemberName(member)}", member, structMember = true)
+}
+
+private data class MemberContext(
+    /** Name of the JsonObjectWriter or JsonArrayWriter */
+    val writerName: String,
+    val valueExpression: String,
+    val shape: MemberShape,
+    /** Whether we're working with a JsonObjectWriter (true) or JsonArrayWriter (false) */
+    val structMember: Boolean,
+    private val givenKeyExpression: String? = null,
+) {
+    val wireName: String = shape.getTrait<JsonNameTrait>()?.value ?: shape.memberName
+    val keyExpression: String = when (givenKeyExpression) {
+        null -> wireName.dq()
+        else -> givenKeyExpression
+    }
+
+    /** Generates an expression that serializes the given [value] expression to the object/array */
+    fun writeValue(w: RustWriter, jsonType: String, key: String, value: String) = when (structMember) {
+        true -> w.rust("$writerName.$jsonType($key, $value);")
+        else -> w.rust("$writerName.$jsonType($value);")
+    }
+
+    /** Generates an expression that serializes the given [inner] expression to the object/array */
+    fun writeInner(w: RustWriter, jsonType: String, key: String, inner: RustWriter.() -> Unit) {
+        w.rustInline("$writerName.$jsonType(")
+        if (structMember) {
+            w.writeInline("$key, ")
+        }
+        inner(w)
+        w.write(");")
+    }
+
+    /** Generates a mutable declaration for serializing a new object */
+    fun writeStartObject(w: RustWriter, decl: String, key: String) = when (structMember) {
+        true -> w.rust("let mut $decl = $writerName.start_object($key);")
+        else -> w.rust("let mut $decl = $writerName.start_object();")
+    }
+
+    /** Generates a mutable declaration for serializing a new array */
+    fun writeStartArray(w: RustWriter, decl: String, key: String) = when (structMember) {
+        true -> w.rust("let mut $decl = $writerName.start_array($key);")
+        else -> w.rust("let mut $decl = $writerName.start_array();")
+    }
+}
+
+class JsonSerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSerializerGenerator {
+    private val model = protocolConfig.model
+    private val symbolProvider = protocolConfig.symbolProvider
+    private val runtimeConfig = protocolConfig.runtimeConfig
+    private val serializerError = RuntimeType.SerdeJson("error::Error")
+    private val smithyTypes = CargoDependency.SmithyTypes(runtimeConfig).asType()
+    private val smithyJson = CargoDependency.smithyJson(runtimeConfig).asType()
+    private val codegenScope = arrayOf(
+        "String" to RuntimeType.String,
+        "Error" to serializerError,
+        "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
+        "JsonObjectWriter" to smithyJson.member("serialize::JsonObjectWriter"),
+    )
+    private val httpIndex = HttpBindingIndex.of(model)
+
+    override fun payloadSerializer(member: MemberShape): RuntimeType {
+        val target = model.expectShape(member.target, StructureShape::class.java)
+        val fnName = "serialize_payload_${target.id.name.toSnakeCase()}_${member.container.name.toSnakeCase()}"
+        return RuntimeType.forInlineFun(fnName, "operation_ser") { writer ->
+            writer.rustBlockTemplate(
+                "pub fn $fnName(input: &#{target}) -> Result<#{SdkBody}, #{Error}>",
+                *codegenScope,
+                "target" to symbolProvider.toSymbol(target)
+            ) {
+                rust("let mut out = String::new();")
+                rustTemplate("let mut object = #{JsonObjectWriter}::new(&mut out);", *codegenScope)
+                serializeStructure(StructContext("object", "input", target, symbolProvider))
+                rust("object.finish();")
+                rustTemplate("Ok(#{SdkBody}::from(out))", *codegenScope)
+            }
+        }
+    }
+
+    override fun operationSerializer(operationShape: OperationShape): RuntimeType? {
+        val inputShape = operationShape.inputShape(model)
+        val inputShapeName = inputShape.expectTrait<SyntheticInputTrait>().originalId?.name
+            ?: throw CodegenException("operation must have a name if it has members")
+        val fnName = "serialize_operation_${inputShapeName.toSnakeCase()}"
+        return RuntimeType.forInlineFun(fnName, "operation_ser") {
+            it.rustBlockTemplate(
+                "pub fn $fnName(input: &#{target}) -> Result<#{SdkBody}, #{Error}>",
+                *codegenScope, "target" to symbolProvider.toSymbol(inputShape)
+            ) {
+                // TODO: Implement operation serialization
+                rust("unimplemented!()")
+            }
+        }
+    }
+
+    override fun documentSerializer(): RuntimeType {
+        val fnName = "serialize_document"
+        return RuntimeType.forInlineFun(fnName, "operation_ser") {
+            it.rustTemplate(
+                // TODO: Implement document parsing
+                """
+                pub fn $fnName(input: &#{Document}) -> Result<#{SdkBody}, #{Error}> {
+                    unimplemented!();
+                }
+                """,
+                "Document" to RuntimeType.Document(runtimeConfig), *codegenScope
+            )
+        }
+    }
+
+    private fun RustWriter.serializeStructure(context: StructContext) {
+        val fnName = "serialize_structure_${context.shape.id.name.toSnakeCase()}"
+        val structureSymbol = symbolProvider.toSymbol(context.shape)
+        val structureSerializer = RuntimeType.forInlineFun(fnName, "json_ser") { writer ->
+            writer.rustBlockTemplate(
+                "pub fn $fnName(${context.objectName}: &mut #{JsonObjectWriter}, input: &#{Shape})",
+                "Shape" to structureSymbol,
+                *codegenScope,
+            ) {
+                if (context.shape.members().isEmpty()) {
+                    rust("let _ = input;") // Suppress an unused argument warning
+                }
+                for (member in context.shape.members()) {
+                    serializeMember(context.member(member))
+                }
+            }
+        }
+        rust("#T(${context.objectName.borrowMut()}, ${context.localName});", structureSerializer)
+    }
+
+    private fun RustWriter.serializeMember(context: MemberContext) {
+        val target = model.expectShape(context.shape.target)
+        handleOptional(context) { inner ->
+            val key = inner.keyExpression
+            val value = inner.valueExpression.borrow()
+            when (target) {
+                is StringShape -> when (target.hasTrait<EnumTrait>()) {
+                    true -> context.writeValue(this, "string", key, "$value.as_str()")
+                    false -> context.writeValue(this, "string", key, value)
+                }
+                is BooleanShape -> context.writeValue(this, "boolean", key, value)
+                is NumberShape -> {
+                    val numberType = when (symbolProvider.toSymbol(target).rustType()) {
+                        is RustType.Float -> "Float"
+                        is RustType.Integer -> "NegInt"
+                        else -> throw IllegalStateException("unreachable")
+                    }
+                    context.writeInner(this, "number", key) {
+                        rustInline("#T::$numberType(*${inner.valueExpression})", smithyTypes.member("Number"))
+                    }
+                }
+                is BlobShape -> context.writeInner(this, "string_unchecked", key) {
+                    rustInline("&#T($value)", RuntimeType.Base64Encode(runtimeConfig))
+                }
+                is TimestampShape -> {
+                    val timestampFormat =
+                        httpIndex.determineTimestampFormat(context.shape, HttpBinding.Location.DOCUMENT, EPOCH_SECONDS)
+                    val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, timestampFormat)
+                    context.writeInner(this, "instant", key) {
+                        rustInline("$value, #T", timestampFormatType)
+                    }
+                }
+                is CollectionShape -> jsonArrayWriter(inner) { arrayName ->
+                    serializeCollection(SimpleContext(arrayName, inner.valueExpression, target))
+                }
+                is MapShape -> jsonObjectWriter(inner) { objectName ->
+                    serializeMap(SimpleContext(objectName, inner.valueExpression, target))
+                }
+                is StructureShape -> jsonObjectWriter(inner) { objectName ->
+                    serializeStructure(StructContext(objectName, inner.valueExpression, target, symbolProvider))
+                }
+                is UnionShape -> jsonObjectWriter(inner) { objectName ->
+                    serializeUnion(SimpleContext(objectName, inner.valueExpression, target))
+                }
+                is DocumentShape -> {
+                    // TODO: Implement document shapes
+                }
+                else -> TODO(target.toString())
+            }
+        }
+    }
+
+    private fun RustWriter.jsonArrayWriter(context: MemberContext, inner: RustWriter.(String) -> Unit) {
+        safeName("array").also { arrayName ->
+            context.writeStartArray(this, arrayName, context.keyExpression)
+            inner(arrayName)
+            rust("$arrayName.finish();")
+        }
+    }
+
+    private fun RustWriter.jsonObjectWriter(context: MemberContext, inner: RustWriter.(String) -> Unit) {
+        safeName("object").also { objectName ->
+            context.writeStartObject(this, objectName, context.keyExpression)
+            inner(objectName)
+            rust("$objectName.finish();")
+        }
+    }
+
+    private fun RustWriter.serializeCollection(context: SimpleContext<CollectionShape>) {
+        val itemName = safeName("item")
+        rustBlock("for $itemName in ${context.localName}") {
+            serializeMember(MemberContext(context.writerName, itemName, context.shape.member, structMember = false))
+        }
+    }
+
+    private fun RustWriter.serializeMap(context: SimpleContext<MapShape>) {
+        val keyName = safeName("key")
+        val valueName = safeName("value")
+        val valueShape = context.shape.value
+        rustBlock("for ($keyName, $valueName) in ${context.localName}") {
+            serializeMember(
+                MemberContext(
+                    context.writerName,
+                    valueName,
+                    valueShape,
+                    structMember = true,
+                    givenKeyExpression = keyName
+                )
+            )
+        }
+    }
+
+    private fun RustWriter.serializeUnion(context: SimpleContext<UnionShape>) {
+        val fnName = "serialize_union_${context.shape.id.name.toSnakeCase()}"
+        val unionSymbol = symbolProvider.toSymbol(context.shape)
+        val unionSerializer = RuntimeType.forInlineFun(fnName, "json_ser") { writer ->
+            writer.rustBlockTemplate(
+                "pub fn $fnName(${context.writerName}: &mut #{JsonObjectWriter}, input: &#{Shape})",
+                "Shape" to unionSymbol,
+                *codegenScope,
+            ) {
+                rustBlock("match input") {
+                    for (member in context.shape.members()) {
+                        val variantName = member.memberName.toPascalCase()
+                        withBlock("#T::$variantName(inner) => {", "},", unionSymbol) {
+                            serializeMember(MemberContext(context.writerName, "inner", member, true))
+                        }
+                    }
+                }
+            }
+        }
+        rust("#T(${context.writerName.borrowMut()}, ${context.localName});", unionSerializer)
+    }
+
+    private fun RustWriter.handleOptional(context: MemberContext, inner: RustWriter.(MemberContext) -> Unit) {
+        if (symbolProvider.toSymbol(context.shape).isOptional()) {
+            safeName().also { localDecl ->
+                rustBlock("if let Some($localDecl) = ${context.valueExpression.borrow()}") {
+                    inner(context.copy(valueExpression = localDecl))
+                }
+            }
+        } else {
+            inner(context)
+        }
+    }
+}
+
+private fun String.borrow(): String = "&$this"
+private fun String.borrowMut(): String = "&mut $this"

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/SerdeJsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/SerdeJsonParserGenerator.kt
@@ -21,7 +21,7 @@ import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.outputShape
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
 
-class JsonParserGenerator(protocolConfig: ProtocolConfig) : StructuredDataParserGenerator {
+class SerdeJsonParserGenerator(protocolConfig: ProtocolConfig) : StructuredDataParserGenerator {
     private val model = protocolConfig.model
     private val symbolProvider = protocolConfig.symbolProvider
     private val runtimeConfig = protocolConfig.runtimeConfig

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/SerdeJsonSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/SerdeJsonSerializerGenerator.kt
@@ -19,7 +19,7 @@ import software.amazon.smithy.rust.codegen.util.expectTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
 
-class JsonSerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSerializerGenerator {
+class SerdeJsonSerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSerializerGenerator {
     private val model = protocolConfig.model
     private val symbolProvider = protocolConfig.symbolProvider
     private val runtimeConfig = protocolConfig.runtimeConfig

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticInputTrait.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticInputTrait.kt
@@ -12,7 +12,12 @@ import software.amazon.smithy.model.traits.AnnotationTrait
 /**
  * Indicates that a shape is a synthetic input (see `OperationNormalizer.kt`)
  */
-class SyntheticInputTrait constructor(val operation: ShapeId, val originalId: ShapeId?, val body: ShapeId?) :
+class SyntheticInputTrait(
+    val operation: ShapeId,
+    val originalId: ShapeId?,
+    // TODO: Remove synthetic body when cleaning up serde json generators
+    val body: ShapeId?
+) :
     AnnotationTrait(ID, ObjectNode.fromStringMap(mapOf("body" to body.toString()))) {
     companion object {
         val ID = ShapeId.from("smithy.api.internal#syntheticInput")
@@ -22,6 +27,7 @@ class SyntheticInputTrait constructor(val operation: ShapeId, val originalId: Sh
 /**
  * Indicates that a shape is a synthetic input body
  */
+// TODO: Remove synthetic body when cleaning up serde json generators
 class InputBodyTrait(objectNode: ObjectNode = ObjectNode.objectNode()) : AnnotationTrait(ID, objectNode) {
     companion object {
         val ID = ShapeId.from("smithy.api.internal#syntheticInputBody")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/OperationNormalizer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/OperationNormalizer.kt
@@ -114,6 +114,7 @@ class OperationNormalizer(private val model: Model) {
         // Rename safety: Operations cannot be renamed
         private fun OperationShape.syntheticInputId() = ShapeId.fromParts(this.id.namespace, "${this.id.name}Input")
         private fun OperationShape.syntheticOutputId() = ShapeId.fromParts(this.id.namespace, "${this.id.name}Output")
+        // TODO: Remove synthetic body when cleaning up serde json generators
         private fun OperationShape.syntheticInputBodyId() = ShapeId.fromParts(this.id.namespace, "${this.id.name}InputBody")
         private fun OperationShape.syntheticOutputBodyId() = ShapeId.fromParts(this.id.namespace, "${this.id.name}OutputBody")
 

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonSerializerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonSerializerGeneratorTest.kt
@@ -1,0 +1,128 @@
+package software.amazon.smithy.rust.codegen.smithy.protocols.parsers
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.smithy.generators.EnumGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.UnionGenerator
+import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
+import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
+import software.amazon.smithy.rust.codegen.testutil.testProtocolConfig
+import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+import software.amazon.smithy.rust.codegen.util.expectTrait
+import software.amazon.smithy.rust.codegen.util.inputShape
+import software.amazon.smithy.rust.codegen.util.lookup
+
+class JsonSerializerGeneratorTest {
+    private val baseModel = """
+        namespace test
+        use aws.protocols#restJson1
+
+        union Choice {
+            map: MyMap,
+            list: SomeList,
+            s: String,
+            enum: FooEnum,
+            date: Timestamp,
+            number: Double,
+            top: Top,
+            blob: Blob,
+            document: Document,
+        }
+
+        @enum([{name: "FOO", value: "FOO"}])
+        string FooEnum
+
+        map MyMap {
+            key: String,
+            value: Choice,
+        }
+
+        list SomeList {
+            member: Choice
+        }
+
+        structure Top {
+            choice: Choice,
+            field: String,
+            extra: Long,
+            recursive: TopList
+        }
+
+        list TopList {
+            member: Top
+        }
+
+        structure OpInput {
+            @httpHeader("x-test")
+            someHeader: String,
+            @httpPayload
+            payload: Top
+        }
+
+        @http(uri: "/top", method: "POST")
+        operation Op {
+            input: OpInput,
+        }
+    """.asSmithyModel()
+
+    @Test
+    fun `generates valid serializers`() {
+        val model = RecursiveShapeBoxer.transform(
+            OperationNormalizer(baseModel).transformModel(
+                OperationNormalizer.NoBody,
+                OperationNormalizer.NoBody
+            )
+        )
+        val symbolProvider = testSymbolProvider(model)
+        val parserGenerator = JsonSerializerGenerator(testProtocolConfig(model))
+        val payloadGenerator = parserGenerator.payloadSerializer(model.lookup("test#OpInput\$payload"))
+        val operationGenerator = parserGenerator.operationSerializer(model.lookup("test#Op"))
+        val documentGenerator = parserGenerator.documentSerializer()
+
+        val project = TestWorkspace.testProject(testSymbolProvider(model))
+        project.lib { writer ->
+            writer.unitTest(
+                """
+                use model::Top;
+
+                // Generate the operation/document serializers even if they're not directly tested
+                // ${writer.format(operationGenerator!!)}
+                // ${writer.format(documentGenerator)}
+
+                let inp = crate::input::OpInput::builder().payload(
+                    Top::builder()
+                        .field("hello!")
+                        .extra(45)
+                        .recursive(Top::builder().extra(55).build())
+                        .build()
+                ).build().unwrap();
+                let serialized = ${writer.format(payloadGenerator)}(&inp.payload.unwrap()).unwrap();
+                let output = std::str::from_utf8(serialized.bytes().unwrap()).unwrap();
+                assert_eq!(output, r#"{"field":"hello!","extra":45,"recursive":[{"extra":55}]}"#);
+                """
+            )
+        }
+        project.withModule(RustModule.default("model", public = true)) {
+            model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, it)
+            UnionGenerator(model, symbolProvider, it, model.lookup("test#Choice")).render()
+            val enum = model.lookup<StringShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, it, enum, enum.expectTrait()).render()
+        }
+
+        project.withModule(RustModule.default("input", public = true)) {
+            model.lookup<OperationShape>("test#Op").inputShape(model).renderWithModelBuilder(model, symbolProvider, it)
+        }
+        println("file:///${project.baseDir}/src/operation_ser.rs")
+        println("file:///${project.baseDir}/src/json_ser.rs")
+        println("file:///${project.baseDir}/src/lib.rs")
+        project.compileAndTest()
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonSerializerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parsers/JsonSerializerGeneratorTest.kt
@@ -53,6 +53,7 @@ class JsonSerializerGeneratorTest {
             choice: Choice,
             field: String,
             extra: Long,
+            @jsonName("rec")
             recursive: TopList
         }
 
@@ -106,7 +107,7 @@ class JsonSerializerGeneratorTest {
                 ).build().unwrap();
                 let serialized = ${writer.format(payloadGenerator)}(&inp.payload.unwrap()).unwrap();
                 let output = std::str::from_utf8(serialized.bytes().unwrap()).unwrap();
-                assert_eq!(output, r#"{"field":"hello!","extra":45,"recursive":[{"extra":55}]}"#);
+                assert_eq!(output, r#"{"field":"hello!","extra":45,"rec":[{"extra":55}]}"#);
                 """
             )
         }
@@ -120,9 +121,10 @@ class JsonSerializerGeneratorTest {
         project.withModule(RustModule.default("input", public = true)) {
             model.lookup<OperationShape>("test#Op").inputShape(model).renderWithModelBuilder(model, symbolProvider, it)
         }
-        println("file:///${project.baseDir}/src/operation_ser.rs")
         println("file:///${project.baseDir}/src/json_ser.rs")
         println("file:///${project.baseDir}/src/lib.rs")
+        println("file:///${project.baseDir}/src/model.rs")
+        println("file:///${project.baseDir}/src/operation_ser.rs")
         project.compileAndTest()
     }
 }


### PR DESCRIPTION
This is more progress towards #161. This renames the existing `JsonSerializerGenerator`/`JsonParserGenerator` classes to be prefixed with `Serde-` to indicate their implementation detail while keeping them wired up, and then introduces a new `JsonSerializerGenerator` that will ultimately replace the `SerdeJsonSerializerGenerator`. So far, this new generator is able to generate payload serialization code that passes the included unit test's model, but it doesn't yet attempt to generate operation or document serialization.

This shouldn't have any impact on the existing SDK since nothing is wired up yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
