### PR TITLE
Fix `token_generator` test against different fastrand algorithms

### DIFF
--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -20,3 +20,4 @@ are to allow this crate to be compilable and testable in isolation, no client co
 
 [dev-dependencies]
 proptest = "1"
+regex = "1"

--- a/rust-runtime/inlineable/src/lib.rs
+++ b/rust-runtime/inlineable/src/lib.rs
@@ -21,6 +21,7 @@ mod test {
     use crate::idempotency_token;
     use crate::idempotency_token::{uuid_v4, IdempotencyTokenProvider};
     use proptest::prelude::*;
+    use regex::Regex;
 
     #[test]
     fn test_uuid() {
@@ -45,10 +46,16 @@ mod test {
 
     #[test]
     fn token_generator() {
-        let provider = IdempotencyTokenProvider::with_seed(123);
-        assert_eq!(
-            provider.make_idempotency_token(),
-            "b4021a03-ae07-4db5-fc1b-38bf919691f8"
+        let provider = IdempotencyTokenProvider::random();
+        let token = provider.make_idempotency_token();
+        assert!(
+            Regex::new(
+                r"[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-4[A-Fa-f0-9]{3}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}"
+            )
+            .unwrap()
+            .is_match(&token),
+            "token {} wasn't a valid random UUID",
+            token
         );
     }
 


### PR DESCRIPTION
fastrand 1.5 changed algorithms which broke the `token_generator` test which had a UUID hardcoded in its assertion. This switches to using a regex to validate the UUID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
