### PR TITLE
Allow the closure passed to `async_provide_credentials_fn` to borrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ vNext (Month Day Year)
 **New This Week**
 - (When complete) Add profile file provider for region (#594, #xyz)
 - Add AssumeRoleProvider parser implementation. (#632)
+- The closure passed to `async_provide_credentials_fn` can now borrow values (#637)
 
 v0.19 (August 3rd, 2021)
 ------------------------


### PR DESCRIPTION
## Motivation and Context
This PR attempts to resolve some of the issues uncovered in discussion aws-sdk-rust#174. This will allow the closure that is passed to `async_provide_credentials_fn` to borrow, but the future returned from that closure will still need to be `'static`.

## Testing
- Added a unit test to exercise the use-case that wouldn't compile before
- Ran the STS example with the changes to verify async credentials still work

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
