### PR TITLE
Make HyperAdapter accessible

### DIFF
--- a/rust-runtime/smithy-client/src/lib.rs
+++ b/rust-runtime/smithy-client/src/lib.rs
@@ -27,7 +27,7 @@ mod hyper_impls;
 
 /// Re-export HyperAdapter
 #[cfg(feature = "hyper")]
-pub mod hyper {
+pub mod hyper_ext {
     pub use crate::hyper_impls::HyperAdapter as Adapter;
 }
 

--- a/rust-runtime/smithy-client/src/lib.rs
+++ b/rust-runtime/smithy-client/src/lib.rs
@@ -25,6 +25,12 @@ pub mod test_connection;
 #[cfg(feature = "hyper")]
 mod hyper_impls;
 
+/// Re-export HyperAdapter
+#[cfg(feature = "hyper")]
+pub mod hyper {
+    pub use crate::hyper_impls::HyperAdapter as Adapter;
+}
+
 // The types in this module are only used to write the bounds in [`Client::check`]. Customers will
 // not need them. But the module and its types must be public so that we can call `check` from
 // doc-tests.


### PR DESCRIPTION
Issue #, if available:
Was trying to use this earlier today to create my own connector and realized the hyper_impls module was private.

Description of changes:
Re-export HyperAdapter as Adapter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.