### PR TITLE
change http checksums to be base64 encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## vNext (Month Day Year)
 **New This Week**
+- :bug: Correctly encode HTTP Checksums using base64 instead of hex. Fixes aws-sdk-rust#164. (#615)
 - (When complete) Add profile file provider for region (#594, #xyz)
 
 ## v0.18.1 (July 27th 2021)

--- a/aws/sdk/aws-models/s3-tests.smithy
+++ b/aws/sdk/aws-models/s3-tests.smithy
@@ -111,7 +111,7 @@ apply PutBucketLifecycleConfiguration @httpRequestTests([
         headers: {
             // we can assert this, but when this test is promoted, it can't assert
             // on the exact contents
-            "content-md5": "b14bbeb8064f913b40c4975a03ef6e4a",
+            "content-md5": "sUu+uAZPkTtAxJdaA+9uSg==",
         },
         bodyMediaType: "application/xml",
         body: """

--- a/codegen-test/model/rest-xml-extras.smithy
+++ b/codegen-test/model/rest-xml-extras.smithy
@@ -192,7 +192,7 @@ map XmlMapsNestedNestedNamespaceInputOutputMap {
     params: {
         field: "hello"
     },
-    headers: { "Content-Md5": "240240a9803ad7032101319e42a45c31" },
+    headers: { "Content-Md5": "JAJAqYA61wMhATGeQqRcMQ==" },
     protocol: "aws.protocols#restXml"
 }])
 @httpChecksumRequired

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/HttpChecksumRequiredGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/HttpChecksumRequiredGenerator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
@@ -46,13 +47,14 @@ class HttpChecksumRequiredGenerator(
                         let checksum = #{md5}::compute(data);
                         req.headers_mut().insert(
                             #{http}::header::HeaderName::from_static("content-md5"),
-                            format!("{:x}", checksum).parse().expect("checksum is valid header value")
+                            #{base64_encode}(&checksum[..]).parse().expect("checksum is valid header value")
                         );
                         Result::<_, #{BuildError}>::Ok(req)
                     })?;
                 """,
                     "md5" to CargoDependency.Md5.asType(),
                     "http" to CargoDependency.Http.asType(),
+                    "base64_encode" to RuntimeType.Base64Encode(protocolConfig.runtimeConfig),
                     "BuildError" to protocolConfig.runtimeConfig.operationBuildError()
                 )
             }


### PR DESCRIPTION
*Issue*: #523 
*Description of changes:*

Due to a misreading of the spec, the http checksums where hex encoded when they should actually be base64 encoded.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
