### PR TITLE
Fix bare links in docs against Rust 1.53

### DIFF
--- a/aws/rust-runtime/aws-types/src/region.rs
+++ b/aws/rust-runtime/aws-types/src/region.rs
@@ -12,7 +12,7 @@ use std::env::VarError;
 /// per-client basis unless otherwise noted. A full list of regions is found in the
 /// "Regions and Endpoints" document.
 ///
-/// See http://docs.aws.amazon.com/general/latest/gr/rande.html for
+/// See <http://docs.aws.amazon.com/general/latest/gr/rande.html> for
 /// information on AWS regions.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Region(

--- a/aws/sdk/examples/dynamo-movies/src/main.rs
+++ b/aws/sdk/examples/dynamo-movies/src/main.rs
@@ -22,7 +22,7 @@ use smithy_types::retry::RetryKind;
 use std::collections::HashMap;
 use std::time::Duration;
 
-/// A partial reimplementation of https://docs.amazonaws.cn/en_us/amazondynamodb/latest/developerguide/GettingStarted.Ruby.html
+/// A partial reimplementation of <https://docs.amazonaws.cn/en_us/amazondynamodb/latest/developerguide/GettingStarted.Ruby.html>
 /// in Rust
 ///
 /// - Create table

--- a/aws/sdk/examples/eks/src/bin/create-cluster.rs
+++ b/aws/sdk/examples/eks/src/bin/create-cluster.rs
@@ -17,7 +17,7 @@ struct Opt {
     /// To create a role-arn:
     ///
     /// 1. Follow instructions to create an IAM role:
-    /// https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html
+    /// <https://docs.aws.amazon.com/eks/latest/userguide/service_IAM_role.html>
     ///
     /// 2. Copy role arn
     #[structopt(long)]

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
@@ -112,4 +112,24 @@ class RustWriterTest {
         sut.docs("A link! #D", symbol)
         sut.toString() shouldContain "/// A link! [`Foo`](crate::model::Foo)"
     }
+
+    @Test
+    fun `generate doc fix bare links`() {
+        val sut = RustWriter.forModule("lib")
+        sut.docs(
+            """
+            Simple link in this line: https://example.com
+            Multiple http://test.org?something=something#foo URLs https://www.test.co.uk/asdf%20asdf?foo=%3C&bar
+            Real http://tools.ietf.org/html/rfc6902#section-4 link
+            Don't touch <a href="https://example.com">html links</a>.
+            """.trimMargin()
+        )
+        sut.toString() shouldContain
+            """
+            /// Simple link in this line: <https://example.com>
+            /// Multiple <http://test.org?something=something#foo> URLs <https://www.test.co.uk/asdf%20asdf?foo=%3C&bar>
+            /// Real <http://tools.ietf.org/html/rfc6902#section-4> link
+            /// Don't touch <a href="https://example.com">html links</a>.
+            """.trimIndent()
+    }
 }

--- a/rust-runtime/smithy-types/src/lib.rs
+++ b/rust-runtime/smithy-types/src/lib.rs
@@ -52,7 +52,7 @@ pub enum Document {
 }
 
 /// A number type that implements Javascript / JSON semantics, modeled on serde_json:
-/// https://docs.serde.rs/src/serde_json/number.rs.html#20-22
+/// <https://docs.serde.rs/src/serde_json/number.rs.html#20-22>
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Number {
     PosInt(u64),


### PR DESCRIPTION
Rust 1.53 added a lint for bare URLs: https://github.com/rust-lang/rust/pull/81764

This PR fixes doc generation so that docs continue to build with the latest stable compiler, but does not attempt to be the long-term documentation normalization strategy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
