### PR TITLE
fix s3 head object errors

### DIFF
--- a/aws/sdk/aws-models/s3-tests.smithy
+++ b/aws/sdk/aws-models/s3-tests.smithy
@@ -1,0 +1,23 @@
+$version: "1.0"
+
+namespace com.amazonaws.s3
+use smithy.test#httpResponseTests
+
+apply NotFound @httpResponseTests([
+    {
+        id: "HeadObjectEmptyBody",
+        documentation: "This test case validates https://github.com/awslabs/smithy-rs/issues/456",
+        params: {
+        },
+        body: "",
+        protocol: "aws.protocols#restXml",
+        code: 404,
+        headers: {
+            "x-amz-request-id": "GRZ6BZ468DF52F2E",
+            "x-amz-id-2": "UTniwu6QmCIjVeuK2ZfeWBOnu7SqMQOS3Vac6B/K4H2ZCawYUl+nDbhGTImuyhZ5DFiojR3Kcz4=",
+            "content-type": "application/xml",
+            "date": "Thu, 03 Jun 2021 04:05:52 GMT",
+            "server": "AmazonS3"
+        }
+    }
+])


### PR DESCRIPTION
*Issue #, if available:* Fixes #456 
*Description of changes:*

s3 head object and head bucket can both return 404 with no body. This requires a special error handling case to avoid attempting to parse the body as XML.


@kstich you may want to pull this protocol test in the smithy core protocol tests for S3 since this is unmodeled behavior.

Generated code diff: https://github.com/awslabs/smithy-rs/compare/main-generated...s3-head-object-generated
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
