### PR TITLE
Attempt to fix CI cache for AWS SDK CI actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -222,6 +222,9 @@ jobs:
       env:
         RUSTC_FORCE_INCREMENTAL: 1
         RUSTFLAGS: -D warnings
+        # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
+        # so we have to manually restore the target directory override
+        CARGO_TARGET_DIR: ../target
 
   test-sdk:
     name: AWS Rust SDK Tier 1 - cargo test
@@ -259,6 +262,9 @@ jobs:
       env:
         RUSTC_FORCE_INCREMENTAL: 1
         RUSTFLAGS: -D warnings
+        # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
+        # so we have to manually restore the target directory override
+        CARGO_TARGET_DIR: ../target
 
   docs-sdk:
     name: AWS Rust SDK Tier 1 - cargo docs
@@ -271,7 +277,10 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargodocs
+        key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-
+          ${{ runner.os }}-${{ env.rust_version }}-
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
@@ -292,6 +301,9 @@ jobs:
       working-directory: aws-sdk
       env:
         RUSTDOCFLAGS: -D warnings
+        # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
+        # so we have to manually restore the target directory override
+        CARGO_TARGET_DIR: ../target
 
   clippy-sdk:
     name: AWS Rust SDK Tier 1 - cargo clippy
@@ -304,7 +316,10 @@ jobs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-cargoclippy
+        key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-
+          ${{ runner.os }}-${{ env.rust_version }}-
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
@@ -323,6 +338,10 @@ jobs:
     - name: Cargo Clippy
       run: cargo clippy -- -D warnings
       working-directory: aws-sdk
+      env:
+        # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
+        # so we have to manually restore the target directory override
+        CARGO_TARGET_DIR: ../target
 
   standalone-integration-tests-check:
     name: AWS Rust SDK Standalone Integration Tests - cargo check


### PR DESCRIPTION
## Motivation and Context
The CI caching is broken for the AWS SDK build steps, which is causing the tests to take ~16 minutes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
