### PR TITLE
Adding a customization for Cloudwatch PutLogEvents that adds the x-amzn-logs-format: json/emf header

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/cloudwatch/CloudWatchDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/cloudwatch/CloudWatchDecorator.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rustsdk.customize.cloudwatch
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.customize.OperationCustomization
+import software.amazon.smithy.rust.codegen.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.letIf
+
+class CloudWatchDecorator : RustCodegenDecorator {
+    override val name: String = "CloudWatch"
+    override val order: Byte = 0
+
+    private fun applies(protocolConfig: ProtocolConfig) = protocolConfig.serviceShape.id == ShapeId.from("com.amazonaws.cloudwatchlogs#PutLogEvents")
+    override fun operationCustomizations(
+        protocolConfig: ProtocolConfig,
+        operation: OperationShape,
+        baseCustomizations: List<OperationCustomization>
+    ): List<OperationCustomization> {
+        return baseCustomizations.letIf(applies(protocolConfig)) {
+            it + CloudwatchAddLogFormatHeader()
+        }
+    }
+}
+
+class CloudwatchAddLogFormatHeader : OperationCustomization() {
+    override fun section(section: OperationSection): Writable = when (section) {
+        is OperationSection.FinalizeOperation -> emptySection
+        OperationSection.OperationImplBlock -> emptySection
+        is OperationSection.MutateRequest -> writable {
+            rust(
+                """${section.request}
+                .request_mut()
+                .headers_mut()
+                .insert("x-amzn-logs-format", #T::HeaderValue::from_static("json/emf"));""",
+                RuntimeType.http
+            )
+        }
+        else -> emptySection
+    }
+}

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -54,7 +54,6 @@ val tier1Services = setOf(
     "batch",
     "cloudformation",
     "cloudwatch",
-    "cloudwatch",
     "cloudwatchlogs",
     "cognitoidentity",
     "cognitoidentityprovider",


### PR DESCRIPTION
*Issue #, if available:* [141](https://github.com/awslabs/aws-sdk-rust/issues/141)

*Description of changes:* Adding a customization for the Cloudwatch `PutLogEvents` operation that adds the `x-amzn-logs-format: json/emf` header (shamelessly ripped off from the APIGW customization that does something similar). Also removed a duplicate entry for Cloudwatch in the `tier1Services` list in the build.gradle.

Thankfully [according to the docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_PutLogEvents.html) `PutLogEvents` only accepts a single value, `json/emf`  for this header or this would have been way more complicated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
