### PR TITLE
Updated EBS code example docs

### DIFF
--- a/aws/sdk/examples/ebs/Cargo.toml
+++ b/aws/sdk/examples/ebs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "ebs"
+name = "ebs-code-examples"
 version = "0.1.0"
 authors = ["Russell Cohen <rcoh@amazon.com>"]
 edition = "2018"
@@ -7,9 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ebs = {  package = "aws-sdk-ebs", path = "../../build/aws-sdk/ebs" }
+ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
+aws-types = { path = "../../build/aws-sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
-aws-sdk-ebs = { path = "../../build/aws-sdk/ebs" }
-aws-sdk-ec2 = { path = "../../build/aws-sdk/ec2" }
-sha2 = "0.9.5"
 base64 = "0.13.0"
+sha2 = "0.9.5"
+structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.19"

--- a/aws/sdk/examples/ebs/Cargo.toml
+++ b/aws/sdk/examples/ebs/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ebs = {  package = "aws-sdk-ebs", path = "../../build/aws-sdk/ebs" }
-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
+aws-sdk-ebs = { package = "aws-sdk-ebs", path = "../../build/aws-sdk/ebs" }
+aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
 aws-types = { path = "../../build/aws-sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 base64 = "0.13.0"

--- a/aws/sdk/examples/ebs/src/bin/create-snapshot.rs
+++ b/aws/sdk/examples/ebs/src/bin/create-snapshot.rs
@@ -111,6 +111,7 @@ async fn main() -> Result<(), Error> {
 
     println!("Snapshot ID {}", snapshot_id);
     println!("The state is 'completed' when all of the modified blocks have been transferred to Amazon S3.");
+    println!("Use the get-snapshot-state code example to get the state of the snapshot.")
 
     Ok(())
 }

--- a/aws/sdk/examples/ebs/src/bin/create-snapshot.rs
+++ b/aws/sdk/examples/ebs/src/bin/create-snapshot.rs
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_types::region::{self, ProvideRegion};
-use ebs::model::ChecksumAlgorithm;
-use ebs::{ByteStream, Client, Config, Error, Region, PKG_VERSION};
+use aws_sdk_ebs::model::ChecksumAlgorithm;
+use aws_sdk_ebs::{ByteStream, Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
 use sha2::Digest;
 use structopt::StructOpt;
 
-/// EBS only supports one fixed size of block
+/// Amazon EBS only supports one fixed size of block
 const EBS_BLOCK_SIZE: usize = 524288;
 
 #[derive(Debug, StructOpt)]
@@ -27,7 +28,7 @@ struct Opt {
     verbose: bool,
 }
 
-/// Creates an EBS snapshot with the specified description.
+/// Creates an Amazon Elastic Block Store snapshot with the specified description.
 /// # Arguments
 ///
 /// * `-d DESCRIPTION` - The description of the snapshot.
@@ -45,7 +46,7 @@ async fn main() -> Result<(), Error> {
         verbose,
     } = Opt::from_args();
 
-    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+    let region = region::ChainProvider::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));
 
@@ -54,14 +55,11 @@ async fn main() -> Result<(), Error> {
     if verbose {
         println!("EBS version: {}", PKG_VERSION);
         println!("Description: {}", description);
-        println!(
-            "Region:      {}",
-            region_provider.region().unwrap().as_ref()
-        );
+        println!("Region:      {}", region.region().unwrap().as_ref());
         println!();
     }
 
-    let config = Config::builder().region(region_provider).build();
+    let config = Config::builder().region(region).build();
     let client = Client::from_conf(config);
 
     let snapshot = client
@@ -111,7 +109,7 @@ async fn main() -> Result<(), Error> {
 
     println!("Snapshot ID {}", snapshot_id);
     println!("The state is 'completed' when all of the modified blocks have been transferred to Amazon S3.");
-    println!("Use the get-snapshot-state code example to get the state of the snapshot.")
+    println!("Use the get-snapshot-state code example to get the state of the snapshot.");
 
     Ok(())
 }

--- a/aws/sdk/examples/ebs/src/bin/create-snapshot.rs
+++ b/aws/sdk/examples/ebs/src/bin/create-snapshot.rs
@@ -3,34 +3,84 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_sdk_ebs::model::ChecksumAlgorithm;
-use aws_sdk_ebs::ByteStream;
-use aws_sdk_ec2::model::Filter;
+use aws_types::region::{self, ProvideRegion};
+use ebs::model::ChecksumAlgorithm;
+use ebs::{ByteStream, Client, Config, Error, Region, PKG_VERSION};
 use sha2::Digest;
+use structopt::StructOpt;
 
 /// EBS only supports one fixed size of block
 const EBS_BLOCK_SIZE: usize = 524288;
 
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// The snapshot's description.
+    #[structopt(short, long)]
+    description: String,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Creates an EBS snapshot with the specified description.
+/// # Arguments
+///
+/// * `-d DESCRIPTION` - The description of the snapshot.
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
+///    If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
 #[tokio::main]
-async fn main() -> Result<(), aws_sdk_ebs::Error> {
+async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
-    let client = aws_sdk_ebs::Client::from_env();
+
+    let Opt {
+        description,
+        region,
+        verbose,
+    } = Opt::from_args();
+
+    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
+
+    if verbose {
+        println!("EBS version: {}", PKG_VERSION);
+        println!("Description: {}", description);
+        println!(
+            "Region:      {}",
+            region_provider.region().unwrap().as_ref()
+        );
+        println!();
+    }
+
+    let config = Config::builder().region(region_provider).build();
+    let client = Client::from_conf(config);
+
     let snapshot = client
         .start_snapshot()
-        .description("new_snapshot")
+        .description(description)
         .encrypted(false)
         .volume_size(1)
         .send()
         .await?;
-    println!("snapshot started: {:?}", snapshot);
+
     let snapshot_id = snapshot.snapshot_id.unwrap();
     let mut blocks = vec![];
-    // append a block of all 1s
+
+    // Append a block of all 1s.
     let mut block: Vec<u8> = Vec::new();
     block.resize(EBS_BLOCK_SIZE, 1);
     blocks.push(block);
 
-    // append a block of all 0s
+    // Append a block of all 0s.
     let mut block: Vec<u8> = Vec::new();
     block.resize(EBS_BLOCK_SIZE, 0);
     blocks.push(block);
@@ -52,27 +102,15 @@ async fn main() -> Result<(), aws_sdk_ebs::Error> {
             .send()
             .await?;
     }
-    let rsp = client
+    client
         .complete_snapshot()
         .changed_blocks_count(2)
         .snapshot_id(&snapshot_id)
         .send()
         .await?;
-    println!("snapshot complete: {:#?}", rsp);
 
-    // NOTE: you need to wait for `status != pending`
-    let ec2_client = aws_sdk_ec2::Client::from_env();
-    let snapshots = ec2_client
-        .describe_snapshots()
-        .filters(
-            Filter::builder()
-                .name("snapshot-id")
-                .values(&snapshot_id)
-                .build(),
-        )
-        .send()
-        .await;
-    println!("snapshot status: {:#?}", snapshots);
+    println!("Snapshot ID {}", snapshot_id);
+    println!("The state is 'completed' when all of the modified blocks have been transferred to Amazon S3.");
 
     Ok(())
 }

--- a/aws/sdk/examples/ebs/src/bin/delete-snapshot.rs
+++ b/aws/sdk/examples/ebs/src/bin/delete-snapshot.rs
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_types::region::{self, ProvideRegion};
-use ec2::{Client, Config, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -22,7 +23,7 @@ struct Opt {
     verbose: bool,
 }
 
-/// Deletes an EBS snapshot.
+/// Deletes an Amazon Elastic Block Store snapshot.
 /// It must be `completed` before you can use the snapshot.
 /// # Arguments
 ///
@@ -41,7 +42,7 @@ async fn main() -> Result<(), Error> {
         verbose,
     } = Opt::from_args();
 
-    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+    let region = region::ChainProvider::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));
 
@@ -49,15 +50,12 @@ async fn main() -> Result<(), Error> {
 
     if verbose {
         println!("EC2 version: {}", PKG_VERSION);
-        println!(
-            "Region:      {}",
-            region_provider.region().unwrap().as_ref()
-        );
+        println!("Region:      {}", region.region().unwrap().as_ref());
         println!("Snapshot ID: {}", snapshot_id);
         println!();
     }
 
-    let config = Config::builder().region(region_provider).build();
+    let config = Config::builder().region(region).build();
     let client = Client::from_conf(config);
 
     client

--- a/aws/sdk/examples/ebs/src/bin/delete-snapshot.rs
+++ b/aws/sdk/examples/ebs/src/bin/delete-snapshot.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_types::region::{self, ProvideRegion};
+use ec2::{Client, Config, Error, Region, PKG_VERSION};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// The ID of the snapshot.
+    #[structopt(short, long)]
+    snapshot_id: String,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Deletes an EBS snapshot.
+/// It must be `completed` before you can use the snapshot.
+/// # Arguments
+///
+/// * `-s SNAPSHOT-ID` - The ID of the snapshot.
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
+///    If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt {
+        region,
+        snapshot_id,
+        verbose,
+    } = Opt::from_args();
+
+    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
+
+    if verbose {
+        println!("EC2 version: {}", PKG_VERSION);
+        println!(
+            "Region:      {}",
+            region_provider.region().unwrap().as_ref()
+        );
+        println!("Snapshot ID: {}", snapshot_id);
+        println!();
+    }
+
+    let config = Config::builder().region(region_provider).build();
+    let client = Client::from_conf(config);
+
+    client
+        .delete_snapshot()
+        .snapshot_id(snapshot_id)
+        .send()
+        .await?;
+
+    println!("Deleted");
+
+    Ok(())
+}

--- a/aws/sdk/examples/ebs/src/bin/get-snapshot-state.rs
+++ b/aws/sdk/examples/ebs/src/bin/get-snapshot-state.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_types::region::{self, ProvideRegion};
+use ec2::model::Filter;
+use ec2::{Client, Config, Error, Region, PKG_VERSION};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// The ID of the snapshot.
+    #[structopt(short, long)]
+    snapshot_id: String,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Retrieves the state of an EBS snapshot.
+/// It must be `completed` before you can use the snapshot.
+/// # Arguments
+///
+/// * `-s SNAPSHOT-ID` - The ID of the snapshot.
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
+///    If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt {
+        region,
+        snapshot_id,
+        verbose,
+    } = Opt::from_args();
+
+    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
+
+    if verbose {
+        println!("EC2 version: {}", PKG_VERSION);
+        println!(
+            "Region:      {}",
+            region_provider.region().unwrap().as_ref()
+        );
+        println!("Snapshot ID: {}", snapshot_id);
+        println!();
+    }
+
+    let config = Config::builder().region(region_provider).build();
+    let client = Client::from_conf(config);
+
+    let resp = client
+        .describe_snapshots()
+        .filters(
+            Filter::builder()
+                .name("snapshot-id")
+                .values(snapshot_id)
+                .build(),
+        )
+        .send()
+        .await?;
+
+    println!(
+        "State: {}",
+        resp.snapshots
+            .unwrap()
+            .pop()
+            .unwrap()
+            .state
+            .unwrap()
+            .as_ref()
+    );
+
+    Ok(())
+}

--- a/aws/sdk/examples/ebs/src/bin/get-snapshot-state.rs
+++ b/aws/sdk/examples/ebs/src/bin/get-snapshot-state.rs
@@ -23,7 +23,7 @@ struct Opt {
     verbose: bool,
 }
 
-/// Retrieves the state of an EBS snapshot.
+/// Retrieves the state of an Amazon EBS snapshot using Amazon EC2 API.
 /// It must be `completed` before you can use the snapshot.
 /// # Arguments
 ///

--- a/aws/sdk/examples/ebs/src/bin/get-snapshot-state.rs
+++ b/aws/sdk/examples/ebs/src/bin/get-snapshot-state.rs
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_types::region::{self, ProvideRegion};
-use ec2::model::Filter;
-use ec2::{Client, Config, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::model::Filter;
+use aws_sdk_ec2::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -23,7 +24,7 @@ struct Opt {
     verbose: bool,
 }
 
-/// Retrieves the state of an Amazon EBS snapshot using Amazon EC2 API.
+/// Retrieves the state of an Amazon Elastic Block Store snapshot using Amazon EC2 API.
 /// It must be `completed` before you can use the snapshot.
 /// # Arguments
 ///
@@ -42,7 +43,7 @@ async fn main() -> Result<(), Error> {
         verbose,
     } = Opt::from_args();
 
-    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+    let region = region::ChainProvider::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));
 
@@ -50,15 +51,12 @@ async fn main() -> Result<(), Error> {
 
     if verbose {
         println!("EC2 version: {}", PKG_VERSION);
-        println!(
-            "Region:      {}",
-            region_provider.region().unwrap().as_ref()
-        );
+        println!("Region:      {}", region.region().unwrap().as_ref());
         println!("Snapshot ID: {}", snapshot_id);
         println!();
     }
 
-    let config = Config::builder().region(region_provider).build();
+    let config = Config::builder().region(region).build();
     let client = Client::from_conf(config);
 
     let resp = client

--- a/aws/sdk/examples/ebs/src/bin/list-snapshots.rs
+++ b/aws/sdk/examples/ebs/src/bin/list-snapshots.rs
@@ -50,8 +50,9 @@ async fn main() -> Result<(), Error> {
     let config = Config::builder().region(region_provider).build();
     let client = Client::from_conf(config);
 
-    // You can find snapshots for any account by replacing
-    // "self" with their account ID.
+    // "self" represents your account ID.
+    // You can list the snapshots for any account by replacing
+    // "self" with that account ID.
     let resp = client.describe_snapshots().owner_ids("self").send().await?;
     let snapshots = resp.snapshots.unwrap();
     let length = snapshots.len();

--- a/aws/sdk/examples/ebs/src/bin/list-snapshots.rs
+++ b/aws/sdk/examples/ebs/src/bin/list-snapshots.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_types::region::{self, ProvideRegion};
+use ec2::{Client, Config, Error, Region, PKG_VERSION};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+/// Displays some information about the EBS snapshots you own in the Region.
+/// # Arguments
+///
+/// * `[-r REGION]` - The Region in which the client is created.
+///    If not supplied, uses the value of the **AWS_REGION** environment variable.
+///    If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display additional information.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt { region, verbose } = Opt::from_args();
+
+    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+
+    println!();
+
+    if verbose {
+        println!("EC2 version: {}", PKG_VERSION);
+        println!(
+            "Region:      {}",
+            region_provider.region().unwrap().as_ref()
+        );
+
+        println!();
+    }
+
+    let config = Config::builder().region(region_provider).build();
+    let client = Client::from_conf(config);
+
+    // You can find snapshots for any account by replacing
+    // "self" with their account ID.
+    let resp = client.describe_snapshots().owner_ids("self").send().await?;
+    let snapshots = resp.snapshots.unwrap();
+    let length = snapshots.len();
+
+    for snapshot in snapshots {
+        println!(
+            "ID:          {}",
+            snapshot.snapshot_id.as_deref().unwrap_or_default()
+        );
+        println!(
+            "Description: {}",
+            snapshot.description.as_deref().unwrap_or_default()
+        );
+        println!("State:       {}", snapshot.state.unwrap().as_ref());
+        println!();
+    }
+
+    println!();
+    println!("Found {} snapshot(s)", length);
+    println!();
+
+    Ok(())
+}

--- a/aws/sdk/examples/ebs/src/bin/list-snapshots.rs
+++ b/aws/sdk/examples/ebs/src/bin/list-snapshots.rs
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_types::region::{self, ProvideRegion};
-use ec2::{Client, Config, Error, Region, PKG_VERSION};
+use aws_sdk_ec2::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region;
+use aws_types::region::ProvideRegion;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
@@ -18,7 +19,7 @@ struct Opt {
     verbose: bool,
 }
 
-/// Displays some information about the EBS snapshots you own in the Region.
+/// Displays some information about the Amazon Elastic Block Store snapshots you own in the Region.
 /// # Arguments
 ///
 /// * `[-r REGION]` - The Region in which the client is created.
@@ -31,7 +32,7 @@ async fn main() -> Result<(), Error> {
 
     let Opt { region, verbose } = Opt::from_args();
 
-    let region_provider = region::ChainProvider::first_try(region.map(Region::new))
+    let region = region::ChainProvider::first_try(region.map(Region::new))
         .or_default_provider()
         .or_else(Region::new("us-west-2"));
 
@@ -39,15 +40,12 @@ async fn main() -> Result<(), Error> {
 
     if verbose {
         println!("EC2 version: {}", PKG_VERSION);
-        println!(
-            "Region:      {}",
-            region_provider.region().unwrap().as_ref()
-        );
+        println!("Region:      {}", region.region().unwrap().as_ref());
 
         println!();
     }
 
-    let config = Config::builder().region(region_provider).build();
+    let config = Config::builder().region(region).build();
     let client = Client::from_conf(config);
 
     // "self" represents your account ID.


### PR DESCRIPTION
*Issue #, if available:*
We had one EBS code example, `create-snapshot`, which had no docs.

*Description of changes:*
- Added doc comments.
- Added `delete-snapshot`, `get-snapshot-state`, and `list-snapshots` code examples.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
