### PR TITLE
Remove optionality from documents that are in unions

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -168,10 +168,7 @@ class SymbolVisitor(
         // an Input shape, then the field is _not optional_.
         val httpLabeledInput =
             container.hasTrait<SyntheticInputTrait>() && member.hasTrait<HttpLabelTrait>()
-        // Documents inside of unions should not be optional
-        val optionalDocument =
-            model.expectShape(member.target).isDocumentShape && !model.expectShape(member.container).isUnionShape
-        return if (nullableIndex.isNullable(member) && !httpLabeledInput || optionalDocument) {
+        return if (nullableIndex.isNullable(member) && !httpLabeledInput) {
             symbol.makeOptional()
         } else symbol
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -168,7 +168,10 @@ class SymbolVisitor(
         // an Input shape, then the field is _not optional_.
         val httpLabeledInput =
             container.hasTrait<SyntheticInputTrait>() && member.hasTrait<HttpLabelTrait>()
-        return if (nullableIndex.isNullable(member) && !httpLabeledInput || model.expectShape(member.target).isDocumentShape) {
+        // Documents inside of unions should not be optional
+        val optionalDocument =
+            model.expectShape(member.target).isDocumentShape && !model.expectShape(member.container).isUnionShape
+        return if (nullableIndex.isNullable(member) && !httpLabeledInput || optionalDocument) {
             symbol.makeOptional()
         } else symbol
     }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -58,8 +58,13 @@ class StructureGeneratorTest {
             // test that sensitive can be applied directly to a member or to the shape
             secretKey: SecretKey
         }
+
+        structure StructWithDoc {
+            doc: Document
+        }
         """.asSmithyModel()
         val struct = model.lookup<StructureShape>("com.test#MyStruct")
+        val structWithDoc = model.lookup<StructureShape>("com.test#StructWithDoc")
         val inner = model.lookup<StructureShape>("com.test#Inner")
         val credentials = model.lookup<StructureShape>("com.test#Credentials")
         val error = model.lookup<StructureShape>("com.test#MyError")
@@ -177,5 +182,21 @@ class StructureGeneratorTest {
             }
 
         writer.compileAndTest()
+    }
+
+    @Test
+    fun `documents are optional in structs`() {
+        val provider = testSymbolProvider(model)
+        val writer = RustWriter.forModule("lib")
+        StructureGenerator(model, provider, writer, structWithDoc).render()
+
+        writer.compileAndTest(
+            """
+            let _struct = StructWithDoc {
+                // This will only compile if the document is optional
+                doc: None
+            };
+            """
+        )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/UnionGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/UnionGeneratorTest.kt
@@ -18,42 +18,37 @@ import software.amazon.smithy.rust.codegen.util.lookup
 class UnionGeneratorTest {
     @Test
     fun `generate basic unions`() {
-        val model = """
-        namespace test
-        union MyUnion {
-            stringConfig: String,
-            @documentation("This *is* documentation about the member")
-            intConfig: PrimitiveInteger
-        }
-        """.asSmithyModel()
-        val provider: SymbolProvider = testSymbolProvider(model)
-        val writer = RustWriter.forModule("model")
-        val generator = UnionGenerator(model, provider, writer, model.lookup("test#MyUnion"))
-        generator.render()
+        val writer = generateUnion(
+            """
+            union MyUnion {
+                stringConfig: String,
+                @documentation("This *is* documentation about the member")
+                intConfig: PrimitiveInteger
+            }
+            """
+        )
+
         writer.compileAndTest(
             """
-        let var_a = MyUnion::StringConfig("abc".to_string());
-        let var_b = MyUnion::IntConfig(10);
-        assert_ne!(var_a, var_b);
-        assert_eq!(var_a, var_a);
-        """
+            let var_a = MyUnion::StringConfig("abc".to_string());
+            let var_b = MyUnion::IntConfig(10);
+            assert_ne!(var_a, var_b);
+            assert_eq!(var_a, var_a);
+            """
         )
         writer.toString() shouldContain "#[non_exhaustive]"
     }
 
     @Test
     fun `generate conversion helper methods`() {
-        val model = """
-        namespace test
-        union MyUnion {
-            stringValue: String,
-            intValue: PrimitiveInteger
-        }
-        """.asSmithyModel()
-        val provider: SymbolProvider = testSymbolProvider(model)
-        val writer = RustWriter.forModule("model")
-        val generator = UnionGenerator(model, provider, writer, model.lookup("test#MyUnion"))
-        generator.render()
+        val writer = generateUnion(
+            """
+            union MyUnion {
+                stringValue: String,
+                intValue: PrimitiveInteger
+            }
+            """
+        )
 
         writer.compileAndTest(
             """
@@ -67,7 +62,26 @@ class UnionGeneratorTest {
             assert_eq!(bar.is_int_value(), true);
             assert_eq!(bar.as_string_value(), None);
             assert_eq!(bar.as_int_value(), Some(&10));
-        """
+            """
         )
+    }
+
+    @Test
+    fun `documents are not optional in unions`() {
+        val writer = generateUnion("union MyUnion { doc: Document, other: String }")
+        writer.compileAndTest(
+            """
+            // If the document isn't optional, this will compile
+            MyUnion::Doc(smithy_types::Document::Null);
+            """
+        )
+    }
+
+    private fun generateUnion(modelSmithy: String, unionName: String = "MyUnion"): RustWriter {
+        val model = "namespace test\n$modelSmithy".asSmithyModel()
+        val provider: SymbolProvider = testSymbolProvider(model)
+        val writer = RustWriter.forModule("model")
+        UnionGenerator(model, provider, writer, model.lookup("test#$unionName")).render()
+        return writer
     }
 }


### PR DESCRIPTION
**⚠️ Breaking Change:** Unions with Documents will see the inner document type change from `Option<Document>` to `Document`.

I don't think it makes sense for Documents to be optional inside of unions. Consider the following:

```
struct Input {
   union: MyUnion
}
union MyUnion {
    doc: Document,
    notDoc: String,
}
```

Currently, this generates:
```
enum MyUnion {
    Doc(Option<Document>),
    NotDoc(String),
}
```

But when you consider the following:
```javascript
// Invalid JSON
{"union":undefined}
{"union":{"doc":undefined}}

// Invalid: variant not specified
{"union":{}}

// Valid, but is Document::Null
{"union":{"doc":null}}

// Valid, but uses the other variant
{"union":{"notDoc":"something"}}
```

It doesn't seem possible to ever have `None` as the document value in the union.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
