### PR TITLE
Fix characters that get URL-encoded during signing

### DIFF
--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 http = "0.2.2"
 # Renaming to clearly indicate that this is not a permanent signing solution
-aws-sigv4-poc = { package = "aws-sigv4", git = "https://github.com/rcoh/sigv4", rev = "13076d1035b02689fec2dbe6a983283ef970e810"}
+aws-sigv4-poc = { package = "aws-sigv4", git = "https://github.com/rcoh/sigv4", rev = "66b1646a7ab119c73be966ca70ee5f556bd8379b"}
 aws-auth = { path = "../aws-auth" }
 aws-types = { path = "../aws-types" }
 smithy-http = { path = "../../../rust-runtime/smithy-http" }

--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 [dependencies]
 http = "0.2.2"
 # Renaming to clearly indicate that this is not a permanent signing solution
-aws-sigv4-poc = { package = "aws-sigv4", git = "https://github.com/rcoh/sigv4", rev = "1854c5f5728c80b0970fcca86c2431bf288f6997"}
+aws-sigv4-poc = { package = "aws-sigv4", git = "https://github.com/rcoh/sigv4", rev = "13076d1035b02689fec2dbe6a983283ef970e810"}
 aws-auth = { path = "../aws-auth" }
 aws-types = { path = "../aws-types" }
 smithy-http = { path = "../../../rust-runtime/smithy-http" }

--- a/aws/rust-runtime/aws-sig-auth/src/signer.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/signer.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_auth::Credentials;
-use aws_sigv4_poc::{SignableBody, SignedBodyHeaderType, SigningSettings, UriEncoding};
+use aws_sigv4_poc::{PayloadChecksumKind, SignableBody, SigningSettings, UriEncoding};
 use aws_types::region::SigningRegion;
 use aws_types::SigningService;
 use http::header::HeaderName;
@@ -118,10 +118,10 @@ impl SigV4Signer {
         } else {
             UriEncoding::Single
         };
-        settings.signed_body_header = if operation_config.signing_options.content_sha256_header {
-            SignedBodyHeaderType::XAmzSha256
+        settings.payload_checksum_kind = if operation_config.signing_options.content_sha256_header {
+            PayloadChecksumKind::XAmzSha256
         } else {
-            SignedBodyHeaderType::NoHeader
+            PayloadChecksumKind::NoHeader
         };
         let sigv4_config = aws_sigv4_poc::Config {
             access_key: credentials.access_key_id(),

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -10,5 +10,11 @@ edition = "2018"
 [dependencies]
 aws-sdk-s3 = { path = "../../build/aws-sdk/s3" }
 smithy-http = { path = "../../build/aws-sdk/smithy-http" }
+tracing-subscriber = "0.2.18"
+
+[dev-dependencies]
+tokio  = { version = "1", features = ["full"]}
 http = "0.2.3"
 bytes = "1"
+aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
+aws-http = { path = "../../build/aws-sdk/aws-http"}

--- a/aws/sdk/integration-tests/s3/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3/tests/signing-it.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_http::user_agent::AwsUserAgent;
+use aws_hyper::test_connection::TestConnection;
+use aws_sdk_s3::operation::ListObjectsV2;
+use aws_sdk_s3::{Credentials, Region};
+use smithy_http::body::SdkBody;
+use std::time::{Duration, UNIX_EPOCH};
+
+#[tokio::test]
+async fn test_signer() -> Result<(), aws_sdk_s3::Error> {
+    let creds = Credentials::from_keys(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+    );
+    let conf = aws_sdk_s3::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let conn = TestConnection::new(vec![(
+        http::Request::builder()
+            .header("authorization", "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210618/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=c3f78ce4969bd55cbb90ba91f46e4fcd14d08dae858f1ac9e508712997eabde7")
+            .uri("https://s3.us-east-1.amazonaws.com/test-bucket?list-type=2&prefix=prefix~")
+            .body(SdkBody::empty())
+            .unwrap(),
+        http::Response::builder().status(200).body("").unwrap(),
+    )]);
+    let client = aws_hyper::Client::new(conn.clone());
+    let mut op = ListObjectsV2::builder()
+        .bucket("test-bucket")
+        .prefix("prefix~")
+        .build()
+        .unwrap()
+        .make_operation(&conf)
+        .unwrap();
+    op.config_mut()
+        .insert(UNIX_EPOCH + Duration::from_secs(1624036048));
+    op.config_mut().insert(AwsUserAgent::for_tests());
+
+    client.call(op).await.expect_err("empty response");
+    for req in conn.requests().iter() {
+        req.assert_matches(vec![]);
+    }
+    assert_eq!(conn.requests().len(), 1);
+    Ok(())
+}

--- a/rust-runtime/smithy-client/src/test_connection.rs
+++ b/rust-runtime/smithy-client/src/test_connection.rs
@@ -34,7 +34,12 @@ impl ValidateRequest {
                     .headers()
                     .get(name)
                     .unwrap_or_else(|| panic!("Header {:?} missing", name));
-                assert_eq!(actual_header, value, "Header mismatch for {:?}", name);
+                assert_eq!(
+                    actual_header.to_str().unwrap(),
+                    value.to_str().unwrap(),
+                    "Header mismatch for {:?}",
+                    name
+                );
             }
         }
         let actual_str = std::str::from_utf8(actual.body().bytes().unwrap_or(&[]));


### PR DESCRIPTION
*Issue #, if available:* Fixes aws-sdk-rust#120

*Description of changes:* Update the signer & add a test. Signer commit: https://github.com/rcoh/sigv4/pull/1/commits/13076d1035b02689fec2dbe6a983283ef970e810

I fixed the bug, manually verified that the signer worked properly, then created a new integration test snapshotting this behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
