### PR TITLE
drop timestream services from full SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 **New This Week**
 - (When complete) Add profile file provider for region (#594, #xyz)
 
+## v0.18.1 (July 27th 2021)
+* Remove timestreamwrite and timestreamquery from the generated services (#613)
+
 ## v0.18 (July 27th 2021)
 **Breaking changes**
 * `test-util` has been made an optional dependency and has moved from
@@ -20,11 +23,11 @@
 
 **New this Week**
 * 🎉 Add support for Autoscaling (#576, #582)
-* `AsyncProvideCredentials` now introduces an additional lifetime parameter, simplifying bridging it with `#[async_trait]` interfaces 
+* `AsyncProvideCredentials` now introduces an additional lifetime parameter, simplifying bridging it with `#[async_trait]` interfaces
 * Fix S3 bug when content type was set explicitly (aws-sdk-rust#131, #566, @eagletmt)
 
 **Contributions**
-Thank you for your contributions! ❤️ 
+Thank you for your contributions! ❤️
 * @eagletmt (#566)
 
 ## v0.16 (July 6th 2021)

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -101,7 +101,11 @@ private val disableServices = setOf(
     // https://github.com/awslabs/smithy-rs/issues/137
     "glacier",
     // https://github.com/awslabs/smithy-rs/issues/606
-    "iotdataplane"
+    "iotdataplane",
+    // timestream requires endpoint discovery
+    // https://github.com/awslabs/aws-sdk-rust/issues/114
+    "timestreamwrite",
+    "timestreamquery"
 )
 
 data class AwsService(


### PR DESCRIPTION
*Issue #, if available:* #109 
*Description of changes:* Timestream also won't work because endpoint discovery is mandatory


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
