### PR TITLE
Add support for AWS-config and related improvements

### DIFF
--- a/aws/sdk/examples/config/Cargo.toml
+++ b/aws/sdk/examples/config/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "config-code-examples"
+version = "0.1.0"
+authors = ["Russell Cohen <rcoh@amazon.com>", "Doug Schwartz <dougsch@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+config = { package = "aws-sdk-config", path = "../../build/aws-sdk/config" }
+aws-types = { path = "../../build/aws-sdk/aws-types" }
+tokio = { version = "1", features = ["full"] }
+structopt = { version = "0.3", default-features = false }
+tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/config/src/bin/config-helloworld.rs
+++ b/aws/sdk/examples/config/src/bin/config-helloworld.rs
@@ -1,0 +1,80 @@
+use aws_types::region;
+use aws_types::region::ProvideRegion;
+use config::model::ResourceType;
+use config::{Client, Config, Error, Region};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The default AWS Region.
+    #[structopt(short, long)]
+    default_region: Option<String>,
+
+    /// The resource id.
+    #[structopt(long)]
+    resource_id: String,
+
+    /// The resource type, eg. "AWS::EC2::SecurityGroup"
+    #[structopt(long)]
+    resource_type: String,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Lists the configuration history for a resource
+///
+/// NOTE: AWS Config must be enabled to discover resources
+/// # Arguments
+///
+/// * `[-d DEFAULT-REGION]` - The Region in which the client is created.
+///   If not supplied, uses the value of the **AWS_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display information.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+    let Opt {
+        default_region,
+        resource_id,
+        resource_type,
+        verbose,
+    } = Opt::from_args();
+
+    let region = region::ChainProvider::first_try(default_region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
+
+    if verbose {
+        println!("Config client version: {}", config::PKG_VERSION);
+        println!("Region:               {:?}", region.region());
+        println!();
+    }
+
+    let conf = Config::builder().region(region).build();
+    // parse resource type from user input
+    let parsed = ResourceType::from(resource_type.as_str());
+    if matches!(parsed, ResourceType::Unknown(_)) {
+        panic!(
+            "unknown resource type: `{}`. Valid resource types: {:#?}",
+            &resource_type,
+            ResourceType::values()
+        )
+    }
+    let client = Client::from_conf(conf);
+    let rsp = client
+        .get_resource_config_history()
+        .resource_id(&resource_id)
+        .resource_type(parsed)
+        .send()
+        .await?;
+    println!("configuration history for {}:", resource_id);
+    for item in rsp.configuration_items.unwrap_or_default() {
+        println!("item: {:?}", item);
+    }
+
+    Ok(())
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -159,6 +159,13 @@ class EnumGenerator(
                     write("$enumName::$UnknownVariant(s) => s.as_ref()")
                 }
             }
+
+            writer.rustBlock("pub fn $Values() -> &'static [&'static str]") {
+                withBlock("&[", "]") {
+                    val memberList = sortedMembers.joinToString(", ") { it.value.doubleQuote() }
+                    write(memberList)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* aws-sdk-rust#31

*Description of changes:* Adds support for the AWS config service

In the process of building this, I made a few other improvements:
1. tier1 services are now "must generate" (if they are missing, codegen will fail)
2. `values` is now always created. This is handy when you want to give someone a list of all possible values for an enum

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
