### PR TITLE
remove cargo check from CI

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -250,7 +250,7 @@ open class RunExampleTask @javax.inject.Inject constructor() : Exec() {
         }
 }
 
-tasks["test"].finalizedBy("cargoCheck", "cargoClippy", "cargoTest", "cargoDocs")
+tasks["test"].finalizedBy("cargoClippy", "cargoTest", "cargoDocs")
 
 tasks["clean"].doFirst {
     delete("smithy-build.json")


### PR DESCRIPTION
We're going to run `cargo test` anyway, no reason to run cargo check

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
