### PR TITLE
fix sigv4 tests to work on httparse 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ vNext (Month Day, Year)
 - Remove Bintray/JCenter source from gradle build. (#651)
 - Add support for the smithy auth trait. This enables authorizations that explicitly disable authorization to work when no credentials have been provided. (#652)
 - :bug: Fix STS Assume Role with WebIdentity & Assume role with SAML to support clients with no credentials provided (#652)
+- (internal): Update sigv4 tests to work around behavior change in httparse 1.5. (#656)
 
 v0.20 (August 10th, 2021)
 --------------------------

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -25,4 +25,4 @@ smithy-eventstream = { path = "../../../rust-runtime/smithy-eventstream", option
 [dev-dependencies]
 bytes = "1"
 pretty_assertions = "0.6"
-httparse = "1"
+httparse = "1.5"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
@@ -555,9 +555,11 @@ mod tests {
 
     fn parse_request(s: &[u8]) -> Result<Request<bytes::Bytes>, Error> {
         let mut headers = [httparse::EMPTY_HEADER; 64];
+        // httparse 1.5 requres two trailing newlines to head the header section.
+        let mut with_newline = Vec::from(s);
+        with_newline.push(b'\n');
         let mut req = httparse::Request::new(&mut headers);
-        let _ = req.parse(s).unwrap();
-        let _ = req.parse(b"\n");
+        let _ = req.parse(&with_newline).unwrap();
 
         let version = match req.version.unwrap() {
             1 => Version::HTTP_11,

--- a/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
@@ -557,6 +557,7 @@ mod tests {
         let mut headers = [httparse::EMPTY_HEADER; 64];
         let mut req = httparse::Request::new(&mut headers);
         let _ = req.parse(s).unwrap();
+        let _ = req.parse(b"\n");
 
         let version = match req.version.unwrap() {
             1 => Version::HTTP_11,


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
httparse 1.5 has a small behavior change: https://github.com/seanmonstar/httparse/issues/102 which
changes the parsing behavior of headers when the request is not terminated with a second newline.

Although 1.5 may eventually fix this issue, this works around the build failure by inserting an additional
newline into the parser prior to parsing the test requests.

## Description
Add an additional newline to the parser so that headers are extracted.

## Testing
- Ran unit tests
- Manually verified that dynamodb works with httparse 1.5

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
