### PR TITLE
Deleted some erroneous copy-and-paste doc comments in RDS helloworld code example

### DIFF
--- a/aws/sdk/examples/rds/src/bin/rds-helloworld.rs
+++ b/aws/sdk/examples/rds/src/bin/rds-helloworld.rs
@@ -25,9 +25,6 @@ struct Opt {
 /// Displays information about your RDS instances.
 /// # Arguments
 ///
-/// * `-k KEY` - The KMS key.
-/// * `-o OUT` - The name of the file to store the encryped key in.
-/// * `-t TEXT` - The string to encrypt.
 /// * `[-d DEFAULT-REGION]` - The region in which the client is created.
 ///    If not supplied, uses the value of the **AWS_DEFAULT_REGION** environment variable.
 ///    If the environment variable is not set, defaults to **us-west-2**.


### PR DESCRIPTION
*Issue #, if available:*
The RDS helloworld code example had some doc comments from another code example
(copy-and-paste error).

*Description of changes:*
Removed the offending doc comments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
