### PR TITLE
Remove jcenter / bintray from gradle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ vNext (Month Day, Year)
 - :bug: Fix name collision that occurred when a model had both a union and a structure named `Result` (#643)
 - Add initial implementation of a default provider chain. (#650)
 - Update smithy-client to simplify creating HTTP/HTTPS connectors (#650)
-- Remove Bintray/JCenter source from gradle build. (#xyz)
+- Remove Bintray/JCenter source from gradle build. (#651)
 
 v0.20 (August 10th, 2021)
 --------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ vNext (Month Day, Year)
 - :bug: Fix name collision that occurred when a model had both a union and a structure named `Result` (#643)
 - Add initial implementation of a default provider chain. (#650)
 - Update smithy-client to simplify creating HTTP/HTTPS connectors (#650)
+- Remove Bintray/JCenter source from gradle build. (#xyz)
 
 v0.20 (August 10th, 2021)
 --------------------------

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,6 @@
 buildscript {
     repositories {
         google()
-        jcenter()
     }
 
     val kotlinVersion: String by project
@@ -23,7 +22,6 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
         google()
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,6 @@
 
 pluginManagement {
     repositories {
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
         mavenCentral()
         maven("https://plugins.gradle.org/m2/")
         google()


### PR DESCRIPTION


## Motivation and Context
During gradle builds, if run with --info you can see:
```
Failed to get resource: HEAD. [HTTP HTTP/1.1 403 Forbidden: https://dl.bintray.com/kotlin/kotlin-eap/software/amazon/smithy/smithy-utils/1.11.0/smithy-utils-1.11.0.pom)]
```

This will happen 5-10 times including retries. It adds 20-30 seconds to a local build.

## Description
Our build was referencing the old bintray repositories. This would 403 and make the build much slower as at retried 5 times against the broken URL. This removes those old repos.

## Testing
Ran a clean build

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
