### PR TITLE
Run CI on main explicitly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
 on:
   push:
+    branches: ['main']
     tags:
     - '*'
   pull_request:


### PR DESCRIPTION

## Motivation and Context
at some point our builder that tested the main branch stopped working

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
Test main explicitly. This is what the badge on the README is relying on.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
