### PR TITLE
improve ByteStream docs & add pub use

### DIFF
--- a/aws/sdk/examples/s3-helloworld/Cargo.toml
+++ b/aws/sdk/examples/s3-helloworld/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/s3" }
-smithy-http = { path = "../../build/aws-sdk/smithy-http" }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"
 

--- a/aws/sdk/examples/s3-helloworld/src/main.rs
+++ b/aws/sdk/examples/s3-helloworld/src/main.rs
@@ -1,5 +1,5 @@
+use s3::ByteStream;
 use s3::Region;
-use smithy_http::byte_stream::ByteStream;
 use std::error::Error;
 use std::path::Path;
 use tracing_subscriber::fmt::format::FmtSpan;

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/SmithyTypesPubUseGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/SmithyTypesPubUseGenerator.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.LibRsSection
 fun pubUseTypes(runtimeConfig: RuntimeConfig) = listOf(
     RuntimeType.Blob(runtimeConfig),
     CargoDependency.SmithyHttp(runtimeConfig).asType().member("result::SdkError"),
+    CargoDependency.SmithyHttp(runtimeConfig).asType().member("byte_stream::ByteStream"),
 )
 
 class SmithyTypesPubUseGenerator(private val runtimeConfig: RuntimeConfig) : LibRsCustomization() {

--- a/rust-runtime/smithy-http/src/body.rs
+++ b/rust-runtime/smithy-http/src/body.rs
@@ -77,6 +77,14 @@ impl SdkBody {
         }
     }
 
+    /// Construct an explicitly retryable SDK body
+    ///
+    /// ## NOTE: This is probably not what you want
+    ///
+    /// All bodies constructed from in-memory data (`String`, `Vec<u8>`, `Bytes`, etc.) will be
+    /// retryable out of the box. If you want to read data from a file, you should use
+    /// [`ByteStream::from_path`](crate::byte_stream::ByteStream::from_path). This function is only necessary when you
+    /// need to enable retries for your own streaming container.
     pub fn retryable(f: impl Fn() -> SdkBody + Send + Sync + 'static) -> Self {
         let initial = f();
         SdkBody {

--- a/rust-runtime/smithy-http/src/byte_stream.rs
+++ b/rust-runtime/smithy-http/src/byte_stream.rs
@@ -174,7 +174,7 @@ mod bytestream_util;
 ///     ```
 ///
 /// 3. **From an `SdkBody` directly**: For more advanced / custom use cases, a ByteStream can be created directly
-/// from an SdkBody. **When created from an SdkBody, care must be taken to ensure retriability.** An SdkBody is retriable
+/// from an SdkBody. **When created from an SdkBody, care must be taken to ensure retriability.** An SdkBody is retryable
 /// when constructured from in-memory data or when using [`SdkBody::retryable`](crate::body::SdkBody::retryable).
 ///     ```rust
 ///     use smithy_http::byte_stream::ByteStream;


### PR DESCRIPTION
*Description of changes:*

This commit attempts to improve the discoverability and useability of `ByteStream`:
1. Adds pub use for bytestream. This is currently added to all crates. At some point in the future, we may wish to prune this to crates that actually use it, but as it doesn't actually add an additional dependency, there isn't currently any harm.
SdkBody is explicitly _not_ pub use'd. Generally, people shouldn't need to use `SdkBody` directly.

2. Clarifies, adds examples, and generally increases the scope of the `ByteStream` documentation.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
