### PR TITLE
add EKS & example

### DIFF
--- a/aws/rust-runtime/aws-types/src/region.rs
+++ b/aws/rust-runtime/aws-types/src/region.rs
@@ -31,6 +31,9 @@ impl Region {
     pub fn new(region: impl Into<Cow<'static, str>>) -> Self {
         Self(region.into())
     }
+    pub const fn from_static(region: &'static str) -> Self {
+        Self(Cow::Borrowed(region))
+    }
 }
 
 /// Provide a [`Region`](Region) to use with AWS requests

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -79,7 +79,8 @@ val tier1Services = setOf(
     "sns",
     "sqs",
     "ssm",
-    "sts"
+    "sts",
+    "eks"
 )
 
 private val disableServices = setOf("transcribestreaming")

--- a/aws/sdk/examples/eks/Cargo.toml
+++ b/aws/sdk/examples/eks/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "eks"
+version = "0.1.0"
+authors = ["Russell Cohen <rcoh@amazon.com>"]
+edition = "2018"
+
+[dependencies]
+structopt = { version = "0.3", default-features = false }
+tokio = { version = "1", features = ["full"]}
+aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-sdk-eks = { path = "../../build/aws-sdk/eks" }

--- a/aws/sdk/examples/eks/src/bin/create-cluster.rs
+++ b/aws/sdk/examples/eks/src/bin/create-cluster.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<(), aws_sdk_eks::Error> {
     let region = region
         .map(Region::new)
         .or_else(|| region::default_provider().region())
-        .unwrap_or(Region::new("us-west-2"));
+        .unwrap_or_else(|| Region::from_static("us-west-2"));
     let conf = aws_sdk_eks::Config::builder().region(region).build();
     let client = aws_sdk_eks::Client::from_conf(conf);
     let cluster = client

--- a/aws/sdk/examples/eks/src/bin/create-cluster.rs
+++ b/aws/sdk/examples/eks/src/bin/create-cluster.rs
@@ -1,0 +1,63 @@
+use aws_sdk_eks::model::VpcConfigRequest;
+use aws_sdk_eks::Region;
+use aws_types::region;
+use aws_types::region::ProvideRegion;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The region
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    #[structopt(short, long)]
+    cluster_name: String,
+
+    /// Role ARN for the cluster
+    /// To create a role-arn:
+    ///
+    /// 1. Follow instructions to create an IAM role:
+    /// https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
+    ///
+    /// 2. Copy role arn
+    #[structopt(long)]
+    role_arn: String,
+
+    /// subnet id
+    ///
+    /// At least two subnet ids must be specified. The subnet ids must be in two separate AZs
+    #[structopt(short, long)]
+    subnet_id: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), aws_sdk_eks::Error> {
+    let Opt {
+        region,
+        cluster_name,
+        role_arn,
+        subnet_id,
+    } = Opt::from_args();
+    let region = region
+        .map(Region::new)
+        .or_else(|| region::default_provider().region())
+        .unwrap_or(Region::new("us-west-2"));
+    let conf = aws_sdk_eks::Config::builder().region(region).build();
+    let client = aws_sdk_eks::Client::from_conf(conf);
+    let cluster = client
+        .create_cluster()
+        .name(&cluster_name)
+        .role_arn(role_arn)
+        .resources_vpc_config(
+            VpcConfigRequest::builder()
+                .set_subnet_ids(Some(subnet_id))
+                .build(),
+        )
+        .send()
+        .await?;
+    println!("cluster created: {:?}", cluster);
+
+    let cluster_deleted = client.delete_cluster().name(&cluster_name).send().await?;
+    println!("cluster deleted: {:?}", cluster_deleted);
+    Ok(())
+}


### PR DESCRIPTION
*Issue #, if available:* aws-sdk-rust#67

*Description of changes:*
Add support for EKS & add a basic usage example. In the future, a full clone of `eksctl` would be a great example project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
