### PR TITLE
Fix response tracing for streaming response bodies

### DIFF
--- a/rust-runtime/smithy-http/src/middleware.rs
+++ b/rust-runtime/smithy-http/src/middleware.rs
@@ -80,8 +80,6 @@ where
         return sdk_result(parsed_response, response);
     }
 
-    trace!(response = ?response);
-
     let (parts, body) = response.into_parts();
     let body = match read_body(body).await {
         Ok(body) => body,
@@ -94,6 +92,7 @@ where
     };
 
     let response = Response::from_parts(parts, Bytes::from(body));
+    trace!(response = ?response);
     let parsed = handler.parse_loaded(&response);
     sdk_result(parsed, response.map(SdkBody::from))
 }

--- a/rust-runtime/smithy-http/src/middleware.rs
+++ b/rust-runtime/smithy-http/src/middleware.rs
@@ -77,6 +77,7 @@ where
     O: ParseHttpResponse<SdkBody, Output = Result<T, E>>,
 {
     if let Some(parsed_response) = handler.parse_unloaded(&mut response) {
+        trace!(response = ?response);
         return sdk_result(parsed_response, response);
     }
 


### PR DESCRIPTION
Tracing the response for a streaming body was omitting the actual body from the trace log:
```
TRACE smithy_http::middleware: response=Response { status: 200, version: HTTP/1.1, headers: ...}, body: SdkBody { inner: Streaming(Body(Streaming)), retryable: false } }
```

This change results in the actual response body ending up in the trace:
```
TRACE smithy_http::middleware: response=Response { status: 200, version: HTTP/1.1, headers: ...}, body: b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<LocationConstraint xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">us-west-2</LocationConstraint>" }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
