### PR TITLE
Prototype async credential caching refresher

### DIFF
--- a/aws/rust-runtime/aws-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-auth/Cargo.toml
@@ -1,12 +1,22 @@
 [package]
 name = "aws-auth"
 version = "0.1.0"
-authors = ["Russell Cohen <rcoh@amazon.com>"]
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 license = "Apache-2.0"
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = []
+tokio-credentials = ["tokio"]
 
 [dependencies]
 smithy-http = { path = "../../../rust-runtime/smithy-http" }
+tokio = { version = "1", features = ["rt", "sync", "time", "macros"], optional = true }
+tracing = "0.1.25"
 zeroize = "1.2.0"
+
+[dev-dependencies]
+env_logger = "*"
+test-env-log = { version = "0.2.7", features = ["trace"] }
+tokio = { version = "1", features = ["macros", "test-util"] }
+tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/rust-runtime/aws-auth/src/lib.rs
+++ b/aws/rust-runtime/aws-auth/src/lib.rs
@@ -4,6 +4,7 @@
  */
 
 pub mod provider;
+pub mod refresh;
 
 use smithy_http::property_bag::PropertyBag;
 use std::error::Error;

--- a/aws/rust-runtime/aws-auth/src/refresh.rs
+++ b/aws/rust-runtime/aws-auth/src/refresh.rs
@@ -1,0 +1,294 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+// TODO: Remove this for final version
+#![allow(unused)]
+
+use crate::{Credentials, CredentialsError, ProvideCredentials};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, RwLock};
+use std::thread;
+use std::time::{Duration, SystemTime};
+use tracing::{error, info, trace_span};
+
+// TODO: Make these configurable with a builder and sane defaults
+const EXECUTOR_PANIC_BACKOFF: Duration = Duration::from_secs(10);
+const REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
+const REFRESH_BUFFER_TIME: Duration = Duration::from_secs(30);
+const MAX_WAIT_TIME: Duration = Duration::from_millis(1000);
+
+const WATCHDOG_STACK_SIZE_BYTES: usize = 256;
+
+pub type AsyncCredentialResult = Result<Credentials, CredentialsError>;
+
+// TODO: Add doc comment
+pub trait AsyncCredentialLoader: Send + Sync {
+    fn load_credentials(&self) -> Pin<Box<dyn Future<Output = AsyncCredentialResult> + Send>>;
+}
+
+mod error {
+    use std::error::Error as StdError;
+    use std::fmt;
+
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub enum Error {
+        RefreshFailed(Box<dyn StdError + Send + Sync>),
+        ThreadSpawnFailed(Box<dyn StdError + Send + Sync>),
+        ExecutorThreadFailed,
+    }
+
+    impl StdError for Error {}
+
+    impl fmt::Display for Error {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Error::RefreshFailed(err) => {
+                    write!(f, "credential refresh failed: {}", err)
+                }
+                Error::ThreadSpawnFailed(err) => {
+                    write!(f, "failed to spawn thread: {}", err)
+                }
+                Error::ExecutorThreadFailed => write!(f, "executor thread panicked"),
+            }
+        }
+    }
+}
+
+pub use error::Error;
+
+// TODO: Consider using https://docs.rs/arc-swap/1.3.0/arc_swap/
+/// Stores a value in a RwLock and never holds the lock open across a section
+/// of code that can panic in order to eliminate the PoisonedError.
+#[derive(Clone)]
+struct RwCell<T: Clone> {
+    value: Arc<RwLock<T>>,
+}
+
+impl<T: Clone> RwCell<T> {
+    pub fn new(initial: T) -> RwCell<T> {
+        RwCell {
+            value: Arc::new(RwLock::new(initial)),
+        }
+    }
+
+    pub fn get(&self) -> T {
+        self.value.read().expect("cannot be poisoned").clone()
+    }
+
+    pub fn set(&self, value: T) {
+        *self.value.write().expect("cannot be poisoned") = value;
+    }
+}
+
+#[derive(Clone)]
+struct Inner {
+    loader: Arc<dyn AsyncCredentialLoader>,
+    credentials: RwCell<Option<Credentials>>,
+}
+
+impl Inner {
+    pub async fn refresh(&self) -> Result<(), CredentialsError> {
+        let credentials = self.loader.load_credentials().await?;
+        self.credentials.set(Some(credentials));
+        Ok(())
+    }
+
+    fn calc_next_refresh_sleep_time(now: SystemTime, expiration: SystemTime) -> Option<Duration> {
+        let expiration = expiration - REFRESH_BUFFER_TIME;
+        if now >= expiration {
+            None
+        } else {
+            let remaining = expiration.duration_since(now).expect("now < expiration");
+            if remaining > MAX_WAIT_TIME {
+                Some(MAX_WAIT_TIME)
+            } else {
+                Some(remaining)
+            }
+        }
+    }
+
+    fn next_refresh_sleep_time(&self, now: SystemTime) -> Option<Duration> {
+        let expiry = self.expiry();
+        Self::calc_next_refresh_sleep_time(now, expiry)
+    }
+
+    fn expiry(&self) -> SystemTime {
+        // TODO: Discuss requirements around refresh. Options:
+        // 1. Default to some time if no expiration given by credentials (15 minutes? configurable?)
+        // 2. Expect implementers of AsyncCredentialLoader to set the expiration if it's
+        //    not set by its origin (such as STS).
+        // 3. Support both #1 and #2 and make it configurable which is used?
+        self.maybe_expiry()
+            .expect("credential refresh loop can only be used with expiring credentials")
+    }
+
+    fn maybe_expiry(&self) -> Option<SystemTime> {
+        self.credentials.get().map(|c| c.expiry()).flatten()
+    }
+}
+
+#[derive(Copy, Clone)]
+enum RefreshLoopState {
+    Running,
+    Canceled,
+}
+
+// TODO: Add doc comment
+pub struct CancelableRefreshLoop {
+    signal: Option<RwCell<RefreshLoopState>>,
+}
+
+impl CancelableRefreshLoop {
+    pub fn cancel(self) {
+        if let Some(signal) = self.signal {
+            signal.set(RefreshLoopState::Canceled);
+        }
+    }
+}
+
+// TODO: Add doc comment
+// TODO: Refactor to have the bulk of the logic be async runtime agnostic
+// TODO: Refactor to facilitate testing
+pub struct RefreshingCredentialProvider {
+    inner: Inner,
+    cancel_signal: Option<RwCell<RefreshLoopState>>,
+}
+
+impl RefreshingCredentialProvider {
+    pub fn new(loader: Arc<dyn AsyncCredentialLoader>) -> RefreshingCredentialProvider {
+        RefreshingCredentialProvider {
+            inner: Inner {
+                loader,
+                credentials: RwCell::new(None),
+            },
+            cancel_signal: None,
+        }
+    }
+
+    #[cfg(feature = "tokio-credentials")]
+    async fn initial_refresh(&self) -> Result<(), Error> {
+        let inner = self.inner.clone();
+        let result = inner.loader.load_credentials().await;
+        match result {
+            Ok(credentials) => self.inner.credentials.set(Some(credentials)),
+            Err(err) => return Err(Error::RefreshFailed(Box::new(err))),
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "tokio-credentials")]
+    pub async fn spawn_refresh_loop(&mut self) -> Result<CancelableRefreshLoop, Error> {
+        self.initial_refresh().await?;
+
+        // Establish cancellation communication
+        let cancel_signal = RwCell::new(RefreshLoopState::Running);
+        self.cancel_signal = Some(cancel_signal.clone());
+
+        // Start watchdog thread
+        let inner = self.inner.clone();
+        let watchdog_signal = cancel_signal.clone();
+        thread::Builder::new()
+            .stack_size(WATCHDOG_STACK_SIZE_BYTES)
+            .name("RefreshingCredentialProvider-watchdog".into())
+            .spawn(move || {
+                Self::watchdog_thread(watchdog_signal, inner);
+            })
+            .map_err(|err| Error::ThreadSpawnFailed(Box::new(err)))?;
+
+        Ok(CancelableRefreshLoop {
+            signal: Some(cancel_signal),
+        })
+    }
+
+    #[cfg(feature = "tokio-credentials")]
+    fn watchdog_thread(signal: RwCell<RefreshLoopState>, inner: Inner) {
+        while let RefreshLoopState::Running = signal.get() {
+            // Spawn an executor thread to run user-provided async credential refresher.
+            // This needs to have its own thread so that a panic won't end the refresh loop.
+            let executor_signal = signal.clone();
+            let executor_inner = inner.clone();
+            let result = thread::Builder::new()
+                .name("RefreshingCredentialProvider-executor".into())
+                .spawn(move || {
+                    RefreshingCredentialProvider::executor_thread(executor_signal, executor_inner);
+                })
+                .map_err(|err| Error::ThreadSpawnFailed(Box::new(err)))
+                .and_then(|joiner| joiner.join().map_err(|_| Error::ExecutorThreadFailed));
+            if let Err(err) = result {
+                error!("RefreshingCredentialProvider executor failed: {}", err);
+                thread::sleep(EXECUTOR_PANIC_BACKOFF);
+            }
+        }
+    }
+
+    #[cfg(feature = "tokio-credentials")]
+    fn executor_thread(signal: RwCell<RefreshLoopState>, inner: Inner) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to start tokio runtime");
+        runtime.block_on(async move {
+            // TODO: Take a name argument from users to indicate which credentials are being refreshed?
+            let span = trace_span!("credential_refresh_loop");
+            let _enter = span.enter();
+
+            info!("Starting credential refresh loop");
+            Self::refresh_loop(signal, inner)
+                .await
+                .expect("refresh loop failed");
+        });
+    }
+
+    #[cfg(feature = "tokio-credentials")]
+    async fn refresh_loop(signal: RwCell<RefreshLoopState>, inner: Inner) -> Result<(), Error> {
+        while let RefreshLoopState::Running = signal.get() {
+            while let Some(sleep_duration) = inner.next_refresh_sleep_time(SystemTime::now()) {
+                tokio::time::sleep(sleep_duration).await;
+            }
+
+            info!("Refreshing credentials");
+            let timeout_future = tokio::time::sleep(REFRESH_TIMEOUT);
+            let refresh_future = inner.refresh();
+            tokio::pin!(timeout_future, refresh_future);
+            loop {
+                // In the event of timeout or failure, the sleep in the next iteration will be
+                // skipped because the credential expiration time won't have changed.
+                // TODO: Should we have backoff for both timeout and refresh failures, or just refresh failures?
+                tokio::select! {
+                    _ = timeout_future => {
+                        error!("Credential refresh timed out after {} seconds", REFRESH_TIMEOUT.as_secs());
+                        break;
+                    }
+                    result = refresh_future => {
+                        if let Err(err) = result {
+                            error!("Failed to refresh credentials: {}", err);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ProvideCredentials for RefreshingCredentialProvider {
+    fn provide_credentials(&self) -> Result<Credentials, CredentialsError> {
+        match self.inner.credentials.get() {
+            Some(credentials) => Ok(credentials),
+            None => Err(CredentialsError::CredentialsNotLoaded),
+        }
+    }
+}
+
+impl Drop for RefreshingCredentialProvider {
+    fn drop(&mut self) {
+        if let Some(signal) = &self.cancel_signal {
+            signal.set(RefreshLoopState::Canceled);
+        }
+    }
+}

--- a/aws/sdk/examples/sts/Cargo.toml
+++ b/aws/sdk/examples/sts/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2018"
 [dependencies]
 sts = { package = "aws-sdk-sts", path = "../../build/aws-sdk/sts" }
 dynamodb = { package = "aws-sdk-dynamodb", path = "../../build/aws-sdk/dynamodb"}
-aws-auth = { package = "aws-auth", path = "../../build/aws-sdk/aws-auth" }
+aws-auth = { package = "aws-auth", path = "../../build/aws-sdk/aws-auth", features = ["tokio-credentials"] }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/sts/src/bin/credentials-provider.rs
+++ b/aws/sdk/examples/sts/src/bin/credentials-provider.rs
@@ -3,10 +3,47 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_auth::{CredentialsError, ProvideCredentials};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use aws_auth::refresh::{
+    AsyncCredentialLoader, AsyncCredentialResult, RefreshingCredentialProvider,
+};
+use aws_auth::CredentialsError;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
 use sts::Credentials;
+
+#[derive(Clone)]
+struct StsCredentialLoader {
+    client: sts::Client,
+}
+
+impl AsyncCredentialLoader for StsCredentialLoader {
+    fn load_credentials(&self) -> Pin<Box<dyn Future<Output = AsyncCredentialResult> + Send>> {
+        let this = self.clone();
+        Box::pin(async move {
+            let session_token = this
+                .client
+                .get_session_token()
+                .duration_seconds(900)
+                .send()
+                .await
+                .map_err(|err| CredentialsError::Unhandled(Box::new(err)))?;
+            let sts_credentials = session_token
+                .credentials
+                .expect("should include credentials");
+            Ok(Credentials::new(
+                sts_credentials.access_key_id.unwrap(),
+                sts_credentials.secret_access_key.unwrap(),
+                sts_credentials.session_token,
+                sts_credentials
+                    .expiration
+                    .map(|expiry| expiry.to_system_time().expect("sts sent a time < 0")),
+                "Sts",
+            ))
+        })
+    }
+}
 
 /// Implements a basic version of ProvideCredentials with AWS STS
 /// and lists the tables in the region based on those credentials.
@@ -14,80 +51,21 @@ use sts::Credentials;
 async fn main() -> Result<(), dynamodb::Error> {
     tracing_subscriber::fmt::init();
     let client = sts::Client::from_env();
-    let sts_provider = StsCredentialsProvider {
-        client,
-        credentials: Arc::new(Mutex::new(None)),
-    };
-    sts_provider.spawn_refresh_loop().await;
+
+    let mut refresher = RefreshingCredentialProvider::new(Arc::new(StsCredentialLoader { client }));
+    refresher
+        .spawn_refresh_loop()
+        .await
+        .expect("spawn credential refresher");
 
     let dynamodb_conf = dynamodb::Config::builder()
-        .credentials_provider(sts_provider)
+        .credentials_provider(refresher)
         .build();
+
     let client = dynamodb::Client::from_conf(dynamodb_conf);
-    println!("tables: {:?}", client.list_tables().send().await?);
-    Ok(())
-}
-
-/// This is a rough example of how you could implement ProvideCredentials with Amazon STS.
-///
-/// Do not use this in production! A high quality implementation is in the roadmap.
-#[derive(Clone)]
-struct StsCredentialsProvider {
-    client: sts::Client,
-    credentials: Arc<Mutex<Option<Credentials>>>,
-}
-
-impl ProvideCredentials for StsCredentialsProvider {
-    fn provide_credentials(&self) -> Result<Credentials, CredentialsError> {
-        let inner = self.credentials.lock().unwrap().clone();
-        inner.ok_or(CredentialsError::CredentialsNotLoaded)
-    }
-}
-
-impl StsCredentialsProvider {
-    pub async fn spawn_refresh_loop(&self) {
-        let _ = self
-            .refresh()
-            .await
-            .map_err(|e| eprintln!("failed to load credentials! {}", e));
-        let this = self.clone();
-        tokio::spawn(async move {
-            loop {
-                let needs_refresh = {
-                    let creds = this.credentials.lock().unwrap();
-                    let expiry = creds.as_ref().and_then(|creds| creds.expiry());
-                    if creds.is_none() {
-                        true
-                    } else {
-                        expiry
-                            .map(|expiry| SystemTime::now() > expiry)
-                            .unwrap_or(false)
-                    }
-                };
-                if needs_refresh {
-                    let _ = this
-                        .refresh()
-                        .await
-                        .map_err(|e| eprintln!("failed to load credentials! {}", e));
-                }
-                tokio::time::sleep(Duration::from_secs(5)).await;
-            }
-        });
-    }
-    pub async fn refresh(&self) -> Result<(), sts::Error> {
-        let session_token = self.client.get_session_token().send().await?;
-        let sts_credentials = session_token
-            .credentials
-            .expect("should include credentials");
-        *self.credentials.lock().unwrap() = Some(Credentials::new(
-            sts_credentials.access_key_id.unwrap(),
-            sts_credentials.secret_access_key.unwrap(),
-            sts_credentials.session_token,
-            sts_credentials
-                .expiration
-                .map(|expiry| expiry.to_system_time().expect("sts sent a time < 0")),
-            "Sts",
-        ));
-        Ok(())
+    loop {
+        println!("tables: {:?}", client.list_tables().send().await?);
+        println!("waiting 15 minutes for session credentials to expire... hit CTRL+C to stop");
+        tokio::time::sleep(Duration::from_secs(915)).await;
     }
 }


### PR DESCRIPTION
This is an incredibly rough prototype of an async caching credential provider.

There are many things absent in this implementation which are noted in TODO comments. The bulk of the functionality was tested in a separate local crate that had reduced times, no network calls, and prolific use of random and panic. This particular implementation was sanity checked with the STS example that's part of the PR running across a 30 minute time period, but none of the error cases were hit with test run.

Posting this to get early feedback. Not intending for this to be merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
