### PR TITLE
Improve documentation on collection builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ vNext (Month Day, Year)
 
 - (When complete) Add Event Stream support (#653, #xyz)
 - (When complete) Add profile file provider for region (#594, #xyz)
+- Improve documentation on collection-aware builders (#TODO)
 
 
 v0.21 (August 19th, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ vNext (Month Day, Year)
 
 - (When complete) Add Event Stream support (#653, #xyz)
 - (When complete) Add profile file provider for region (#594, #xyz)
-- Improve documentation on collection-aware builders (#TODO)
+- Improve documentation on collection-aware builders (#664)
 
 
 v0.21 (August 19th, 2021)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.generators
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.docs
+import software.amazon.smithy.rust.codegen.rustlang.documentShape
+import software.amazon.smithy.rust.codegen.rustlang.render
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+
+class FluentClientCore(private val model: Model) {
+    fun RustWriter.renderVecHelper(member: MemberShape, memberName: String, coreType: RustType.Vec) {
+        docs("Appends an item to `${member.memberName}.`")
+        rust("///")
+        docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        documentShape(member, model)
+        rustBlock("pub fn $memberName(mut self, inp: impl Into<${coreType.member.render(true)}>) -> Self") {
+            rust(
+                """
+                self.inner = self.inner.$memberName(inp);
+                self
+            """
+            )
+        }
+    }
+
+    fun RustWriter.renderMapHelper(member: MemberShape, memberName: String, coreType: RustType.HashMap) {
+        docs("Adds a key-value pair to `${member.memberName}.`")
+        rust("///")
+        docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        documentShape(member, model)
+        val k = coreType.key
+        val v = coreType.member
+
+        rustBlock("pub fn $memberName(mut self, k: impl Into<${k.render()}>, v: impl Into<${v.render()}>) -> Self") {
+            rust(
+                """
+                self.inner = self.inner.$memberName(k, v);
+                self
+            """
+            )
+        }
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -17,7 +17,7 @@ import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 
 class FluentClientCore(private val model: Model) {
     fun RustWriter.renderVecHelper(member: MemberShape, memberName: String, coreType: RustType.Vec) {
-        docs("Appends an item to `${member.memberName}.`")
+        docs("Appends an item to `${member.memberName}`.")
         rust("///")
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         documentShape(member, model)
@@ -32,7 +32,7 @@ class FluentClientCore(private val model: Model) {
     }
 
     fun RustWriter.renderMapHelper(member: MemberShape, memberName: String, coreType: RustType.HashMap) {
-        docs("Adds a key-value pair to `${member.memberName}.`")
+        docs("Adds a key-value pair to `${member.memberName}`.")
         rust("///")
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         documentShape(member, model)


### PR DESCRIPTION
## Motivation and Context
Generated builders include "magic" collection methods that will append to the builder. However, the generated names of these methods are confusing because they are often pluralized.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
To alleviate this, this diff will generate doc hints on these methods to clarify their behavior.

<img width="750" alt="Screen Shot 2021-08-23 at 9 46 05 AM" src="https://user-images.githubusercontent.com/492903/130459433-62529a0f-36b6-454c-9dfe-0cc174ff93dd.png">
<img width="841" alt="Screen Shot 2021-08-23 at 9 45 33 AM" src="https://user-images.githubusercontent.com/492903/130459441-c4bb1723-11a3-4482-b56a-e408e0966af3.png">

<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
