### PR TITLE
Fix precision issue with RFC-3339 timestamp serialization

### DIFF
--- a/rust-runtime/smithy-types/Cargo.toml
+++ b/rust-runtime/smithy-types/Cargo.toml
@@ -10,8 +10,8 @@ chrono-conversions = []
 default = ["chrono-conversions"]
 
 [dependencies]
-# alloc can be removed if we implement our own date formatting, TBD if this is worthwhile
-chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+chrono = { version = "0.4", default-features = false, features = [] }
 
 [dev-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 proptest = "1"

--- a/rust-runtime/smithy-types/src/instant/format.rs
+++ b/rust-runtime/smithy-types/src/instant/format.rs
@@ -442,7 +442,7 @@ pub mod iso_8601 {
         );
 
         let mut out = String::with_capacity(33);
-        if year >= 0 && year <= 9999 {
+        if (0..=9999).contains(&year) {
             write!(out, "{:04}", year).unwrap();
         } else if year < 0 {
             write!(out, "{:05}", year).unwrap();

--- a/rust-runtime/smithy-types/src/instant/mod.rs
+++ b/rust-runtime/smithy-types/src/instant/mod.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::instant::format::DateParseError;
-use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use std::str::FromStr;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -134,26 +134,7 @@ impl Instant {
 
     pub fn fmt(&self, format: Format) -> String {
         match format {
-            Format::DateTime => {
-                // TODO: hand write rfc3339 formatter & remove Chrono alloc feature
-                let rfc3339 = self
-                    .to_chrono_internal()
-                    .to_rfc3339_opts(SecondsFormat::AutoSi, true);
-                // If the date ends in `:00` eg. 2019-12-16T23:48:00Z we don't want to strip
-                // those 0s. We only need to strip subsecond zeros when they appear
-                let fixed_date = if !rfc3339.ends_with(":00Z") {
-                    // There's a bug(?) where trailing 0s aren't trimmed
-                    let mut trimmed = rfc3339
-                        .trim_end_matches('Z')
-                        .trim_end_matches('0')
-                        .to_owned();
-                    trimmed.push('Z');
-                    trimmed
-                } else {
-                    rfc3339
-                };
-                fixed_date
-            }
+            Format::DateTime => format::iso_8601::format(&self),
             Format::EpochSeconds => {
                 if self.subsecond_nanos == 0 {
                     format!("{}", self.seconds)


### PR DESCRIPTION
Fixes #478 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
