### PR TITLE
Escape control characters in JSON strings

### DIFF
--- a/rust-runtime/smithy-json/src/escape.rs
+++ b/rust-runtime/smithy-json/src/escape.rs
@@ -5,35 +5,38 @@
 
 use std::borrow::Cow;
 
-const ESCAPES: &[char] = &['"', '\\', '\u{08}', '\u{0C}', '\n', '\r', '\t'];
-
 /// Escapes a string for embedding in a JSON string value.
 pub fn escape_string(value: &str) -> Cow<str> {
-    if !value.contains(ESCAPES) {
-        return Cow::Borrowed(value);
+    let bytes = value.as_bytes();
+    for (index, byte) in bytes.iter().enumerate() {
+        match byte {
+            0..=0x1F | b'"' | b'\\' => {
+                return Cow::Owned(escape_string_inner(&bytes[0..index], &bytes[index..]))
+            }
+            _ => {}
+        }
     }
+    Cow::Borrowed(value)
+}
 
-    let mut escaped = String::new();
-    let (mut last, end) = (0, value.len());
-    for (index, chr) in value
-        .char_indices()
-        .filter(|(_index, chr)| ESCAPES.contains(chr))
-    {
-        escaped.push_str(&value[last..index]);
-        escaped.push_str(match chr {
-            '"' => "\\\"",
-            '\\' => "\\\\",
-            '\u{08}' => "\\b",
-            '\u{0C}' => "\\f",
-            '\n' => "\\n",
-            '\r' => "\\r",
-            '\t' => "\\t",
-            _ => unreachable!(),
-        });
-        last = index + 1;
+fn escape_string_inner(start: &[u8], rest: &[u8]) -> String {
+    let mut escaped = start.to_vec();
+    for byte in rest {
+        match byte {
+            b'"' => escaped.extend("\\\"".bytes()),
+            b'\\' => escaped.extend("\\\\".bytes()),
+            0x08 => escaped.extend("\\b".bytes()),
+            0x0C => escaped.extend("\\f".bytes()),
+            b'\n' => escaped.extend("\\n".bytes()),
+            b'\r' => escaped.extend("\\r".bytes()),
+            b'\t' => escaped.extend("\\t".bytes()),
+            0..=0x1F => escaped.extend(format!("\\u{:04x}", byte).bytes()),
+            _ => escaped.push(*byte),
+        }
     }
-    escaped.push_str(&value[last..end]);
-    Cow::Owned(escaped)
+    // Our input was originally valid UTF-8, and we didn't do anything to invalidate it
+    debug_assert!(String::from_utf8(escaped.clone()).is_ok());
+    unsafe { String::from_utf8_unchecked(escaped) }
 }
 
 #[cfg(test)]
@@ -53,12 +56,14 @@ mod test {
             escape_string("\u{08}f\u{0C}o\to\r\n").as_ref()
         );
         assert_eq!("\\\"test\\\"", escape_string("\"test\"").as_ref());
+        assert_eq!("\\u0000", escape_string("\u{0}").as_ref());
+        assert_eq!("\\u001f", escape_string("\u{1f}").as_ref());
     }
 
     use proptest::proptest;
     proptest! {
         #[test]
-        fn matches_serde_json(s: String) {
+        fn matches_serde_json(s in ".*") {
             assert_eq!(
                 serde_json::to_string(&s).unwrap(),
                 format!(r#""{}""#, escape_string(&s))

--- a/rust-runtime/smithy-json/src/escape.rs
+++ b/rust-runtime/smithy-json/src/escape.rs
@@ -41,7 +41,7 @@ fn escape_string_inner(start: &[u8], rest: &[u8]) -> String {
     // - The original input was valid UTF-8 since it came in as a `&str`
     // - Only single-byte code points were escaped
     // - The escape sequences are valid UTF-8
-    debug_assert!(String::from_utf8(escaped.clone()).is_ok());
+    debug_assert!(std::str::from_utf8(&escaped).is_ok());
     unsafe { String::from_utf8_unchecked(escaped) }
 }
 
@@ -70,10 +70,9 @@ mod test {
     proptest! {
         #[test]
         fn matches_serde_json(s in ".*") {
-            assert_eq!(
-                serde_json::to_string(&s).unwrap(),
-                format!(r#""{}""#, escape_string(&s))
-            )
+            let serde_escaped = serde_json::to_string(&s).unwrap();
+            let serde_escaped = &serde_escaped[1..(serde_escaped.len() - 1)];
+            assert_eq!(serde_escaped,escape_string(&s))
         }
     }
 


### PR DESCRIPTION
This escapes the control characters in range 0x00-0x1F (inclusive), and also reworks the escaping so that it should be more performant. It now only iterates over the input string exactly once, rather than once to see if escaping is necessary, and then once again to escape, and there's no longer any conversion to `char`.

To verify it correctly escapes everything, I ran the following additional test (not included in the PR since it takes approximately 100 seconds in a debug test run):
```
    #[test]
    fn all_of_them() {
        for value in 0..u32::MAX {
            if let Some(chr) = char::from_u32(value) {
                let string = String::from(chr);
                let escaped = escape_string(&string);
                let serde_escaped = serde_json::to_string(&string).unwrap();
                let serde_escaped = &serde_escaped[1..(serde_escaped.len() - 1)];
                assert_eq!(&escaped, serde_escaped);
            }
        }
    }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
