### PR TITLE
Add EC2 Query protocol support

### DIFF
--- a/codegen-test/build.gradle.kts
+++ b/codegen-test/build.gradle.kts
@@ -33,6 +33,7 @@ val CodegenTests = listOf(
     CodegenTest("aws.protocoltests.restjson#RestJsonExtras", "rest_json_extas"),
     CodegenTest("aws.protocoltests.restxml#RestXml", "rest_xml"),
     CodegenTest("aws.protocoltests.query#AwsQuery", "aws_query"),
+    CodegenTest("aws.protocoltests.ec2#AwsEc2", "ec2_query"),
     CodegenTest(
         "aws.protocoltests.restxml.xmlns#RestXmlWithNamespace",
         "rest_xml_namespace"

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -107,6 +107,9 @@ class InlineDependency(
             CargoDependency.SmithyHttp(runtimeConfig)
         )
 
+        fun ec2QueryErrors(runtimeConfig: RuntimeConfig): InlineDependency =
+            forRustFile("ec2_query_errors", CargoDependency.smithyXml(runtimeConfig))
+
         fun wrappedXmlErrors(runtimeConfig: RuntimeConfig): InlineDependency =
             forRustFile("rest_xml_wrapped_errors", CargoDependency.smithyXml(runtimeConfig))
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -225,6 +225,9 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
             namespace = "smithy_http::response"
         )
 
+        fun ec2QueryErrors(runtimeConfig: RuntimeConfig) =
+            forInlineDependency(InlineDependency.ec2QueryErrors(runtimeConfig))
+
         fun wrappedXmlErrors(runtimeConfig: RuntimeConfig) =
             forInlineDependency(InlineDependency.wrappedXmlErrors(runtimeConfig))
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.protocols
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.pattern.UriPattern
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.HttpTrait
+import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolGeneratorFactory
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolSupport
+import software.amazon.smithy.rust.codegen.smithy.protocols.parse.Ec2QueryParserGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.parse.StructuredDataParserGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.serialize.Ec2QuerySerializerGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.serialize.StructuredDataSerializerGenerator
+import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
+import software.amazon.smithy.rust.codegen.smithy.transformers.RemoveEventStreamOperations
+
+class Ec2QueryFactory : ProtocolGeneratorFactory<HttpBoundProtocolGenerator> {
+    override fun buildProtocolGenerator(protocolConfig: ProtocolConfig): HttpBoundProtocolGenerator =
+        HttpBoundProtocolGenerator(protocolConfig, Ec2QueryProtocol(protocolConfig))
+
+    override fun transformModel(model: Model): Model {
+        return OperationNormalizer(model).transformModel(
+            inputBodyFactory = OperationNormalizer.NoBody,
+            outputBodyFactory = OperationNormalizer.NoBody
+        ).let(RemoveEventStreamOperations::transform)
+    }
+
+    override fun support(): ProtocolSupport {
+        return ProtocolSupport(
+            requestSerialization = true,
+            requestBodySerialization = true,
+            responseDeserialization = true,
+            errorDeserialization = true,
+        )
+    }
+}
+
+class Ec2QueryProtocol(private val protocolConfig: ProtocolConfig) : Protocol {
+    private val runtimeConfig = protocolConfig.runtimeConfig
+    private val ec2QueryErrors: RuntimeType = RuntimeType.ec2QueryErrors(runtimeConfig)
+    override val httpBindingResolver: HttpBindingResolver = StaticHttpBindingResolver(
+        protocolConfig.model,
+        HttpTrait.builder()
+            .code(200)
+            .method("POST")
+            .uri(UriPattern.parse("/"))
+            .build(),
+        "application/x-www-form-urlencoded"
+    )
+
+    override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.DATE_TIME
+
+    override fun structuredDataParser(operationShape: OperationShape): StructuredDataParserGenerator =
+        Ec2QueryParserGenerator(protocolConfig, ec2QueryErrors)
+
+    override fun structuredDataSerializer(operationShape: OperationShape): StructuredDataSerializerGenerator =
+        Ec2QuerySerializerGenerator(protocolConfig)
+
+    override fun parseGenericError(operationShape: OperationShape): RuntimeType {
+        /**
+         fn parse_generic(response: &Response<Bytes>) -> Result<smithy_types::error::Generic, T: Error>
+         **/
+        return RuntimeType.forInlineFun("parse_generic_error", "xml_deser") {
+            it.rustBlockTemplate(
+                "pub fn parse_generic_error(response: &#{Response}<#{Bytes}>) -> Result<#{Error}, #{XmlError}>",
+                "Response" to RuntimeType.http.member("Response"),
+                "Bytes" to RuntimeType.Bytes,
+                "Error" to RuntimeType.GenericError(runtimeConfig),
+                "XmlError" to CargoDependency.smithyXml(runtimeConfig).asType().member("decode::XmlError")
+            ) {
+                rust("#T::parse_generic_error(response.body().as_ref())", ec2QueryErrors)
+            }
+        }
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/ProtocolLoader.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.smithy.protocols
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_0Trait
 import software.amazon.smithy.aws.traits.protocols.AwsJson1_1Trait
 import software.amazon.smithy.aws.traits.protocols.AwsQueryTrait
+import software.amazon.smithy.aws.traits.protocols.Ec2QueryTrait
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
 import software.amazon.smithy.codegen.core.CodegenException
@@ -40,6 +41,7 @@ class ProtocolLoader(private val supportedProtocols: ProtocolMap) {
             AwsJson1_0Trait.ID to BasicAwsJsonFactory(AwsJsonVersion.Json10),
             AwsJson1_1Trait.ID to BasicAwsJsonFactory(AwsJsonVersion.Json11),
             AwsQueryTrait.ID to AwsQueryFactory(),
+            Ec2QueryTrait.ID to Ec2QueryFactory(),
             RestJson1Trait.ID to RestJsonFactory(),
             RestXmlTrait.ID to RestXmlFactory(),
         )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/Ec2QueryParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/Ec2QueryParserGenerator.kt
@@ -1,0 +1,40 @@
+package software.amazon.smithy.rust.codegen.smithy.protocols.parse
+
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+
+/**
+ * The EC2 query protocol's responses are identical to REST XML's, except that they are wrapped
+ * in a Response tag:
+ *
+ * ```
+ * <SomeOperationResponse>
+ *    <ActualData /> <!-- This part is the same as REST XML -->
+ * </SomeOperationResponse>
+ * ```
+ *
+ * This class wraps [XmlBindingTraitParserGenerator] and uses it to render the vast majority
+ * of the response parsing, but it overrides [operationParser] to add the protocol differences.
+ */
+class Ec2QueryParserGenerator(
+    protocolConfig: ProtocolConfig,
+    xmlErrors: RuntimeType,
+    private val xmlBindingTraitParserGenerator: XmlBindingTraitParserGenerator =
+        XmlBindingTraitParserGenerator(
+            protocolConfig,
+            xmlErrors
+        ) { context, inner ->
+            val operationName = protocolConfig.symbolProvider.toSymbol(context.shape).name
+            val responseWrapperName = operationName + "Response"
+            rustTemplate(
+                """
+                if !(${XmlBindingTraitParserGenerator.XmlName(responseWrapperName).matchExpression("start_el")}) {
+                    return Err(#{XmlError}::custom(format!("invalid root, expected $responseWrapperName got {:?}", start_el)))
+                }
+                """,
+                "XmlError" to context.xmlErrorType
+            )
+            inner("decoder")
+        }
+) : StructuredDataParserGenerator by xmlBindingTraitParserGenerator

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGenerator.kt
@@ -1,0 +1,312 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.protocols.serialize
+
+import software.amazon.smithy.aws.traits.protocols.Ec2QueryNameTrait
+import software.amazon.smithy.model.shapes.BlobShape
+import software.amazon.smithy.model.shapes.BooleanShape
+import software.amazon.smithy.model.shapes.CollectionShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.NumberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.TimestampShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.EnumTrait
+import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.model.traits.XmlNameTrait
+import software.amazon.smithy.rust.codegen.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.isOptional
+import software.amazon.smithy.rust.codegen.smithy.protocols.serializeFunctionName
+import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.getTrait
+import software.amazon.smithy.rust.codegen.util.hasTrait
+import software.amazon.smithy.rust.codegen.util.inputShape
+import software.amazon.smithy.rust.codegen.util.orNull
+import software.amazon.smithy.rust.codegen.util.toPascalCase
+import software.amazon.smithy.utils.StringUtils
+
+class Ec2QuerySerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSerializerGenerator {
+    private data class Context<T : Shape>(
+        /** Expression that yields a QueryValueWriter */
+        val writerExpression: String,
+        /** Expression representing the value to write to the QueryValueWriter */
+        val valueExpression: ValueExpression,
+        val shape: T,
+    )
+
+    private data class MemberContext(
+        /** Expression that yields a QueryValueWriter */
+        val writerExpression: String,
+        /** Expression representing the value to write to the QueryValueWriter */
+        val valueExpression: ValueExpression,
+        val shape: MemberShape,
+    ) {
+        companion object {
+            fun structMember(context: Context<StructureShape>, member: MemberShape, symProvider: RustSymbolProvider): MemberContext =
+                MemberContext(
+                    context.writerExpression,
+                    ValueExpression.Value("${context.valueExpression.name}.${symProvider.toMemberName(member)}"),
+                    member
+                )
+
+            fun unionMember(context: Context<UnionShape>, variantReference: String, member: MemberShape): MemberContext =
+                MemberContext(
+                    context.writerExpression,
+                    ValueExpression.Reference(variantReference),
+                    member
+                )
+        }
+    }
+
+    private val model = protocolConfig.model
+    private val symbolProvider = protocolConfig.symbolProvider
+    private val runtimeConfig = protocolConfig.runtimeConfig
+    private val serviceShape = protocolConfig.serviceShape
+    private val serializerError = RuntimeType.SerdeJson("error::Error")
+    private val smithyTypes = CargoDependency.SmithyTypes(runtimeConfig).asType()
+    private val smithyQuery = CargoDependency.smithyQuery(runtimeConfig).asType()
+    private val serdeUtil = SerializerUtil(model)
+    private val codegenScope = arrayOf(
+        "String" to RuntimeType.String,
+        "Error" to serializerError,
+        "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
+        "QueryWriter" to smithyQuery.member("QueryWriter"),
+        "QueryValueWriter" to smithyQuery.member("QueryValueWriter"),
+    )
+
+    override fun documentSerializer(): RuntimeType {
+        TODO("AwsQuery doesn't support document types")
+    }
+
+    override fun payloadSerializer(member: MemberShape): RuntimeType {
+        TODO("The Aws Query protocol doesn't support http payload traits")
+    }
+
+    override fun operationSerializer(operationShape: OperationShape): RuntimeType? {
+        val fnName = symbolProvider.serializeFunctionName(operationShape)
+        val inputShape = operationShape.inputShape(model)
+        return RuntimeType.forInlineFun(fnName, "operation_ser") { writer ->
+            writer.rustBlockTemplate(
+                "pub fn $fnName(input: &#{target}) -> Result<#{SdkBody}, #{Error}>",
+                *codegenScope, "target" to symbolProvider.toSymbol(inputShape)
+            ) {
+                val action = operationShape.id.name
+                val version = serviceShape.version
+
+                if (inputShape.members().isEmpty()) {
+                    rust("let _ = input;")
+                }
+                rust("let mut out = String::new();")
+                Attribute.AllowUnusedMut.render(writer)
+                rustTemplate(
+                    "let mut writer = #{QueryWriter}::new(&mut out, ${action.dq()}, ${version.dq()});",
+                    *codegenScope
+                )
+                serializeStructureInner(Context("writer", ValueExpression.Reference("input"), inputShape))
+                rust("writer.finish();")
+                rustTemplate("Ok(#{SdkBody}::from(out))", *codegenScope)
+            }
+        }
+    }
+
+    private fun RustWriter.serializeStructure(context: Context<StructureShape>) {
+        val fnName = symbolProvider.serializeFunctionName(context.shape)
+        val structureSymbol = symbolProvider.toSymbol(context.shape)
+        val structureSerializer = RuntimeType.forInlineFun(fnName, "query_ser") { writer ->
+            Attribute.AllowUnusedMut.render(writer)
+            writer.rustBlockTemplate(
+                "pub fn $fnName(mut writer: #{QueryValueWriter}, input: &#{Input})",
+                "Input" to structureSymbol,
+                *codegenScope
+            ) {
+                if (context.shape.members().isEmpty()) {
+                    rust("let (_, _) = (writer, input);") // Suppress unused argument warnings
+                }
+                serializeStructureInner(context)
+            }
+        }
+        rust("#T(${context.writerExpression}, ${context.valueExpression.name});", structureSerializer)
+    }
+
+    private fun RustWriter.serializeStructureInner(context: Context<StructureShape>) {
+        context.copy(writerExpression = "writer", valueExpression = ValueExpression.Reference("input"))
+            .also { inner ->
+                for (member in inner.shape.members()) {
+                    val memberContext = MemberContext.structMember(inner, member, symbolProvider)
+                    structWriter(memberContext) { writerExpression ->
+                        serializeMember(memberContext.copy(writerExpression = writerExpression))
+                    }
+                }
+            }
+    }
+
+    private fun RustWriter.serializeMember(context: MemberContext) {
+        val targetShape = model.expectShape(context.shape.target)
+        if (symbolProvider.toSymbol(context.shape).isOptional()) {
+            safeName().also { local ->
+                rustBlock("if let Some($local) = ${context.valueExpression.asRef()}") {
+                    val innerContext = context.copy(valueExpression = ValueExpression.Reference(local))
+                    serializeMemberValue(innerContext, targetShape)
+                }
+            }
+        } else {
+            with(serdeUtil) {
+                ignoreZeroValues(context.shape, context.valueExpression) {
+                    serializeMemberValue(context, targetShape)
+                }
+            }
+        }
+    }
+
+    private fun RustWriter.serializeMemberValue(context: MemberContext, target: Shape) {
+        val writer = context.writerExpression
+        val value = context.valueExpression
+        when (target) {
+            is StringShape -> when (target.hasTrait<EnumTrait>()) {
+                true -> rust("$writer.string(${value.name}.as_str());")
+                false -> rust("$writer.string(${value.name});")
+            }
+            is BooleanShape -> rust("$writer.boolean(${value.asValue()});")
+            is NumberShape -> {
+                val numberType = when (symbolProvider.toSymbol(target).rustType()) {
+                    is RustType.Float -> "Float"
+                    // NegInt takes an i64 while PosInt takes u64. We need this to be signed here
+                    is RustType.Integer -> "NegInt"
+                    else -> throw IllegalStateException("unreachable")
+                }
+                rust(
+                    "$writer.number(##[allow(clippy::useless_conversion)]#T::$numberType((${value.asValue()}).into()));",
+                    smithyTypes.member("Number")
+                )
+            }
+            is BlobShape -> rust(
+                "$writer.string(&#T(${value.name}));",
+                RuntimeType.Base64Encode(runtimeConfig)
+            )
+            is TimestampShape -> {
+                val timestampFormat = determineTimestampFormat(context.shape)
+                val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, timestampFormat)
+                rust("$writer.instant(${value.name}, #T);", timestampFormatType)
+            }
+            is CollectionShape -> serializeCollection(context, Context(writer, context.valueExpression, target))
+            is MapShape -> serializeMap(context, Context(writer, context.valueExpression, target))
+            is StructureShape -> serializeStructure(Context(writer, context.valueExpression, target))
+            is UnionShape -> structWriter(context) { writerExpression ->
+                serializeUnion(Context(writerExpression, context.valueExpression, target))
+            }
+            else -> TODO(target.toString())
+        }
+    }
+
+    private fun determineTimestampFormat(shape: MemberShape): TimestampFormatTrait.Format =
+        shape.getMemberTrait(model, TimestampFormatTrait::class.java).orNull()?.format
+            ?: TimestampFormatTrait.Format.DATE_TIME
+
+    private fun MemberShape.ec2QueryKeyName(prioritizedFallback: String? = null): String =
+        getTrait<Ec2QueryNameTrait>()?.value
+            ?: getTrait<XmlNameTrait>()?.value?.let { StringUtils.capitalize(it) }
+            ?: prioritizedFallback
+            ?: StringUtils.capitalize(memberName)
+
+    private fun RustWriter.structWriter(context: MemberContext, inner: RustWriter.(String) -> Unit) {
+        val prefix = context.shape.ec2QueryKeyName()
+        safeName("scope").also { scopeName ->
+            Attribute.AllowUnusedMut.render(this)
+            rust("let mut $scopeName = ${context.writerExpression}.prefix(${prefix.dq()});")
+            inner(scopeName)
+        }
+    }
+
+    private fun RustWriter.serializeCollection(memberContext: MemberContext, context: Context<CollectionShape>) {
+        val memberOverride = when (val override = context.shape.member.getTrait<XmlNameTrait>()?.value) {
+            null -> "None"
+            else -> "Some(${override.dq()})"
+        }
+        val itemName = safeName("item")
+        safeName("list").also { listName ->
+            rust("let mut $listName = ${context.writerExpression}.start_list(true, $memberOverride);")
+            rustBlock("for $itemName in ${context.valueExpression.asRef()}") {
+                val entryName = safeName("entry")
+                Attribute.AllowUnusedMut.render(this)
+                rust("let mut $entryName = $listName.entry();")
+                val targetShape = model.expectShape(context.shape.member.target)
+                serializeMemberValue(
+                    MemberContext(entryName, ValueExpression.Reference(itemName), context.shape.member),
+                    targetShape
+                )
+            }
+            rust("$listName.finish();")
+        }
+    }
+
+    private fun RustWriter.serializeMap(memberContext: MemberContext, context: Context<MapShape>) {
+        val entryKeyName = context.shape.key.ec2QueryKeyName("key").dq()
+        val entryValueName = context.shape.value.ec2QueryKeyName("value").dq()
+        safeName("map").also { mapName ->
+            val keyName = safeName("key")
+            val valueName = safeName("value")
+            rust("let mut $mapName = ${context.writerExpression}.start_map(true, $entryKeyName, $entryValueName);")
+            rustBlock("for ($keyName, $valueName) in ${context.valueExpression.asRef()}") {
+                val keyTarget = model.expectShape(context.shape.key.target)
+                val keyExpression = when (keyTarget.hasTrait<EnumTrait>()) {
+                    true -> "$keyName.as_str()"
+                    else -> keyName
+                }
+                val entryName = safeName("entry")
+                Attribute.AllowUnusedMut.render(this)
+                rust("let mut $entryName = $mapName.entry($keyExpression);")
+                serializeMember(MemberContext(entryName, ValueExpression.Reference(valueName), context.shape.value))
+            }
+            rust("$mapName.finish();")
+        }
+    }
+
+    private fun RustWriter.serializeUnion(context: Context<UnionShape>) {
+        val fnName = symbolProvider.serializeFunctionName(context.shape)
+        val unionSymbol = symbolProvider.toSymbol(context.shape)
+        val unionSerializer = RuntimeType.forInlineFun(fnName, "query_ser") { writer ->
+            Attribute.AllowUnusedMut.render(writer)
+            writer.rustBlockTemplate(
+                "pub fn $fnName(mut writer: #{QueryValueWriter}, input: &#{Input})",
+                "Input" to unionSymbol,
+                *codegenScope,
+            ) {
+                rustBlock("match input") {
+                    for (member in context.shape.members()) {
+                        val variantName = member.memberName.toPascalCase()
+                        withBlock("#T::$variantName(inner) => {", "},", unionSymbol) {
+                            serializeMember(
+                                MemberContext.unionMember(
+                                    context.copy(writerExpression = "writer"),
+                                    "inner",
+                                    member
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        rust("#T(${context.writerExpression}, ${context.valueExpression.asRef()});", unionSerializer)
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2QueryTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2QueryTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.protocols
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.smithy.RustCodegenPlugin
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.generatePluginContext
+import software.amazon.smithy.rust.codegen.util.runCommand
+
+class Ec2QueryTest {
+    private val model = """
+        namespace test
+        use aws.protocols#ec2Query
+
+        @ec2Query
+        @xmlNamespace(uri: "https://example.com/")
+        service TestService {
+            version: "2019-12-16",
+            operations: [SomeOperation]
+        }
+
+        operation SomeOperation {
+            input: SomeOperationInputOutput,
+            output: SomeOperationInputOutput,
+        }
+
+        structure SomeOperationInputOutput {
+            payload: String,
+            a: String,
+            b: Integer
+        }
+    """.asSmithyModel()
+
+    @Test
+    fun `generate an aws query service that compiles`() {
+        val (pluginContext, testDir) = generatePluginContext(model)
+        RustCodegenPlugin().execute(pluginContext)
+        "cargo check".runCommand(testDir)
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/Ec2QueryParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/Ec2QueryParserGeneratorTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.protocols.parse
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
+import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
+import software.amazon.smithy.rust.codegen.testutil.TestRuntimeConfig
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
+import software.amazon.smithy.rust.codegen.testutil.testProtocolConfig
+import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+import software.amazon.smithy.rust.codegen.util.lookup
+import software.amazon.smithy.rust.codegen.util.outputShape
+
+class Ec2QueryParserGeneratorTest {
+    private val baseModel = """
+        namespace test
+        use aws.protocols#awsQuery
+
+        structure SomeOutput {
+            @xmlAttribute
+            someAttribute: Long,
+
+            someVal: String
+        }
+
+        operation SomeOperation {
+            output: SomeOutput
+        }
+    """.asSmithyModel()
+
+    @Test
+    fun `it modifies operation parsing to include Response and Result tags`() {
+        val model = RecursiveShapeBoxer.transform(
+            OperationNormalizer(baseModel)
+                .transformModel(OperationNormalizer.NoBody, OperationNormalizer.NoBody)
+        )
+        val symbolProvider = testSymbolProvider(model)
+        val parserGenerator = Ec2QueryParserGenerator(
+            testProtocolConfig(model),
+            RuntimeType.wrappedXmlErrors(TestRuntimeConfig)
+        )
+        val operationParser = parserGenerator.operationParser(model.lookup("test#SomeOperation"))!!
+        val project = TestWorkspace.testProject(testSymbolProvider(model))
+
+        project.lib { writer ->
+            writer.unitTest(
+                name = "valid_input",
+                test = """
+                let xml = br#"
+                <SomeOperationResponse someAttribute="5">
+                    <someVal>Some value</someVal>
+                </someOperationResponse>
+                "#;
+                let output = ${writer.format(operationParser)}(xml, output::some_operation_output::Builder::default()).unwrap().build();
+                assert_eq!(output.some_attribute, Some(5));
+                assert_eq!(output.some_val, Some("Some value".to_string()));
+                """
+            )
+        }
+
+        project.withModule(RustModule.default("model", public = true)) {
+            model.lookup<StructureShape>("test#SomeOutput").renderWithModelBuilder(model, symbolProvider, it)
+        }
+
+        project.withModule(RustModule.default("output", public = true)) {
+            model.lookup<OperationShape>("test#SomeOperation").outputShape(model)
+                .renderWithModelBuilder(model, symbolProvider, it)
+        }
+        println("file:///${project.baseDir}/src/lib.rs")
+        println("file:///${project.baseDir}/src/model.rs")
+        println("file:///${project.baseDir}/src/output.rs")
+        println("file:///${project.baseDir}/src/xml_deser.rs")
+        project.compileAndTest()
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGeneratorTest.kt
@@ -1,0 +1,142 @@
+package software.amazon.smithy.rust.codegen.smithy.protocols.serialize
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.smithy.generators.EnumGenerator
+import software.amazon.smithy.rust.codegen.smithy.generators.UnionGenerator
+import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
+import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.renderWithModelBuilder
+import software.amazon.smithy.rust.codegen.testutil.testProtocolConfig
+import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+import software.amazon.smithy.rust.codegen.util.expectTrait
+import software.amazon.smithy.rust.codegen.util.inputShape
+import software.amazon.smithy.rust.codegen.util.lookup
+
+class Ec2QuerySerializerGeneratorTest {
+    private val baseModel = """
+        namespace test
+
+        union Choice {
+            blob: Blob,
+            boolean: Boolean,
+            date: Timestamp,
+            enum: FooEnum,
+            int: Integer,
+            @xmlFlattened
+            list: SomeList,
+            long: Long,
+            map: MyMap,
+            number: Double,
+            s: String,
+            top: Top,
+        }
+
+        @enum([{name: "FOO", value: "FOO"}])
+        string FooEnum
+
+        map MyMap {
+            key: String,
+            value: Choice,
+        }
+
+        list SomeList {
+            member: Choice
+        }
+
+        structure Top {
+            choice: Choice,
+            field: String,
+            extra: Long,
+            @xmlName("rec")
+            recursive: TopList
+        }
+
+        list TopList {
+            @xmlName("item")
+            member: Top
+        }
+
+        structure OpInput {
+            @xmlName("some_bool")
+            boolean: Boolean,
+            list: SomeList,
+            map: MyMap,
+            top: Top,
+        }
+
+        @http(uri: "/top", method: "POST")
+        operation Op {
+            input: OpInput,
+        }
+    """.asSmithyModel()
+
+    @Test
+    fun `generates valid serializers`() {
+        val model = RecursiveShapeBoxer.transform(
+            OperationNormalizer(baseModel).transformModel(
+                OperationNormalizer.NoBody,
+                OperationNormalizer.NoBody
+            )
+        )
+        val symbolProvider = testSymbolProvider(model)
+        val parserGenerator = Ec2QuerySerializerGenerator(testProtocolConfig(model))
+        val operationGenerator = parserGenerator.operationSerializer(model.lookup("test#Op"))
+
+        val project = TestWorkspace.testProject(testSymbolProvider(model))
+        project.lib { writer ->
+            writer.unitTest(
+                """
+                use model::Top;
+
+                let input = crate::input::OpInput::builder()
+                    .top(
+                        Top::builder()
+                            .field("hello!")
+                            .extra(45)
+                            .recursive(Top::builder().extra(55).build())
+                            .build()
+                    )
+                    .boolean(true)
+                    .build()
+                    .unwrap();
+                let serialized = ${writer.format(operationGenerator!!)}(&input).unwrap();
+                let output = std::str::from_utf8(serialized.bytes().unwrap()).unwrap();
+                assert_eq!(
+                    output,
+                    "\
+                    Action=Op\
+                    &Version=test\
+                    &Some_bool=true\
+                    &Top.Field=hello%21\
+                    &Top.Extra=45\
+                    &Top.Rec.1.Extra=55\
+                    "
+                );
+                """
+            )
+        }
+        project.withModule(RustModule.default("model", public = true)) {
+            model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, it)
+            UnionGenerator(model, symbolProvider, it, model.lookup("test#Choice")).render()
+            val enum = model.lookup<StringShape>("test#FooEnum")
+            EnumGenerator(model, symbolProvider, it, enum, enum.expectTrait()).render()
+        }
+
+        project.withModule(RustModule.default("input", public = true)) {
+            model.lookup<OperationShape>("test#Op").inputShape(model).renderWithModelBuilder(model, symbolProvider, it)
+        }
+        println("file:///${project.baseDir}/src/lib.rs")
+        println("file:///${project.baseDir}/src/model.rs")
+        println("file:///${project.baseDir}/src/operation_ser.rs")
+        println("file:///${project.baseDir}/src/query_ser.rs")
+        project.compileAndTest()
+    }
+}

--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "inlineable"
 version = "0.1.0"
-authors = ["Russell Cohen <rcoh@amazon.com>"]
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 edition = "2018"
 description = """
 The modules of this crate are intended to be inlined directly into the SDK as needed. The dependencies here

--- a/rust-runtime/inlineable/src/ec2_query_errors.rs
+++ b/rust-runtime/inlineable/src/ec2_query_errors.rs
@@ -1,0 +1,127 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use smithy_xml::decode::{try_data, Document, ScopedDecoder, XmlError};
+use std::convert::TryFrom;
+
+#[allow(unused)]
+pub fn body_is_error(body: &[u8]) -> Result<bool, XmlError> {
+    let mut doc = Document::try_from(body)?;
+    let scoped = doc.root_element()?;
+    Ok(scoped.start_el().matches("Response"))
+}
+
+pub fn parse_generic_error(body: &[u8]) -> Result<smithy_types::Error, XmlError> {
+    let mut doc = Document::try_from(body)?;
+    let mut root = doc.root_element()?;
+    let mut err_builder = smithy_types::Error::builder();
+    while let Some(mut tag) = root.next_tag() {
+        match tag.start_el().local() {
+            "Errors" => {
+                while let Some(mut error_tag) = tag.next_tag() {
+                    if let "Error" = error_tag.start_el().local() {
+                        while let Some(mut error_field) = error_tag.next_tag() {
+                            match error_field.start_el().local() {
+                                "Code" => {
+                                    err_builder.code(try_data(&mut error_field)?);
+                                }
+                                "Message" => {
+                                    err_builder.message(try_data(&mut error_field)?);
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+            }
+            "RequestId" => {
+                err_builder.request_id(try_data(&mut tag)?);
+            }
+            _ => {}
+        }
+    }
+    Ok(err_builder.build())
+}
+
+#[allow(unused)]
+pub fn error_scope<'a, 'b>(doc: &'a mut Document<'b>) -> Result<ScopedDecoder<'b, 'a>, XmlError> {
+    let root = doc
+        .next_start_element()
+        .ok_or_else(|| XmlError::custom("no root found searching for an Error"))?;
+    if !root.matches("Response") {
+        return Err(XmlError::custom("expected Response as root"));
+    }
+
+    while let Some(el) = doc.next_start_element() {
+        if el.matches("Errors") && el.depth() == 1 {
+            while let Some(el) = doc.next_start_element() {
+                if el.matches("Error") && el.depth() == 2 {
+                    return Ok(doc.scoped_to(el));
+                }
+            }
+        }
+        // otherwise, ignore it
+    }
+    Err(XmlError::custom("No Error found inside of Response"))
+}
+
+#[cfg(test)]
+mod test {
+    use super::{body_is_error, parse_generic_error};
+    use crate::ec2_query_errors::error_scope;
+    use smithy_xml::decode::Document;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn parse_wrapped_error() {
+        let xml = br#"
+        <Response>
+            <Errors>
+                <Error>
+                    <Code>InvalidGreeting</Code>
+                    <Message>Hi</Message>
+                    <AnotherSetting>setting</AnotherSetting>
+                    <Ignore><This/></Ignore>
+                </Error>
+            </Errors>
+            <RequestId>foo-id</RequestId>
+        </Response>
+        "#;
+        assert!(body_is_error(xml).unwrap());
+        let parsed = parse_generic_error(xml).expect("valid xml");
+        assert_eq!(parsed.request_id(), Some("foo-id"));
+        assert_eq!(parsed.message(), Some("Hi"));
+        assert_eq!(parsed.code(), Some("InvalidGreeting"));
+    }
+
+    #[test]
+    fn test_error_scope() {
+        let xml: &[u8] = br#"
+        <Response>
+            <RequestId>foo-id</RequestId>
+            <MorePreamble>foo-id</RequestId>
+            <Sneaky><Error>These are not the errors you are looking for</Error></Sneaky>
+            <Errors>
+                <Sneaky><Error>These are not the errors you are looking for</Error></Sneaky>
+                <Error>
+                    <Code>InvalidGreeting</Code>
+                    <Message>Hi</Message>
+                    <AnotherSetting>setting</AnotherSetting>
+                    <Ignore><This/></Ignore>
+                </Error>
+            </Errors>
+            <RequestId>foo-id</RequestId>
+        </Response>
+        "#;
+        let mut doc = Document::try_from(xml).expect("valid");
+        let mut error = error_scope(&mut doc).expect("contains error");
+        let mut keys = vec![];
+        while let Some(tag) = error.next_tag() {
+            keys.push(tag.start_el().local().to_owned());
+            // read this the full contents of this element
+        }
+        assert_eq!(keys, vec!["Code", "Message", "AnotherSetting", "Ignore"])
+    }
+}

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -9,6 +9,8 @@ mod blob_serde;
 #[allow(dead_code)]
 mod doc_json;
 #[allow(dead_code)]
+mod ec2_query_errors;
+#[allow(dead_code)]
 mod idempotency_token;
 mod instant_epoch;
 mod instant_httpdate;


### PR DESCRIPTION
Fixes #221.

This PR copies most of the AWS Query support, and then makes the following tweaks to bring it in line with EC2 Query:
- Adds support for the `@ec2QueryName` trait and its specified name fallback chain: `@ec2QueryName -> @xmlName capitalized -> "key"/"value" (for map key/values only) -> member name capitalized`
- Flattens all lists and maps
- Doesn't expect a nested `<Result>` tag inside of responses

Also forked the RestXml inline wrapped error parser since EC2 query wraps the `<Error>` tag in an `<Errors>` tag.

I think there's a discussion to be had about whether we want to attempt to share the code between AwsQueryParserGenerator and Ec2QueryParserGenerator given the small diff between the two:

```
-class AwsQuerySerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSerializerGenerator {
+class Ec2QuerySerializerGenerator(protocolConfig: ProtocolConfig) : StructuredDataSerializerGenerator {
     private data class Context<T : Shape>(
         /** Expression that yields a QueryValueWriter */
         val writerExpression: String,
         /** Expression representing the value to write to the QueryValueWriter */
         val valueExpression: ValueExpression,
@@ -219,28 +220,33 @@

     private fun determineTimestampFormat(shape: MemberShape): TimestampFormatTrait.Format =
         shape.getMemberTrait(model, TimestampFormatTrait::class.java).orNull()?.format
             ?: TimestampFormatTrait.Format.DATE_TIME

+    private fun MemberShape.ec2QueryKeyName(prioritizedFallback: String? = null): String =
+        getTrait<Ec2QueryNameTrait>()?.value
+            ?: getTrait<XmlNameTrait>()?.value?.let { StringUtils.capitalize(it) }
+            ?: prioritizedFallback
+            ?: StringUtils.capitalize(memberName)
+
     private fun RustWriter.structWriter(context: MemberContext, inner: RustWriter.(String) -> Unit) {
-        val prefix = context.shape.getTrait<XmlNameTrait>()?.value ?: context.shape.memberName
+        val prefix = context.shape.ec2QueryKeyName()
         safeName("scope").also { scopeName ->
             Attribute.AllowUnusedMut.render(this)
             rust("let mut $scopeName = ${context.writerExpression}.prefix(${prefix.dq()});")
             inner(scopeName)
         }
     }

     private fun RustWriter.serializeCollection(memberContext: MemberContext, context: Context<CollectionShape>) {
-        val flat = memberContext.shape.getTrait<XmlFlattenedTrait>() != null
         val memberOverride = when (val override = context.shape.member.getTrait<XmlNameTrait>()?.value) {
             null -> "None"
             else -> "Some(${override.dq()})"
         }
         val itemName = safeName("item")
         safeName("list").also { listName ->
-            rust("let mut $listName = ${context.writerExpression}.start_list($flat, $memberOverride);")
+            rust("let mut $listName = ${context.writerExpression}.start_list(true, $memberOverride);")
             rustBlock("for $itemName in ${context.valueExpression.asRef()}") {
                 val entryName = safeName("entry")
                 Attribute.AllowUnusedMut.render(this)
                 rust("let mut $entryName = $listName.entry();")
                 val targetShape = model.expectShape(context.shape.member.target)
@@ -252,17 +258,16 @@
             rust("$listName.finish();")
         }
     }

     private fun RustWriter.serializeMap(memberContext: MemberContext, context: Context<MapShape>) {
-        val flat = memberContext.shape.getTrait<XmlFlattenedTrait>() != null
-        val entryKeyName = (context.shape.key.getTrait<XmlNameTrait>()?.value ?: "key").dq()
-        val entryValueName = (context.shape.value.getTrait<XmlNameTrait>()?.value ?: "value").dq()
+        val entryKeyName = context.shape.key.ec2QueryKeyName("key").dq()
+        val entryValueName = context.shape.value.ec2QueryKeyName("value").dq()
         safeName("map").also { mapName ->
             val keyName = safeName("key")
             val valueName = safeName("value")
-            rust("let mut $mapName = ${context.writerExpression}.start_map($flat, $entryKeyName, $entryValueName);")
+            rust("let mut $mapName = ${context.writerExpression}.start_map(true, $entryKeyName, $entryValueName);")
             rustBlock("for ($keyName, $valueName) in ${context.valueExpression.asRef()}") {
                 val keyTarget = model.expectShape(context.shape.key.target)
                 val keyExpression = when (keyTarget.hasTrait<EnumTrait>()) {
                     true -> "$keyName.as_str()"
                     else -> keyName
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
