### PR TITLE
*breaking change*: don't rename exception => error AWS SDK

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -105,7 +105,8 @@ fun generateSmithyBuild(tests: List<AwsService>): String {
                         "relativePath": "../"
                       },
                       "codegen": {
-                        "includeFluentClient": false
+                        "includeFluentClient": false,
+                        "renameErrors": false
                       },
                       "service": "${it.service}",
                       "module": "aws-sdk-${it.module}",

--- a/aws/sdk/examples/lambda/src/bin/invoke-function.rs
+++ b/aws/sdk/examples/lambda/src/bin/invoke-function.rs
@@ -137,7 +137,7 @@ async fn main() {
         //
         // For our example, we will simply print that the function doesn't
         // exist and return a non-zero exit code to indicate the failure.
-        Err(SdkError::ServiceError { err, .. }) if err.is_resource_not_found_error() => {
+        Err(SdkError::ServiceError { err, .. }) if err.is_resource_not_found_exception() => {
             println!("This lambda function does not exist: {}", err);
             process::exit(1);
         }

--- a/aws/sdk/integration-tests/kms/tests/integration.rs
+++ b/aws/sdk/integration-tests/kms/tests/integration.rs
@@ -10,7 +10,6 @@ use aws_hyper::{Client, SdkError};
 use aws_sdk_kms as kms;
 use http::header::AUTHORIZATION;
 use http::Uri;
-use kms::error::GenerateRandomErrorKind;
 use kms::operation::GenerateRandom;
 use kms::{Config, Region};
 use smithy_http::body::SdkBody;
@@ -191,10 +190,7 @@ async fn generate_random_keystore_not_found() {
         SdkError::ServiceError { err, .. } => err,
         other => panic!("Incorrect error received: {:}", other),
     };
-    assert!(matches!(
-        inner.kind,
-        GenerateRandomErrorKind::CustomKeyStoreNotFoundError(_)
-    ));
+    assert!(inner.is_custom_key_store_not_found_exception());
     assert_eq!(
         inner.request_id(),
         Some("bfe81a0a-9a08-4e71-9910-cdb5ab6ea3b6")


### PR DESCRIPTION
*Description of changes:*
For AWS models the "optimization" to avoid the word exception wasn't worth the headache in naming conflicts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
