### PR TITLE
fix restXml enum map key deserialization

### DIFF
--- a/codegen-test/model/rest-xml-extras.smithy
+++ b/codegen-test/model/rest-xml-extras.smithy
@@ -4,6 +4,7 @@ namespace aws.protocoltests.restxml
 use aws.protocols#restXml
 use aws.api#service
 use smithy.test#httpResponseTests
+use smithy.test#httpRequestTests
 
 
 /// A REST XML service that sends XML requests and responses.
@@ -11,7 +12,7 @@ use smithy.test#httpResponseTests
 @restXml
 service RestXmlExtras {
     version: "2019-12-16",
-    operations: [AttributeParty, XmlMapsFlattenedNestedXmlNamespace]
+    operations: [AttributeParty, XmlMapsFlattenedNestedXmlNamespace, EnumKeys]
 }
 
 @enum([{"value": "enumvalue", "name": "V"}])
@@ -32,6 +33,42 @@ structure AttributePartyInputOutput {
 
     @xmlAttribute
     bool: Boolean
+}
+
+structure XmlMapEnumKeys {
+    data: EnumKeyMap
+}
+
+map EnumKeyMap {
+    key: StringEnum,
+    value: String
+}
+
+@httpResponseTests([{
+    id: "DeserEnumMap",
+    code: 200,
+    body: "<XmlMapEnumKeys><data><entry><key>enumvalue</key><value>hello</value></entry></data></XmlMapEnumKeys>",
+    params: {
+        data: { "enumvalue": "hello" }
+    },
+    bodyMediaType: "application/xml",
+    protocol: "aws.protocols#restXml"
+}])
+@httpRequestTests([{
+    id: "SerEnumMap",
+    method: "POST",
+    body: "<XmlMapEnumKeys><data><entry><key>enumvalue</key><value>hello</value></entry></data></XmlMapEnumKeys>",
+    uri: "/enumkeys",
+    bodyMediaType: "application/xml",
+    params: {
+        data: { "enumvalue": "hello" }
+    },
+    protocol: "aws.protocols#restXml"
+}])
+@http(uri: "/enumkeys", method: "POST")
+operation EnumKeys {
+    input: XmlMapEnumKeys,
+    output: XmlMapEnumKeys
 }
 
 @httpResponseTests([{

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -53,12 +53,12 @@ fun <T : CodeWriter> T.conditionalBlock(
     block: T.() -> Unit
 ): T {
     if (conditional) {
-        openBlock(textBeforeNewLine, *args)
+        openBlock(textBeforeNewLine.trim(), *args)
     }
 
     block(this)
     if (conditional) {
-        closeBlock(textAfterNewLine)
+        closeBlock(textAfterNewLine.trim())
     }
     return this
 }
@@ -115,7 +115,7 @@ fun <T : CodeWriter> T.rustTemplate(
     check(ctx.distinctBy { it.first.toLowerCase() }.size == ctx.size) { "Duplicate cased keys not supported" }
     this.pushState()
     this.putContext(ctx.toMap().mapKeys { (k, _) -> k.toLowerCase() })
-    this.write(contents.replace(Regex("""#\{([a-zA-Z_0-9]+)\}""")) { matchResult -> "#{${matchResult.groupValues[1].toLowerCase()}:T}" })
+    this.write(contents.trim().replace(Regex("""#\{([a-zA-Z_0-9]+)\}""")) { matchResult -> "#{${matchResult.groupValues[1].toLowerCase()}:T}" })
     this.popState()
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -501,7 +501,8 @@ class XmlBindingTraitParserGenerator(
                 *codegenScope,
                 "Map" to symbolProvider.toSymbol(target)
             ) {
-                rust("let mut k: Option<String> = None;")
+                val keySymbol = symbolProvider.toSymbol(target.key)
+                rust("let mut k: Option<#T> = None;", keySymbol)
                 rust(
                     "let mut v: Option<#T> = None;",
                     symbolProvider.toSymbol(model.expectShape(target.value.target))


### PR DESCRIPTION
*Issue #, if available:* #351 
*Description of changes:* Fix bug discovered while adding SQS. Maps with enum keys did not compile because `String` was hardcoded.

I also added calls to `.trim()` to fix a couple more spots that were causing `rustfmt` to error out on trailing whitespace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
