### PR TITLE
Add support for Data Service API for Aurora serverless DB cluster

### DIFF
--- a/aws/sdk/aws-models/rdsdata.json
+++ b/aws/sdk/aws-models/rdsdata.json
@@ -1,0 +1,1339 @@
+{
+    "smithy": "1.0",
+    "shapes": {
+        "com.amazonaws.rdsdata#Arn": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 11,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#ArrayOfArray": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#ArrayValue"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An array of arrays.</p>\n        <note>\n            <p>Some array entries can be null.</p>\n        </note>"
+            }
+        },
+        "com.amazonaws.rdsdata#ArrayValue": {
+            "type": "union",
+            "members": {
+                "booleanValues": {
+                    "target": "com.amazonaws.rdsdata#BooleanArray",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of Boolean values.</p>"
+                    }
+                },
+                "longValues": {
+                    "target": "com.amazonaws.rdsdata#LongArray",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of floating point numbers.</p>"
+                    }
+                },
+                "doubleValues": {
+                    "target": "com.amazonaws.rdsdata#DoubleArray",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of integers.</p>"
+                    }
+                },
+                "stringValues": {
+                    "target": "com.amazonaws.rdsdata#StringArray",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of strings.</p>"
+                    }
+                },
+                "arrayValues": {
+                    "target": "com.amazonaws.rdsdata#ArrayOfArray",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of arrays.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains an array.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#ArrayValueList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#Value"
+            }
+        },
+        "com.amazonaws.rdsdata#BadRequestException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.rdsdata#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The error message returned by this <code>BadRequestException</code> error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>There is an error in the call or in a SQL statement.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.rdsdata#BatchExecuteStatement": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.rdsdata#BatchExecuteStatementRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.rdsdata#BatchExecuteStatementResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.rdsdata#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ForbiddenException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#InternalServerErrorException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ServiceUnavailableError"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#StatementTimeoutException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Runs a batch SQL statement over an array of data.</p>\n        <p>You can run bulk update and insert operations for multiple records using a DML \n            statement with different parameter sets. Bulk operations can provide a significant \n            performance improvement over individual insert and update operations.</p>\n        <important>    \n            <p>If a call isn't part of a transaction because it doesn't include the\n                    <code>transactionID</code> parameter, changes that result from the call are\n                committed automatically.</p>    \n        </important>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/BatchExecute",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#BatchExecuteStatementRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "secretArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name or ARN of the secret that enables access to the DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sql": {
+                    "target": "com.amazonaws.rdsdata#SqlStatement",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SQL statement to run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "database": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database.</p>"
+                    }
+                },
+                "schema": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database schema.</p>"
+                    }
+                },
+                "parameterSets": {
+                    "target": "com.amazonaws.rdsdata#SqlParameterSets",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The parameter set for the batch operation.</p>\n        <p>The SQL statement is executed as many times as the number of parameter sets provided. \n          To execute a SQL statement with no parameters, use one of the following options:</p>\n        <ul>\n            <li>\n                <p>Specify one or more empty parameter sets.</p>\n            </li>\n            <li>\n                <p>Use the <code>ExecuteStatement</code> operation instead of the <code>BatchExecuteStatement</code> operation.</p>\n            </li>\n         </ul>\n        <note>\n            <p>Array parameters are not supported.</p>\n        </note>"
+                    }
+                },
+                "transactionId": {
+                    "target": "com.amazonaws.rdsdata#Id",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a transaction that was started by using the\n                <code>BeginTransaction</code> operation. Specify the transaction ID of the\n            transaction that you want to include the SQL statement in.</p>\n        <p>If the SQL statement is not part of a transaction, don't set this\n            parameter.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request parameters represent the input of a SQL statement over an array of\n            data.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#BatchExecuteStatementResponse": {
+            "type": "structure",
+            "members": {
+                "updateResults": {
+                    "target": "com.amazonaws.rdsdata#UpdateResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The execution results of each batch entry.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the output of a SQL statement over an array of\n            data.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#BeginTransaction": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.rdsdata#BeginTransactionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.rdsdata#BeginTransactionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.rdsdata#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ForbiddenException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#InternalServerErrorException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ServiceUnavailableError"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#StatementTimeoutException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Starts a SQL transaction.</p>\n        \n        <important>\n            <p>A transaction can run for a maximum of 24 hours. A transaction is terminated and \n                rolled back automatically after 24 hours.</p>\n            <p>A transaction times out if no calls use its transaction ID in three minutes. \n                If a transaction times out before it's committed, it's rolled back\n                automatically.</p>\n            <p>DDL statements inside a transaction cause an implicit commit. We recommend \n                that you run each DDL statement in a separate <code>ExecuteStatement</code> call with \n                <code>continueAfterTimeout</code> enabled.</p>\n        </important>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/BeginTransaction",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#BeginTransactionRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "secretArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name or ARN of the secret that enables access to the DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "database": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database.</p>"
+                    }
+                },
+                "schema": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database schema.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request parameters represent the input of a request to start a SQL\n            transaction.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#BeginTransactionResponse": {
+            "type": "structure",
+            "members": {
+                "transactionId": {
+                    "target": "com.amazonaws.rdsdata#Id",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The transaction ID of the transaction started by the call.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the output of a request to start a SQL\n            transaction.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#Blob": {
+            "type": "blob"
+        },
+        "com.amazonaws.rdsdata#Boolean": {
+            "type": "boolean"
+        },
+        "com.amazonaws.rdsdata#BooleanArray": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#BoxedBoolean"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An array of Boolean values.</p>\n        <note>\n            <p>Some array entries can be null.</p>\n        </note>"
+            }
+        },
+        "com.amazonaws.rdsdata#BoxedBoolean": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "com.amazonaws.rdsdata#BoxedDouble": {
+            "type": "double",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "com.amazonaws.rdsdata#BoxedFloat": {
+            "type": "float",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "com.amazonaws.rdsdata#BoxedInteger": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "com.amazonaws.rdsdata#BoxedLong": {
+            "type": "long",
+            "traits": {
+                "smithy.api#box": {}
+            }
+        },
+        "com.amazonaws.rdsdata#ColumnMetadata": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the column.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.rdsdata#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the column.</p>"
+                    }
+                },
+                "typeName": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The database-specific data type of the column.</p>"
+                    }
+                },
+                "label": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The label for the column.</p>"
+                    }
+                },
+                "schemaName": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the schema that owns the table that includes the column.</p>"
+                    }
+                },
+                "tableName": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the table that includes the column.</p>"
+                    }
+                },
+                "isAutoIncrement": {
+                    "target": "com.amazonaws.rdsdata#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether the column increments automatically.</p>"
+                    }
+                },
+                "isSigned": {
+                    "target": "com.amazonaws.rdsdata#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether an integer column is signed.</p>"
+                    }
+                },
+                "isCurrency": {
+                    "target": "com.amazonaws.rdsdata#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether the column contains currency values.</p>"
+                    }
+                },
+                "isCaseSensitive": {
+                    "target": "com.amazonaws.rdsdata#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether the column is case-sensitive.</p>"
+                    }
+                },
+                "nullable": {
+                    "target": "com.amazonaws.rdsdata#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether the column is nullable.</p>"
+                    }
+                },
+                "precision": {
+                    "target": "com.amazonaws.rdsdata#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The precision value of a decimal number column.</p>"
+                    }
+                },
+                "scale": {
+                    "target": "com.amazonaws.rdsdata#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The scale value of a decimal number column.</p>"
+                    }
+                },
+                "arrayBaseColumnType": {
+                    "target": "com.amazonaws.rdsdata#Integer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the column.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the metadata for a column.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#CommitTransaction": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.rdsdata#CommitTransactionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.rdsdata#CommitTransactionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.rdsdata#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ForbiddenException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#InternalServerErrorException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ServiceUnavailableError"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#StatementTimeoutException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Ends a SQL transaction started with the <code>BeginTransaction</code> operation and\n            commits the changes.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/CommitTransaction",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#CommitTransactionRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "secretArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name or ARN of the secret that enables access to the DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "transactionId": {
+                    "target": "com.amazonaws.rdsdata#Id",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the transaction to end and commit.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request parameters represent the input of a commit transaction request.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#CommitTransactionResponse": {
+            "type": "structure",
+            "members": {
+                "transactionStatus": {
+                    "target": "com.amazonaws.rdsdata#TransactionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the commit operation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the output of a commit transaction request.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#DbName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 64
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#DecimalReturnType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "STRING",
+                        "name": "STRING"
+                    },
+                    {
+                        "value": "DOUBLE_OR_LONG",
+                        "name": "DOUBLE_OR_LONG"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.rdsdata#DoubleArray": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#BoxedDouble"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An array of floating point numbers.</p>\n        <note>\n            <p>Some array entries can be null.</p>\n        </note>"
+            }
+        },
+        "com.amazonaws.rdsdata#ErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.rdsdata#ExecuteSql": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.rdsdata#ExecuteSqlRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.rdsdata#ExecuteSqlResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.rdsdata#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ForbiddenException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#InternalServerErrorException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ServiceUnavailableError"
+                }
+            ],
+            "traits": {
+                "smithy.api#deprecated": {
+                    "since": "2019-03-21",
+                    "message": "The ExecuteSql API is deprecated, please use the ExecuteStatement API."
+                },
+                "smithy.api#documentation": "<p>Runs one or more SQL statements.</p>\n        <important>\n            <p>This operation is deprecated. Use the <code>BatchExecuteStatement</code> or\n                    <code>ExecuteStatement</code> operation.</p>\n        </important>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/ExecuteSql",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#ExecuteSqlRequest": {
+            "type": "structure",
+            "members": {
+                "dbClusterOrInstanceArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the Aurora Serverless DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "awsSecretStoreArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the secret that enables access to the DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sqlStatements": {
+                    "target": "com.amazonaws.rdsdata#SqlStatement",
+                    "traits": {
+                        "smithy.api#documentation": "<p>One or more SQL statements to run on the DB cluster.</p>\n        <p>You can separate SQL statements from each other with a semicolon (;). Any valid SQL\n            statement is permitted, including data definition, data manipulation, and commit\n            statements. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "database": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database.</p>"
+                    }
+                },
+                "schema": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database schema.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request parameters represent the input of a request to run one or more SQL\n            statements.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#ExecuteSqlResponse": {
+            "type": "structure",
+            "members": {
+                "sqlStatementResults": {
+                    "target": "com.amazonaws.rdsdata#SqlStatementResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The results of the SQL statement or statements.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the output of a request to run one or more SQL\n            statements.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#ExecuteStatement": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.rdsdata#ExecuteStatementRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.rdsdata#ExecuteStatementResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.rdsdata#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ForbiddenException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#InternalServerErrorException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ServiceUnavailableError"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#StatementTimeoutException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Runs a SQL statement against a database.</p>\n        <important>    \n            <p>If a call isn't part of a transaction because it doesn't include the\n                    <code>transactionID</code> parameter, changes that result from the call are\n                committed automatically.</p>    \n        </important>\n        <p>The response size limit is 1 MB. If the call returns more than 1 MB of response data, the call is terminated.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/Execute",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#ExecuteStatementRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "secretArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name or ARN of the secret that enables access to the DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "sql": {
+                    "target": "com.amazonaws.rdsdata#SqlStatement",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The SQL statement to run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "database": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database.</p>"
+                    }
+                },
+                "schema": {
+                    "target": "com.amazonaws.rdsdata#DbName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database schema.</p>\n        <note>\n            <p>Currently, the <code>schema</code> parameter isn't supported.</p>\n        </note>"
+                    }
+                },
+                "parameters": {
+                    "target": "com.amazonaws.rdsdata#SqlParametersList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The parameters for the SQL statement.</p>\n        <note>\n            <p>Array parameters are not supported.</p>\n        </note>"
+                    }
+                },
+                "transactionId": {
+                    "target": "com.amazonaws.rdsdata#Id",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a transaction that was started by using the\n                <code>BeginTransaction</code> operation. Specify the transaction ID of the\n            transaction that you want to include the SQL statement in.</p>\n        <p>If the SQL statement is not part of a transaction, don't set this parameter.</p>"
+                    }
+                },
+                "includeResultMetadata": {
+                    "target": "com.amazonaws.rdsdata#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether to include metadata in the results.</p>"
+                    }
+                },
+                "continueAfterTimeout": {
+                    "target": "com.amazonaws.rdsdata#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates whether to continue running the statement after \n            the call times out. By default, the statement stops running when the call \n            times out.</p>\n        <important>\n            <p>For DDL statements, we recommend continuing to run the statement after \n               the call times out. When a DDL statement terminates before it is finished \n               running, it can result in errors and possibly corrupted data structures.</p>\n        </important>"
+                    }
+                },
+                "resultSetOptions": {
+                    "target": "com.amazonaws.rdsdata#ResultSetOptions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Options that control how the result set is returned.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request parameters represent the input of a request to run a SQL statement against\n            a database.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#ExecuteStatementResponse": {
+            "type": "structure",
+            "members": {
+                "records": {
+                    "target": "com.amazonaws.rdsdata#SqlRecords",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The records returned by the SQL statement.</p>"
+                    }
+                },
+                "columnMetadata": {
+                    "target": "com.amazonaws.rdsdata#Metadata",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Metadata for the columns included in the results.</p>"
+                    }
+                },
+                "numberOfRecordsUpdated": {
+                    "target": "com.amazonaws.rdsdata#RecordsUpdated",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of records updated by the request.</p>"
+                    }
+                },
+                "generatedFields": {
+                    "target": "com.amazonaws.rdsdata#FieldList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Values for fields generated during the request.</p>\n        \n        <note>\n            <p>The <code>generatedFields</code> data isn't supported by Aurora PostgreSQL.\n                To get the values of generated fields, use the <code>RETURNING</code> clause. For\n                more information, see <a href=\"https://www.postgresql.org/docs/10/dml-returning.html\">Returning Data From\n                    Modified Rows</a> in the PostgreSQL documentation.</p>\n        </note>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the output of a request to run a SQL statement against\n            a database.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#Field": {
+            "type": "union",
+            "members": {
+                "isNull": {
+                    "target": "com.amazonaws.rdsdata#BoxedBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A NULL value.</p>"
+                    }
+                },
+                "booleanValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value of Boolean data type.</p>"
+                    }
+                },
+                "longValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedLong",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value of long data type.</p>"
+                    }
+                },
+                "doubleValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedDouble",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value of double data type.</p>"
+                    }
+                },
+                "stringValue": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value of string data type.</p>"
+                    }
+                },
+                "blobValue": {
+                    "target": "com.amazonaws.rdsdata#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value of BLOB data type.</p>"
+                    }
+                },
+                "arrayValue": {
+                    "target": "com.amazonaws.rdsdata#ArrayValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of values.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains a value.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#FieldList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#Field"
+            }
+        },
+        "com.amazonaws.rdsdata#ForbiddenException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.rdsdata#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The error message returned by this <code>ForbiddenException</code> error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>There are insufficient privileges to make the call.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.rdsdata#Id": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 192
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#Integer": {
+            "type": "integer"
+        },
+        "com.amazonaws.rdsdata#InternalServerErrorException": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>An internal error occurred.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.rdsdata#Long": {
+            "type": "long"
+        },
+        "com.amazonaws.rdsdata#LongArray": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#BoxedLong"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An array of integers.</p>\n        <note>\n            <p>Some array entries can be null.</p>\n        </note>"
+            }
+        },
+        "com.amazonaws.rdsdata#Metadata": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#ColumnMetadata"
+            }
+        },
+        "com.amazonaws.rdsdata#NotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.rdsdata#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The error message returned by this <code>NotFoundException</code> error.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The <code>resourceArn</code>, <code>secretArn</code>, or <code>transactionId</code> value can't be found.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.rdsdata#ParameterName": {
+            "type": "string"
+        },
+        "com.amazonaws.rdsdata#RdsDataService": {
+            "type": "service",
+            "version": "2018-08-01",
+            "operations": [
+                {
+                    "target": "com.amazonaws.rdsdata#BatchExecuteStatement"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#BeginTransaction"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#CommitTransaction"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ExecuteSql"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ExecuteStatement"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#RollbackTransaction"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "RDS Data",
+                    "arnNamespace": "rds-data",
+                    "cloudFormationName": "RdsDataService",
+                    "cloudTrailEventSource": "rds-data.amazonaws.com",
+                    "endpointPrefix": "rds-data"
+                },
+                "aws.auth#sigv4": {
+                    "name": "rds-data"
+                },
+                "aws.protocols#restJson1": {},
+                "smithy.api#cors": {},
+                "smithy.api#documentation": "<fullname>Amazon RDS Data Service</fullname>\n        <p>Amazon RDS provides an HTTP endpoint to run SQL statements on an Amazon Aurora\n            Serverless DB cluster. To run these statements, you work with the Data Service\n            API.</p>\n        <p>For more information about the Data Service API, see <a href=\"https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html\">Using the Data API for Aurora\n                Serverless</a> in the <i>Amazon Aurora User Guide</i>.</p>",
+                "smithy.api#title": "AWS RDS DataService"
+            }
+        },
+        "com.amazonaws.rdsdata#Record": {
+            "type": "structure",
+            "members": {
+                "values": {
+                    "target": "com.amazonaws.rdsdata#Row",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The values returned in the record.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A record returned by a call.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#Records": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#Record"
+            }
+        },
+        "com.amazonaws.rdsdata#RecordsUpdated": {
+            "type": "long"
+        },
+        "com.amazonaws.rdsdata#ResultFrame": {
+            "type": "structure",
+            "members": {
+                "resultSetMetadata": {
+                    "target": "com.amazonaws.rdsdata#ResultSetMetadata",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The result-set metadata in the result set.</p>"
+                    }
+                },
+                "records": {
+                    "target": "com.amazonaws.rdsdata#Records",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The records in the result set.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The result set returned by a SQL statement.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#ResultSetMetadata": {
+            "type": "structure",
+            "members": {
+                "columnCount": {
+                    "target": "com.amazonaws.rdsdata#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of columns in the result set.</p>"
+                    }
+                },
+                "columnMetadata": {
+                    "target": "com.amazonaws.rdsdata#Metadata",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The metadata of the columns in the result set.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The metadata of the result set returned by a SQL statement.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#ResultSetOptions": {
+            "type": "structure",
+            "members": {
+                "decimalReturnType": {
+                    "target": "com.amazonaws.rdsdata#DecimalReturnType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value that indicates how a field of <code>DECIMAL</code> type is represented\n            in the response. The value of <code>STRING</code>, the default, specifies that\n            it is converted to a String value. The value of <code>DOUBLE_OR_LONG</code>\n            specifies that it is converted to a Long value if its scale is 0, or to a Double\n            value otherwise.</p>\n        <important>\n            <p>Conversion to Double or Long can result in roundoff errors due to precision loss.\n                We recommend converting to String, especially when working with currency values.</p>\n        </important>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Options that control how the result set is returned.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#RollbackTransaction": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.rdsdata#RollbackTransactionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.rdsdata#RollbackTransactionResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.rdsdata#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ForbiddenException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#InternalServerErrorException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#ServiceUnavailableError"
+                },
+                {
+                    "target": "com.amazonaws.rdsdata#StatementTimeoutException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Performs a rollback of a transaction. Rolling back a transaction cancels its changes.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/RollbackTransaction",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#RollbackTransactionRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Aurora Serverless DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "secretArn": {
+                    "target": "com.amazonaws.rdsdata#Arn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name or ARN of the secret that enables access to the DB cluster.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "transactionId": {
+                    "target": "com.amazonaws.rdsdata#Id",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the transaction to roll back.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request parameters represent the input of a request to perform a rollback of a\n            transaction.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#RollbackTransactionResponse": {
+            "type": "structure",
+            "members": {
+                "transactionStatus": {
+                    "target": "com.amazonaws.rdsdata#TransactionStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the rollback operation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the output of a request to perform a rollback of a\n            transaction.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#Row": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#Value"
+            }
+        },
+        "com.amazonaws.rdsdata#ServiceUnavailableError": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>The service specified by the <code>resourceArn</code> parameter is not\n            available.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 503
+            }
+        },
+        "com.amazonaws.rdsdata#SqlParameter": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.rdsdata#ParameterName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the parameter.</p>"
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.rdsdata#Field",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of the parameter.</p>"
+                    }
+                },
+                "typeHint": {
+                    "target": "com.amazonaws.rdsdata#TypeHint",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A hint that specifies the correct object type for data type mapping. Possible values\n            are as follows:</p>\n        <ul>\n            <li>\n               <p>\n                  <code>DATE</code> - The corresponding <code>String</code> parameter value is sent as an object \n              of <code>DATE</code> type to the database. The accepted format is <code>YYYY-MM-DD</code>.</p>\n            </li>\n            <li>\n                <p>\n                  <code>DECIMAL</code> - The corresponding <code>String</code> parameter value is sent as an object \n                    of <code>DECIMAL</code> type to the database.</p>\n            </li>\n            <li>\n               <p>\n                  <code>JSON</code> - The corresponding <code>String</code> parameter value is sent as an\n           object of <code>JSON</code> type to the database.</p>\n            </li>\n            <li>\n                <p>\n                  <code>TIME</code> - The corresponding <code>String</code> parameter value is sent as an object \n                    of <code>TIME</code> type to the database. The accepted format is <code>HH:MM:SS[.FFF]</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>TIMESTAMP</code> - The corresponding <code>String</code> parameter value is sent as an object \n              of <code>TIMESTAMP</code> type to the database. The accepted format is <code>YYYY-MM-DD HH:MM:SS[.FFF]</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UUID</code> - The corresponding <code>String</code> parameter value is sent as an object of\n             <code>UUID</code> type to the database.\n          </p>\n            </li>\n         </ul>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A parameter used in a SQL statement.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#SqlParameterSets": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#SqlParametersList"
+            }
+        },
+        "com.amazonaws.rdsdata#SqlParametersList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#SqlParameter"
+            }
+        },
+        "com.amazonaws.rdsdata#SqlRecords": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#FieldList"
+            }
+        },
+        "com.amazonaws.rdsdata#SqlStatement": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 65536
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#SqlStatementResult": {
+            "type": "structure",
+            "members": {
+                "resultFrame": {
+                    "target": "com.amazonaws.rdsdata#ResultFrame",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The result set of the SQL statement.</p>"
+                    }
+                },
+                "numberOfRecordsUpdated": {
+                    "target": "com.amazonaws.rdsdata#RecordsUpdated",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The number of records updated by a SQL statement.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The result of a SQL statement.</p>\n        \n        <important>\n            <p>This data type is deprecated.</p>\n        </important>"
+            }
+        },
+        "com.amazonaws.rdsdata#SqlStatementResults": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#SqlStatementResult"
+            }
+        },
+        "com.amazonaws.rdsdata#StatementTimeoutException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.rdsdata#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The error message returned by this <code>StatementTimeoutException</code> error.</p>"
+                    }
+                },
+                "dbConnectionId": {
+                    "target": "com.amazonaws.rdsdata#Long",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The database connection ID that executed the SQL statement.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The execution of the SQL statement timed out.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.rdsdata#String": {
+            "type": "string"
+        },
+        "com.amazonaws.rdsdata#StringArray": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#String"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An array of strings.</p>\n        <note>\n            <p>Some array entries can be null.</p>\n        </note>"
+            }
+        },
+        "com.amazonaws.rdsdata#StructValue": {
+            "type": "structure",
+            "members": {
+                "attributes": {
+                    "target": "com.amazonaws.rdsdata#ArrayValueList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The attributes returned in the record.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A structure value returned by a call.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#TransactionStatus": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.rdsdata#TypeHint": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "JSON",
+                        "name": "JSON"
+                    },
+                    {
+                        "value": "UUID",
+                        "name": "UUID"
+                    },
+                    {
+                        "value": "TIMESTAMP",
+                        "name": "TIMESTAMP"
+                    },
+                    {
+                        "value": "DATE",
+                        "name": "DATE"
+                    },
+                    {
+                        "value": "TIME",
+                        "name": "TIME"
+                    },
+                    {
+                        "value": "DECIMAL",
+                        "name": "DECIMAL"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.rdsdata#UpdateResult": {
+            "type": "structure",
+            "members": {
+                "generatedFields": {
+                    "target": "com.amazonaws.rdsdata#FieldList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Values for fields generated during the request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The response elements represent the results of an update.</p>"
+            }
+        },
+        "com.amazonaws.rdsdata#UpdateResults": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.rdsdata#UpdateResult"
+            }
+        },
+        "com.amazonaws.rdsdata#Value": {
+            "type": "union",
+            "members": {
+                "isNull": {
+                    "target": "com.amazonaws.rdsdata#BoxedBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A NULL value.</p>"
+                    }
+                },
+                "bitValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of BIT data type.</p>"
+                    }
+                },
+                "bigIntValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedLong",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of big integer data type.</p>"
+                    }
+                },
+                "intValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of integer data type.</p>"
+                    }
+                },
+                "doubleValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedDouble",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of double data type.</p>"
+                    }
+                },
+                "realValue": {
+                    "target": "com.amazonaws.rdsdata#BoxedFloat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of real data type.</p>"
+                    }
+                },
+                "stringValue": {
+                    "target": "com.amazonaws.rdsdata#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of string data type.</p>"
+                    }
+                },
+                "blobValue": {
+                    "target": "com.amazonaws.rdsdata#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of BLOB data type.</p>"
+                    }
+                },
+                "arrayValues": {
+                    "target": "com.amazonaws.rdsdata#ArrayValueList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of column values.</p>"
+                    }
+                },
+                "structValue": {
+                    "target": "com.amazonaws.rdsdata#StructValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A value for a column of STRUCT data type.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the value of a column.</p>\n        \n        <important>\n            <p>This data type is deprecated.</p>\n        </important>"
+            }
+        }
+    }
+}

--- a/aws/sdk/examples/rdsdata-helloworld/Cargo.toml
+++ b/aws/sdk/examples/rdsdata-helloworld/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+authors = ["LMJW <heysuperming@gmail.com>"]
+edition = "2018"
+name = "rdsdata-helloworld"
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rdsdata = {package = "aws-sdk-rdsdata", path = "../../build/aws-sdk/rdsdata"}
+
+tokio = {version = "1", features = ["full"]}

--- a/aws/sdk/examples/rdsdata-helloworld/src/main.rs
+++ b/aws/sdk/examples/rdsdata-helloworld/src/main.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+// Example `RESOURCE_ARN` and `SECRET_ARN`
+// const RESOURCE_ARN: &str = "arn:aws:rds:us-west-2:AWS_ACCOUNT:cluster:database-2";
+// const SECRET_ARN: &str =
+//     "arn:aws:secretsmanager:us-west-2:AWS_ACCOUNT:secret:database2/test/postgres-b8maVb";
+const RESOURCE_ARN: &str = "your aurora serverless db cluster resource arn";
+const SECRET_ARN: &str = "your secret arn from secret manager";
+
+#[tokio::main]
+async fn main() -> Result<(), rdsdata::Error> {
+    let conf = rdsdata::Config::builder()
+        .region(rdsdata::Region::new("us-west-2"))
+        .build();
+    let client = rdsdata::Client::from_conf(conf);
+    let st = client
+        .execute_statement()
+        .resource_arn(RESOURCE_ARN)
+        .database("postgres") // Do not confuse this with db instance name
+        .sql("SELECT * FROM pg_catalog.pg_tables limit 1")
+        .secret_arn(SECRET_ARN);
+
+    let result = st.send().await?;
+
+    println!("{:?}", result);
+    Ok(())
+}


### PR DESCRIPTION
*Issue #, if available:*
Add support for Data Service API for [Aurora serverless DB cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html)
*Description of changes:*
- add rdsdata.json model
- add rdadata-helloworld example

`rdadata-helloworld` example output
```
Running `/Users/xxx/github.com/smithy-rs/aws/sdk/build/aws-sdk/target/debug/rdsdata-helloworld`
ExecuteStatementOutput { records: Some([[StringValue("public"), StringValue("accounts"), StringValue("postgres"), IsNull(true), BooleanValue(true), BooleanValue(false), BooleanValue(false), BooleanValue(false)]]), column_metadata: None, number_of_records_updated: 0, generated_fields: None }
```

*Test:*
- `./gradlew :aws:sdk:assemble` PASS
- `./gradlew :aws:sdk:test` PASS
- `./gradlew :aws:sdk:cargoCheck` PASS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
