### PR TITLE
Fix Idempotency token bug

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rust.codegen.smithy.generators.config
 
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.OperationIndex
+import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
@@ -69,7 +70,8 @@ sealed class ServiceConfig(name: String) : Section(name) {
 // TODO: if this becomes hot, it may need to be cached in a knowledge index
 fun ServiceShape.needsIdempotencyToken(model: Model): Boolean {
     val operationIndex = OperationIndex.of(model)
-    return this.allOperations.flatMap { operationIndex.getInputMembers(it).values }.any { it.hasTrait<IdempotencyTokenTrait>() }
+    val topDownIndex = TopDownIndex.of(model)
+    return topDownIndex.getContainedOperations(this.id).flatMap { operationIndex.getInputMembers(it).values }.any { it.hasTrait<IdempotencyTokenTrait>() }
 }
 
 typealias ConfigCustomization = NamedSectionGenerator<ServiceConfig>

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGeneratorTest.kt
@@ -53,6 +53,30 @@ internal class ServiceConfigGeneratorTest {
     }
 
     @Test
+    fun `find idempotency token via resources`() {
+        val model = """
+            namespace com.example
+            service ResourceService {
+                resources: [Resource],
+                version: "1"
+            }
+
+            resource Resource {
+                operations: [CreateResource]
+            }
+            operation CreateResource {
+                input: IdempotentInput
+            }
+
+            structure IdempotentInput {
+                @idempotencyToken
+                tok: String
+            }
+        """.asSmithyModel()
+        model.lookup<ServiceShape>("com.example#ResourceService").needsIdempotencyToken(model) shouldBe true
+    }
+
+    @Test
     fun `generate customizations as specified`() {
         class ServiceCustomizer : NamedSectionGenerator<ServiceConfig>() {
             override fun section(section: ServiceConfig): Writable {


### PR DESCRIPTION
If an idempotency token was brought into scope via a resource instead of a directly bound operation, we would fail to properly augment config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
