### PR TITLE
Updated SQS hello-world example

### DIFF
--- a/aws/sdk/examples/sqs/Cargo.toml
+++ b/aws/sdk/examples/sqs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "sqs"
+name = "sqs-code-examples"
 version = "0.1.0"
-authors = ["Russell Cohen <rcoh@amazon.com>"]
+authors = ["Russell Cohen <rcoh@amazon.com>", "Doug Schwartz <dougsch@amazon.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -10,6 +10,3 @@ edition = "2018"
 sqs = { package = "aws-sdk-sqs", path = "../../build/aws-sdk/sqs" }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"
-
-[[bin]]
-name = "sqs-hello-world"

--- a/aws/sdk/examples/sqs/src/bin/sqs-hello-world.rs
+++ b/aws/sdk/examples/sqs/src/bin/sqs-hello-world.rs
@@ -37,8 +37,6 @@ async fn main() -> Result<(), sqs::Error> {
 
     let rcv_message_output = client
         .receive_message()
-        // TODO: this should not be required, https://github.com/awslabs/smithy-rs/issues/439
-        .max_number_of_messages(1)
         .queue_url(&queue_url)
         .send()
         .await?;

--- a/aws/sdk/examples/sqs/src/bin/sqs-hello-world.rs
+++ b/aws/sdk/examples/sqs/src/bin/sqs-hello-world.rs
@@ -5,6 +5,7 @@
 
 use std::process::exit;
 
+/// Sends a message to and receives the message from a queue.
 #[tokio::main]
 async fn main() -> Result<(), sqs::Error> {
     tracing_subscriber::fmt::init();
@@ -18,15 +19,21 @@ async fn main() -> Result<(), sqs::Error> {
             exit(1);
         }
     };
-    println!("sending a receiving on `{}`", queue_url);
+
+    println!(
+        "Sending and receiving messages on with URL: `{}`",
+        queue_url
+    );
 
     let rsp = client
         .send_message()
         .queue_url(&queue_url)
         .message_body("hello from my queue")
+        .message_group_id("MyGroup")
         .send()
         .await?;
-    println!("sent a message: {:#?}", rsp);
+
+    println!("Response from sending a message: {:#?}", rsp);
 
     let rcv_message_output = client
         .receive_message()
@@ -35,8 +42,10 @@ async fn main() -> Result<(), sqs::Error> {
         .queue_url(&queue_url)
         .send()
         .await?;
+
     for message in rcv_message_output.messages.unwrap_or_default() {
-        println!("got a message: {:#?}", message);
+        println!("Got the message: {:#?}", message);
     }
+
     Ok(())
 }


### PR DESCRIPTION
*Issue #, if available:*
The hello-world code example was missing the required message_group_id parameter for send_message call

*Description of changes:*
Added the parameter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
