### PR TITLE
Delete dead "rootProject" setting

### DIFF
--- a/aws/sdk-codegen-test/build.gradle.kts
+++ b/aws/sdk-codegen-test/build.gradle.kts
@@ -41,9 +41,6 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
                       "module": "${it.module}",
                       "moduleAuthors": ["protocoltest@example.com"],
                       "moduleVersion": "0.0.1",
-                      "build": {
-                        "rootProject": true
-                      }
                       ${it.extraConfig ?: ""}
                  }
                }

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -73,10 +73,7 @@ fun generateSmithyBuild(tests: List<AwsService>): String {
                       "module": "aws-sdk-${it.module}",
                       "moduleVersion": "0.0.5-alpha",
                       "moduleAuthors": ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"],
-                      "license": "Apache-2.0",
-                      "build": {
-                        "rootProject": true
-                      }
+                      "license": "Apache-2.0"
                       ${it.extraConfig ?: ""}
                  }
                }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/Rust.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/Rust.kt
@@ -19,7 +19,6 @@ import software.amazon.smithy.rust.codegen.rustlang.RustDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.raw
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
-import software.amazon.smithy.rust.codegen.smithy.BuildSettings
 import software.amazon.smithy.rust.codegen.smithy.CodegenConfig
 import software.amazon.smithy.rust.codegen.smithy.DefaultPublicModules
 import software.amazon.smithy.rust.codegen.smithy.RuntimeCrateLocation
@@ -164,12 +163,11 @@ fun TestWriterDelegator.compileAndTest() {
             ShapeId.from("fake#Fake"),
             "test_${baseDir.toFile().nameWithoutExtension}",
             "0.0.1",
+            moduleAuthors = listOf("test@module.com"),
             runtimeConfig = TestRuntimeConfig,
             codegenConfig = CodegenConfig(),
-            build = BuildSettings.Default(),
-            model = stubModel,
-            moduleAuthors = listOf("test@module.com"),
-            license = null
+            license = null,
+            model = stubModel
         ),
         libRsCustomizations = listOf(),
     )


### PR DESCRIPTION
Setting copied from Kotlin, but we don't actually use it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
