### PR TITLE
Remove redundant check step from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: ['main']
+    branches: [main]
     tags:
     - '*'
   pull_request:
@@ -186,46 +186,6 @@ jobs:
       with:
         name: aws-sdk-${{ env.name }}-tier1-${{ github.sha }}
         path: sdk.tar
-
-  check-sdk:
-    name: AWS Rust SDK Tier 1 - cargo check
-    needs: generate-sdk
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.rust_version }}
-        components: ${{ env.rust_toolchain_components }}
-        default: true
-    - name: Generate a name for the SDK
-      id: gen-name
-      run: echo "name=${GITHUB_REF##*/}" >> $GITHUB_ENV
-    - uses: actions/download-artifact@v2
-      name: Download SDK Artifact
-      with:
-        name: aws-sdk-${{ env.name }}-tier1-${{ github.sha }}
-        path: artifact
-    - name: untar
-      run: mkdir aws-sdk && cd aws-sdk && tar -xvf ../artifact/sdk.tar
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-
-          ${{ runner.os }}-${{ env.rust_version }}-
-    - name: Cargo Check
-      run: cargo check --lib --tests --benches
-      working-directory: aws-sdk
-      env:
-        RUSTC_FORCE_INCREMENTAL: 1
-        RUSTFLAGS: -D warnings
-        # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
-        # so we have to manually restore the target directory override
-        CARGO_TARGET_DIR: ../target
 
   test-sdk:
     name: AWS Rust SDK Tier 1 - cargo test


### PR DESCRIPTION
## Motivation and Context
The `cargo check` CI action is actually already being covered by the `cargo test` action, so we should just remove it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
