### PR TITLE
Add bug fix that was lumped in with other changes to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ impl ProvideCredentials for CustomCreds {
 - Update AWS SDK models (#677)
 - :bug: Fix sigv4 signing when request ALPN negotiates to HTTP/2. (#674)
 - :bug: Fix integer size on S3 `Size` (#679, aws-sdk-rust#209)
+- :bug: Fix acronym case disagreement between FluentClientGenerator and HttpProtocolGenerator type aliasing (#668)
 
 **Internal Changes**
 - Add NowOrLater future to smithy-async (#672)


### PR DESCRIPTION
## Motivation and Context
There a case disagreement between `FluentClientGenerator` and `HttpProtocolGenerator` that was fixed [in the latter](https://github.com/awslabs/smithy-rs/pull/668/files#diff-df56e69541e915e99c8919f6db25d46365e1d4eaf92615e17da146084b45ff90). This bug fix was lumped in with the rest of the fluent client consolidation changes and was missed in the changelog.

## Checklist
- [x] I have updated the CHANGELOG

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
