### PR TITLE
fixes regression in rustdoc ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,10 +246,10 @@ jobs:
         name: aws-sdk-${{ env.name }}-${{ github.sha }}
         path: aws-sdk
     - name: Cargo Docs
-      run: cargo doc --no-deps
+      run: cargo doc --no-deps --document-private-items
       working-directory: aws-sdk
       env:
-        RUSTFLAGS: -D warnings
+        RUSTDOCFLAGS: -D warnings
   clippy-sdk:
     name: cargo clippy AWS SDK
     needs: generate-sdk


### PR DESCRIPTION
*Description of changes:*

When ci.yaml was updated, the warning flags for `cargo doc` were not set properly which allowed documentation warnings to be present in the final build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
