### PR TITLE
fix and test a number of codegen bugs

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/FluentClientGenerator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/FluentClientGenerator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.Feature
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.asOptional
@@ -139,7 +140,7 @@ class FluentClientGenerator(protocolConfig: ProtocolConfig) {
                 val name = symbolProvider.toSymbol(operation).name
                 rust(
                     """
-                    pub fn ${name.toSnakeCase()}(&self) -> fluent_builders::$name<C> {
+                    pub fn ${RustReservedWords.escapeIfNeeded(name.toSnakeCase())}(&self) -> fluent_builders::$name<C> {
                         fluent_builders::$name::new(self.handle.clone())
                     }"""
                 )

--- a/codegen-test/model/naming-obstacle-course.smithy
+++ b/codegen-test/model/naming-obstacle-course.smithy
@@ -17,6 +17,7 @@ service Config {
        ErrCollisions,
        Result,
        Option,
+       Match
     ]
 }
 
@@ -38,6 +39,11 @@ operation ReservedWordsAsMembers {
     input: ReservedWords
 }
 
+// tests that module names are properly escaped
+operation Match {
+    input: ReservedWords
+}
+
 
 structure ReservedWords {
     as: Integer,
@@ -45,7 +51,10 @@ structure ReservedWords {
     enum: UnknownVariantCollidingEnum,
     self: Boolean,
     crate: Boolean,
-    super: Boolean
+    super: Boolean,
+    build: String,
+    default: String,
+    send: String
 }
 
 @httpRequestTests([

--- a/codegen-test/model/rest-json-extras.smithy
+++ b/codegen-test/model/rest-json-extras.smithy
@@ -200,7 +200,7 @@ operation MapWithEnumKeyOp {
 
 
 @enum([
-    { value: "has\"quotes", name: "HAS_QUOTES" },
+    { value: "has\"quotes", name: "HAS_QUOTES", documentation: "this needs#tobe escaped" },
     { value: "normal", name: "NORMAL" },
 ])
 string EnumWithEscapedChars
@@ -245,9 +245,14 @@ map NonSparseMap {
     value: String,
 }
 
+union SingleElementUnion {
+    a: String
+}
+
 structure NullInNonSparseOutput {
     list: NonSparseList,
     map: NonSparseMap,
+    union: SingleElementUnion
 }
 
 @http(uri: "/null-in-non-sparse", method: "POST")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustReservedWords.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustReservedWords.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.rust.codegen.smithy.MaybeRenamed
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.WrappingSymbolProvider
+import software.amazon.smithy.rust.codegen.util.orNull
 import software.amazon.smithy.rust.codegen.util.toPascalCase
 
 class RustReservedWordSymbolProvider(private val base: RustSymbolProvider) : WrappingSymbolProvider(base) {
@@ -21,7 +22,12 @@ class RustReservedWordSymbolProvider(private val base: RustSymbolProvider) : Wra
         ReservedWordSymbolProvider.builder().symbolProvider(base).memberReservedWords(RustReservedWords).build()
 
     override fun toMemberName(shape: MemberShape): String {
-        return internal.toMemberName(shape)
+        return when (val baseName = internal.toMemberName(shape)) {
+            "build" -> "build_value"
+            "default" -> "default_value"
+            "send" -> "send_value"
+            else -> baseName
+        }
     }
 
     override fun toSymbol(shape: Shape): Symbol {
@@ -30,8 +36,8 @@ class RustReservedWordSymbolProvider(private val base: RustSymbolProvider) : Wra
 
     override fun toEnumVariantName(definition: EnumDefinition): MaybeRenamed? {
         val baseName = base.toEnumVariantName(definition) ?: return null
-        check(baseName.name.toPascalCase() == baseName.name) {
-            "Enum variants must already be in pascal case"
+        check(definition.name.orNull()?.toPascalCase() == baseName.name) {
+            "Enum variants must already be in pascal case ${baseName.name} differed from ${baseName.name.toPascalCase()}. Definition: ${definition.name}"
         }
         check(baseName.renamedFrom == null) {
             "definitions should only pass through the renamer once"
@@ -113,6 +119,11 @@ object RustReservedWords : ReservedWords {
     override fun escape(word: String): String = when {
         cantBeRaw.contains(word) -> "${word}_"
         else -> "r##$word"
+    }
+
+    fun escapeIfNeeded(word: String): String = when (isReserved(word)) {
+        true -> escape(word)
+        else -> word
     }
 
     override fun isReserved(word: String): Boolean = RustKeywords.contains(word)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.asOptional
@@ -34,7 +35,8 @@ import software.amazon.smithy.rust.codegen.util.toSnakeCase
 
 fun StructureShape.builderSymbol(symbolProvider: RustSymbolProvider): RuntimeType {
     val symbol = symbolProvider.toSymbol(this)
-    return RuntimeType("Builder", null, "${symbol.namespace}::${symbol.name.toSnakeCase()}")
+    val builderNamespace = RustReservedWords.escapeIfNeeded(symbol.name.toSnakeCase())
+    return RuntimeType("Builder", null, "${symbol.namespace}::$builderNamespace")
 }
 
 fun RuntimeConfig.operationBuildError() = RuntimeType.operationModule(this).member("BuildError")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
+import software.amazon.smithy.rust.codegen.rustlang.escape
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.withBlock
@@ -56,7 +57,7 @@ internal class EnumMemberModel(private val definition: EnumDefinition, private v
 }
 
 private fun RustWriter.docWithNote(doc: String?, note: String?) {
-    doc?.also { docs(it) }
+    doc?.also { docs(escape(it)) }
     note?.also {
         // Add a blank line between the docs and the note to visually differentiate
         doc?.also { write("///") }
@@ -178,7 +179,7 @@ class EnumGenerator(
             impl std::str::FromStr for $enumName {
                 type Err = std::convert::Infallible;
 
-                fn from_str(s: &str) -> Result<Self, Self::Err> {
+                fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
                     Ok($enumName::from(s))
                 }
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.Feature
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.asOptional
@@ -249,7 +250,7 @@ class FluentClientGenerator(protocolConfig: ProtocolConfig) {
                 val name = symbolProvider.toSymbol(operation).name
                 rust(
                     """
-                    pub fn ${name.toSnakeCase()}(&self) -> fluent_builders::$name<C, M, R> {
+                    pub fn ${RustReservedWords.escapeIfNeeded(name.toSnakeCase())}(&self) -> fluent_builders::$name<C, M, R> {
                         fluent_builders::$name::new(self.handle.clone())
                     }"""
                 )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -47,6 +48,9 @@ class UnionGenerator(
                 val funcNamePart = member.memberName.toSnakeCase()
                 val variantName = member.memberName.toPascalCase()
 
+                if (sortedMembers.size == 1) {
+                    Attribute.Custom("allow(irrefutable_let_patterns)").render(this)
+                }
                 rustBlock("pub fn as_$funcNamePart(&self) -> Result<&#T, &Self>", memberSymbol) {
                     rust("if let ${unionSymbol.name}::$variantName(val) = &self { Ok(&val) } else { Err(&self) }")
                 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
@@ -32,10 +32,10 @@ class EnumGeneratorTest {
                   documentation: "Some documentation." },
                 { value: "some-value-2",
                   name: "someName2",
-                  documentation: "More documentation" },
+                  documentation: "More documentation #escape" },
                 { value: "unknown",
                   name: "unknown",
-                  documentation: "It has some docs" }
+                  documentation: "It has some docs that #need to be escaped" }
             ])
             string EnumWithUnknown
         """.asSmithyModel()
@@ -75,7 +75,7 @@ class EnumGeneratorTest {
             println(rendered.lines())
             rendered shouldContain
                 """
-                /// It has some docs
+                /// It has some docs that #need to be escaped
                 ///
                 /// **NOTE:** `::Unknown` has been renamed to `::UnknownValue`.
                 UnknownValue,


### PR DESCRIPTION
*Description of changes:*
Fixes and tests for some misc bugs that came up when adding every service:
- fields named `build`, `send`, `default`
- operations named keywords
- single-element unions needed a clippy lint ignored
- enum docs needed `escape` to be invoked




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
