### PR TITLE
Add support for the Smithy Auth trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ vNext (Month Day, Year)
 - Update smithy-client to simplify creating HTTP/HTTPS connectors (#650)
 - Remove Bintray/JCenter source from gradle build. (#651)
 - Add support for the smithy auth trait. This enables authorizations that explicitly disable authorization to work when no credentials have been provided. (#652)
-- :bug: Fix STS Assume Role with WebIdentity & Assume role with SAML to support clients with no credentials provided.
+- :bug: Fix STS Assume Role with WebIdentity & Assume role with SAML to support clients with no credentials provided (#652)
 
 v0.20 (August 10th, 2021)
 --------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ vNext (Month Day, Year)
 - Add initial implementation of a default provider chain. (#650)
 - Update smithy-client to simplify creating HTTP/HTTPS connectors (#650)
 - Remove Bintray/JCenter source from gradle build. (#651)
+- Add support for the smithy auth trait. This enables authorizations that explicitly disable authorization to work when no credentials have been provided. (#652)
+- :bug: Fix STS Assume Role with WebIdentity & Assume role with SAML to support clients with no credentials provided.
 
 v0.20 (August 10th, 2021)
 --------------------------

--- a/aws/rust-runtime/aws-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-auth/src/middleware.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use crate::provider::CredentialsProvider;
+use crate::provider::{CredentialsError, CredentialsProvider};
 use smithy_http::middleware::AsyncMapRequest;
 use smithy_http::operation::Request;
 use std::future::Future;
@@ -23,6 +23,30 @@ pub struct CredentialsStage;
 impl CredentialsStage {
     pub fn new() -> Self {
         CredentialsStage
+    }
+
+    async fn load_creds(mut request: Request) -> Result<Request, CredentialsStageError> {
+        let provider = request.properties().get::<CredentialsProvider>().cloned();
+        let provider = match provider {
+            Some(provider) => provider,
+            None => {
+                tracing::info!("no credentials provider for request");
+                return Ok(request);
+            }
+        };
+        match provider.provide_credentials().await {
+            Ok(creds) => {
+                request.properties_mut().insert(creds);
+            }
+            // ignore the case where there is no provider wired up
+            Err(CredentialsError::CredentialsNotLoaded) => {
+                tracing::info!("provider returned CredentialsNotLoaded, ignoring")
+            }
+            // if we get another error class, there is probably something actually wrong that the user will
+            // want to know about
+            Err(other) => return Err(CredentialsStageError::CredentialsLoadingError(other)),
+        }
+        Ok(request)
     }
 }
 
@@ -70,29 +94,15 @@ impl AsyncMapRequest for CredentialsStage {
     type Error = CredentialsStageError;
     type Future = Pin<Box<dyn Future<Output = Result<Request, Self::Error>> + Send + 'static>>;
 
-    fn apply(&self, mut request: Request) -> BoxFuture<Result<Request, Self::Error>> {
-        Box::pin(async move {
-            let provider = {
-                let properties = request.properties();
-                let credential_provider = properties
-                    .get::<CredentialsProvider>()
-                    .ok_or(CredentialsStageError::MissingCredentialsProvider)?;
-                // we need to enable releasing the config lock so that we don't hold the config
-                // lock across an await point
-                credential_provider.clone()
-            };
-            let cred_future = { provider.provide_credentials() };
-            let credentials = cred_future.await?;
-            request.properties_mut().insert(credentials);
-            Ok(request)
-        })
+    fn apply(&self, request: Request) -> BoxFuture<Result<Request, Self::Error>> {
+        Box::pin(Self::load_creds(request))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::CredentialsStage;
-    use crate::provider::set_provider;
+    use crate::provider::{async_provide_credentials_fn, set_provider, CredentialsError};
     use crate::Credentials;
     use smithy_http::body::SdkBody;
     use smithy_http::middleware::AsyncMapRequest;
@@ -100,12 +110,42 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
-    async fn async_map_request_apply_requires_credential_provider() {
+    async fn no_cred_provider_is_ok() {
         let req = operation::Request::new(http::Request::new(SdkBody::from("some body")));
         CredentialsStage::new()
             .apply(req)
             .await
-            .expect_err("should fail if there's no credential provider in the bag");
+            .expect("no credential provider should not populate credentials");
+    }
+
+    #[tokio::test]
+    async fn provider_failure_is_failure() {
+        let mut req = operation::Request::new(http::Request::new(SdkBody::from("some body")));
+        set_provider(
+            &mut req.properties_mut(),
+            Arc::new(async_provide_credentials_fn(|| async {
+                Err(CredentialsError::Unhandled("whoops".into()))
+            })),
+        );
+        CredentialsStage::new()
+            .apply(req)
+            .await
+            .expect_err("no credential provider should not populate credentials");
+    }
+
+    #[tokio::test]
+    async fn credentials_not_loaded_is_ok() {
+        let mut req = operation::Request::new(http::Request::new(SdkBody::from("some body")));
+        set_provider(
+            &mut req.properties_mut(),
+            Arc::new(async_provide_credentials_fn(|| async {
+                Err(CredentialsError::CredentialsNotLoaded)
+            })),
+        );
+        CredentialsStage::new()
+            .apply(req)
+            .await
+            .expect("credentials not loaded is OK");
     }
 
     #[tokio::test]

--- a/aws/rust-runtime/aws-sig-auth/src/signer.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/signer.rs
@@ -40,10 +40,12 @@ pub enum HttpSignatureType {
 /// Although these fields MAY be customized on a per request basis, they are generally static
 /// for a given operation
 #[derive(Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct OperationSigningConfig {
     pub algorithm: SigningAlgorithm,
     pub signature_type: HttpSignatureType,
     pub signing_options: SigningOptions,
+    pub signing_requirements: SigningRequirements,
 }
 
 impl OperationSigningConfig {
@@ -58,8 +60,23 @@ impl OperationSigningConfig {
                 double_uri_encode: true,
                 content_sha256_header: false,
             },
+            signing_requirements: SigningRequirements::Required,
         }
     }
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum SigningRequirements {
+    /// A signature MAY be added if credentials are defined
+    Optional,
+
+    /// A signature MUST be added.
+    ///
+    /// If no credentials are provided, this will return an error without dispatching the operation.
+    Required,
+
+    /// A signature MUST NOT be added.
+    Disabled,
 }
 
 #[derive(Clone, Eq, PartialEq)]

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rustsdk
 
 import software.amazon.smithy.rust.codegen.smithy.customize.CombinedCodegenDecorator
 import software.amazon.smithy.rustsdk.customize.apigateway.ApiGatewayDecorator
+import software.amazon.smithy.rustsdk.customize.auth.DisabledAuthDecorator
 import software.amazon.smithy.rustsdk.customize.ec2.Ec2Decorator
 import software.amazon.smithy.rustsdk.customize.s3.S3Decorator
 
@@ -23,6 +24,7 @@ val DECORATORS = listOf(
     CrateLicenseDecorator(),
 
     // Service specific decorators
+    DisabledAuthDecorator(),
     ApiGatewayDecorator(),
     S3Decorator(),
     Ec2Decorator()

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -7,9 +7,12 @@ package software.amazon.smithy.rustsdk
 
 import software.amazon.smithy.aws.traits.auth.SigV4Trait
 import software.amazon.smithy.aws.traits.auth.UnsignedPayloadTrait
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.ServiceIndex
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.OptionalAuthTrait
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -55,7 +58,7 @@ class SigV4SigningDecorator : RustCodegenDecorator {
         baseCustomizations: List<OperationCustomization>
     ): List<OperationCustomization> {
         return baseCustomizations.letIf(applies(protocolConfig)) {
-            it + SigV4SigningFeature(operation, protocolConfig.runtimeConfig, protocolConfig.serviceShape)
+            it + SigV4SigningFeature(operation, protocolConfig.runtimeConfig, protocolConfig.serviceShape, protocolConfig.model)
         }
     }
 }
@@ -94,11 +97,14 @@ fun disableDoubleEncode(service: ServiceShape) = when {
 class SigV4SigningFeature(
     private val operation: OperationShape,
     runtimeConfig: RuntimeConfig,
-    private val service: ServiceShape
+    private val service: ServiceShape,
+    model: Model
 ) :
     OperationCustomization() {
     private val codegenScope =
         arrayOf("sig_auth" to runtimeConfig.sigAuth().asType(), "aws_types" to awsTypes(runtimeConfig).asType())
+
+    private val serviceIndex = ServiceIndex.of(model)
 
     override fun section(section: OperationSection): Writable {
         return when (section) {
@@ -122,6 +128,15 @@ class SigV4SigningFeature(
                         "${section.request}.properties_mut().insert(#{sig_auth}::signer::SignableBody::UnsignedPayload);",
                         *codegenScope
                     )
+                }
+                // some operations are either unsigned or optionally signed:
+                val authSchemes = serviceIndex.getEffectiveAuthSchemes(service, operation)
+                if (!authSchemes.containsKey(SigV4Trait.ID)) {
+                    rustTemplate("signing_config.signing_requirements = #{sig_auth}::signer::SigningRequirements::Disabled;", *codegenScope)
+                } else {
+                    if (operation.hasTrait<OptionalAuthTrait>()) {
+                        rustTemplate("signing_config.signing_requirements = #{sig_auth}::signer::SigningRequirements::Optional;", *codegenScope)
+                    }
                 }
                 rustTemplate(
                     """

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/auth/DisabledAuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/auth/DisabledAuthDecorator.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rustsdk.customize.auth
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.AuthTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+
+private fun String.shapeId() = ShapeId.from(this)
+// / STS (and possibly other services) need to have auth manually set to []
+class DisabledAuthDecorator : RustCodegenDecorator {
+    override val name: String = "OptionalAuth"
+    override val order: Byte = 0
+
+    private val optionalAuth =
+        mapOf(
+            "com.amazonaws.sts#AWSSecurityTokenServiceV20110615".shapeId() to
+                setOf(
+                    "com.amazonaws.sts#AssumeRoleWithSAML".shapeId(),
+                    "com.amazonaws.sts#AssumeRoleWithWebIdentity".shapeId()
+                )
+        )
+
+    private fun applies(service: ServiceShape) =
+        optionalAuth.containsKey(service.id)
+
+    override fun transformModel(service: ServiceShape, model: Model): Model {
+        if (!applies(service)) {
+            return model
+        }
+        val optionalOperations = optionalAuth[service.id]!!
+        return ModelTransformer.create().mapShapes(model) {
+            if (optionalOperations.contains(it.id) && it is OperationShape) {
+                it.toBuilder().addTrait(AuthTrait(listOf())).build()
+            } else {
+                it
+            }
+        }
+    }
+}

--- a/aws/sdk/integration-tests/Cargo.toml
+++ b/aws/sdk/integration-tests/Cargo.toml
@@ -7,4 +7,5 @@ members = [
     "kms",
     "qldbsession",
     "s3",
+    "sts"
 ]

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -1,0 +1,18 @@
+# This Cargo.toml is unused in generated code. It exists solely to enable these tests to compile in-situ
+[package]
+name = "sts-tests"
+version = "0.1.0"
+authors = ["Russell Cohen <rcoh@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-sdk-sts = { path = "../../build/aws-sdk/sts" }
+smithy-client = { path = "../../build/aws-sdk/smithy-client", features = ["test-util"] }
+smithy-http = { path = "../../build/aws-sdk/smithy-http" }
+tracing-subscriber = "0.2"
+
+[dev-dependencies]
+tokio  = { version = "1", features = ["full"]}
+aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}

--- a/aws/sdk/integration-tests/sts/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/sts/tests/signing-it.rs
@@ -5,7 +5,6 @@
 
 use aws_sdk_sts::{Credentials, Region};
 use smithy_client::test_connection::capture_request;
-use std::time::Duration;
 
 #[tokio::test]
 async fn assume_role_signed() {

--- a/aws/sdk/integration-tests/sts/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/sts/tests/signing-it.rs
@@ -1,0 +1,80 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_sdk_sts::{Credentials, Region};
+use smithy_client::test_connection::capture_request;
+use std::time::Duration;
+
+#[tokio::test]
+async fn assume_role_signed() {
+    let creds = Credentials::from_keys(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+    );
+    let conf = aws_sdk_sts::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let (server, request) = capture_request(None);
+    let client = aws_sdk_sts::Client::from_conf_conn(conf, server);
+    let _ = client.assume_role().send().await;
+    // assume role should have an auth header
+    assert_ne!(
+        request.expect_request().headers().get("AUTHORIZATION"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn web_identity_unsigned() {
+    let creds = Credentials::from_keys(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+    );
+    let conf = aws_sdk_sts::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let (server, request) = capture_request(None);
+    let client = aws_sdk_sts::Client::from_conf_conn(conf, server);
+    let _ = client.assume_role_with_web_identity().send().await;
+    // web identity should be unsigned
+    assert_eq!(
+        request.expect_request().headers().get("AUTHORIZATION"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn assume_role_saml_unsigned() {
+    let conf = aws_sdk_sts::Config::builder()
+        .region(Region::new("us-east-1"))
+        .build();
+    let (server, request) = capture_request(None);
+    let client = aws_sdk_sts::Client::from_conf_conn(conf, server);
+    let resp = client.assume_role_with_saml().send().await;
+    // web identity should be unsigned
+    assert_eq!(
+        request.expect_request().headers().get("AUTHORIZATION"),
+        None
+    );
+}
+
+#[tokio::test]
+async fn web_identity_no_creds() {
+    let conf = aws_sdk_sts::Config::builder()
+        .region(Region::new("us-east-1"))
+        .build();
+    let (server, request) = capture_request(None);
+    let client = aws_sdk_sts::Client::from_conf_conn(conf, server);
+    let _ = client.assume_role_with_web_identity().send().await;
+    // web identity should be unsigned and work without credentials
+    assert_eq!(
+        request.expect_request().headers().get("AUTHORIZATION"),
+        None
+    );
+}

--- a/aws/sdk/integration-tests/sts/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/sts/tests/signing-it.rs
@@ -55,7 +55,7 @@ async fn assume_role_saml_unsigned() {
         .build();
     let (server, request) = capture_request(None);
     let client = aws_sdk_sts::Client::from_conf_conn(conf, server);
-    let resp = client.assume_role_with_saml().send().await;
+    let _ = client.assume_role_with_saml().send().await;
     // web identity should be unsigned
     assert_eq!(
         request.expect_request().headers().get("AUTHORIZATION"),


### PR DESCRIPTION
## Motivation and Context
Web Identity Token providers require making a credential-free request to STS. To support this and to resolve aws-sdk-rust#161, we need to handle the auth trait.

## Description
Some services have explicitly disabled authentication. This adds two things:
1. Customization to remove auth schemes for 2 STS operations
2. Add codegen support for the OptionalAuth and Auth trait to code generation
3. A "capture request" test connection to make it easy to test that a single request/response was produced

CredentialsStage now will pass through unset credentials and the signer will check the signing trait.

A future enhancement may remove the signing middleware entirely.

## Testing
- Integration test of STS
- Manual verification that the STS requests work as expected.

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
