### PR TITLE
merge path in smithy endpoint

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolTestGenerator.kt
@@ -444,11 +444,7 @@ class HttpProtocolTestGenerator(
         private val RestXml = "aws.protocoltests.restxml#RestXml"
         private val AwsQuery = "aws.protocoltests.query#AwsQuery"
         private val Ec2Query = "aws.protocoltests.ec2#AwsEc2"
-        private val ExpectFail = setOf<FailingTest>(
-            FailingTest(
-                service = RestJson, id = "RestJsonHostWithPath", action = Action.Request
-            )
-        )
+        private val ExpectFail = setOf<FailingTest>()
         private val RunOnly: Set<String>? = null
 
         // These tests are not even attempted to be generated, either because they will not compile

--- a/rust-runtime/smithy-http/src/endpoint.rs
+++ b/rust-runtime/smithy-http/src/endpoint.rs
@@ -4,6 +4,7 @@
  */
 
 use http::uri::{Authority, InvalidUri, Uri};
+use std::borrow::Cow;
 use std::str::FromStr;
 
 /// API Endpoint
@@ -82,10 +83,27 @@ impl Endpoint {
         let new_uri = Uri::builder()
             .authority(authority)
             .scheme(scheme.clone())
-            .path_and_query(uri.path_and_query().unwrap().clone())
+            .path_and_query(Self::merge_paths(&self.uri, &uri).as_ref())
             .build()
             .expect("valid uri");
         *uri = new_uri;
+    }
+
+    fn merge_paths<'a>(endpoint: &'a Uri, uri: &'a Uri) -> Cow<'a, str> {
+        if let Some(query) = endpoint.path_and_query().and_then(|pq| pq.query()) {
+            tracing::warn!(query = %query, "query specified in endpoint will be ignored during endpoint resolution");
+        }
+        let endpoint_path = endpoint.path();
+        let uri_path_and_query = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("");
+        if endpoint_path == "" {
+            Cow::Borrowed(uri_path_and_query)
+        } else {
+            let ep_no_slash = endpoint_path.strip_suffix("/").unwrap_or(endpoint_path);
+            let uri_path_no_slash = uri_path_and_query
+                .strip_prefix("/")
+                .unwrap_or(uri_path_and_query);
+            Cow::Owned(format!("{}/{}", ep_no_slash, uri_path_no_slash))
+        }
     }
 }
 
@@ -138,6 +156,26 @@ mod test {
             uri,
             Uri::from_static("https://us-east-1.dynamo.amazonaws.com/list_tables?k=v")
         );
+    }
+
+    #[test]
+    fn endpoint_with_path() {
+        for uri in [
+            // check that trailing slashes are properly normalized
+            "https://us-east-1.dynamo.amazonaws.com/private",
+            "https://us-east-1.dynamo.amazonaws.com/private/",
+        ] {
+            let ep = Endpoint::immutable(Uri::from_static(uri));
+            let mut uri = Uri::from_static("/list_tables?k=v");
+            ep.set_endpoint(
+                &mut uri,
+                Some(&EndpointPrefix::new("subregion.").expect("valid prefix")),
+            );
+            assert_eq!(
+                uri,
+                Uri::from_static("https://us-east-1.dynamo.amazonaws.com/private/list_tables?k=v")
+            );
+        }
     }
 
     #[test]

--- a/rust-runtime/smithy-http/src/endpoint.rs
+++ b/rust-runtime/smithy-http/src/endpoint.rs
@@ -160,7 +160,7 @@ mod test {
 
     #[test]
     fn endpoint_with_path() {
-        for uri in [
+        for uri in &[
             // check that trailing slashes are properly normalized
             "https://us-east-1.dynamo.amazonaws.com/private",
             "https://us-east-1.dynamo.amazonaws.com/private/",

--- a/rust-runtime/smithy-http/src/endpoint.rs
+++ b/rust-runtime/smithy-http/src/endpoint.rs
@@ -95,7 +95,7 @@ impl Endpoint {
         }
         let endpoint_path = endpoint.path();
         let uri_path_and_query = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or("");
-        if endpoint_path == "" {
+        if endpoint_path.is_empty() {
             Cow::Borrowed(uri_path_and_query)
         } else {
             let ep_no_slash = endpoint_path.strip_suffix("/").unwrap_or(endpoint_path);


### PR DESCRIPTION
*Issue #, if available:* Fixes #574. 

*Description of changes:*
Fix a bug in Smithy Endpoint merging that caused it to ignore the path of a custom endpoint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
