### PR TITLE
Adding Snowball APIs and Corresponding Examples

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -85,6 +85,7 @@ val tier1Services = setOf(
     "sagemakerfeaturestoreruntime",
     "secretsmanager",
     "sesv2",
+    "snowball",
     "sns",
     "sqs",
     "ssm",

--- a/aws/sdk/examples/snowball/Cargo.toml
+++ b/aws/sdk/examples/snowball/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "snowball-code-examples"
+version = "0.1.0"
+authors = ["Landon James <lnj@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1", features = ["full"]}
+aws-sdk-snowball = { path = "../../build/aws-sdk/snowball" }
+aws-hyper = { path = "../../build/aws-sdk/aws-hyper" }
+aws-types = { path = "../../build/aws-sdk/aws-types" }
+structopt = { version = "0.3", default-features = false }
+tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/snowball/src/bin/create-address.rs
+++ b/aws/sdk/examples/snowball/src/bin/create-address.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use aws_sdk_snowball::model::Address;
 use aws_sdk_snowball::{Config, Region};
 use aws_types::region::{EnvironmentProvider, ProvideRegion};

--- a/aws/sdk/examples/snowball/src/bin/create-address.rs
+++ b/aws/sdk/examples/snowball/src/bin/create-address.rs
@@ -1,0 +1,103 @@
+use aws_sdk_snowball::model::Address;
+use aws_sdk_snowball::{Config, Region};
+use aws_types::region::{EnvironmentProvider, ProvideRegion};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The region
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    // Address information
+    #[structopt(long)]
+    city: Option<String>,
+
+    #[structopt(long)]
+    company: Option<String>,
+
+    #[structopt(long)]
+    country: Option<String>,
+
+    #[structopt(long)]
+    landmark: Option<String>,
+
+    #[structopt(long)]
+    name: Option<String>,
+
+    #[structopt(long)]
+    phone_number: Option<String>,
+
+    #[structopt(long)]
+    postal_code: Option<String>,
+
+    #[structopt(long)]
+    prefecture_or_district: Option<String>,
+
+    #[structopt(long)]
+    state: Option<String>,
+
+    #[structopt(long)]
+    street1: Option<String>,
+
+    #[structopt(long)]
+    street2: Option<String>,
+
+    #[structopt(long)]
+    street3: Option<String>,
+}
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#[tokio::main]
+async fn main() -> Result<(), aws_sdk_snowball::Error> {
+    let Opt {
+        region,
+        city,
+        company,
+        country,
+        landmark,
+        name,
+        phone_number,
+        postal_code,
+        prefecture_or_district,
+        state,
+        street1,
+        street2,
+        street3,
+    } = Opt::from_args();
+
+    let region = EnvironmentProvider::new()
+        .region()
+        .or_else(|| region.as_ref().map(|region| Region::new(region.clone())))
+        .unwrap_or_else(|| Region::new("us-west-2"));
+
+    let new_address = Address::builder()
+        .set_address_id(None)
+        .set_name(name)
+        .set_company(company)
+        .set_street1(street1)
+        .set_street2(street2)
+        .set_street3(street3)
+        .set_city(city)
+        .set_state_or_province(state)
+        .set_prefecture_or_district(prefecture_or_district)
+        .set_landmark(landmark)
+        .set_country(country)
+        .set_postal_code(postal_code)
+        .set_phone_number(phone_number)
+        .set_is_restricted(Some(false))
+        .build();
+
+    let conf = Config::builder().region(region).build();
+    let client = aws_sdk_snowball::Client::from_conf(conf);
+
+    let result = client.create_address().address(new_address).send().await?;
+
+    println!("Address: {:?}", result.address_id.unwrap());
+
+    Ok(())
+}

--- a/aws/sdk/examples/snowball/src/bin/create-address.rs
+++ b/aws/sdk/examples/snowball/src/bin/create-address.rs
@@ -52,11 +52,6 @@ struct Opt {
     street3: Option<String>,
 }
 
-/*
- * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0.
- */
-
 #[tokio::main]
 async fn main() -> Result<(), aws_sdk_snowball::Error> {
     let Opt {

--- a/aws/sdk/examples/snowball/src/bin/describe-addresses.rs
+++ b/aws/sdk/examples/snowball/src/bin/describe-addresses.rs
@@ -1,0 +1,19 @@
+use aws_sdk_snowball::{Config, Region};
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#[tokio::main]
+async fn main() -> Result<(), aws_sdk_snowball::Error> {
+    let region = Region::new("us-east-1");
+    let conf = Config::builder().region(region).build();
+    let client = aws_sdk_snowball::Client::from_conf(conf);
+    let addresses = client.describe_addresses().send().await?;
+    for address in addresses.addresses.unwrap() {
+        println!("Address: {:?}", address);
+    }
+
+    Ok(())
+}

--- a/aws/sdk/examples/snowball/src/bin/describe-addresses.rs
+++ b/aws/sdk/examples/snowball/src/bin/describe-addresses.rs
@@ -1,9 +1,9 @@
-use aws_sdk_snowball::{Config, Region};
-
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+use aws_sdk_snowball::{Config, Region};
 
 #[tokio::main]
 async fn main() -> Result<(), aws_sdk_snowball::Error> {

--- a/aws/sdk/examples/snowball/src/bin/list-jobs.rs
+++ b/aws/sdk/examples/snowball/src/bin/list-jobs.rs
@@ -1,9 +1,9 @@
-use aws_sdk_snowball::{Config, Region};
-
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
+
+use aws_sdk_snowball::{Config, Region};
 
 #[tokio::main]
 async fn main() -> Result<(), aws_sdk_snowball::Error> {

--- a/aws/sdk/examples/snowball/src/bin/list-jobs.rs
+++ b/aws/sdk/examples/snowball/src/bin/list-jobs.rs
@@ -1,0 +1,19 @@
+use aws_sdk_snowball::{Config, Region};
+
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#[tokio::main]
+async fn main() -> Result<(), aws_sdk_snowball::Error> {
+    let region = Region::new("us-east-1");
+    let conf = Config::builder().region(region).build();
+    let client = aws_sdk_snowball::Client::from_conf(conf);
+    let jobs = client.list_jobs().send().await?;
+    for job in jobs.job_list_entries.unwrap() {
+        println!("JobId: {:?}", job.job_id);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
AWS SnowFamily (formerly Snowball) is a collection of ruggedized edge computing and large scale data transport devices. I have enabled the APIs in the SDK and added several small examples of calling the APIs. These examples include two small listing API calls with no input, and a slightly larger example showing how to create a shipping address and showcasing the builder pattern for model structs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
