### PR TITLE
Fix JSON parsing bug for modeled empty structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ impl ProvideCredentials for CustomCreds {
 - Update AWS SDK models (#677)
 - :bug: Fix sigv4 signing when request ALPN negotiates to HTTP/2. (#674)
 - :bug: Fix integer size on S3 `Size` (#679, aws-sdk-rust#209)
+- :bug: Fix JSON parsing issue for modeled empty structs (#683, aws-sdk-rust#212)
 
 **Internal Changes**
 - Add NowOrLater future to smithy-async (#672)

--- a/codegen-test/model/rest-json-extras.smithy
+++ b/codegen-test/model/rest-json-extras.smithy
@@ -62,7 +62,8 @@ service RestJsonExtras {
         PrimitiveIntOp,
         EscapedStringValues,
         NullInNonSparse,
-        CaseInsensitiveErrorOperation
+        CaseInsensitiveErrorOperation,
+        EmptyStructWithContentOnWireOp,
     ]
 }
 
@@ -288,4 +289,23 @@ operation CaseInsensitiveErrorOperation {
 @error("server")
 structure CaseInsensitiveError {
     message: String
+}
+
+structure EmptyStruct {}
+structure EmptyStructWithContentOnWireOpOutput {
+    empty: EmptyStruct,
+}
+
+@http(uri: "/empty-struct-with-content-on-wire-op", method: "GET")
+@httpResponseTests([
+    {
+        id: "EmptyStructWithContentOnWire",
+        protocol: "aws.protocols#restJson1",
+        code: 200,
+        body: "{\"empty\": {\"value\":\"not actually empty\"}}",
+        params: { empty: {} }
+    }
+])
+operation EmptyStructWithContentOnWireOp {
+    output: EmptyStructWithContentOnWireOpOutput,
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -72,13 +72,17 @@ class JsonParserGeneratorTest {
             member: Choice
         }
 
+        structure EmptyStruct {
+        }
+
         structure Top {
             @required
             choice: Choice,
             field: String,
             extra: Integer,
             @jsonName("rec")
-            recursive: TopList
+            recursive: TopList,
+            empty: EmptyStruct,
         }
 
         list TopList {
@@ -133,7 +137,8 @@ class JsonParserGeneratorTest {
                         { "extra": 45,
                           "field": "something",
                           "choice":
-                              { "int": 5 }}}
+                              { "int": 5 },
+                          "empty": { "not_empty": true }}}
                 "#;
 
                 let output = ${writer.format(operationGenerator!!)}(json, output::op_output::Builder::default()).unwrap().build();
@@ -157,6 +162,7 @@ class JsonParserGeneratorTest {
         }
         project.withModule(RustModule.default("model", public = true)) {
             model.lookup<StructureShape>("test#Top").renderWithModelBuilder(model, symbolProvider, it)
+            model.lookup<StructureShape>("test#EmptyStruct").renderWithModelBuilder(model, symbolProvider, it)
             UnionGenerator(model, symbolProvider, it, model.lookup("test#Choice")).render()
             val enum = model.lookup<StringShape>("test#FooEnum")
             EnumGenerator(model, symbolProvider, it, enum, enum.expectTrait()).render()


### PR DESCRIPTION
## Motivation and Context
This will fix aws-sdk-rust#212.

## Testing
- Reproduced the issue with the following:
```rust
#[tokio::main]
async fn main() {
    tracing_subscriber::fmt::init();

    let resp = http::Response::builder()
        .status(200)
        .body(
            r#"
            {"scheduleActions":[{"actionName":"REDACTED","scheduleActionStartSettings":
            {"immediateModeScheduleActionStartSettings":{"time":"2021-08-29T21:54:42.651"}},
            "scheduleActionSettings":{"inputSwitchSettings":
            {"inputAttachmentNameReference":"REDACTED","urlPath":[]}}}]}
            "#,
        )
        .unwrap();

    let _schedule = DescribeSchedule::new()
        .parse_loaded(&resp.map(Bytes::from))
        .unwrap();
}
```
- Also reproduced the issue in the JsonParserGeneratorTest.
- Added rest-json-extras test case.
- Verified all work correctly after code fix.

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
