### PR TITLE
Implement Event Stream Sender/Receiver for use in generated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ vNext (Month Day Year)
 **New This Week**
 - (When complete) Add profile file provider for region (#594, #xyz)
 - Add AssumeRoleProvider parser implementation. (#632)
+- Add `Sender`/`Receiver` implementations for Event Stream (#639)
 
 v0.19 (August 3rd, 2021)
 ------------------------

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -21,24 +21,25 @@ val smithyVersion: String by project
 
 val sdkOutputDir = buildDir.resolve("aws-sdk")
 val runtimeModules = listOf(
+    "protocol-test-helpers",
     "smithy-async",
-    "smithy-types",
-    "smithy-json",
-    "smithy-query",
-    "smithy-xml",
+    "smithy-client",
+    "smithy-eventstream",
     "smithy-http",
     "smithy-http-tower",
-    "smithy-client",
-    "protocol-test-helpers"
+    "smithy-json",
+    "smithy-query",
+    "smithy-types",
+    "smithy-xml"
 )
 val awsModules = listOf(
     "aws-auth",
+    "aws-auth-providers",
     "aws-endpoint",
-    "aws-types",
+    "aws-http",
     "aws-hyper",
     "aws-sig-auth",
-    "aws-http",
-    "aws-auth-providers"
+    "aws-types"
 )
 
 buildscript {

--- a/rust-runtime/smithy-eventstream/src/frame.rs
+++ b/rust-runtime/smithy-eventstream/src/frame.rs
@@ -24,7 +24,7 @@ pub type SignMessageError = Box<dyn StdError + Send + Sync + 'static>;
 
 /// Signs an Event Stream message.
 pub trait SignMessage {
-    fn sign(&self, message: Message) -> Result<Message, SignMessageError>;
+    fn sign(&mut self, message: Message) -> Result<Message, SignMessageError>;
 }
 
 /// Converts a Smithy modeled Event Stream type into a [`Message`](Message).

--- a/rust-runtime/smithy-eventstream/src/frame.rs
+++ b/rust-runtime/smithy-eventstream/src/frame.rs
@@ -11,6 +11,7 @@ use crate::error::Error;
 use crate::str_bytes::StrBytes;
 use bytes::{Buf, BufMut, Bytes};
 use std::convert::{TryFrom, TryInto};
+use std::error::Error as StdError;
 use std::mem::size_of;
 
 const PRELUDE_LENGTH_BYTES: u32 = 3 * size_of::<u32>() as u32;
@@ -18,6 +19,29 @@ const PRELUDE_LENGTH_BYTES_USIZE: usize = PRELUDE_LENGTH_BYTES as usize;
 const MESSAGE_CRC_LENGTH_BYTES: u32 = size_of::<u32>() as u32;
 const MAX_HEADER_NAME_LEN: usize = 255;
 const MIN_HEADER_LEN: usize = 2;
+
+pub type SignMessageError = Box<dyn StdError + Send + Sync + 'static>;
+
+/// Signs an Event Stream message.
+pub trait SignMessage {
+    fn sign(&self, message: Message) -> Result<Message, SignMessageError>;
+}
+
+/// Converts a Smithy modeled Event Stream type into a [`Message`](Message).
+pub trait MarshallMessage {
+    /// Smithy modeled input type to convert from.
+    type Input;
+
+    fn marshall(&self, input: Self::Input) -> Result<Message, Error>;
+}
+
+/// Converts an Event Stream [`Message`](Message) into a Smithy modeled type.
+pub trait UnmarshallMessage {
+    /// Smithy modeled type to convert into.
+    type Output;
+
+    fn unmarshall(&self, message: Message) -> Result<Self::Output, Error>;
+}
 
 mod value {
     use crate::error::Error;

--- a/rust-runtime/smithy-http/Cargo.toml
+++ b/rust-runtime/smithy-http/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.6", optional = true }
 tokio-util = { version = "0.6", optional = true}
 
 [dev-dependencies]
+async-stream = "0.3"
 futures-util = "0.3"
 hyper = { version = "0.14.5", features = ["stream"] }
 proptest = "1"

--- a/rust-runtime/smithy-http/Cargo.toml
+++ b/rust-runtime/smithy-http/Cargo.toml
@@ -7,11 +7,14 @@ license = "Apache-2.0"
 
 [features]
 bytestream-util = ["tokio/fs", "tokio-util/io"]
-default = ["bytestream-util"]
+event-stream = ["smithy-eventstream"]
+default = ["bytestream-util", "event-stream"]
 
 [dependencies]
 smithy-types = { path = "../smithy-types" }
+smithy-eventstream = { path = "../smithy-eventstream", optional = true }
 bytes = "1"
+bytes-utils = "0.1"
 http-body = "0.4.0"
 http = "0.2.3"
 thiserror = "1"
@@ -23,12 +26,13 @@ tracing = "0.1"
 hyper = "0.14.5"
 
 # ByteStream internals
-bytes-utils = "0.1.1"
 futures-core = "0.3.14"
 tokio = { version = "1.6", optional = true }
 tokio-util = { version = "0.6", optional = true}
 
 [dev-dependencies]
+futures-util = "0.3"
+hyper = { version = "0.14.5", features = ["stream"] }
 proptest = "1"
 tokio = {version = "1.6", features = ["macros", "rt", "fs", "io-util"]}
 tokio-stream = "0.1.5"

--- a/rust-runtime/smithy-http/src/event_stream.rs
+++ b/rust-runtime/smithy-http/src/event_stream.rs
@@ -271,7 +271,7 @@ mod tests {
         impl MarshallMessage for BadMarshaller {
             type Input = UnmarshalledMessage;
 
-            fn marshall(&self, input: Self::Input) -> Result<Message, EventStreamError> {
+            fn marshall(&self, _input: Self::Input) -> Result<Message, EventStreamError> {
                 Err(EventStreamError::InvalidMessageLength)
             }
         }

--- a/rust-runtime/smithy-http/src/event_stream.rs
+++ b/rust-runtime/smithy-http/src/event_stream.rs
@@ -1,0 +1,290 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! Provides Sender/Receiver implementations for Event Stream codegen.
+
+use crate::body::SdkBody;
+use crate::result::SdkError;
+use bytes::Bytes;
+use bytes_utils::SegmentedBuf;
+use hyper::body::HttpBody;
+use smithy_eventstream::error::Error as EventStreamError;
+use smithy_eventstream::frame::{DecodedFrame, Message, MessageFrameDecoder};
+use std::error::Error as StdError;
+use std::marker::PhantomData;
+
+/// Converts a Smithy modeled Event Stream type into a [`Message`](Message).
+pub trait MarshallMessage {
+    /// Smithy modeled input type to convert from.
+    type Input;
+
+    fn marshall(&self, input: Self::Input) -> Result<Message, EventStreamError>;
+}
+
+/// Converts an Event Stream [`Message`](Message) into a Smithy modeled type.
+pub trait UnmarshallMessage {
+    /// Smithy modeled type to convert into.
+    type Output;
+
+    fn unmarshall(&self, message: Message) -> Result<Self::Output, EventStreamError>;
+}
+
+/// Sends Smithy-modeled messages on an Event Stream.
+pub struct Sender<T, E: StdError + Send + Sync> {
+    marshaller: Box<dyn MarshallMessage<Input = T>>,
+    http_sender: hyper::body::Sender,
+    _phantom: PhantomData<E>,
+}
+
+impl<T, E: StdError + Send + Sync> Sender<T, E> {
+    /// Creates a new `Sender` with the given message marshaller and HTTP sender.
+    pub fn new(
+        marshaller: impl MarshallMessage<Input = T> + 'static,
+        http_sender: hyper::body::Sender,
+    ) -> Self {
+        Sender {
+            marshaller: Box::new(marshaller),
+            http_sender,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Asynchronously sends a message on the stream. Returns `Ok(())` if the message was sent
+    /// successfully. Returns `Err(SdkError::ConstructionFailure)` if the message couldn't be
+    /// marshalled into an Event Stream frame, (e.g., if the message payload was too large).
+    /// Returns `Err(SdkError::DispatchFailure)` if a transport failure occurred.
+    pub async fn send(&mut self, input: T) -> Result<(), SdkError<E>> {
+        let message = self
+            .marshaller
+            .marshall(input)
+            .map_err(|err| SdkError::ConstructionFailure(Box::new(err)))?;
+        let mut buffer = Vec::new();
+        message
+            .write_to(&mut buffer)
+            .map_err(|err| SdkError::ConstructionFailure(Box::new(err)))?;
+        self.http_sender
+            .send_data(buffer.into())
+            .await
+            .map_err(|err| SdkError::DispatchFailure(Box::new(err)))
+    }
+}
+
+/// Receives Smithy-modeled messages out of an Event Stream.
+pub struct Receiver<T, E: StdError + Send + Sync> {
+    unmarshaller: Box<dyn UnmarshallMessage<Output = T>>,
+    decoder: MessageFrameDecoder,
+    buffer: SegmentedBuf<Bytes>,
+    body: SdkBody,
+    _phantom: PhantomData<E>,
+}
+
+impl<T, E: StdError + Send + Sync> Receiver<T, E> {
+    /// Creates a new `Receiver` with the given message unmarshaller and SDK body.
+    pub fn new(unmarshaller: impl UnmarshallMessage<Output = T> + 'static, body: SdkBody) -> Self {
+        Receiver {
+            unmarshaller: Box::new(unmarshaller),
+            decoder: MessageFrameDecoder::new(),
+            buffer: SegmentedBuf::new(),
+            body,
+            _phantom: Default::default(),
+        }
+    }
+
+    /// Asynchronously tries to receive a message from the stream. If the stream has ended,
+    /// it returns an `Ok(None)`. If there is a transport layer error, it will return
+    /// `Err(SdkError::DispatchFailure)`. Service-modeled errors will be a part of the returned
+    /// messages.
+    pub async fn recv(&mut self) -> Result<Option<T>, SdkError<E>> {
+        let next_chunk = self
+            .body
+            .data()
+            .await
+            .transpose()
+            .map_err(|err| SdkError::DispatchFailure(err))?;
+        if let Some(chunk) = next_chunk {
+            // The SegmentedBuf will automatically purge when it reads off the end of a chunk boundary
+            self.buffer.push(chunk);
+            if let DecodedFrame::Complete(message) = self
+                .decoder
+                .decode_frame(&mut self.buffer)
+                .map_err(|err| SdkError::DispatchFailure(Box::new(err)))?
+            {
+                return Ok(Some(
+                    self.unmarshaller
+                        .unmarshall(message)
+                        .map_err(|err| SdkError::DispatchFailure(Box::new(err)))?,
+                ));
+            }
+        }
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MarshallMessage, Receiver, Sender, UnmarshallMessage};
+    use crate::body::SdkBody;
+    use crate::result::SdkError;
+    use bytes::Bytes;
+    use hyper::body::{Body, HttpBody};
+    use smithy_eventstream::error::Error as EventStreamError;
+    use smithy_eventstream::frame::Message;
+    use std::error::Error as StdError;
+    use std::io::{Error as IOError, ErrorKind};
+
+    fn encode_message(message: &str) -> Bytes {
+        let mut buffer = Vec::new();
+        Message::new(Bytes::copy_from_slice(message.as_bytes()))
+            .write_to(&mut buffer)
+            .unwrap();
+        buffer.into()
+    }
+
+    #[derive(Debug)]
+    struct FakeError;
+    impl std::fmt::Display for FakeError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FakeError")
+        }
+    }
+    impl StdError for FakeError {}
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct UnmarshalledMessage(String);
+
+    struct Marshaller;
+    impl MarshallMessage for Marshaller {
+        type Input = UnmarshalledMessage;
+
+        fn marshall(&self, input: Self::Input) -> Result<Message, EventStreamError> {
+            Ok(Message::new(input.0.as_bytes().to_vec()))
+        }
+    }
+
+    struct Unmarshaller;
+    impl UnmarshallMessage for Unmarshaller {
+        type Output = UnmarshalledMessage;
+
+        fn unmarshall(&self, message: Message) -> Result<Self::Output, EventStreamError> {
+            Ok(UnmarshalledMessage(
+                std::str::from_utf8(&message.payload()[..]).unwrap().into(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn receive_success() {
+        let chunks: Vec<Result<_, IOError>> =
+            vec![Ok(encode_message("one")), Ok(encode_message("two"))];
+        let chunk_stream = futures_util::stream::iter(chunks);
+        let body = SdkBody::from(Body::wrap_stream(chunk_stream));
+        let mut receiver =
+            Receiver::<UnmarshalledMessage, EventStreamError>::new(Unmarshaller, body);
+        assert_eq!(
+            UnmarshalledMessage("one".into()),
+            receiver.recv().await.unwrap().unwrap()
+        );
+        assert_eq!(
+            UnmarshalledMessage("two".into()),
+            receiver.recv().await.unwrap().unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn receive_network_failure() {
+        let chunks: Vec<Result<_, IOError>> = vec![
+            Ok(encode_message("one")),
+            Err(IOError::new(ErrorKind::ConnectionReset, FakeError)),
+        ];
+        let chunk_stream = futures_util::stream::iter(chunks);
+        let body = SdkBody::from(Body::wrap_stream(chunk_stream));
+        let mut receiver =
+            Receiver::<UnmarshalledMessage, EventStreamError>::new(Unmarshaller, body);
+        assert_eq!(
+            UnmarshalledMessage("one".into()),
+            receiver.recv().await.unwrap().unwrap()
+        );
+        assert!(matches!(
+            receiver.recv().await,
+            Err(SdkError::DispatchFailure(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn receive_message_parse_failure() {
+        let chunks: Vec<Result<_, IOError>> = vec![
+            Ok(encode_message("one")),
+            // A zero length message will be invalid. We need to provide a minimum of 12 bytes
+            // for the MessageFrameDecoder to actually start parsing it.
+            Ok(Bytes::from_static(&[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])),
+        ];
+        let chunk_stream = futures_util::stream::iter(chunks);
+        let body = SdkBody::from(Body::wrap_stream(chunk_stream));
+        let mut receiver =
+            Receiver::<UnmarshalledMessage, EventStreamError>::new(Unmarshaller, body);
+        assert_eq!(
+            UnmarshalledMessage("one".into()),
+            receiver.recv().await.unwrap().unwrap()
+        );
+        assert!(matches!(
+            receiver.recv().await,
+            Err(SdkError::DispatchFailure(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_success() {
+        let (http_sender, mut http_body) = hyper::Body::channel();
+        let mut sender =
+            Sender::<UnmarshalledMessage, EventStreamError>::new(Marshaller, http_sender);
+
+        sender
+            .send(UnmarshalledMessage("test".into()))
+            .await
+            .unwrap();
+
+        let mut sent_bytes = http_body.data().await.unwrap().unwrap();
+        let sent = Message::read_from(&mut sent_bytes).unwrap();
+        assert_eq!(&b"test"[..], &sent.payload()[..]);
+    }
+
+    #[tokio::test]
+    async fn send_network_failure() {
+        let (http_sender, http_body) = hyper::Body::channel();
+        let mut sender =
+            Sender::<UnmarshalledMessage, EventStreamError>::new(Marshaller, http_sender);
+
+        drop(http_body);
+        let result = sender.send(UnmarshalledMessage("test".into())).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err().unwrap(),
+            SdkError::DispatchFailure(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn send_construction_failure() {
+        struct BadMarshaller;
+        impl MarshallMessage for BadMarshaller {
+            type Input = UnmarshalledMessage;
+
+            fn marshall(&self, input: Self::Input) -> Result<Message, EventStreamError> {
+                Err(EventStreamError::InvalidMessageLength)
+            }
+        }
+
+        let (http_sender, _http_body) = hyper::Body::channel();
+        let mut sender =
+            Sender::<UnmarshalledMessage, EventStreamError>::new(BadMarshaller, http_sender);
+
+        let result = sender.send(UnmarshalledMessage("test".into())).await;
+        assert!(result.is_err());
+        assert!(matches!(
+            result.err().unwrap(),
+            SdkError::ConstructionFailure(_)
+        ));
+    }
+}

--- a/rust-runtime/smithy-http/src/lib.rs
+++ b/rust-runtime/smithy-http/src/lib.rs
@@ -12,10 +12,14 @@ pub mod header;
 pub mod label;
 pub mod middleware;
 pub mod operation;
-mod pin_util;
 pub mod property_bag;
 pub mod query;
 pub mod response;
 pub mod result;
 pub mod retry;
+
+#[cfg(feature = "event-stream")]
+pub mod event_stream;
+
+mod pin_util;
 mod urlencode;


### PR DESCRIPTION
## Motivation and Context
This is more progress towards the Event Stream protocol implementation (#121). This adds `Sender` and `Receiver` types that will end up on on the generated Input and Output types.

## Testing
- Unit tested

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
