### PR TITLE
Implement initial lazy caching credentials provider

### DIFF
--- a/aws/rust-runtime/aws-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-auth/Cargo.toml
@@ -16,5 +16,5 @@ zeroize = "1.2.0"
 env_logger = "*"
 http = "0.2.3"
 test-env-log = { version = "0.2.7", features = ["trace"] }
-tokio = { version = "1", features = ["macros", "rt", "test-util"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/rust-runtime/aws-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-auth/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "aws-auth"
 version = "0.1.0"
-authors = ["Russell Cohen <rcoh@amazon.com>"]
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"]
 license = "Apache-2.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 smithy-http = { path = "../../../rust-runtime/smithy-http" }
+tokio = { version = "1", features = ["sync"] }
+tracing = "0.1.25"
 zeroize = "1.2.0"
 
 [dev-dependencies]
+env_logger = "*"
 http = "0.2.3"
-tokio = { version = "1.0", features = ["rt", "macros"] }
+test-env-log = { version = "0.2.7", features = ["trace"] }
+tokio = { version = "1", features = ["macros", "rt", "test-util"] }
+tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/rust-runtime/aws-auth/src/credentials.rs
+++ b/aws/rust-runtime/aws-auth/src/credentials.rs
@@ -19,6 +19,7 @@ use zeroize::Zeroizing;
 #[derive(Clone)]
 pub struct Credentials(Arc<Inner>);
 
+#[derive(Clone)]
 struct Inner {
     access_key_id: Zeroizing<String>,
     secret_access_key: Zeroizing<String>,
@@ -87,6 +88,10 @@ impl Credentials {
 
     pub fn expiry(&self) -> Option<SystemTime> {
         self.0.expires_after
+    }
+
+    pub fn expiry_mut(&mut self) -> &mut Option<SystemTime> {
+        &mut Arc::make_mut(&mut self.0).expires_after
     }
 
     pub fn session_token(&self) -> Option<&str> {

--- a/aws/rust-runtime/aws-auth/src/provider.rs
+++ b/aws/rust-runtime/aws-auth/src/provider.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+mod cache;
 pub mod env;
 pub mod lazy_caching;
 mod time;

--- a/aws/rust-runtime/aws-auth/src/provider.rs
+++ b/aws/rust-runtime/aws-auth/src/provider.rs
@@ -4,6 +4,7 @@
  */
 
 pub mod env;
+pub mod lazy_caching;
 
 use crate::Credentials;
 use smithy_http::property_bag::PropertyBag;
@@ -82,8 +83,8 @@ where
 /// use aws_auth::provider::async_provide_credentials_fn;
 ///
 /// async_provide_credentials_fn(|| async {
-///     // Async process to retrieve credentials goes here
-///     let credentials: Credentials = todo!().await?;
+///     // An async process to retrieve credentials would go here:
+///     let credentials: Credentials = Credentials::from_keys("example", "example", None);
 ///     Ok(credentials)
 /// });
 /// ```

--- a/aws/rust-runtime/aws-auth/src/provider.rs
+++ b/aws/rust-runtime/aws-auth/src/provider.rs
@@ -5,6 +5,7 @@
 
 pub mod env;
 pub mod lazy_caching;
+mod time;
 
 use crate::Credentials;
 use smithy_http::property_bag::PropertyBag;

--- a/aws/rust-runtime/aws-auth/src/provider/cache.rs
+++ b/aws/rust-runtime/aws-auth/src/provider/cache.rs
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use crate::provider::CredentialsResult;
+use crate::Credentials;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::{OnceCell, RwLock};
+
+#[derive(Clone)]
+pub(super) struct Cache {
+    margin: Duration,
+    value: Arc<RwLock<OnceCell<Credentials>>>,
+}
+
+impl Cache {
+    pub fn new(margin: Duration) -> Cache {
+        Cache {
+            margin,
+            value: Arc::new(RwLock::new(OnceCell::new())),
+        }
+    }
+
+    #[cfg(test)]
+    async fn get(&self) -> Option<Credentials> {
+        self.value.read().await.get().cloned()
+    }
+
+    pub async fn refresh<F, Fut>(&self, f: F) -> CredentialsResult
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = CredentialsResult>,
+    {
+        let lock = self.value.read().await;
+        let future = lock.get_or_try_init(f);
+        future.await.map(|creds| creds.clone())
+    }
+
+    /// If the credentials are expired, clears the cache. Otherwise, yields the current credentials value.
+    pub async fn yield_or_clear_if_expired(&self, now: SystemTime) -> Option<Credentials> {
+        // Short-circuit if the credential is not expired
+        if let Some(credentials) = self.value.read().await.get() {
+            if !expired(credentials, self.margin, now) {
+                return Some(credentials.clone());
+            }
+        }
+
+        // Only clear the cache if it hasn't been cleared by another thread. If it was already
+        // cleared, then another thread is initializing the empty cell.
+        let mut lock = self.value.write().await;
+        if let Some(credentials) = lock.get() {
+            if expired(credentials, self.margin, now) {
+                *lock = OnceCell::new();
+            }
+        }
+        None
+    }
+}
+
+fn expired(credentials: &Credentials, margin: Duration, now: SystemTime) -> bool {
+    credentials
+        .expiry()
+        .map(|expiration| now >= (expiration - margin))
+        .expect("Cached credentials don't have an expiration time. This is a bug in aws-auth.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expired, Cache};
+    use crate::Credentials;
+    use std::time::{Duration, SystemTime};
+
+    fn credentials(expired_secs: u64) -> Credentials {
+        Credentials::new("test", "test", None, Some(epoch_secs(expired_secs)), "test")
+    }
+
+    fn epoch_secs(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn expired_check() {
+        let creds = credentials(100);
+        assert!(expired(&creds, Duration::from_secs(10), epoch_secs(1000)));
+        assert!(expired(&creds, Duration::from_secs(10), epoch_secs(90)));
+        assert!(!expired(&creds, Duration::from_secs(10), epoch_secs(10)));
+    }
+
+    #[test_env_log::test(tokio::test)]
+    async fn cache_clears_if_expired_only() {
+        let cache = Cache::new(Duration::from_secs(10));
+        assert!(cache
+            .yield_or_clear_if_expired(epoch_secs(100))
+            .await
+            .is_none());
+
+        cache
+            .refresh(|| async { Ok(credentials(100)) })
+            .await
+            .unwrap();
+        assert_eq!(Some(epoch_secs(100)), cache.get().await.unwrap().expiry());
+
+        // It should not clear the credentials if they're not expired
+        assert_eq!(
+            Some(epoch_secs(100)),
+            cache
+                .yield_or_clear_if_expired(epoch_secs(10))
+                .await
+                .unwrap()
+                .expiry()
+        );
+
+        // It should clear the credentials if they're expired
+        assert!(cache
+            .yield_or_clear_if_expired(epoch_secs(500))
+            .await
+            .is_none());
+        assert!(cache.get().await.is_none());
+    }
+}

--- a/aws/rust-runtime/aws-auth/src/provider/lazy_caching.rs
+++ b/aws/rust-runtime/aws-auth/src/provider/lazy_caching.rs
@@ -111,7 +111,7 @@ pub mod builder {
         /// Defaults to 5 seconds.
         pub fn refresh_timeout(mut self, timeout: Duration) -> Self {
             self.refresh_timeout = Some(timeout);
-            self
+            unimplemented!("refresh_timeout hasn't been implemented yet")
         }
 
         /// (Optional) Amount of time before the actual credential expiration time

--- a/aws/rust-runtime/aws-auth/src/provider/lazy_caching.rs
+++ b/aws/rust-runtime/aws-auth/src/provider/lazy_caching.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+use crate::provider::time::{SystemTimeSource, TimeSource};
 use crate::provider::{AsyncProvideCredentials, BoxFuture, CredentialsResult};
 use crate::Credentials;
 use std::future::Future;
@@ -134,20 +135,6 @@ pub mod builder {
                 default_credential_expiration,
             )
         }
-    }
-}
-
-// Allows us to abstract time for tests.
-trait TimeSource: Clone + Send + Sync + 'static {
-    fn now(&self) -> SystemTime;
-}
-
-#[derive(Copy, Clone)]
-struct SystemTimeSource;
-
-impl TimeSource for SystemTimeSource {
-    fn now(&self) -> SystemTime {
-        SystemTime::now()
     }
 }
 

--- a/aws/rust-runtime/aws-auth/src/provider/lazy_caching.rs
+++ b/aws/rust-runtime/aws-auth/src/provider/lazy_caching.rs
@@ -1,0 +1,463 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use crate::provider::{AsyncProvideCredentials, BoxFuture, CredentialsResult};
+use crate::Credentials;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+use tokio::sync::{OnceCell, RwLock};
+use tracing::{trace_span, warn};
+
+const DEFAULT_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_CREDENTIAL_EXPIRATION: Duration = Duration::from_secs(15 * 60);
+
+// TODO: Implement async runtime-agnostic timeouts
+// TODO: Add catch_unwind() to handle panics
+// TODO: Update doc comment below once catch_unwind and timeouts are implemented
+// TODO: Update warning not to use this in the STS example once it's prod ready
+
+/// `LazyCachingCredentialsProvider` implements [`AsyncProvideCredentials`] by caching
+/// credentials that it loads by calling a user-provided [`AsyncProvideCredentials`] implementation.
+///
+/// For example, you can provide an [`AsyncProvideCredentials`] implementation that calls
+/// AWS STS's AssumeRole operation to get temporary credentials, and `LazyCachingCredentialsProvider`
+/// will cache those credentials until they expire.
+///
+/// # Note
+///
+/// This is __NOT__ production ready yet. Timeouts and panic safety have not been implemented yet.
+pub struct LazyCachingCredentialsProvider(Provider<SystemTimeProvider>);
+
+impl LazyCachingCredentialsProvider {
+    fn new(
+        refresh: Arc<dyn AsyncProvideCredentials>,
+        refresh_timeout: Duration,
+        default_credential_expiration: Duration,
+    ) -> Self {
+        LazyCachingCredentialsProvider(Provider::new(
+            SystemTimeProvider,
+            refresh,
+            refresh_timeout,
+            default_credential_expiration,
+        ))
+    }
+
+    /// Returns a new `Builder` that can be used to construct the `LazyCachingCredentialsProvider`.
+    pub fn builder() -> builder::Builder {
+        builder::Builder::new()
+    }
+}
+
+impl AsyncProvideCredentials for LazyCachingCredentialsProvider {
+    fn provide_credentials(&self) -> BoxFuture<CredentialsResult> {
+        self.0.provide_credentials()
+    }
+}
+
+pub mod builder {
+    use crate::provider::lazy_caching::{
+        LazyCachingCredentialsProvider, DEFAULT_CREDENTIAL_EXPIRATION, DEFAULT_REFRESH_TIMEOUT,
+    };
+    use crate::provider::AsyncProvideCredentials;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Builder for constructing a [`LazyCachingCredentialsProvider`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use aws_auth::Credentials;
+    /// use aws_auth::provider::async_provide_credentials_fn;
+    /// use aws_auth::provider::lazy_caching::LazyCachingCredentialsProvider;
+    /// use std::sync::Arc;
+    /// use std::time::Duration;
+    ///
+    /// let provider = LazyCachingCredentialsProvider::builder()
+    ///     .refresh(async_provide_credentials_fn(|| async {
+    ///         // An async process to retrieve credentials would go here:
+    ///         Ok(Credentials::from_keys("example", "example", None))
+    ///     }))
+    ///     .refresh_timeout(Duration::from_secs(30))
+    ///     .build();
+    /// ```
+    #[derive(Default)]
+    pub struct Builder {
+        refresh: Option<Arc<dyn AsyncProvideCredentials>>,
+        refresh_timeout: Option<Duration>,
+        default_credential_expiration: Option<Duration>,
+    }
+
+    impl Builder {
+        pub fn new() -> Self {
+            Default::default()
+        }
+
+        /// An implementation of [`AsyncProvideCredentials`] that will be used to refresh
+        /// the cached credentials once they're expired.
+        pub fn refresh(mut self, refresh: impl AsyncProvideCredentials + 'static) -> Self {
+            self.refresh = Some(Arc::new(refresh));
+            self
+        }
+
+        /// (Optional) Timeout for the given [`AsyncProvideCredentials`] implementation.
+        /// Defaults to 5 seconds.
+        pub fn refresh_timeout(mut self, timeout: Duration) -> Self {
+            self.refresh_timeout = Some(timeout);
+            self
+        }
+
+        /// (Optional) Default expiration time to set on credentials if they don't
+        /// have an expiration time. This is only used if the given [`AsyncProvideCredentials`]
+        /// returns [`Credentials`](crate::Credentials) that don't have their `expiry` set.
+        /// This must be at least 15 minutes.
+        pub fn default_credential_expiration(mut self, duration: Duration) -> Self {
+            self.default_credential_expiration = Some(duration);
+            self
+        }
+
+        /// Creates the [`LazyCachingCredentialsProvider`].
+        pub fn build(self) -> LazyCachingCredentialsProvider {
+            let default_credential_expiration = self
+                .default_credential_expiration
+                .unwrap_or(DEFAULT_CREDENTIAL_EXPIRATION);
+            assert!(
+                default_credential_expiration >= DEFAULT_CREDENTIAL_EXPIRATION,
+                "default_credential_expiration must be at least 15 minutes"
+            );
+            LazyCachingCredentialsProvider::new(
+                self.refresh.expect("refresh provider is required"),
+                self.refresh_timeout.unwrap_or(DEFAULT_REFRESH_TIMEOUT),
+                default_credential_expiration,
+            )
+        }
+    }
+}
+
+// Allows us to abstract time for tests.
+trait TimeProvider: Clone + Send + Sync + 'static {
+    fn now(&self) -> SystemTime;
+}
+
+#[derive(Copy, Clone)]
+struct SystemTimeProvider;
+
+impl TimeProvider for SystemTimeProvider {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+}
+
+/// Returns whether or not the `credentials` are expired based on the given time.
+/// This will panic if the credentials don't have an `expiry` set.
+fn expired(credentials: &Credentials, now: SystemTime) -> bool {
+    let expiration = credentials
+        .expiry()
+        .expect("refresh sets expiry if not given");
+    now > expiration
+}
+
+#[derive(Clone)]
+struct Inner<T: TimeProvider> {
+    time: T,
+    cache: Cache,
+    refresh: Arc<dyn AsyncProvideCredentials>,
+    refresh_timeout: Duration,
+    default_credential_expiration: Duration,
+}
+
+impl<T: TimeProvider> Inner<T> {
+    async fn refresh(&self) -> CredentialsResult {
+        let time = self.time.clone();
+        let default_credential_expiration = self.default_credential_expiration;
+        let future = self.refresh.provide_credentials();
+        self.cache
+            .refresh(|| async move {
+                let credentials = future.await?;
+                // If the credentials don't have an expiration time, then create a default one
+                let credentials = if credentials.expiry().is_none() {
+                    Credentials::new(
+                        credentials.access_key_id(),
+                        credentials.secret_access_key(),
+                        credentials.session_token().map(|s| s.to_string()),
+                        Some(time.now() + default_credential_expiration),
+                        "lazy_caching_default_credential_expiration",
+                    )
+                } else {
+                    credentials
+                };
+                Ok(credentials)
+            })
+            .await
+    }
+
+    async fn needs_refresh(&self, now: SystemTime) -> bool {
+        if let Some(credentials) = self.cache.get().await {
+            if expired(&credentials, now) {
+                self.cache.clear_if_expired(now).await
+            } else {
+                false
+            }
+        } else {
+            true
+        }
+    }
+
+    async fn cached(&self) -> Credentials {
+        self.cache
+            .get()
+            .await
+            .expect("refresh requirement checked in advance")
+    }
+}
+
+struct Provider<T: TimeProvider> {
+    inner: Inner<T>,
+}
+
+impl<T: TimeProvider> Provider<T> {
+    fn new(
+        time: T,
+        refresh: Arc<dyn AsyncProvideCredentials>,
+        refresh_timeout: Duration,
+        default_credential_expiration: Duration,
+    ) -> Self {
+        Provider {
+            inner: Inner {
+                time,
+                cache: Cache::new(),
+                refresh,
+                refresh_timeout,
+                default_credential_expiration,
+            },
+        }
+    }
+
+    fn provide_credentials(&self) -> BoxFuture<CredentialsResult> {
+        let inner = self.inner.clone();
+        Box::pin(async move {
+            let now = inner.time.now();
+            if inner.needs_refresh(now).await {
+                let span = trace_span!("lazy_refresh_credentials");
+                let _enter = span.enter();
+                inner.refresh().await
+            } else {
+                Ok(inner.cached().await)
+            }
+        })
+    }
+}
+
+#[derive(Clone)]
+struct Cache {
+    value: Arc<RwLock<OnceCell<Credentials>>>,
+}
+
+impl Cache {
+    pub fn new() -> Cache {
+        Cache {
+            value: Arc::new(RwLock::new(OnceCell::new())),
+        }
+    }
+
+    pub async fn get(&self) -> Option<Credentials> {
+        self.value.read().await.get().cloned()
+    }
+
+    pub async fn refresh<F, Fut>(&self, f: F) -> CredentialsResult
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = CredentialsResult>,
+    {
+        let lock = self.value.read().await;
+        let future = lock.get_or_try_init(f);
+        future.await.map(|creds| creds.clone())
+    }
+
+    /// Returns true if the cache was cleared
+    pub async fn clear_if_expired(&self, now: SystemTime) -> bool {
+        let mut lock = self.value.write().await;
+
+        // Only clear the cache if it hasn't been cleared by another thread. If it was already
+        // cleared, then another thread is initializing the empty cell.
+        if let Some(credentials) = lock.get() {
+            let should_clear = credentials
+                .expiry()
+                .map(|expiration| now > expiration)
+                .unwrap_or({
+                    warn!("Cached credentials don't have an expiration time. This is a bug in aws-auth.");
+                    false
+                });
+            if should_clear {
+                *lock = OnceCell::new();
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expired;
+    use crate::provider::lazy_caching::{
+        Cache, Provider, TimeProvider, DEFAULT_CREDENTIAL_EXPIRATION, DEFAULT_REFRESH_TIMEOUT,
+    };
+    use crate::provider::{async_provide_credentials_fn, CredentialsError, CredentialsResult};
+    use crate::Credentials;
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, SystemTime};
+    use tracing::info;
+
+    #[derive(Clone)]
+    struct TestTime {
+        time: Arc<Mutex<SystemTime>>,
+    }
+
+    impl TestTime {
+        fn new(time: SystemTime) -> Self {
+            TestTime {
+                time: Arc::new(Mutex::new(time)),
+            }
+        }
+
+        fn set(&self, time: SystemTime) {
+            *self.time.lock().unwrap() = time;
+        }
+    }
+
+    impl TimeProvider for TestTime {
+        fn now(&self) -> SystemTime {
+            *self.time.lock().unwrap()
+        }
+    }
+
+    fn test_provider<T: TimeProvider>(
+        time: T,
+        refresh_list: Vec<CredentialsResult>,
+    ) -> Provider<T> {
+        let refresh_list = Arc::new(Mutex::new(refresh_list));
+        Provider::new(
+            time,
+            Arc::new(async_provide_credentials_fn(move || {
+                let list = refresh_list.clone();
+                async move {
+                    let next = list.lock().unwrap().remove(0);
+                    info!("refreshing the credentials to {:?}", next);
+                    next
+                }
+            })),
+            DEFAULT_REFRESH_TIMEOUT,
+            DEFAULT_CREDENTIAL_EXPIRATION,
+        )
+    }
+
+    fn epoch_secs(secs: u64) -> SystemTime {
+        SystemTime::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    fn credentials(expired_secs: u64) -> Credentials {
+        Credentials::new("test", "test", None, Some(epoch_secs(expired_secs)), "test")
+    }
+
+    async fn expect_creds<T: TimeProvider>(expired_secs: u64, provider: &Provider<T>) {
+        let creds = provider
+            .provide_credentials()
+            .await
+            .expect("expected credentials");
+        assert_eq!(Some(epoch_secs(expired_secs)), creds.expiry());
+    }
+
+    #[test]
+    fn expired_check() {
+        let creds = credentials(100);
+        assert!(expired(&creds, epoch_secs(1000)));
+        assert!(!expired(&creds, epoch_secs(10)));
+    }
+
+    #[test_env_log::test(tokio::test)]
+    async fn cache_clears_if_expired_only() {
+        let cache = Cache::new();
+        assert!(!cache.clear_if_expired(epoch_secs(100)).await);
+
+        cache
+            .refresh(|| async { Ok(credentials(100)) })
+            .await
+            .unwrap();
+        assert_eq!(Some(epoch_secs(100)), cache.get().await.unwrap().expiry());
+
+        // It should not clear the credentials if they're not expired
+        assert!(!cache.clear_if_expired(epoch_secs(10)).await);
+        assert_eq!(Some(epoch_secs(100)), cache.get().await.unwrap().expiry());
+
+        // It should clear the credentials if they're expired
+        assert!(cache.clear_if_expired(epoch_secs(500)).await);
+        assert!(cache.get().await.is_none());
+    }
+
+    #[test_env_log::test(tokio::test)]
+    async fn initial_populate_credentials() {
+        let time = TestTime::new(epoch_secs(100));
+        let refresh = Arc::new(async_provide_credentials_fn(|| async {
+            info!("refreshing the credentials");
+            Ok(credentials(1000))
+        }));
+        let provider = Provider::new(
+            time,
+            refresh,
+            DEFAULT_REFRESH_TIMEOUT,
+            DEFAULT_CREDENTIAL_EXPIRATION,
+        );
+        assert_eq!(
+            epoch_secs(1000),
+            provider
+                .provide_credentials()
+                .await
+                .unwrap()
+                .expiry()
+                .unwrap()
+        );
+    }
+
+    #[test_env_log::test(tokio::test)]
+    async fn refresh_expired_credentials() {
+        let provider = test_provider(
+            TestTime::new(epoch_secs(100)),
+            vec![
+                Ok(credentials(1000)),
+                Ok(credentials(2000)),
+                Ok(credentials(3000)),
+            ],
+        );
+
+        expect_creds(1000, &provider).await;
+        expect_creds(1000, &provider).await;
+        provider.inner.time.set(epoch_secs(1500));
+        expect_creds(2000, &provider).await;
+        expect_creds(2000, &provider).await;
+        provider.inner.time.set(epoch_secs(2500));
+        expect_creds(3000, &provider).await;
+        expect_creds(3000, &provider).await;
+    }
+
+    #[test_env_log::test(tokio::test)]
+    async fn refresh_failed_error() {
+        let provider = test_provider(
+            TestTime::new(epoch_secs(100)),
+            vec![
+                Ok(credentials(1000)),
+                Err(CredentialsError::CredentialsNotLoaded),
+            ],
+        );
+
+        expect_creds(1000, &provider).await;
+        provider.inner.time.set(epoch_secs(1500));
+        assert!(provider.provide_credentials().await.is_err());
+    }
+}

--- a/aws/rust-runtime/aws-auth/src/provider/time.rs
+++ b/aws/rust-runtime/aws-auth/src/provider/time.rs
@@ -6,7 +6,7 @@
 use std::time::SystemTime;
 
 /// Allows us to abstract time for tests.
-pub(super) trait TimeSource: Clone + Send + Sync + 'static {
+pub(super) trait TimeSource: Send + Sync + 'static {
     fn now(&self) -> SystemTime;
 }
 

--- a/aws/rust-runtime/aws-auth/src/provider/time.rs
+++ b/aws/rust-runtime/aws-auth/src/provider/time.rs
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use std::time::SystemTime;
+
+/// Allows us to abstract time for tests.
+pub(super) trait TimeSource: Clone + Send + Sync + 'static {
+    fn now(&self) -> SystemTime;
+}
+
+#[derive(Copy, Clone)]
+pub(super) struct SystemTimeSource;
+
+impl TimeSource for SystemTimeSource {
+    fn now(&self) -> SystemTime {
+        SystemTime::now()
+    }
+}


### PR DESCRIPTION
This implements an initial lazy caching credentials provider, but doesn't attempt to add async runtime-agnostic timeouts or panic handling yet. Both of those will take a considerable amount of work still.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
