### PR TITLE
Add full Event Stream marshalling support and working S3 example

### DIFF
--- a/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
@@ -5,12 +5,12 @@
 
 use crate::middleware::Signature;
 use aws_auth::Credentials;
-use aws_sigv4::event_stream::sign_message;
+use aws_sigv4::event_stream::{sign_empty_message, sign_message};
 use aws_sigv4::SigningParams;
 use aws_types::region::SigningRegion;
 use aws_types::SigningService;
 use smithy_eventstream::frame::{Message, SignMessage, SignMessageError};
-use smithy_http::property_bag::SharedPropertyBag;
+use smithy_http::property_bag::{PropertyBag, SharedPropertyBag};
 use std::time::SystemTime;
 
 /// Event Stream SigV4 signing implementation.
@@ -27,6 +27,27 @@ impl SigV4Signer {
             last_signature: None,
         }
     }
+
+    fn signing_params(properties: &PropertyBag) -> SigningParams<()> {
+        // Every single one of these values would have been retrieved during the initial request,
+        // so we can safely assume they all exist in the property bag at this point.
+        let credentials = properties.get::<Credentials>().unwrap();
+        let region = properties.get::<SigningRegion>().unwrap();
+        let signing_service = properties.get::<SigningService>().unwrap();
+        let time = properties
+            .get::<SystemTime>()
+            .copied()
+            .unwrap_or_else(SystemTime::now);
+        SigningParams {
+            access_key: credentials.access_key_id(),
+            secret_key: credentials.secret_access_key(),
+            security_token: credentials.session_token(),
+            region: region.as_ref(),
+            service_name: signing_service.as_ref(),
+            date_time: time.into(),
+            settings: (),
+        }
+    }
 }
 
 impl SignMessage for SigV4Signer {
@@ -37,29 +58,25 @@ impl SignMessage for SigV4Signer {
             self.last_signature = Some(properties.get::<Signature>().unwrap().as_ref().into())
         }
 
-        // Every single one of these values would have been retrieved during the initial request,
-        // so we can safely assume they all exist in the property bag at this point.
-        let credentials = properties.get::<Credentials>().unwrap();
-        let region = properties.get::<SigningRegion>().unwrap();
-        let signing_service = properties.get::<SigningService>().unwrap();
-        let time = properties
-            .get::<SystemTime>()
-            .copied()
-            .unwrap_or_else(SystemTime::now);
-        let params = SigningParams {
-            access_key: credentials.access_key_id(),
-            secret_key: credentials.secret_access_key(),
-            security_token: credentials.session_token(),
-            region: region.as_ref(),
-            service_name: signing_service.as_ref(),
-            date_time: time.into(),
-            settings: (),
+        let (signed_message, signature) = {
+            let params = Self::signing_params(&properties);
+            sign_message(&message, self.last_signature.as_ref().unwrap(), &params).into_parts()
         };
-
-        let (signed_message, signature) =
-            sign_message(&message, self.last_signature.as_ref().unwrap(), &params).into_parts();
         self.last_signature = Some(signature);
+        Ok(signed_message)
+    }
 
+    fn sign_empty(&mut self) -> Result<Message, SignMessageError> {
+        let properties = self.properties.acquire();
+        if self.last_signature.is_none() {
+            // The Signature property should exist in the property bag for all Event Stream requests.
+            self.last_signature = Some(properties.get::<Signature>().unwrap().as_ref().into())
+        }
+        let (signed_message, signature) = {
+            let params = Self::signing_params(&properties);
+            sign_empty_message(self.last_signature.as_ref().unwrap(), &params).into_parts()
+        };
+        self.last_signature = Some(signature);
         Ok(signed_message)
     }
 }
@@ -73,7 +90,7 @@ mod tests {
     use aws_types::region::SigningRegion;
     use aws_types::SigningService;
     use smithy_eventstream::frame::{HeaderValue, Message, SignMessage};
-    use smithy_http::property_bag::SharedPropertyBag;
+    use smithy_http::property_bag::PropertyBag;
     use std::time::{Duration, UNIX_EPOCH};
 
     #[test]

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -9,10 +9,11 @@ description = "AWS SigV4 signer"
 
 [features]
 sign-http = ["http", "http-body", "percent-encoding", "form_urlencoded"]
-sign-eventstream = ["smithy-eventstream"]
+sign-eventstream = ["smithy-eventstream", "bytes"]
 default = ["sign-http"]
 
 [dependencies]
+bytes = { version = "1", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 form_urlencoded = { version = "1.0", optional = true }
 hex = "0.4"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -88,8 +88,8 @@ class SigV4SigningConfig(
             runtimeConfig.awsRuntimeDependency("aws-sig-auth", setOf("sign-eventstream")),
             "aws_sig_auth::event_stream"
         ),
-        "PropertyBag" to RuntimeType(
-            "PropertyBag",
+        "SharedPropertyBag" to RuntimeType(
+            "SharedPropertyBag",
             CargoDependency.SmithyHttp(runtimeConfig),
             "smithy_http::property_bag"
         )
@@ -116,7 +116,7 @@ class SigV4SigningConfig(
                         /// Creates a new Event Stream `SignMessage` implementor.
                         pub fn new_event_stream_signer(
                             &self,
-                            properties: std::sync::Arc<std::sync::Mutex<#{PropertyBag}>>
+                            properties: #{SharedPropertyBag}
                         ) -> #{SigV4Signer} {
                             #{SigV4Signer}::new(properties)
                         }

--- a/aws/sdk/README.md
+++ b/aws/sdk/README.md
@@ -28,4 +28,4 @@ You can use gradle properties to opt/out of generating specific services:
 The generation logic is as follows:
 1. If `aws.services` is specified, generate an SDK based on the inclusion/exclusion list.
 2. Otherwise, if `aws.fullsdk` is specified generate an SDK based on `aws.services.fullsdk`.
-3. Otherwise, generate an SDK based on `aws.services.tier1`
+3. Otherwise, generate an SDK based on `aws.services.group1`

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -235,7 +235,7 @@ task("generateSmithyBuild") {
         projectDir.resolve("smithy-build.json").writeText(generateSmithyBuild(awsServices))
     }
     inputs.property("servicelist", awsServices.sortedBy { it.module }.toString())
-    // TODO(EventStream): Remove this when removing SMITHYRS_EXPERIMENTAL_EVENTSTREAM
+    // TODO(EventStream): [CLEANUP] Remove this when removing SMITHYRS_EXPERIMENTAL_EVENTSTREAM
     inputs.property("_eventStreamCacheInvalidation", System.getenv("SMITHYRS_EXPERIMENTAL_EVENTSTREAM") ?: "0")
     inputs.dir(projectDir.resolve("aws-models"))
     outputs.file(projectDir.resolve("smithy-build.json"))

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -117,12 +117,13 @@ data class AwsService(
 }
 
 val awsServices: List<AwsService> by lazy { discoverServices() }
+val eventStreamAllowList: Set<String> by lazy { eventStreamAllowList() }
 
 fun loadServiceMembership(): Membership {
     val membershipOverride = getProperty("aws.services")?.let { parseMembership(it) }
     println(membershipOverride)
     val fullSdk = parseMembership(getProperty("aws.services.fullsdk") ?: throw kotlin.Exception("never list missing"))
-    val tier1 = parseMembership(getProperty("aws.services.tier1") ?: throw kotlin.Exception("tier1 list missing"))
+    val tier1 = parseMembership(getProperty("aws.services.group1") ?: throw kotlin.Exception("group1 list missing"))
     return membershipOverride ?: if ((getProperty("aws.fullsdk") ?: "") == "true") {
         fullSdk
     } else {
@@ -188,6 +189,11 @@ fun discoverServices(): List<AwsService> {
     }
 }
 
+fun eventStreamAllowList(): Set<String> {
+    val list = getProperty("aws.services.eventstream.allowlist") ?: ""
+    return list.split(",").map { it.trim() }.toSet()
+}
+
 fun generateSmithyBuild(tests: List<AwsService>): String {
     val projections = tests.joinToString(",\n") {
         val files = it.files().map { extraFile ->
@@ -196,27 +202,29 @@ fun generateSmithyBuild(tests: List<AwsService>): String {
                 ""
             )
         }
+        val eventStreamAllowListMembers = eventStreamAllowList.joinToString(", ") { "\"$it\"" }
         """
             "${it.module}": {
                 "imports": [${files.joinToString()}],
 
                 "plugins": {
                     "rust-codegen": {
-                      "runtimeConfig": {
-                        "relativePath": "../"
-                      },
-                      "codegen": {
-                        "includeFluentClient": false,
-                        "renameErrors": false
-                      },
-                      "service": "${it.service}",
-                      "module": "aws-sdk-${it.module}",
-                      "moduleVersion": "${getProperty("aws.sdk.version")}",
-                      "moduleAuthors": ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"],
-                      "license": "Apache-2.0"
-                      ${it.extraConfig ?: ""}
-                 }
-               }
+                        "runtimeConfig": {
+                            "relativePath": "../"
+                        },
+                        "codegen": {
+                            "includeFluentClient": false,
+                            "renameErrors": false,
+                            "eventStreamAllowList": [$eventStreamAllowListMembers]
+                        },
+                        "service": "${it.service}",
+                        "module": "aws-sdk-${it.module}",
+                        "moduleVersion": "${getProperty("aws.sdk.version")}",
+                        "moduleAuthors": ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"],
+                        "license": "Apache-2.0"
+                        ${it.extraConfig ?: ""}
+                    }
+                }
             }
         """.trimIndent()
     }
@@ -231,14 +239,14 @@ fun generateSmithyBuild(tests: List<AwsService>): String {
 
 task("generateSmithyBuild") {
     description = "generate smithy-build.json"
+    inputs.property("servicelist", awsServices.sortedBy { it.module }.toString())
+    inputs.property("eventStreamAllowList", eventStreamAllowList)
+    inputs.dir(projectDir.resolve("aws-models"))
+    outputs.file(projectDir.resolve("smithy-build.json"))
+
     doFirst {
         projectDir.resolve("smithy-build.json").writeText(generateSmithyBuild(awsServices))
     }
-    inputs.property("servicelist", awsServices.sortedBy { it.module }.toString())
-    // TODO(EventStream): [CLEANUP] Remove this when removing SMITHYRS_EXPERIMENTAL_EVENTSTREAM
-    inputs.property("_eventStreamCacheInvalidation", System.getenv("SMITHYRS_EXPERIMENTAL_EVENTSTREAM") ?: "0")
-    inputs.dir(projectDir.resolve("aws-models"))
-    outputs.file(projectDir.resolve("smithy-build.json"))
 }
 
 task("relocateServices") {

--- a/aws/sdk/examples/s3/src/bin/select-object-content.rs
+++ b/aws/sdk/examples/s3/src/bin/select-object-content.rs
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_auth_providers::DefaultProviderChain;
+use aws_sdk_s3::model::{
+    CompressionType, CsvInput, CsvOutput, ExpressionType, FileHeaderInfo, InputSerialization,
+    OutputSerialization, SelectObjectContentEventStream,
+};
+use aws_sdk_s3::{Client, Config, Error, Region, PKG_VERSION};
+use aws_types::region::{default_provider, ProvideRegion};
+
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// The bucket name to select from.
+    #[structopt(short, long)]
+    bucket: String,
+
+    /// The object key to scan. This example expects the object to be an uncompressed CSV file with:
+    /// ```csv
+    /// Name,PhoneNumber,City,Occupation
+    /// Sam,(949) 555-6701,Irvine,Solutions Architect
+    /// Vinod,(949) 555-6702,Los Angeles,Solutions Architect
+    /// Jeff,(949) 555-6703,Seattle,AWS Evangelist
+    /// Jane,(949) 555-6704,Chicago,Developer
+    /// Sean,(949) 555-6705,Chicago,Developer
+    /// Mary,(949) 555-6706,Chicago,Developer
+    /// Kate,(949) 555-6707,Chicago,Developer
+    /// ```
+    #[structopt(short, long)]
+    object: String,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+
+    let Opt {
+        region,
+        bucket,
+        object,
+        verbose,
+    } = Opt::from_args();
+
+    let region = region::ChainProvider::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-east-2"));
+
+    println!();
+
+    if verbose {
+        println!("S3 client version: {}", PKG_VERSION);
+        println!(
+            "Region:            {}",
+            region.region().await.unwrap().as_ref()
+        );
+        println!();
+    }
+
+    let credential_provider = DefaultProviderChain::builder()
+        .region(region.clone())
+        .build();
+
+    let config = Config::builder()
+        .region(region)
+        .credentials_provider(credential_provider)
+        .build();
+
+    let client = Client::from_conf(config);
+
+    let mut output = client
+        .select_object_content()
+        .bucket(bucket)
+        .key(object)
+        .expression_type(ExpressionType::Sql)
+        .expression("SELECT * FROM s3object s WHERE s.\"Name\" = 'Jane'")
+        .input_serialization(
+            InputSerialization::builder()
+                .csv(
+                    CsvInput::builder()
+                        .file_header_info(FileHeaderInfo::Use)
+                        .build(),
+                )
+                .compression_type(CompressionType::None)
+                .build(),
+        )
+        .output_serialization(
+            OutputSerialization::builder()
+                .csv(CsvOutput::builder().build())
+                .build(),
+        )
+        .send()
+        .await?;
+
+    loop {
+        match output.payload.recv().await {
+            Ok(None) => break,
+            Ok(Some(event)) => match event {
+                SelectObjectContentEventStream::Records(records) => {
+                    println!(
+                        "Record: {}",
+                        records
+                            .payload
+                            .as_ref()
+                            .map(|p| std::str::from_utf8(p.as_ref()).unwrap())
+                            .unwrap_or("")
+                    );
+                }
+                SelectObjectContentEventStream::Stats(stats) => {
+                    println!("Stats: {:?}", stats.details.unwrap());
+                }
+                SelectObjectContentEventStream::Progress(progress) => {
+                    println!("Progress: {:?}", progress.details.unwrap());
+                }
+                SelectObjectContentEventStream::Cont(_) => {
+                    println!("Continuation Event");
+                }
+                SelectObjectContentEventStream::End(_) => {
+                    println!("End Event");
+                }
+                otherwise => panic!("Unknown event type: {:?}", otherwise),
+            },
+            Err(err) => println!("Received error: {:?}", err),
+        }
+    }
+
+    Ok(())
+}

--- a/aws/sdk/examples/s3/src/bin/select-object-content.rs
+++ b/aws/sdk/examples/s3/src/bin/select-object-content.rs
@@ -103,35 +103,31 @@ async fn main() -> Result<(), Error> {
         .send()
         .await?;
 
-    loop {
-        match output.payload.recv().await {
-            Ok(None) => break,
-            Ok(Some(event)) => match event {
-                SelectObjectContentEventStream::Records(records) => {
-                    println!(
-                        "Record: {}",
-                        records
-                            .payload
-                            .as_ref()
-                            .map(|p| std::str::from_utf8(p.as_ref()).unwrap())
-                            .unwrap_or("")
-                    );
-                }
-                SelectObjectContentEventStream::Stats(stats) => {
-                    println!("Stats: {:?}", stats.details.unwrap());
-                }
-                SelectObjectContentEventStream::Progress(progress) => {
-                    println!("Progress: {:?}", progress.details.unwrap());
-                }
-                SelectObjectContentEventStream::Cont(_) => {
-                    println!("Continuation Event");
-                }
-                SelectObjectContentEventStream::End(_) => {
-                    println!("End Event");
-                }
-                otherwise => panic!("Unknown event type: {:?}", otherwise),
-            },
-            Err(err) => println!("Received error: {:?}", err),
+    while Some(event) = output.payload.recv().await? {
+        match event {
+            SelectObjectContentEventStream::Records(records) => {
+                println!(
+                    "Record: {}",
+                    records
+                        .payload
+                        .as_ref()
+                        .map(|p| std::str::from_utf8(p.as_ref()).unwrap())
+                        .unwrap_or("")
+                );
+            }
+            SelectObjectContentEventStream::Stats(stats) => {
+                println!("Stats: {:?}", stats.details.unwrap());
+            }
+            SelectObjectContentEventStream::Progress(progress) => {
+                println!("Progress: {:?}", progress.details.unwrap());
+            }
+            SelectObjectContentEventStream::Cont(_) => {
+                println!("Continuation Event");
+            }
+            SelectObjectContentEventStream::End(_) => {
+                println!("End Event");
+            }
+            otherwise => panic!("Unknown event type: {:?}", otherwise),
         }
     }
 

--- a/aws/sdk/examples/transcribestreaming/src/main.rs
+++ b/aws/sdk/examples/transcribestreaming/src/main.rs
@@ -4,18 +4,29 @@
  */
 
 use async_stream::stream;
+use aws_auth_providers::DefaultProviderChain;
 use aws_sdk_transcribestreaming::model::{
     AudioEvent, AudioStream, LanguageCode, MediaEncoding, TranscriptResultStream,
 };
-use aws_sdk_transcribestreaming::{Blob, Client, Config, Region};
+use aws_sdk_transcribestreaming::{Blob, Client, Config, Error, Region};
 use bytes::BufMut;
 use std::time::Duration;
 
 const CHUNK_SIZE: usize = 8192;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
+
+    let region = Region::from_static("us-west-2");
+    let credential_provider = DefaultProviderChain::builder()
+        .region(region.clone())
+        .build();
+    let config = Config::builder()
+        .region(region)
+        .credentials_provider(credential_provider)
+        .build();
+    let client = Client::from_conf(config);
 
     let input_stream = stream! {
         let pcm = pcm_data();
@@ -24,14 +35,7 @@ async fn main() {
             tokio::time::sleep(Duration::from_millis(100)).await;
             yield Ok(AudioStream::AudioEvent(AudioEvent::builder().audio_chunk(Blob::new(chunk)).build()));
         }
-        // Must send an empty chunk at the end
-        yield Ok(AudioStream::AudioEvent(AudioEvent::builder().audio_chunk(Blob::new(Vec::new())).build()));
     };
-
-    let config = Config::builder()
-        .region(Region::from_static("us-west-2"))
-        .build();
-    let client = Client::from_conf(config);
 
     let mut output = client
         .start_stream_transcription()
@@ -40,33 +44,30 @@ async fn main() {
         .media_encoding(MediaEncoding::Pcm)
         .audio_stream(input_stream.into())
         .send()
-        .await
-        .unwrap();
+        .await?;
 
     let mut full_message = String::new();
-    loop {
-        match output.transcript_result_stream.recv().await {
-            Ok(Some(transcription)) => match transcription {
-                TranscriptResultStream::TranscriptEvent(event) => {
-                    let transcript = event.transcript.unwrap();
-                    for result in transcript.results.unwrap_or_else(|| Vec::new()) {
-                        if result.is_partial {
-                            println!("Partial: {:?}", result);
-                        } else {
-                            let first_alternative = &result.alternatives.as_ref().unwrap()[0];
-                            full_message += first_alternative.transcript.as_ref().unwrap();
-                            full_message.push('\n');
-                        }
+    while let Some(event) = output.transcript_result_stream.recv().await? {
+        match event {
+            TranscriptResultStream::TranscriptEvent(transcript_event) => {
+                let transcript = transcript_event.transcript.unwrap();
+                for result in transcript.results.unwrap_or_else(|| Vec::new()) {
+                    if result.is_partial {
+                        println!("Partial: {:?}", result);
+                    } else {
+                        let first_alternative = &result.alternatives.as_ref().unwrap()[0];
+                        full_message += first_alternative.transcript.as_ref().unwrap();
+                        full_message.push('\n');
                     }
                 }
-                otherwise => panic!("received unexpected event type: {:?}", otherwise),
-            },
-            Ok(None) => break,
-            Err(err) => println!("Received an error: {:?}", err),
+            }
+            otherwise => panic!("received unexpected event type: {:?}", otherwise),
         }
     }
     println!("\nFully transcribed message:\n\n{}", full_message);
-    println!("Done.")
+    println!("Done.");
+
+    Ok(())
 }
 
 fn pcm_data() -> Vec<u8> {

--- a/aws/sdk/gradle.properties
+++ b/aws/sdk/gradle.properties
@@ -37,4 +37,5 @@ aws.services.group1=\
 
 # List of services to generate Event Stream operations for:
 aws.services.eventstream.allowlist=\
-    aws-sdk-transcribestreaming
+    aws-sdk-transcribestreaming,\
+    aws-sdk-s3

--- a/aws/sdk/gradle.properties
+++ b/aws/sdk/gradle.properties
@@ -14,50 +14,27 @@ aws.sdk.version=0.0.16-alpha
 # timestream requires endpoint discovery: https://github.com/awslabs/aws-sdk-rust/issues/114
 aws.services.fullsdk=-transcribestreaming,-glacier,-timestreamwrite,-timestreamquery
 
-# Generate an entire sdk vs. aws.services.tier1
+# Generate an entire sdk vs. aws.services.group1
 aws.fullsdk=false
 
-# base set of services that are generated unless other options are specified:
-aws.services.tier1=+apigateway,\
-    +applicationautoscaling,\
-    +autoscaling,\
-    +autoscalingplans,\
-    +batch,\
-    +cloudformation,\
-    +cloudwatch,\
-    +cloudwatch,\
-    +cloudwatchlogs,\
-    +cognitoidentity,\
-    +cognitoidentityprovider,\
-    +cognitosync,\
+# Below is a base set of services that are generated unless other options are specified.
+# These are carefully selected to exercise every Smithy protocol.
+#  - @awsJson1_0: dynamodb
+#  - @awsJson1_1: config
+#  - @awsQuery: sts
+#  - @ec2Query: ec2
+#  - @restJson1: polly
+#  - @restXml: s3
+#  - Allow-listed Event Stream: transcribestreaming
+aws.services.group1=\
     +config,\
     +dynamodb,\
-    +ebs,\
     +ec2,\
-    +ecr,\
-    +ecs,\
-    +eks,\
-    +iam,\
-    +kinesis,\
-    +kms,\
-    +lambda,\
-    +medialive,\
-    +mediapackage,\
     +polly,\
-    +qldb,\
-    +qldbsession,\
-    +rds,\
-    +rdsdata,\
-    +route53,\
     +s3,\
-    +sagemaker,\
-    +sagemakera2iruntime,\
-    +sagemakeredge,\
-    +sagemakerfeaturestoreruntime,\
-    +secretsmanager,\
-    +sesv2,\
-    +snowball,\
-    +sns,\
-    +sqs,\
-    +ssm,\
-    +sts
+    +sts,\
+    +transcribestreaming
+
+# List of services to generate Event Stream operations for:
+aws.services.eventstream.allowlist=\
+    aws-sdk-transcribestreaming

--- a/codegen-test/build.gradle.kts
+++ b/codegen-test/build.gradle.kts
@@ -100,16 +100,12 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
     """
 }
 
-
 task("generateSmithyBuild") {
     description = "generate smithy-build.json"
     doFirst {
         projectDir.resolve("smithy-build.json").writeText(generateSmithyBuild(CodegenTests))
     }
-    // TODO(EventStream): [CLEANUP] Remove this when removing SMITHYRS_EXPERIMENTAL_EVENTSTREAM
-    inputs.property("_eventStreamCacheInvalidation", System.getenv("SMITHYRS_EXPERIMENTAL_EVENTSTREAM") ?: "0")
 }
-
 
 fun generateCargoWorkspace(tests: List<CodegenTest>): String {
     return """

--- a/codegen-test/build.gradle.kts
+++ b/codegen-test/build.gradle.kts
@@ -106,7 +106,7 @@ task("generateSmithyBuild") {
     doFirst {
         projectDir.resolve("smithy-build.json").writeText(generateSmithyBuild(CodegenTests))
     }
-    // TODO(EventStream): Remove this when removing SMITHYRS_EXPERIMENTAL_EVENTSTREAM
+    // TODO(EventStream): [CLEANUP] Remove this when removing SMITHYRS_EXPERIMENTAL_EVENTSTREAM
     inputs.property("_eventStreamCacheInvalidation", System.getenv("SMITHYRS_EXPERIMENTAL_EVENTSTREAM") ?: "0")
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
@@ -82,7 +82,7 @@ class CodegenVisitor(context: PluginContext, private val codegenDecorator: RustC
         model.let(RecursiveShapeBoxer::transform)
             .letIf(settings.codegenConfig.addMessageToErrors, AddErrorMessage::transform)
             .let(OperationNormalizer::transform)
-            .let(RemoveEventStreamOperations::transform)
+            .let { RemoveEventStreamOperations.transform(it, settings) }
             .let(EventStreamNormalizer::transform)
 
     fun execute() {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
@@ -42,7 +42,9 @@ data class CodegenConfig(
     val renameExceptions: Boolean = true,
     val includeFluentClient: Boolean = true,
     val addMessageToErrors: Boolean = true,
-    val formatTimeoutSeconds: Int = 20
+    val formatTimeoutSeconds: Int = 20,
+    // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
+    val eventStreamAllowList: Set<String> = emptySet(),
 ) {
     companion object {
         fun fromNode(node: Optional<ObjectNode>): CodegenConfig {
@@ -52,7 +54,9 @@ data class CodegenConfig(
                     node.get().getBooleanMemberOrDefault("includeFluentClient", true),
                     node.get().getBooleanMemberOrDefault("addMessageToErrors", true),
                     node.get().getNumberMemberOrDefault("formatTimeoutSeconds", 20).toInt(),
-
+                    node.get().getArrayMember("eventStreamAllowList")
+                        .map { array -> array.toList().mapNotNull { node -> node.asStringNode().orNull()?.value } }
+                        .orNull()?.toSet() ?: emptySet()
                 )
             } else {
                 CodegenConfig()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
@@ -151,22 +151,11 @@ abstract class HttpProtocolGenerator(
         return with(writer) { "${format(operationT)}<$output, $retry>" }
     }
 
-    private fun buildOperationTypeOutput(
-        writer: RustWriter,
-        shape: OperationShape,
-    ): String {
-        val outputSymbol = symbolProvider.toSymbol(shape)
-        return with(writer) { "${format(outputSymbol)}" }
-    }
+    private fun buildOperationTypeOutput(writer: RustWriter, shape: OperationShape): String =
+        writer.format(symbolProvider.toSymbol(shape))
 
-    private fun buildOperationTypeRetry(
-        writer: RustWriter,
-        features: List<OperationCustomization>,
-    ): String {
-        val retryType = features.mapNotNull { it.retryType() }.firstOrNull()?.let { writer.format(it) } ?: "()"
-
-        return with(writer) { "$retryType" }
-    }
+    private fun buildOperationTypeRetry(writer: RustWriter, features: List<OperationCustomization>): String =
+        features.mapNotNull { it.retryType() }.firstOrNull()?.let { writer.format(it) } ?: "()"
 
     private fun buildOperation(
         implBlockWriter: RustWriter,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/HttpProtocolGenerator.kt
@@ -195,7 +195,7 @@ abstract class HttpProtocolGenerator(
         ) {
             withBlock("Ok({", "})") {
                 features.forEach { it.section(OperationSection.MutateInput("self", "_config"))(this) }
-                rust("let properties = std::sync::Arc::new(std::sync::Mutex::new(smithy_http::property_bag::PropertyBag::new()));")
+                rust("let properties = smithy_http::property_bag::SharedPropertyBag::new();")
                 rust("let request = self.request_builder_base()?;")
                 withBlock("let body =", ";") {
                     body("self", shape)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGenerator.kt
@@ -69,12 +69,14 @@ class TopLevelErrorGenerator(protocolConfig: ProtocolConfig, private val operati
         }
     }
 
-    private fun RustWriter.renderImplFrom(
-        operationShape: OperationShape,
-    ) {
+    private fun RustWriter.renderImplFrom(operationShape: OperationShape) {
         val operationError = operationShape.errorSymbol(symbolProvider)
-        rustBlock("impl From<#T<#T>> for Error", sdkError, operationError) {
-            rustBlock("fn from(err: #T<#T>) -> Self", sdkError, operationError) {
+        rustBlock(
+            "impl<R> From<#T<#T, R>> for Error where R: Send + Sync + std::fmt::Debug + 'static",
+            sdkError,
+            operationError
+        ) {
+            rustBlock("fn from(err: #T<#T, R>) -> Self", sdkError, operationError) {
                 rustBlock("match err") {
                     val operationErrors = operationShape.errors.map { model.expectShape(it) }
                     rustBlock("#T::ServiceError { err, ..} => match err.kind", sdkError) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -177,7 +177,8 @@ class ResponseBindingGenerator(
             runtimeConfig,
             symbolProvider,
             operationShape,
-            target
+            target,
+            protocol.httpBindingResolver.responseContentType(operationShape),
         ).render()
         rustTemplate(
             """

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -177,8 +177,7 @@ class ResponseBindingGenerator(
             runtimeConfig,
             symbolProvider,
             operationShape,
-            target,
-            protocol.httpBindingResolver.responseContentType(operationShape),
+            target
         ).render()
         rustTemplate(
             """

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson.kt
@@ -142,13 +142,18 @@ class AwsJson(
         return RuntimeType.forInlineFun("parse_generic_error", "json_deser") {
             it.rustTemplate(
                 """
-                pub fn parse_generic_error(response: &#{Response}<#{Bytes}>) -> Result<#{Error}, #{JsonError}> {
-                    #{json_errors}::parse_generic_error(response)
+                pub fn parse_generic_error(
+                    payload: &#{Bytes},
+                    _http_status: Option<u16>,
+                    headers: Option<&#{HeaderMap}<#{HeaderValue}>>,
+                ) -> Result<#{Error}, #{JsonError}> {
+                    #{json_errors}::parse_generic_error(payload, headers)
                 }
                 """,
-                "Response" to RuntimeType.http.member("Response"),
                 "Bytes" to RuntimeType.Bytes,
                 "Error" to RuntimeType.GenericError(runtimeConfig),
+                "HeaderMap" to RuntimeType.http.member("HeaderMap"),
+                "HeaderValue" to RuntimeType.http.member("HeaderValue"),
                 "JsonError" to CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize::Error"),
                 "json_errors" to RuntimeType.jsonErrors(runtimeConfig)
             )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson.kt
@@ -82,6 +82,8 @@ class AwsJsonHttpBindingResolver(
 
     override fun requestContentType(operationShape: OperationShape): String =
         "application/x-amz-json-${awsJsonVersion.value}"
+
+    override fun responseContentType(operationShape: OperationShape): String = requestContentType(operationShape)
 }
 
 /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
@@ -70,18 +70,22 @@ class AwsQueryProtocol(private val protocolConfig: ProtocolConfig) : Protocol {
         AwsQuerySerializerGenerator(protocolConfig)
 
     override fun parseGenericError(operationShape: OperationShape): RuntimeType {
-        /**
-         fn parse_generic(response: &Response<Bytes>) -> Result<smithy_types::error::Generic, T: Error>
-         **/
         return RuntimeType.forInlineFun("parse_generic_error", "xml_deser") {
             it.rustBlockTemplate(
-                "pub fn parse_generic_error(response: &#{Response}<#{Bytes}>) -> Result<#{Error}, #{XmlError}>",
-                "Response" to RuntimeType.http.member("Response"),
+                """
+                pub fn parse_generic_error(
+                    payload: &#{Bytes},
+                    _http_status: Option<u16>,
+                    _headers: Option<&#{HeaderMap}<#{HeaderValue}>>,
+                ) -> Result<#{Error}, #{XmlError}>
+                """,
                 "Bytes" to RuntimeType.Bytes,
                 "Error" to RuntimeType.GenericError(runtimeConfig),
+                "HeaderMap" to RuntimeType.http.member("HeaderMap"),
+                "HeaderValue" to RuntimeType.http.member("HeaderValue"),
                 "XmlError" to CargoDependency.smithyXml(runtimeConfig).asType().member("decode::XmlError")
             ) {
-                rust("#T::parse_generic_error(response.body().as_ref())", awsQueryErrors)
+                rust("#T::parse_generic_error(payload.as_ref())", awsQueryErrors)
             }
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
@@ -49,7 +49,7 @@ private val awsQueryHttpTrait = HttpTrait.builder()
     .build()
 
 class AwsQueryBindingResolver(private val model: Model) :
-    StaticHttpBindingResolver(model, awsQueryHttpTrait, "application/x-www-form-urlencoded") {
+    StaticHttpBindingResolver(model, awsQueryHttpTrait, "application/x-www-form-urlencoded", "text/xml") {
     override fun errorCode(errorShape: ToShapeId): String {
         val error = model.expectShape(errorShape.toShapeId())
         return error.getTrait<AwsQueryErrorTrait>()?.code ?: errorShape.toShapeId().name

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
@@ -49,7 +49,8 @@ class Ec2QueryProtocol(private val protocolConfig: ProtocolConfig) : Protocol {
             .method("POST")
             .uri(UriPattern.parse("/"))
             .build(),
-        "application/x-www-form-urlencoded"
+        "application/x-www-form-urlencoded",
+        "text/xml"
     )
 
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.DATE_TIME

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
@@ -81,6 +81,11 @@ interface HttpBindingResolver {
      * Determines the request content type for given [operationShape].
      */
     fun requestContentType(operationShape: OperationShape): String
+
+    /**
+     * Determines the response content type for given [operationShape].
+     */
+    fun responseContentType(operationShape: OperationShape): String
 }
 
 /**
@@ -89,6 +94,7 @@ interface HttpBindingResolver {
 class HttpTraitHttpBindingResolver(
     model: Model,
     private val defaultRequestContentType: String,
+    private val defaultResponseContentType: String,
     private val documentRequestContentType: String?,
 ) : HttpBindingResolver {
     private val httpIndex: HttpBindingIndex = HttpBindingIndex.of(model)
@@ -115,6 +121,10 @@ class HttpTraitHttpBindingResolver(
         httpIndex.determineRequestContentType(operationShape, documentRequestContentType)
             .orElse(defaultRequestContentType)
 
+    override fun responseContentType(operationShape: OperationShape): String =
+        httpIndex.determineResponseContentType(operationShape, documentRequestContentType)
+            .orElse(defaultResponseContentType)
+
     // Sort the members after extracting them from the map to have a consistent order
     private fun mappedBindings(bindings: Map<String, HttpBinding>): List<HttpBindingDescriptor> =
         bindings.values.map(::HttpBindingDescriptor).sortedBy { it.memberName }
@@ -128,6 +138,7 @@ open class StaticHttpBindingResolver(
     private val model: Model,
     private val httpTrait: HttpTrait,
     private val requestContentType: String,
+    private val responseContentType: String,
 ) : HttpBindingResolver {
     private fun bindings(shape: ToShapeId?) =
         shape?.let { model.expectShape(it.toShapeId()) }?.members()
@@ -147,4 +158,6 @@ open class StaticHttpBindingResolver(
         bindings(errorShape)
 
     override fun requestContentType(operationShape: OperationShape): String = requestContentType
+
+    override fun responseContentType(operationShape: OperationShape): String = responseContentType
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -137,7 +137,8 @@ class HttpBoundProtocolGenerator(
             runtimeConfig,
             symbolProvider,
             unionShape,
-            serializerGenerator
+            serializerGenerator,
+            httpBindingResolver.requestContentType(operationShape),
         ).render()
 
         // TODO(EventStream): [RPC] RPC protocols need to send an initial message with the

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestJson.kt
@@ -42,7 +42,7 @@ class RestJson(private val protocolConfig: ProtocolConfig) : Protocol {
     private val runtimeConfig = protocolConfig.runtimeConfig
 
     override val httpBindingResolver: HttpBindingResolver =
-        HttpTraitHttpBindingResolver(protocolConfig.model, "application/json", "application/json")
+        HttpTraitHttpBindingResolver(protocolConfig.model, "application/json", "application/json", "application/json")
 
     override val defaultTimestampFormat: TimestampFormatTrait.Format = TimestampFormatTrait.Format.EPOCH_SECONDS
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -53,7 +53,7 @@ open class RestXml(private val protocolConfig: ProtocolConfig) : Protocol {
     }
 
     override val httpBindingResolver: HttpBindingResolver =
-        HttpTraitHttpBindingResolver(protocolConfig.model, "application/xml", null)
+        HttpTraitHttpBindingResolver(protocolConfig.model, "application/xml", "application/xml", null)
 
     override val defaultTimestampFormat: TimestampFormatTrait.Format =
         TimestampFormatTrait.Format.DATE_TIME

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -67,18 +67,22 @@ open class RestXml(private val protocolConfig: ProtocolConfig) : Protocol {
     }
 
     override fun parseGenericError(operationShape: OperationShape): RuntimeType {
-        /**
-         fn parse_generic(response: &Response<Bytes>) -> Result<smithy_types::error::Generic, T: Error>
-         **/
         return RuntimeType.forInlineFun("parse_generic_error", "xml_deser") {
             it.rustBlockTemplate(
-                "pub fn parse_generic_error(response: &#{Response}<#{Bytes}>) -> Result<#{Error}, #{XmlError}>",
-                "Response" to RuntimeType.http.member("Response"),
+                """
+                pub fn parse_generic_error(
+                    payload: &#{Bytes},
+                    _http_status: Option<u16>,
+                    _headers: Option<&#{HeaderMap}<#{HeaderValue}>>,
+                ) -> Result<#{Error}, #{XmlError}>
+                """,
                 "Bytes" to RuntimeType.Bytes,
                 "Error" to RuntimeType.GenericError(runtimeConfig),
+                "HeaderMap" to RuntimeType.http.member("HeaderMap"),
+                "HeaderValue" to RuntimeType.http.member("HeaderValue"),
                 "XmlError" to CargoDependency.smithyXml(runtimeConfig).asType().member("decode::XmlError")
             ) {
-                rust("#T::parse_generic_error(response.body().as_ref())", restXmlErrors)
+                rust("#T::parse_generic_error(payload.as_ref())", restXmlErrors)
             }
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
@@ -47,7 +47,6 @@ class EventStreamUnmarshallerGenerator(
     private val symbolProvider: RustSymbolProvider,
     private val operationShape: OperationShape,
     private val unionShape: UnionShape,
-    private val payloadContentType: String,
 ) {
     private val unionSymbol = symbolProvider.toSymbol(unionShape)
     private val operationErrorSymbol = operationShape.errorSymbol(symbolProvider)
@@ -123,10 +122,9 @@ class EventStreamUnmarshallerGenerator(
     }
 
     private fun expectedContentType(payloadTarget: Shape): String? = when (payloadTarget) {
-        null -> null
         is BlobShape -> "application/octet-stream"
         is StringShape -> "text/plain"
-        else -> payloadContentType
+        else -> null
     }
 
     private fun RustWriter.renderUnmarshallEvent() {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
@@ -8,10 +8,16 @@ package software.amazon.smithy.rust.codegen.smithy.protocols.serialize
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.BlobShape
+import software.amazon.smithy.model.shapes.BooleanShape
+import software.amazon.smithy.model.shapes.ByteShape
+import software.amazon.smithy.model.shapes.IntegerShape
+import software.amazon.smithy.model.shapes.LongShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShortShape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.EventHeaderTrait
 import software.amazon.smithy.model.traits.EventPayloadTrait
@@ -22,15 +28,16 @@ import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.smithy.isOptional
 import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.toPascalCase
 
-// TODO(EventStream): [TEST] Unit test EventStreamMarshallerGenerator
 class EventStreamMarshallerGenerator(
     private val model: Model,
     runtimeConfig: RuntimeConfig,
@@ -90,7 +97,7 @@ class EventStreamMarshallerGenerator(
                         rustBlock("Self::Input::${member.memberName.toPascalCase()}(inner) => ") {
                             addStringHeader(":event-type", "${eventType.dq()}.into()")
                             val target = model.expectShape(member.target, StructureShape::class.java)
-                            serializeEvent(target)
+                            renderMarshallEvent(member, target)
                         }
                     }
                 }
@@ -99,21 +106,59 @@ class EventStreamMarshallerGenerator(
         }
     }
 
-    private fun RustWriter.serializeEvent(struct: StructureShape) {
-        for (member in struct.members()) {
+    private fun RustWriter.renderMarshallEvent(unionMember: MemberShape, struct: StructureShape) {
+        val headerMembers = struct.members().filter { it.hasTrait<EventHeaderTrait>() }
+        val payloadMember = struct.members().firstOrNull { it.hasTrait<EventPayloadTrait>() }
+        for (member in headerMembers) {
             val memberName = symbolProvider.toMemberName(member)
             val target = model.expectShape(member.target)
-            if (member.hasTrait<EventPayloadTrait>()) {
-                serializeUnionMember(memberName, member, target)
-            } else if (member.hasTrait<EventHeaderTrait>()) {
-                TODO("TODO(EventStream): Implement @eventHeader trait")
-            } else {
-                throw IllegalStateException("Event Stream members must be a header or payload")
+            renderMarshallEventHeader(memberName, member, target)
+        }
+        if (payloadMember != null) {
+            val memberName = symbolProvider.toMemberName(payloadMember)
+            val target = model.expectShape(payloadMember.target)
+            renderMarshallEventPayload("inner.$memberName", payloadMember, target)
+        } else if (headerMembers.isEmpty()) {
+            renderMarshallEventPayload("inner", unionMember, struct)
+        } else {
+            addStringHeader(":content-type", "application/octet-stream".dq() + ".into()")
+            rust("Vec::new()")
+        }
+    }
+
+    private fun RustWriter.renderMarshallEventHeader(memberName: String, member: MemberShape, target: Shape) {
+        val headerName = member.memberName
+        handleOptional(
+            symbolProvider.toSymbol(member).isOptional(),
+            "inner.$memberName",
+            "value",
+            { input -> renderAddHeader(headerName, input, target) },
+        )
+    }
+
+    private fun RustWriter.renderAddHeader(headerName: String, inputName: String, target: Shape) {
+        withBlock("headers.push(", ");") {
+            rustTemplate("#{Header}::new", *codegenScope)
+            withBlock("(", ")") {
+                rust("${headerName.dq()},")
+                rustTemplate("#{HeaderValue}::", *codegenScope)
+                when (target) {
+                    is BooleanShape -> rust("Bool($inputName)")
+                    is ByteShape -> rust("Byte($inputName)")
+                    is ShortShape -> rust("Int16($inputName)")
+                    is IntegerShape -> rust("Int32($inputName)")
+                    is LongShape -> rust("Int64($inputName)")
+                    is BlobShape -> rust("ByteArray($inputName.into_inner().into())")
+                    is StringShape -> rust("String($inputName.into())")
+                    is TimestampShape -> rust("Timestamp($inputName)")
+                    else -> throw IllegalStateException("unsupported event stream header shape type: $target")
+                }
             }
         }
     }
 
-    private fun RustWriter.serializeUnionMember(memberName: String, member: MemberShape, target: Shape) {
+    private fun RustWriter.renderMarshallEventPayload(inputExpr: String, member: MemberShape, target: Shape) {
+        val optional = symbolProvider.toSymbol(member).isOptional()
         if (target is BlobShape || target is StringShape) {
             data class PayloadContext(val conversionFn: String, val contentType: String)
             val ctx = when (target) {
@@ -122,31 +167,54 @@ class EventStreamMarshallerGenerator(
                 else -> throw IllegalStateException("unreachable")
             }
             addStringHeader(":content-type", "${ctx.contentType.dq()}.into()")
-            if (member.isOptional) {
-                rust(
-                    """
-                    if let Some(inner_payload) = inner.$memberName {
-                        inner_payload.${ctx.conversionFn}()
-                    } else {
-                        Vec::new()
-                    }
-                    """
-                )
-            } else {
-                rust("inner.$memberName.${ctx.conversionFn}()")
-            }
+            handleOptional(
+                optional,
+                inputExpr,
+                "inner_payload",
+                { input -> rust("$input.${ctx.conversionFn}()") },
+                { rust("Vec::new()") }
+            )
         } else {
             addStringHeader(":content-type", "${payloadContentType.dq()}.into()")
 
             val serializerFn = serializerGenerator.payloadSerializer(member)
-            rustTemplate(
-                """
-                        #{serializerFn}(&inner.$memberName)
+            handleOptional(
+                optional,
+                inputExpr,
+                "inner_payload",
+                { input ->
+                    rustTemplate(
+                        """
+                        #{serializerFn}(&$input)
                             .map_err(|err| #{Error}::Marshalling(format!("{}", err)))?
                         """,
-                "serializerFn" to serializerFn,
-                *codegenScope
+                        "serializerFn" to serializerFn,
+                        *codegenScope
+                    )
+                },
+                { rust("unimplemented!(\"TODO(EventStream): Figure out what to do when there's no payload\")") }
             )
+        }
+    }
+
+    private fun RustWriter.handleOptional(
+        optional: Boolean,
+        inputExpr: String,
+        someName: String,
+        writeSomeCase: RustWriter.(String) -> Unit,
+        writeNoneCase: (RustWriter.() -> Unit)? = null,
+    ) {
+        if (optional) {
+            rustBlock("if let Some($someName) = $inputExpr") {
+                writeSomeCase(someName)
+            }
+            if (writeNoneCase != null) {
+                rustBlock(" else ") {
+                    writeNoneCase()
+                }
+            }
+        } else {
+            writeSomeCase(inputExpr)
         }
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
@@ -37,6 +37,7 @@ class EventStreamMarshallerGenerator(
     private val symbolProvider: RustSymbolProvider,
     private val unionShape: UnionShape,
     private val serializerGenerator: StructuredDataSerializerGenerator,
+    private val payloadContentType: String,
 ) {
     private val smithyEventStream = CargoDependency.SmithyEventStream(runtimeConfig)
     private val codegenScope = arrayOf(
@@ -135,8 +136,7 @@ class EventStreamMarshallerGenerator(
                 rust("inner.$memberName.${ctx.conversionFn}()")
             }
         } else {
-            // TODO(EventStream): Select content-type based on protocol
-            addStringHeader(":content-type", "\"TODO\".into()")
+            addStringHeader(":content-type", "${payloadContentType.dq()}.into()")
 
             val serializerFn = serializerGenerator.payloadSerializer(member)
             rustTemplate(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/QuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/QuerySerializerGenerator.kt
@@ -101,9 +101,9 @@ abstract class QuerySerializerGenerator(protocolConfig: ProtocolConfig) : Struct
     }
 
     override fun payloadSerializer(member: MemberShape): RuntimeType {
-        // TODO(EventStream): [RPC] The query will need to be rendered to the initial message,
-        // so this needs to be implemented
-        TODO("The $protocolName protocol doesn't support http payload traits")
+        // TODO(EventStream): Query payload serialization is required for RPC initial message as well as for message
+        // frames that have a struct/union type.
+        TODO("$protocolName doesn't support payload serialization yet")
     }
 
     override fun operationSerializer(operationShape: OperationShape): RuntimeType? {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RemoveEventStreamOperations.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RemoveEventStreamOperations.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.smithy.RustSettings
 import software.amazon.smithy.rust.codegen.util.findStreamingMember
 import software.amazon.smithy.rust.codegen.util.orNull
 import java.util.logging.Logger
@@ -18,13 +19,12 @@ import java.util.logging.Logger
 object RemoveEventStreamOperations {
     private val logger = Logger.getLogger(javaClass.name)
 
-    private fun eventStreamEnabled(): Boolean =
-        System.getenv()["SMITHYRS_EXPERIMENTAL_EVENTSTREAM"] == "1"
-
-    fun transform(model: Model): Model {
-        if (eventStreamEnabled()) {
+    fun transform(model: Model, settings: RustSettings): Model {
+        // If Event Stream is allowed in build config, then don't remove the operations
+        if (settings.codegenConfig.eventStreamAllowList.contains(settings.moduleName)) {
             return model
         }
+
         return ModelTransformer.create().filterShapes(model) { parentShape ->
             if (parentShape !is OperationShape) {
                 true

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RemoveEventStreamOperations.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RemoveEventStreamOperations.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.rust.codegen.util.findStreamingMember
 import software.amazon.smithy.rust.codegen.util.orNull
 import java.util.logging.Logger
 
-// TODO(EventStream): Remove this class once the Event Stream implementation is stable
+// TODO(EventStream): [CLEANUP] Remove this class once the Event Stream implementation is stable
 /** Transformer to REMOVE operations that use EventStreaming until event streaming is supported */
 object RemoveEventStreamOperations {
     private val logger = Logger.getLogger(javaClass.name)

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/ResponseBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/ResponseBindingGeneratorTest.kt
@@ -74,7 +74,7 @@ class ResponseBindingGeneratorTest {
     private fun RustWriter.renderOperation() {
         operationShape.outputShape(model).renderWithModelBuilder(model, symbolProvider, this)
         rustBlock("impl PutObjectOutput") {
-            val bindings = HttpTraitHttpBindingResolver(model, "dont-care", "dont-care")
+            val bindings = HttpTraitHttpBindingResolver(model, "dont-care", "dont-care", "dont-care")
                 .responseBindings(operationShape)
                 .filter { it.location == HttpLocation.HEADER }
             bindings.forEach { binding ->

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
@@ -114,7 +114,8 @@ object EventStreamTestModels {
     data class TestCase(
         val protocolShapeId: String,
         val model: Model,
-        val contentType: String,
+        val requestContentType: String,
+        val responseContentType: String,
         val validTestStruct: String,
         val validMessageWithNoHeaderPayloadTraits: String,
         val validTestUnion: String,
@@ -132,7 +133,8 @@ object EventStreamTestModels {
                     TestCase(
                         protocolShapeId = "aws.protocols#restJson1",
                         model = restJson1(),
-                        contentType = "application/json",
+                        requestContentType = "application/json",
+                        responseContentType = "application/json",
                         validTestStruct = """{"someString":"hello","someInt":5}""",
                         validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
                         validTestUnion = """{"Foo":"hello"}""",
@@ -144,7 +146,8 @@ object EventStreamTestModels {
                     TestCase(
                         protocolShapeId = "aws.protocols#awsJson1_1",
                         model = awsJson11(),
-                        contentType = "application/x-amz-json-1.1",
+                        requestContentType = "application/x-amz-json-1.1",
+                        responseContentType = "application/x-amz-json-1.1",
                         validTestStruct = """{"someString":"hello","someInt":5}""",
                         validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
                         validTestUnion = """{"Foo":"hello"}""",
@@ -156,7 +159,8 @@ object EventStreamTestModels {
                     TestCase(
                         protocolShapeId = "aws.protocols#restXml",
                         model = restXml(),
-                        contentType = "text/xml",
+                        requestContentType = "application/xml",
+                        responseContentType = "application/xml",
                         validTestStruct = """
                             <TestStruct>
                                 <someString>hello</someString>
@@ -194,7 +198,8 @@ object EventStreamTestModels {
                     TestCase(
                         protocolShapeId = "aws.protocols#awsQuery",
                         model = awsQuery(),
-                        contentType = "application/x-www-form-urlencoded",
+                        requestContentType = "application/x-www-form-urlencoded",
+                        responseContentType = "text/xml",
                         validTestStruct = """
                             <TestStruct>
                                 <someString>hello</someString>
@@ -232,7 +237,8 @@ object EventStreamTestModels {
                     TestCase(
                         protocolShapeId = "aws.protocols#ec2Query",
                         model = ec2Query(),
-                        contentType = "application/x-www-form-urlencoded",
+                        requestContentType = "application/x-www-form-urlencoded",
+                        responseContentType = "text/xml",
                         validTestStruct = """
                             <TestStruct>
                                 <someString>hello</someString>

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
@@ -119,6 +119,7 @@ object EventStreamTestModels {
         val validMessageWithNoHeaderPayloadTraits: String,
         val validTestUnion: String,
         val validSomeError: String,
+        val validUnmodeledError: String,
         val protocolBuilder: (ProtocolConfig) -> Protocol,
     ) {
         override fun toString(): String = protocolShapeId
@@ -136,6 +137,7 @@ object EventStreamTestModels {
                         validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
                         validTestUnion = """{"Foo":"hello"}""",
                         validSomeError = """{"Message":"some error"}""",
+                        validUnmodeledError = """{"Message":"unmodeled error"}""",
                     ) { RestJson(it) }
                 ),
                 Arguments.of(
@@ -147,6 +149,7 @@ object EventStreamTestModels {
                         validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
                         validTestUnion = """{"Foo":"hello"}""",
                         validSomeError = """{"Message":"some error"}""",
+                        validUnmodeledError = """{"Message":"unmodeled error"}""",
                     ) { AwsJson(it, AwsJsonVersion.Json11) }
                 ),
                 Arguments.of(
@@ -175,7 +178,16 @@ object EventStreamTestModels {
                                     <Message>some error</Message>
                                 </Error>
                             </ErrorResponse>
-                        """.trimIndent()
+                        """.trimIndent(),
+                        validUnmodeledError = """
+                            <ErrorResponse>
+                                <Error>
+                                    <Type>UnmodeledError</Type>
+                                    <Code>UnmodeledError</Code>
+                                    <Message>unmodeled error</Message>
+                                </Error>
+                            </ErrorResponse>
+                        """.trimIndent(),
                     ) { RestXml(it) }
                 ),
                 Arguments.of(
@@ -204,7 +216,16 @@ object EventStreamTestModels {
                                     <Message>some error</Message>
                                 </Error>
                             </ErrorResponse>
-                        """.trimIndent()
+                        """.trimIndent(),
+                        validUnmodeledError = """
+                            <ErrorResponse>
+                                <Error>
+                                    <Type>UnmodeledError</Type>
+                                    <Code>UnmodeledError</Code>
+                                    <Message>unmodeled error</Message>
+                                </Error>
+                            </ErrorResponse>
+                        """.trimIndent(),
                     ) { AwsQueryProtocol(it) }
                 ),
                 Arguments.of(
@@ -233,9 +254,20 @@ object EventStreamTestModels {
                                         <Code>SomeError</Code>
                                         <Message>some error</Message>
                                     </Error>
-                                </Error>
+                                </Errors>
                             </Response>
-                        """.trimIndent()
+                        """.trimIndent(),
+                        validUnmodeledError = """
+                            <Response>
+                                <Errors>
+                                    <Error>
+                                        <Type>UnmodeledError</Type>
+                                        <Code>UnmodeledError</Code>
+                                        <Message>unmodeled error</Message>
+                                    </Error>
+                                </Errors>
+                            </Response>
+                        """.trimIndent(),
                     ) { Ec2QueryProtocol(it) }
                 ),
             )

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
@@ -105,11 +105,13 @@ private fun fillInBaseModel(
 """
 
 object EventStreamTestModels {
-    fun restJson1(): Model = fillInBaseModel("restJson1").asSmithyModel()
-    fun restXml(): Model = fillInBaseModel("restXml").asSmithyModel()
-    fun awsJson11(): Model = fillInBaseModel("awsJson1_1").asSmithyModel()
-    fun awsQuery(): Model = fillInBaseModel("awsQuery", "@xmlNamespace(uri: \"https://example.com\")").asSmithyModel()
-    fun ec2Query(): Model = fillInBaseModel("ec2Query", "@xmlNamespace(uri: \"https://example.com\")").asSmithyModel()
+    private fun restJson1(): Model = fillInBaseModel("restJson1").asSmithyModel()
+    private fun restXml(): Model = fillInBaseModel("restXml").asSmithyModel()
+    private fun awsJson11(): Model = fillInBaseModel("awsJson1_1").asSmithyModel()
+    private fun awsQuery(): Model =
+        fillInBaseModel("awsQuery", "@xmlNamespace(uri: \"https://example.com\")").asSmithyModel()
+    private fun ec2Query(): Model =
+        fillInBaseModel("ec2Query", "@xmlNamespace(uri: \"https://example.com\")").asSmithyModel()
 
     data class TestCase(
         val protocolShapeId: String,
@@ -126,157 +128,176 @@ object EventStreamTestModels {
         override fun toString(): String = protocolShapeId
     }
 
-    class ModelArgumentsProvider : ArgumentsProvider {
+    private val testCases = listOf(
+        //
+        // restJson1
+        //
+        TestCase(
+            protocolShapeId = "aws.protocols#restJson1",
+            model = restJson1(),
+            requestContentType = "application/json",
+            responseContentType = "application/json",
+            validTestStruct = """{"someString":"hello","someInt":5}""",
+            validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
+            validTestUnion = """{"Foo":"hello"}""",
+            validSomeError = """{"Message":"some error"}""",
+            validUnmodeledError = """{"Message":"unmodeled error"}""",
+        ) { RestJson(it) },
+
+        //
+        // awsJson1_1
+        //
+        TestCase(
+            protocolShapeId = "aws.protocols#awsJson1_1",
+            model = awsJson11(),
+            requestContentType = "application/x-amz-json-1.1",
+            responseContentType = "application/x-amz-json-1.1",
+            validTestStruct = """{"someString":"hello","someInt":5}""",
+            validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
+            validTestUnion = """{"Foo":"hello"}""",
+            validSomeError = """{"Message":"some error"}""",
+            validUnmodeledError = """{"Message":"unmodeled error"}""",
+        ) { AwsJson(it, AwsJsonVersion.Json11) },
+
+        //
+        // restXml
+        //
+        TestCase(
+            protocolShapeId = "aws.protocols#restXml",
+            model = restXml(),
+            requestContentType = "application/xml",
+            responseContentType = "application/xml",
+            validTestStruct = """
+                        <TestStruct>
+                            <someString>hello</someString>
+                            <someInt>5</someInt>
+                        </TestStruct>
+            """.trimIndent(),
+            validMessageWithNoHeaderPayloadTraits = """
+                        <MessageWithNoHeaderPayloadTraits>
+                            <someString>hello</someString>
+                            <someInt>5</someInt>
+                        </MessageWithNoHeaderPayloadTraits>
+            """.trimIndent(),
+            validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
+            validSomeError = """
+                        <ErrorResponse>
+                            <Error>
+                                <Type>SomeError</Type>
+                                <Code>SomeError</Code>
+                                <Message>some error</Message>
+                            </Error>
+                        </ErrorResponse>
+            """.trimIndent(),
+            validUnmodeledError = """
+                        <ErrorResponse>
+                            <Error>
+                                <Type>UnmodeledError</Type>
+                                <Code>UnmodeledError</Code>
+                                <Message>unmodeled error</Message>
+                            </Error>
+                        </ErrorResponse>
+            """.trimIndent(),
+        ) { RestXml(it) },
+
+        //
+        // awsQuery
+        //
+        TestCase(
+            protocolShapeId = "aws.protocols#awsQuery",
+            model = awsQuery(),
+            requestContentType = "application/x-www-form-urlencoded",
+            responseContentType = "text/xml",
+            validTestStruct = """
+                        <TestStruct>
+                            <someString>hello</someString>
+                            <someInt>5</someInt>
+                        </TestStruct>
+            """.trimIndent(),
+            validMessageWithNoHeaderPayloadTraits = """
+                        <MessageWithNoHeaderPayloadTraits>
+                            <someString>hello</someString>
+                            <someInt>5</someInt>
+                        </MessageWithNoHeaderPayloadTraits>
+            """.trimIndent(),
+            validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
+            validSomeError = """
+                        <ErrorResponse>
+                            <Error>
+                                <Type>SomeError</Type>
+                                <Code>SomeError</Code>
+                                <Message>some error</Message>
+                            </Error>
+                        </ErrorResponse>
+            """.trimIndent(),
+            validUnmodeledError = """
+                        <ErrorResponse>
+                            <Error>
+                                <Type>UnmodeledError</Type>
+                                <Code>UnmodeledError</Code>
+                                <Message>unmodeled error</Message>
+                            </Error>
+                        </ErrorResponse>
+            """.trimIndent(),
+        ) { AwsQueryProtocol(it) },
+
+        //
+        // ec2Query
+        //
+        TestCase(
+            protocolShapeId = "aws.protocols#ec2Query",
+            model = ec2Query(),
+            requestContentType = "application/x-www-form-urlencoded",
+            responseContentType = "text/xml",
+            validTestStruct = """
+                        <TestStruct>
+                            <someString>hello</someString>
+                            <someInt>5</someInt>
+                        </TestStruct>
+            """.trimIndent(),
+            validMessageWithNoHeaderPayloadTraits = """
+                        <MessageWithNoHeaderPayloadTraits>
+                            <someString>hello</someString>
+                            <someInt>5</someInt>
+                        </MessageWithNoHeaderPayloadTraits>
+            """.trimIndent(),
+            validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
+            validSomeError = """
+                        <Response>
+                            <Errors>
+                                <Error>
+                                    <Type>SomeError</Type>
+                                    <Code>SomeError</Code>
+                                    <Message>some error</Message>
+                                </Error>
+                            </Errors>
+                        </Response>
+            """.trimIndent(),
+            validUnmodeledError = """
+                        <Response>
+                            <Errors>
+                                <Error>
+                                    <Type>UnmodeledError</Type>
+                                    <Code>UnmodeledError</Code>
+                                    <Message>unmodeled error</Message>
+                                </Error>
+                            </Errors>
+                        </Response>
+            """.trimIndent(),
+        ) { Ec2QueryProtocol(it) },
+    )
+
+    class UnmarshallTestCasesProvider : ArgumentsProvider {
         override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
-            Stream.of(
-                Arguments.of(
-                    TestCase(
-                        protocolShapeId = "aws.protocols#restJson1",
-                        model = restJson1(),
-                        requestContentType = "application/json",
-                        responseContentType = "application/json",
-                        validTestStruct = """{"someString":"hello","someInt":5}""",
-                        validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
-                        validTestUnion = """{"Foo":"hello"}""",
-                        validSomeError = """{"Message":"some error"}""",
-                        validUnmodeledError = """{"Message":"unmodeled error"}""",
-                    ) { RestJson(it) }
-                ),
-                Arguments.of(
-                    TestCase(
-                        protocolShapeId = "aws.protocols#awsJson1_1",
-                        model = awsJson11(),
-                        requestContentType = "application/x-amz-json-1.1",
-                        responseContentType = "application/x-amz-json-1.1",
-                        validTestStruct = """{"someString":"hello","someInt":5}""",
-                        validMessageWithNoHeaderPayloadTraits = """{"someString":"hello","someInt":5}""",
-                        validTestUnion = """{"Foo":"hello"}""",
-                        validSomeError = """{"Message":"some error"}""",
-                        validUnmodeledError = """{"Message":"unmodeled error"}""",
-                    ) { AwsJson(it, AwsJsonVersion.Json11) }
-                ),
-                Arguments.of(
-                    TestCase(
-                        protocolShapeId = "aws.protocols#restXml",
-                        model = restXml(),
-                        requestContentType = "application/xml",
-                        responseContentType = "application/xml",
-                        validTestStruct = """
-                            <TestStruct>
-                                <someString>hello</someString>
-                                <someInt>5</someInt>
-                            </TestStruct>
-                        """.trimIndent(),
-                        validMessageWithNoHeaderPayloadTraits = """
-                            <MessageWithNoHeaderPayloadTraits>
-                                <someString>hello</someString>
-                                <someInt>5</someInt>
-                            </MessageWithNoHeaderPayloadTraits>
-                        """.trimIndent(),
-                        validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
-                        validSomeError = """
-                            <ErrorResponse>
-                                <Error>
-                                    <Type>SomeError</Type>
-                                    <Code>SomeError</Code>
-                                    <Message>some error</Message>
-                                </Error>
-                            </ErrorResponse>
-                        """.trimIndent(),
-                        validUnmodeledError = """
-                            <ErrorResponse>
-                                <Error>
-                                    <Type>UnmodeledError</Type>
-                                    <Code>UnmodeledError</Code>
-                                    <Message>unmodeled error</Message>
-                                </Error>
-                            </ErrorResponse>
-                        """.trimIndent(),
-                    ) { RestXml(it) }
-                ),
-                Arguments.of(
-                    TestCase(
-                        protocolShapeId = "aws.protocols#awsQuery",
-                        model = awsQuery(),
-                        requestContentType = "application/x-www-form-urlencoded",
-                        responseContentType = "text/xml",
-                        validTestStruct = """
-                            <TestStruct>
-                                <someString>hello</someString>
-                                <someInt>5</someInt>
-                            </TestStruct>
-                        """.trimIndent(),
-                        validMessageWithNoHeaderPayloadTraits = """
-                            <MessageWithNoHeaderPayloadTraits>
-                                <someString>hello</someString>
-                                <someInt>5</someInt>
-                            </MessageWithNoHeaderPayloadTraits>
-                        """.trimIndent(),
-                        validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
-                        validSomeError = """
-                            <ErrorResponse>
-                                <Error>
-                                    <Type>SomeError</Type>
-                                    <Code>SomeError</Code>
-                                    <Message>some error</Message>
-                                </Error>
-                            </ErrorResponse>
-                        """.trimIndent(),
-                        validUnmodeledError = """
-                            <ErrorResponse>
-                                <Error>
-                                    <Type>UnmodeledError</Type>
-                                    <Code>UnmodeledError</Code>
-                                    <Message>unmodeled error</Message>
-                                </Error>
-                            </ErrorResponse>
-                        """.trimIndent(),
-                    ) { AwsQueryProtocol(it) }
-                ),
-                Arguments.of(
-                    TestCase(
-                        protocolShapeId = "aws.protocols#ec2Query",
-                        model = ec2Query(),
-                        requestContentType = "application/x-www-form-urlencoded",
-                        responseContentType = "text/xml",
-                        validTestStruct = """
-                            <TestStruct>
-                                <someString>hello</someString>
-                                <someInt>5</someInt>
-                            </TestStruct>
-                        """.trimIndent(),
-                        validMessageWithNoHeaderPayloadTraits = """
-                            <MessageWithNoHeaderPayloadTraits>
-                                <someString>hello</someString>
-                                <someInt>5</someInt>
-                            </MessageWithNoHeaderPayloadTraits>
-                        """.trimIndent(),
-                        validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
-                        validSomeError = """
-                            <Response>
-                                <Errors>
-                                    <Error>
-                                        <Type>SomeError</Type>
-                                        <Code>SomeError</Code>
-                                        <Message>some error</Message>
-                                    </Error>
-                                </Errors>
-                            </Response>
-                        """.trimIndent(),
-                        validUnmodeledError = """
-                            <Response>
-                                <Errors>
-                                    <Error>
-                                        <Type>UnmodeledError</Type>
-                                        <Code>UnmodeledError</Code>
-                                        <Message>unmodeled error</Message>
-                                    </Error>
-                                </Errors>
-                            </Response>
-                        """.trimIndent(),
-                    ) { Ec2QueryProtocol(it) }
-                ),
-            )
+            testCases.map { Arguments.of(it) }.stream()
+    }
+
+    class MarshallTestCasesProvider : ArgumentsProvider {
+        override fun provideArguments(context: ExtensionContext?): Stream<out Arguments> =
+            // Don't include awsQuery or ec2Query for now since marshall support for them is unimplemented
+            testCases
+                .filter { testCase -> !testCase.protocolShapeId.contains("Query") }
+                .map { Arguments.of(it) }.stream()
     }
 }
 
@@ -319,8 +340,10 @@ object EventStreamTestTools {
         println("file:///${project.baseDir}/src/error.rs")
         println("file:///${project.baseDir}/src/event_stream.rs")
         println("file:///${project.baseDir}/src/event_stream_serde.rs")
+        println("file:///${project.baseDir}/src/json_ser.rs")
         println("file:///${project.baseDir}/src/lib.rs")
         println("file:///${project.baseDir}/src/model.rs")
+        println("file:///${project.baseDir}/src/operation_ser.rs")
         return TestEventStreamProject(model, serviceShape, operationShape, unionShape, symbolProvider, project)
     }
 

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGeneratorTest.kt
@@ -37,8 +37,7 @@ class EventStreamUnmarshallerGeneratorTest {
             TestRuntimeConfig,
             test.symbolProvider,
             test.operationShape,
-            test.streamShape,
-            testCase.responseContentType
+            test.streamShape
         )
 
         test.project.lib { writer ->
@@ -263,7 +262,7 @@ class EventStreamUnmarshallerGeneratorTest {
                 """
                 let message = msg(
                     "event",
-                    "MessageWithStruct",
+                    "MessageWithBlob",
                     "wrong-content-type",
                     br#"${testCase.validTestStruct}"#
                 );

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGeneratorTest.kt
@@ -18,7 +18,7 @@ import software.amazon.smithy.rust.codegen.testutil.unitTest
 
 class EventStreamUnmarshallerGeneratorTest {
     @ParameterizedTest
-    @ArgumentsSource(EventStreamTestModels.ModelArgumentsProvider::class)
+    @ArgumentsSource(EventStreamTestModels.UnmarshallTestCasesProvider::class)
     fun test(testCase: EventStreamTestModels.TestCase) {
         val test = EventStreamTestTools.generateTestProject(testCase.model)
 

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -110,7 +110,7 @@ class JsonParserGeneratorTest {
         val symbolProvider = testSymbolProvider(model)
         val parserGenerator = JsonParserGenerator(
             testProtocolConfig(model),
-            HttpTraitHttpBindingResolver(model, "application/json", "application/json")
+            HttpTraitHttpBindingResolver(model, "application/json", "application/json", "application/json")
         )
         val operationGenerator = parserGenerator.operationParser(model.lookup("test#Op"))
         val documentGenerator = parserGenerator.documentParser(model.lookup("test#Op"))

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/EventStreamMarshallerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/EventStreamMarshallerGeneratorTest.kt
@@ -1,0 +1,239 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.protocols.serialize
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.DependencyScope
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.ProtocolConfig
+import software.amazon.smithy.rust.codegen.smithy.protocols.EventStreamTestModels
+import software.amazon.smithy.rust.codegen.smithy.protocols.EventStreamTestTools
+import software.amazon.smithy.rust.codegen.testutil.TestRuntimeConfig
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+import software.amazon.smithy.rust.codegen.util.dq
+
+class EventStreamMarshallerGeneratorTest {
+    @ParameterizedTest
+    @ArgumentsSource(EventStreamTestModels.MarshallTestCasesProvider::class)
+    fun test(testCase: EventStreamTestModels.TestCase) {
+        val test = EventStreamTestTools.generateTestProject(testCase.model)
+
+        val protocolConfig = ProtocolConfig(
+            test.model,
+            test.symbolProvider,
+            TestRuntimeConfig,
+            test.serviceShape,
+            ShapeId.from(testCase.protocolShapeId),
+            "test"
+        )
+        val protocol = testCase.protocolBuilder(protocolConfig)
+        val generator = EventStreamMarshallerGenerator(
+            test.model,
+            TestRuntimeConfig,
+            test.symbolProvider,
+            test.streamShape,
+            protocol.structuredDataSerializer(test.operationShape),
+            testCase.requestContentType
+        )
+
+        test.project.lib { writer ->
+            val protocolTestHelpers = CargoDependency.ProtocolTestHelpers(TestRuntimeConfig)
+                .copy(scope = DependencyScope.Compile)
+            writer.rustTemplate(
+                """
+                use smithy_eventstream::frame::{Message, Header, HeaderValue, MarshallMessage};
+                use std::collections::HashMap;
+                use smithy_types::{Blob, Instant};
+                use crate::error::*;
+                use crate::model::*;
+
+                use #{validate_body};
+                use #{MediaType};
+
+                fn headers_to_map<'a>(headers: &'a [Header]) -> HashMap<String, &'a HeaderValue> {
+                    let mut map = HashMap::new();
+                    for header in headers {
+                        map.insert(header.name().as_str().to_string(), header.value());
+                    }
+                    map
+                }
+
+                fn str_header(value: &'static str) -> HeaderValue {
+                    HeaderValue::String(value.into())
+                }
+                """,
+                "validate_body" to RuntimeType("validate_body", protocolTestHelpers, "protocol_test_helpers"),
+                "MediaType" to RuntimeType("MediaType", protocolTestHelpers, "protocol_test_helpers"),
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithBlob(
+                    MessageWithBlob::builder().data(Blob::new(&b"hello, world!"[..])).build()
+                );
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let message = result.unwrap();
+                let headers = headers_to_map(message.headers());
+                assert_eq!(&str_header("event"), *headers.get(":message-type").unwrap());
+                assert_eq!(&str_header("MessageWithBlob"), *headers.get(":event-type").unwrap());
+                assert_eq!(&str_header("application/octet-stream"), *headers.get(":content-type").unwrap());
+                assert_eq!(&b"hello, world!"[..], message.payload());
+                """,
+                "message_with_blob",
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithString(
+                    MessageWithString::builder().data("hello, world!").build()
+                );
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let message = result.unwrap();
+                let headers = headers_to_map(message.headers());
+                assert_eq!(&str_header("event"), *headers.get(":message-type").unwrap());
+                assert_eq!(&str_header("MessageWithString"), *headers.get(":event-type").unwrap());
+                assert_eq!(&str_header("text/plain"), *headers.get(":content-type").unwrap());
+                assert_eq!(&b"hello, world!"[..], message.payload());
+                """,
+                "message_with_string",
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithStruct(
+                    MessageWithStruct::builder().some_struct(
+                        TestStruct::builder()
+                            .some_string("hello")
+                            .some_int(5)
+                            .build()
+                    ).build()
+                );
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let message = result.unwrap();
+                let headers = headers_to_map(message.headers());
+                assert_eq!(&str_header("event"), *headers.get(":message-type").unwrap());
+                assert_eq!(&str_header("MessageWithStruct"), *headers.get(":event-type").unwrap());
+                assert_eq!(&str_header(${testCase.requestContentType.dq()}), *headers.get(":content-type").unwrap());
+
+                validate_body(
+                    message.payload(),
+                    ${testCase.validTestStruct.dq()},
+                    MediaType::from(${testCase.requestContentType.dq()})
+                ).unwrap();
+                """,
+                "message_with_struct",
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithUnion(MessageWithUnion::builder().some_union(
+                    TestUnion::Foo("hello".into())
+                ).build());
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let message = result.unwrap();
+                let headers = headers_to_map(message.headers());
+                assert_eq!(&str_header("event"), *headers.get(":message-type").unwrap());
+                assert_eq!(&str_header("MessageWithUnion"), *headers.get(":event-type").unwrap());
+                assert_eq!(&str_header(${testCase.requestContentType.dq()}), *headers.get(":content-type").unwrap());
+
+                validate_body(
+                    message.payload(),
+                    ${testCase.validTestUnion.dq()},
+                    MediaType::from(${testCase.requestContentType.dq()})
+                ).unwrap();
+                """,
+                "message_with_union",
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithHeaders(MessageWithHeaders::builder()
+                    .blob(Blob::new(&b"test"[..]))
+                    .boolean(true)
+                    .byte(55i8)
+                    .int(100_000i32)
+                    .long(9_000_000_000i64)
+                    .short(16_000i16)
+                    .string("test")
+                    .timestamp(Instant::from_epoch_seconds(5))
+                    .build()
+                );
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let actual_message = result.unwrap();
+                let expected_message = Message::new(&b""[..])
+                    .add_header(Header::new(":message-type", HeaderValue::String("event".into())))
+                    .add_header(Header::new(":event-type", HeaderValue::String("MessageWithHeaders".into())))
+                    .add_header(Header::new("blob", HeaderValue::ByteArray((&b"test"[..]).into())))
+                    .add_header(Header::new("boolean", HeaderValue::Bool(true)))
+                    .add_header(Header::new("byte", HeaderValue::Byte(55i8)))
+                    .add_header(Header::new("int", HeaderValue::Int32(100_000i32)))
+                    .add_header(Header::new("long", HeaderValue::Int64(9_000_000_000i64)))
+                    .add_header(Header::new("short", HeaderValue::Int16(16_000i16)))
+                    .add_header(Header::new("string", HeaderValue::String("test".into())))
+                    .add_header(Header::new("timestamp", HeaderValue::Timestamp(Instant::from_epoch_seconds(5))))
+                    .add_header(Header::new(":content-type", HeaderValue::String("application/octet-stream".into())));
+                assert_eq!(expected_message, actual_message);
+                """,
+                "message_with_headers",
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithHeaderAndPayload(MessageWithHeaderAndPayload::builder()
+                    .header("header")
+                    .payload(Blob::new(&b"payload"[..]))
+                    .build()
+                );
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let actual_message = result.unwrap();
+                let expected_message = Message::new(&b"payload"[..])
+                    .add_header(Header::new(":message-type", HeaderValue::String("event".into())))
+                    .add_header(Header::new(":event-type", HeaderValue::String("MessageWithHeaderAndPayload".into())))
+                    .add_header(Header::new("header", HeaderValue::String("header".into())))
+                    .add_header(Header::new(":content-type", HeaderValue::String("application/octet-stream".into())));
+                assert_eq!(expected_message, actual_message);
+                """,
+                "message_with_header_and_payload",
+            )
+
+            writer.unitTest(
+                """
+                let event = TestStream::MessageWithNoHeaderPayloadTraits(MessageWithNoHeaderPayloadTraits::builder()
+                    .some_int(5)
+                    .some_string("hello")
+                    .build()
+                );
+                let result = ${writer.format(generator.render())}().marshall(event);
+                assert!(result.is_ok(), "expected ok, got: {:?}", result);
+                let message = result.unwrap();
+                let headers = headers_to_map(message.headers());
+                assert_eq!(&str_header("event"), *headers.get(":message-type").unwrap());
+                assert_eq!(&str_header("MessageWithNoHeaderPayloadTraits"), *headers.get(":event-type").unwrap());
+                assert_eq!(&str_header(${testCase.requestContentType.dq()}), *headers.get(":content-type").unwrap());
+
+                validate_body(
+                    message.payload(),
+                    ${testCase.validMessageWithNoHeaderPayloadTraits.dq()},
+                    MediaType::from(${testCase.requestContentType.dq()})
+                ).unwrap();
+                """,
+                "message_with_no_header_payload_traits",
+            )
+        }
+        test.project.compileAndTest()
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGeneratorTest.kt
@@ -102,7 +102,7 @@ class JsonSerializerGeneratorTest {
         val symbolProvider = testSymbolProvider(model)
         val parserSerializer = JsonSerializerGenerator(
             testProtocolConfig(model),
-            HttpTraitHttpBindingResolver(model, "application/json", null)
+            HttpTraitHttpBindingResolver(model, "application/json", "application/json", null)
         )
         val operationGenerator = parserSerializer.operationSerializer(model.lookup("test#Op"))
         val documentGenerator = parserSerializer.documentSerializer()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
@@ -107,7 +107,7 @@ internal class XmlBindingTraitSerializerGeneratorTest {
         val symbolProvider = testSymbolProvider(model)
         val parserGenerator = XmlBindingTraitSerializerGenerator(
             testProtocolConfig(model),
-            HttpTraitHttpBindingResolver(model, "application/xml", null)
+            HttpTraitHttpBindingResolver(model, "application/xml", "application/xml", null)
         )
         val operationParser = parserGenerator.payloadSerializer(model.lookup("test#OpInput\$payload"))
 

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RemoveEventStreamOperationsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RemoveEventStreamOperationsTest.kt
@@ -6,14 +6,18 @@
 package software.amazon.smithy.rust.codegen.smithy.transformers
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.smithy.CodegenConfig
+import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.smithy.RustSettings
 import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import java.util.Optional
 
 internal class RemoveEventStreamOperationsTest {
-    @Test
-    fun `event stream operations are removed from the model`() {
-        val model = """
+    private val model = """
         namespace test
         operation EventStream {
             input: StreamingInput,
@@ -40,10 +44,43 @@ internal class RemoveEventStreamOperationsTest {
         }
 
         structure Foo {}
+    """.asSmithyModel()
 
-        """.asSmithyModel()
-        val transformed = RemoveEventStreamOperations.transform(model)
+    @Test
+    fun `remove event stream ops from services that are not in the allow list`() {
+        val transformed = RemoveEventStreamOperations.transform(
+            model,
+            RustSettings(
+                service = ShapeId.from("notrelevant#notrelevant"),
+                moduleName = "test-module",
+                moduleVersion = "notrelevant",
+                moduleAuthors = listOf("notrelevant"),
+                runtimeConfig = RuntimeConfig(),
+                codegenConfig = CodegenConfig(eventStreamAllowList = setOf("not-test-module")),
+                license = null,
+                model = model
+            )
+        )
         transformed.expectShape(ShapeId.from("test#BlobStream"))
-        transformed.getShape(ShapeId.from("test#EventStream")).shouldBe(java.util.Optional.empty())
+        transformed.getShape(ShapeId.from("test#EventStream")) shouldBe Optional.empty()
+    }
+
+    @Test
+    fun `keep event stream ops from services that are in the allow list`() {
+        val transformed = RemoveEventStreamOperations.transform(
+            model,
+            RustSettings(
+                service = ShapeId.from("notrelevant#notrelevant"),
+                moduleName = "test-module",
+                moduleVersion = "notrelevant",
+                moduleAuthors = listOf("notrelevant"),
+                runtimeConfig = RuntimeConfig(),
+                codegenConfig = CodegenConfig(eventStreamAllowList = setOf("test-module")),
+                license = null,
+                model = model
+            )
+        )
+        transformed.expectShape(ShapeId.from("test#BlobStream"))
+        transformed.getShape(ShapeId.from("test#EventStream")) shouldNotBe Optional.empty<Shape>()
     }
 }

--- a/rust-runtime/inlineable/src/json_errors.rs
+++ b/rust-runtime/inlineable/src/json_errors.rs
@@ -5,7 +5,7 @@
 
 use bytes::Bytes;
 use http::header::ToStrError;
-use http::Response;
+use http::{HeaderMap, HeaderValue};
 use smithy_json::deserialize::token::skip_value;
 use smithy_json::deserialize::{json_token_iter, Error as DeserializeError, Token};
 use smithy_types::Error as SmithyError;
@@ -17,12 +17,17 @@ pub fn is_error<B>(response: &http::Response<B>) -> bool {
     !response.status().is_success()
 }
 
-fn error_type_from_header<B>(response: &http::Response<B>) -> Result<Option<&str>, ToStrError> {
-    response
-        .headers()
-        .get("X-Amzn-Errortype")
-        .map(|v| v.to_str())
-        .transpose()
+fn error_type_from_header(
+    headers: Option<&HeaderMap<HeaderValue>>,
+) -> Result<Option<&str>, ToStrError> {
+    headers
+        .map(|headers| {
+            headers
+                .get("X-Amzn-Errortype")
+                .map(|v| v.to_str())
+                .transpose()
+        })
+        .unwrap_or(Ok(None))
 }
 
 fn sanitize_error_code(error_code: &str) -> &str {
@@ -39,11 +44,14 @@ fn sanitize_error_code(error_code: &str) -> &str {
     }
 }
 
-fn request_id(response: &Response<Bytes>) -> Option<&str> {
-    response
-        .headers()
-        .get("X-Amzn-Requestid")
-        .and_then(|v| v.to_str().ok())
+fn request_id(headers: Option<&HeaderMap<HeaderValue>>) -> Option<&str> {
+    headers
+        .map(|headers| {
+            headers
+                .get("X-Amzn-Requestid")
+                .and_then(|v| v.to_str().ok())
+        })
+        .flatten()
 }
 
 struct ErrorBody<'a> {
@@ -90,11 +98,14 @@ fn parse_error_body(bytes: &[u8]) -> Result<ErrorBody, DeserializeError> {
     })
 }
 
-pub fn parse_generic_error(response: &Response<Bytes>) -> Result<SmithyError, DeserializeError> {
-    let ErrorBody { code, message } = parse_error_body(response.body().as_ref())?;
+pub fn parse_generic_error(
+    payload: &Bytes,
+    headers: Option<&HeaderMap<HeaderValue>>,
+) -> Result<SmithyError, DeserializeError> {
+    let ErrorBody { code, message } = parse_error_body(payload.as_ref())?;
 
     let mut err_builder = SmithyError::builder();
-    if let Some(code) = error_type_from_header(response)
+    if let Some(code) = error_type_from_header(headers)
         .map_err(|_| DeserializeError::custom("X-Amzn-Errortype header was not valid UTF-8"))?
         .or_else(|| code.as_deref())
         .map(|c| sanitize_error_code(c))
@@ -104,7 +115,7 @@ pub fn parse_generic_error(response: &Response<Bytes>) -> Result<SmithyError, De
     if let Some(message) = message {
         err_builder.message(message);
     }
-    if let Some(request_id) = request_id(response) {
+    if let Some(request_id) = request_id(headers) {
         err_builder.request_id(request_id);
     }
     Ok(err_builder.build())
@@ -126,7 +137,7 @@ mod test {
             ))
             .unwrap();
         assert_eq!(
-            parse_generic_error(&response).unwrap(),
+            parse_generic_error(response.body(), Some(response.headers())).unwrap(),
             Error::builder()
                 .code("FooError")
                 .message("Go to foo")
@@ -208,7 +219,7 @@ mod test {
             ))
             .unwrap();
         assert_eq!(
-            parse_generic_error(&response).unwrap(),
+            parse_generic_error(response.body(), Some(response.headers())).unwrap(),
             Error::builder()
                 .code("ResourceNotFoundException")
                 .message("Functions from 'us-west-2' are not reachable from us-east-1")

--- a/rust-runtime/protocol-test-helpers/src/lib.rs
+++ b/rust-runtime/protocol-test-helpers/src/lib.rs
@@ -268,6 +268,7 @@ impl<T: AsRef<str>> From<T> for MediaType {
     fn from(inp: T) -> Self {
         match inp.as_ref() {
             "application/json" => MediaType::Json,
+            "application/x-amz-json-1.1" => MediaType::Json,
             "application/xml" => MediaType::Xml,
             "application/x-www-form-urlencoded" => MediaType::UrlEncodedForm,
             other => MediaType::Other(other.to_string()),

--- a/rust-runtime/smithy-eventstream/src/frame.rs
+++ b/rust-runtime/smithy-eventstream/src/frame.rs
@@ -26,6 +26,8 @@ pub type SignMessageError = Box<dyn StdError + Send + Sync + 'static>;
 /// Signs an Event Stream message.
 pub trait SignMessage: fmt::Debug {
     fn sign(&mut self, message: Message) -> Result<Message, SignMessageError>;
+
+    fn sign_empty(&mut self) -> Result<Message, SignMessageError>;
 }
 
 /// Converts a Smithy modeled Event Stream type into a [`Message`](Message).

--- a/rust-runtime/smithy-http/src/operation.rs
+++ b/rust-runtime/smithy-http/src/operation.rs
@@ -4,11 +4,10 @@
  */
 
 use crate::body::SdkBody;
-use crate::property_bag::PropertyBag;
+use crate::property_bag::{PropertyBag, SharedPropertyBag};
 use std::borrow::Cow;
 use std::error::Error;
 use std::ops::{Deref, DerefMut};
-use std::sync::{Arc, Mutex, MutexGuard};
 use thiserror::Error;
 
 #[derive(Clone, Debug)]
@@ -147,7 +146,7 @@ pub struct Request {
     ///
     /// Middleware can read and write from the property bag and use its
     /// contents to augment the request (see [`Request::augment`](Request::augment))
-    properties: Arc<Mutex<PropertyBag>>,
+    properties: SharedPropertyBag,
 }
 
 impl Request {
@@ -155,12 +154,12 @@ impl Request {
     pub fn new(inner: http::Request<SdkBody>) -> Self {
         Request {
             inner,
-            properties: Arc::new(Mutex::new(PropertyBag::new())),
+            properties: SharedPropertyBag::new(),
         }
     }
 
     /// Creates a new operation `Request` from its parts.
-    pub fn from_parts(inner: http::Request<SdkBody>, properties: Arc<Mutex<PropertyBag>>) -> Self {
+    pub fn from_parts(inner: http::Request<SdkBody>, properties: SharedPropertyBag) -> Self {
         Request { inner, properties }
     }
 
@@ -170,7 +169,7 @@ impl Request {
         f: impl FnOnce(http::Request<SdkBody>, &mut PropertyBag) -> Result<http::Request<SdkBody>, T>,
     ) -> Result<Request, T> {
         let inner = {
-            let properties: &mut PropertyBag = &mut self.properties.lock().unwrap();
+            let properties: &mut PropertyBag = &mut self.properties.acquire_mut();
             f(self.inner, properties)?
         };
         Ok(Request {
@@ -180,13 +179,13 @@ impl Request {
     }
 
     /// Gives mutable access to the properties.
-    pub fn properties_mut(&mut self) -> MutexGuard<'_, PropertyBag> {
-        self.properties.lock().unwrap()
+    pub fn properties_mut(&mut self) -> impl DerefMut<Target = PropertyBag> + '_ {
+        self.properties.acquire_mut()
     }
 
     /// Gives readonly access to the properties.
-    pub fn properties(&self) -> MutexGuard<'_, PropertyBag> {
-        self.properties.lock().unwrap()
+    pub fn properties(&self) -> impl Deref<Target = PropertyBag> + '_ {
+        self.properties.acquire()
     }
 
     /// Gives mutable access to the underlying HTTP request.
@@ -221,7 +220,7 @@ impl Request {
     }
 
     /// Consumes the operation `Request` and returns the underlying HTTP request and properties.
-    pub fn into_parts(self) -> (http::Request<SdkBody>, Arc<Mutex<PropertyBag>>) {
+    pub fn into_parts(self) -> (http::Request<SdkBody>, SharedPropertyBag) {
         (self.inner, self.properties)
     }
 }
@@ -235,7 +234,7 @@ pub struct Response {
     inner: http::Response<SdkBody>,
 
     /// Property bag of configuration options
-    properties: Arc<Mutex<PropertyBag>>,
+    properties: SharedPropertyBag,
 }
 
 impl Response {
@@ -243,18 +242,18 @@ impl Response {
     pub fn new(inner: http::Response<SdkBody>) -> Self {
         Response {
             inner,
-            properties: Arc::new(Mutex::new(PropertyBag::new())),
+            properties: SharedPropertyBag::new(),
         }
     }
 
     /// Gives mutable access to the properties.
-    pub fn properties_mut(&mut self) -> MutexGuard<'_, PropertyBag> {
-        self.properties.lock().unwrap()
+    pub fn properties_mut(&mut self) -> impl DerefMut<Target = PropertyBag> + '_ {
+        self.properties.acquire_mut()
     }
 
     /// Gives readonly access to the properties.
-    pub fn properties(&self) -> MutexGuard<'_, PropertyBag> {
-        self.properties.lock().unwrap()
+    pub fn properties(&self) -> impl Deref<Target = PropertyBag> + '_ {
+        self.properties.acquire()
     }
 
     /// Gives mutable access to the underlying HTTP response.
@@ -268,12 +267,12 @@ impl Response {
     }
 
     /// Consumes the operation `Request` and returns the underlying HTTP response and properties.
-    pub fn into_parts(self) -> (http::Response<SdkBody>, Arc<Mutex<PropertyBag>>) {
+    pub fn into_parts(self) -> (http::Response<SdkBody>, SharedPropertyBag) {
         (self.inner, self.properties)
     }
 
     /// Creates a new operation `Response` from an HTTP response and property bag.
-    pub fn from_parts(inner: http::Response<SdkBody>, properties: Arc<Mutex<PropertyBag>>) -> Self {
+    pub fn from_parts(inner: http::Response<SdkBody>, properties: SharedPropertyBag) -> Self {
         Response { inner, properties }
     }
 }
@@ -309,6 +308,6 @@ mod test {
         );
         assert_eq!(request.headers().get(CONTENT_LENGTH).unwrap(), "456");
         assert_eq!(request.body().bytes().unwrap(), "hello world!".as_bytes());
-        assert_eq!(config.lock().unwrap().get::<&str>(), Some(&"hello"));
+        assert_eq!(config.acquire().get::<&str>(), Some(&"hello"));
     }
 }

--- a/rust-runtime/smithy-http/src/property_bag.rs
+++ b/rust-runtime/smithy-http/src/property_bag.rs
@@ -13,6 +13,8 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::{BuildHasherDefault, Hasher};
+use std::ops::{Deref, DerefMut};
+use std::sync::{Arc, Mutex};
 
 type AnyMap = HashMap<TypeId, Box<dyn Any + Send + Sync>, BuildHasherDefault<IdHasher>>;
 
@@ -64,22 +66,19 @@ impl PropertyBag {
 
     /// Insert a type into this `PropertyBag`.
     ///
-    /// If a extension of this type already existed, it will
-    /// be returned.
-    ///
-    /// Generally, this method should not be called directly. The best practice is
-    /// calling this method via an extension trait on `PropertyBag`.
+    /// If a value of this type already existed, it will be returned.
     ///
     /// # Example
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
-    /// let mut ext = PropertyBag::new();
+    /// let mut props = PropertyBag::new();
+    ///
     /// #[derive(Debug, Eq, PartialEq)]
     /// struct Endpoint(&'static str);
-    /// assert!(ext.insert(Endpoint("dynamo.amazon.com")).is_none());
+    /// assert!(props.insert(Endpoint("dynamo.amazon.com")).is_none());
     /// assert_eq!(
-    ///     ext.insert(Endpoint("kinesis.amazon.com")),
+    ///     props.insert(Endpoint("kinesis.amazon.com")),
     ///     Some(Endpoint("dynamo.amazon.com"))
     /// );
     /// ```
@@ -100,11 +99,11 @@ impl PropertyBag {
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
-    /// let mut ext = PropertyBag::new();
-    /// assert!(ext.get::<i32>().is_none());
-    /// ext.insert(5i32);
+    /// let mut props = PropertyBag::new();
+    /// assert!(props.get::<i32>().is_none());
+    /// props.insert(5i32);
     ///
-    /// assert_eq!(ext.get::<i32>(), Some(&5i32));
+    /// assert_eq!(props.get::<i32>(), Some(&5i32));
     /// ```
     pub fn get<T: Send + Sync + 'static>(&self) -> Option<&T> {
         self.map
@@ -118,11 +117,11 @@ impl PropertyBag {
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
-    /// let mut ext = PropertyBag::new();
-    /// ext.insert(String::from("Hello"));
-    /// ext.get_mut::<String>().unwrap().push_str(" World");
+    /// let mut props = PropertyBag::new();
+    /// props.insert(String::from("Hello"));
+    /// props.get_mut::<String>().unwrap().push_str(" World");
     ///
-    /// assert_eq!(ext.get::<String>().unwrap(), "Hello World");
+    /// assert_eq!(props.get::<String>().unwrap(), "Hello World");
     /// ```
     pub fn get_mut<T: Send + Sync + 'static>(&mut self) -> Option<&mut T> {
         self.map
@@ -132,16 +131,16 @@ impl PropertyBag {
 
     /// Remove a type from this `PropertyBag`.
     ///
-    /// If a extension of this type existed, it will be returned.
+    /// If a value of this type existed, it will be returned.
     ///
     /// # Example
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
-    /// let mut ext = PropertyBag::new();
-    /// ext.insert(5i32);
-    /// assert_eq!(ext.remove::<i32>(), Some(5i32));
-    /// assert!(ext.get::<i32>().is_none());
+    /// let mut props = PropertyBag::new();
+    /// props.insert(5i32);
+    /// assert_eq!(props.remove::<i32>(), Some(5i32));
+    /// assert!(props.get::<i32>().is_none());
     /// ```
     pub fn remove<T: Send + Sync + 'static>(&mut self) -> Option<T> {
         self.map.remove(&TypeId::of::<T>()).and_then(|boxed| {
@@ -158,12 +157,11 @@ impl PropertyBag {
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
-    /// let mut ext = PropertyBag::new();
-    /// ext.insert(5i32);
-    /// ext.clear();
+    /// let mut props = PropertyBag::new();
+    /// props.insert(5i32);
+    /// props.clear();
     ///
-    /// assert!(ext.get::<i32>().is_none());
-    /// ```
+    /// assert!(props.get::<i32>().is_none());
     #[inline]
     pub fn clear(&mut self) {
         self.map.clear();
@@ -176,6 +174,34 @@ impl fmt::Debug for PropertyBag {
     }
 }
 
+/// A new-type of [`PropertyBag`] that can be safely shared across threads and cheaply cloned.
+#[derive(Clone, Debug, Default)]
+pub struct SharedPropertyBag(Arc<Mutex<PropertyBag>>);
+
+impl SharedPropertyBag {
+    /// Create an empty `SharedPropertyBag`.
+    pub fn new() -> Self {
+        SharedPropertyBag(Arc::new(Mutex::new(PropertyBag::new())))
+    }
+
+    /// Acquire an immutable reference to the property bag.
+    pub fn acquire(&self) -> impl Deref<Target = PropertyBag> + '_ {
+        self.0.lock().unwrap()
+    }
+
+    /// Acquire a mutable reference to the property bag.
+    pub fn acquire_mut(&self) -> impl DerefMut<Target = PropertyBag> + '_ {
+        self.0.lock().unwrap()
+    }
+}
+
+impl From<PropertyBag> for SharedPropertyBag {
+    fn from(bag: PropertyBag) -> Self {
+        SharedPropertyBag(Arc::new(Mutex::new(bag)))
+    }
+}
+
+#[cfg(test)]
 #[test]
 fn test_extensions() {
     #[derive(Debug, PartialEq)]

--- a/rust-runtime/smithy-http/src/result.rs
+++ b/rust-runtime/smithy-http/src/result.rs
@@ -52,9 +52,10 @@ where
     }
 }
 
-impl<E> Error for SdkError<E>
+impl<E, R> Error for SdkError<E, R>
 where
     E: Error + 'static,
+    R: Debug,
 {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {


### PR DESCRIPTION
## Motivation and Context
This is more progress towards #121.

## Description
- Completed implementation of the Event Stream marshall/unmarshall codegen
- Refactored `Arc<Mutex<PropertyBag>>` to be `SharedPropertyBag`
- Fixed bug where a signed empty frame wasn't being sent on end of stream (fixes BadRequestException response in the Transcribe example)
- Started on RPC initial-response support by adding `try_recv_initial()` to `Receiver`
- Reduced number of AWS services in tier-1 CI build

## Testing
- Marshall/unmarshall codegen is thoroughly unit tested
- Manually tested against Transcribe StartStreamTranscription and S3 SelectObjectContent

## Checklist
- [ ] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
