### PR TITLE
Include `iotdataplane` in tier-2 services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## vNext (Month Day Year)
 **New This Week**
+- :tada: IoT Data Plane is now available! If you discover it isn't functioning as expected, please let us know! (#624)
 - :tada: Add LazyCachingCredentialsProvider to aws-auth for use with expiring credentials, such as STS AssumeRole. Update STS example to use this new provider (#578, #595)
 - :bug: Correctly encode HTTP Checksums using base64 instead of hex. Fixes aws-sdk-rust#164. (#615)
 - Update SDK gradle build logic to use gradle properties (#620)

--- a/aws/sdk/gradle.properties
+++ b/aws/sdk/gradle.properties
@@ -9,7 +9,7 @@
 # https://github.com/awslabs/smithy-rs/issues/137
 # IOT data plane requires a signing customization https://github.com/awslabs/smithy-rs/issues/606
 # timestream requires endpoint discovery: https://github.com/awslabs/aws-sdk-rust/issues/114
-aws.services.fullsdk=-transcribestreaming,-glacier,-iotdataplane,-timestreamwrite,-timestreamquery
+aws.services.fullsdk=-transcribestreaming,-glacier,-timestreamwrite,-timestreamquery
 
 # Generate an entire sdk vs. aws.services.tier1
 aws.fullsdk=false


### PR DESCRIPTION
I manually verified `iot` and `iotdataplane` are working, so `iotdataplane` can go into the tier 2 list now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
