### PR TITLE
Minor refactor: use `impl AsRef<Path>` to make `from_path` more flexible

### DIFF
--- a/rust-runtime/smithy-http/src/byte_stream.rs
+++ b/rust-runtime/smithy-http/src/byte_stream.rs
@@ -82,8 +82,9 @@
 //! }
 //!
 //! async fn bytestream_from_file() -> GetObjectInput {
-//!     let f = Path::new("docs/some-large-file.csv");
-//!     let bytestream = ByteStream::from_path(&f).await.expect("valid path");
+//!     let bytestream = ByteStream::from_path("docs/some-large-file.csv")
+//!         .await
+//!         .expect("valid path");
 //!     GetObjectInput { body: bytestream }
 //! }
 //! ```
@@ -211,12 +212,13 @@ impl ByteStream {
     /// use smithy_http::byte_stream::ByteStream;
     /// use std::path::Path;
     ///  async fn make_bytestream() -> ByteStream {
-    ///     ByteStream::from_path(&Path::new("docs/rows.csv")).await.expect("file should be readable")
+    ///     ByteStream::from_path("docs/rows.csv").await.expect("file should be readable")
     /// }
     /// ```
     #[cfg(feature = "bytestream-util")]
     #[cfg_attr(docsrs, doc(cfg(feature = "bytestream-util")))]
-    pub async fn from_path(path: &Path) -> Result<Self, Error> {
+    pub async fn from_path(path: impl AsRef<Path>) -> Result<Self, Error> {
+        let path = path.as_ref();
         let path_buf = path.to_path_buf();
         let sz = tokio::fs::metadata(path)
             .await
@@ -446,7 +448,7 @@ mod tests {
         for i in 0..10000 {
             writeln!(file, "Brian was here. Briefly. {}", i)?;
         }
-        let body = ByteStream::from_path(file.path()).await?.into_inner();
+        let body = ByteStream::from_path(&file).await?.into_inner();
         // assert that a valid size hint is immediately ready
         assert_eq!(body.size_hint().exact(), Some(298890));
         let mut body1 = body.try_clone().expect("retryable bodies are cloneable");


### PR DESCRIPTION
*Issue #, if available:* #414

*Description of changes:* Change the method `ByteStream::from_path` signature from taking a concrate type `&Path` to `impl AsRef<Path>` to make the method more easy to use. Instead of user has to provide `&Path`, user can use `&str` instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Note**, in line change `let body = ByteStream::from_path(&file).await?.into_inner();`, if I use `file` instead, this test case will fail due to 
```
---- byte_stream::tests::path_based_bytestreams stdout ----
thread 'byte_stream::tests::path_based_bytestreams' panicked at 'read should not fail: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/byte_stream.rs:460:14
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Using `&file` or `file.path()` will pass without any issue.
