### PR TITLE
Lots of doc tweaks and cleanups

### DIFF
--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -3,7 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-//! Default Provider chains for [`region`](default_provider::region) and credentials (TODO)
+//! Default Provider chains for [`region`](default_provider::region) and [`credentials`](default_provider::credentials).
+//!
+//! Unless specific configuration is required, these should be constructed via [`ConfigLoader`](crate::ConfigLoader).
+//!
+//!
 
 /// Default region provider chain
 pub mod region {

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -1,13 +1,15 @@
 #![deny(missing_docs)]
 
-//! `aws-config` provides implementations of region, credential (todo), and connector (todo) resolution.
+//! `aws-config` provides implementations of region, credential resolution.
 //!
-//! These implementations can be used either adhoc or via [`from_env`](from_env)/[`ConfigLoader`](ConfigLoader).
+//! These implementations can be used either via the default chain implementation
+//! [`from_env`]/[`ConfigLoader`] or ad-hoc individual credential and region providers.
+//!
 //! [`ConfigLoader`](ConfigLoader) can combine different configuration sources into an AWS shared-config:
 //! [`Config`](aws_types::config::Config). [`Config`](aws_types::config::Config) can be used configure
 //! an AWS service client.
 //!
-//! ## Examples
+//! # Examples
 //! Load default SDK configuration:
 //! ```rust
 //! # mod aws_sdk_dynamodb {
@@ -66,7 +68,7 @@ pub mod provider_config;
 
 /// Create an environment loader for AWS Configuration
 ///
-/// ## Example
+/// # Examples
 /// ```rust
 /// # async fn create_config() {
 /// use aws_types::region::Region;
@@ -112,7 +114,7 @@ mod loader {
     impl ConfigLoader {
         /// Override the region used to build [`Config`](aws_types::config::Config).
         ///
-        /// # Example
+        /// # Examples
         /// ```rust
         /// # async fn create_config() {
         /// use aws_types::region::Region;
@@ -127,7 +129,7 @@ mod loader {
         }
 
         /// Override the credentials provider used to build [`Config`](aws_types::config::Config).
-        /// # Example
+        /// # Examples
         /// Override the credentials provider but load the default value for region:
         /// ```rust
         /// # use aws_types::Credentials;

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -18,7 +18,7 @@ use tracing::Instrument;
 ///   the next provider will be checked.
 /// * Finally, if a provider returns any other error condition, an error will be returned immediately.
 ///
-/// ## Example
+/// # Examples
 /// ```rust
 /// use aws_config::meta::credentials::CredentialsProviderChain;
 /// use aws_types::Credentials;

--- a/aws/rust-runtime/aws-config/src/meta/credentials/credential_fn.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/credential_fn.rs
@@ -36,7 +36,7 @@ where
 /// to create an [`ProvideCredentials`] implementation from an async block that returns
 /// a [`credentials::Result`].
 ///
-/// # Example
+/// # Examples
 ///
 /// ```
 /// use aws_types::Credentials;

--- a/aws/rust-runtime/aws-config/src/meta/credentials/lazy_caching.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/lazy_caching.rs
@@ -125,7 +125,7 @@ mod builder {
 
     /// Builder for constructing a [`LazyCachingCredentialsProvider`].
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// use aws_types::Credentials;

--- a/aws/rust-runtime/aws-config/src/meta/credentials/mod.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/mod.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+//! Credential providers that augment an existing credentials providers to add functionality
+
 mod chain;
 pub use chain::CredentialsProviderChain;
 

--- a/aws/rust-runtime/aws-config/src/meta/mod.rs
+++ b/aws/rust-runtime/aws-config/src/meta/mod.rs
@@ -3,8 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-/// Region Providers
 pub mod region;
 
-/// Credential Providers
 pub mod credentials;

--- a/aws/rust-runtime/aws-config/src/meta/region.rs
+++ b/aws/rust-runtime/aws-config/src/meta/region.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+//! Region providers that augment existing providers with new functionality
+
 use aws_types::region::Region;
 use std::borrow::Cow;
 use std::fmt::Debug;
@@ -10,7 +12,7 @@ use tracing::Instrument;
 
 /// Load a region by selecting the first from a series of region providers.
 ///
-/// # Example
+/// # Examples
 /// ```rust
 /// use aws_types::region::Region;
 /// use std::env;

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -293,7 +293,7 @@ pub struct Builder {
 impl Builder {
     /// Override the configuration for the [`ProfileFileCredentialsProvider`]
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # async fn test() {
     /// use aws_config::profile::ProfileFileCredentialsProvider;
@@ -310,7 +310,7 @@ impl Builder {
 
     /// Adds a custom credential source
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```rust
     /// use aws_types::credentials::{self, ProvideCredentials, future};

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -66,16 +66,10 @@ impl AssumeRoleProvider {
     }
 }
 
+#[derive(Debug)]
 pub(super) struct ProviderChain {
     base: Arc<dyn ProvideCredentials>,
     chain: Vec<AssumeRoleProvider>,
-}
-
-impl Debug for ProviderChain {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        // TODO: ProvideCredentials should probably mandate debug
-        f.debug_struct("ProviderChain").finish()
-    }
 }
 
 impl ProviderChain {

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -18,7 +18,7 @@ use crate::web_identity_token::{StaticConfiguration, WebIdentityTokenCredentials
 use aws_types::credentials::{self, CredentialsError, ProvideCredentials};
 use aws_types::os_shim_internal::Fs;
 use smithy_client::erase::DynConnector;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct AssumeRoleProvider {

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -6,13 +6,16 @@
 //! Load configuration from AWS Profiles
 //!
 //! AWS profiles are typically stored in `~/.aws/config` and `~/.aws/credentials`. For more details
-//! see <todo>
+//! see the [`load`](parser::load) function.
 
 mod parser;
+#[doc(inline)]
 pub use parser::{load, Profile, ProfileSet, Property};
 
 pub mod credentials;
 pub mod region;
 
+#[doc(inline)]
 pub use credentials::ProfileFileCredentialsProvider;
+#[doc(inline)]
 pub use region::ProfileFileRegionProvider;

--- a/aws/rust-runtime/aws-config/src/profile/region.rs
+++ b/aws/rust-runtime/aws-config/src/profile/region.rs
@@ -15,15 +15,23 @@ use aws_types::region::Region;
 /// This provider will attempt to load AWS shared configuration, then read the `region` property
 /// from the active profile.
 ///
-/// Example:
+/// # Examples
 ///
+/// **Loads "us-west-2" as the region
 /// ```ini
-/// # `~/.aws/config
 /// [default]
 /// region = us-west-2
 /// ```
 ///
-/// This provider is part of the [default provider chain](crate::default_provider::region).
+/// **Loads `us-east-1` as the region _if and only if_ the `AWS_PROFILE` environment variable is set
+/// to `other`.
+///
+/// ```ini
+/// [profile other]
+/// region = us-east-1
+/// ```
+///
+/// This provider is part of the [default region provider chain](crate::default_provider::region).
 #[derive(Debug, Default)]
 pub struct ProfileFileRegionProvider {
     fs: Fs,

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -52,7 +52,7 @@ impl ProviderConfig {
     /// a `ProviderConfig` without these fields set, use [`ProviderConfig::empty`].
     ///
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use aws_config::provider_config::ProviderConfig;
     /// use aws_sdk_sts::Region;
@@ -80,7 +80,7 @@ impl ProviderConfig {
 
     /// Create a default provider config with the region region automatically loaded from the default chain.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # async fn test() {
     /// use aws_config::provider_config::ProviderConfig;

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -5,15 +5,26 @@
 
 //! Load Credentials from Web Identity Tokens
 //!
-//! WebIdentity tokens can be loaded via environment variables, or via profiles:
+//! Web identity tokens can be loaded from file. The path may be set in one of three ways:
+//! 1. [Environment Variables](#environment-variable-configuration)
+//! 2. [AWS profile](#aws-profile-configuration) defined in `~/.aws/config`
+//! 3. Static configuration via [`static_configuration`](Builder::static_configuration)
 //!
-//! ## Via Environment Variables
+//! **Note:** [WebIdentityTokenCredentialsProvider] is part of the [default provider chain](crate::default_provider).
+//! Unless you need specific behavior or configuration overrides, it is recommended to use the
+//! default chain instead of using this provider directly. This client should be considered a "low level"
+//! client as it does not include caching or profile-file resolution when used in isolation.
+//!
+//! ## Environment Variable Configuration
 //! WebIdentityTokenCredentialProvider will load the following environment variables:
 //! - `AWS_WEB_IDENTITY_TOKEN_FILE`: **required**, location to find the token file containing a JWT token
 //! - `AWS_ROLE_ARN`: **required**, role ARN to assume
 //! - `AWS_IAM_ROLE_SESSION_NAME`: **optional**: Session name to use when assuming the role
 //!
-//! ## Via Shared Config Profiles
+//! ## AWS Profile Configuration
+//! **Note:** Configuration of the web identity token provider via a shared profile is only supported
+//! when using the [`ProfileFileCredentialsProvider`](crate::profile::credentials).
+//!
 //! Web identity token credentials can be loaded from `~/.aws/config` in two ways:
 //! 1. Directly:
 //!   ```ini
@@ -34,19 +45,21 @@
 //!   web_identity_token_file = /token.jwt
 //!   ```
 //!
-//! # Example
-//! Web Identity Token providers are part of the [default chain](crate::default_provider::credentials),
-//! however, you can construct one explicitly if you don't want to use the default provider chain:
+//! # Examples
+//! Web Identity Token providers are part of the [default chain](crate::default_provider::credentials).
+//! However, they may be directly constructed if you don't want to use the default provider chain.
+//! Unless overridden with [`static_configuration`](Builder::static_configuration), the provider will
+//! load configuration from environment variables.
 //!
-/// ```rust
-/// # async fn test() {
-/// use aws_config::web_identity_token::WebIdentityTokenCredentialsProvider;
-/// use aws_config::provider_config::ProviderConfig;
-/// let provider = WebIdentityTokenCredentialsProvider::builder()
-///     .configure(&ProviderConfig::with_default_region().await)
-///     .build();
-/// # }
-/// ```
+//! ```rust
+//! # async fn test() {
+//! use aws_config::web_identity_token::WebIdentityTokenCredentialsProvider;
+//! use aws_config::provider_config::ProviderConfig;
+//! let provider = WebIdentityTokenCredentialsProvider::builder()
+//!     .configure(&ProviderConfig::with_default_region().await)
+//!     .build();
+//! # }
+//! ```
 use aws_sdk_sts::Region;
 use aws_types::os_shim_internal::{Env, Fs};
 
@@ -164,7 +177,7 @@ pub struct Builder {
 impl Builder {
     /// Configure generic options of the [WebIdentityTokenCredentialsProvider]
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// # async fn test() {
     /// use aws_config::web_identity_token::WebIdentityTokenCredentialsProvider;

--- a/aws/rust-runtime/aws-config/test-data/profile-parser-tests.json
+++ b/aws/rust-runtime/aws-config/test-data/profile-parser-tests.json
@@ -659,7 +659,6 @@
         "profiles": {}
       }
     },
-
     {
       "name": "Comment characters adjacent to profile decls",
       "input": {
@@ -687,17 +686,23 @@
         "configFile": "[profilefoo]\nname = value\n[profile bar]"
       },
       "output": {
-        "profiles": { "bar":  {} }
+        "profiles": {
+          "bar": {}
+        }
       }
     },
-
     {
       "name": "profile name with extra whitespace",
       "input": {
         "configFile": "[   profile foo    ]\nname = value\n[profile bar]"
       },
       "output": {
-        "profiles": { "bar":  {}, "foo": {"name":  "value"} }
+        "profiles": {
+          "bar": {},
+          "foo": {
+            "name": "value"
+          }
+        }
       }
     },
     {
@@ -706,7 +711,27 @@
         "credentialsFile": "[   foo    ]\nname = value\n[profile bar]"
       },
       "output": {
-        "profiles": { "foo": {"name":  "value"} }
+        "profiles": {
+          "foo": {
+            "name": "value"
+          }
+        }
+      }
+    },
+    {
+      "name": "properties from an invalid profile name are ignored",
+      "input": {
+        "configFile": "[profile foo]\nname = value\n[profile in valid]\nx = 1\n[profile bar]\nname = value2"
+      },
+      "output": {
+        "profiles": {
+          "bar": {
+            "name": "value2"
+          },
+          "foo": {
+            "name": "value"
+          }
+        }
       }
     }
   ]

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -28,7 +28,7 @@ pub struct Builder {
 impl Builder {
     /// Set the region for the builder
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use aws_types::config::Config;
     /// use aws_types::region::Region;
@@ -41,7 +41,7 @@ impl Builder {
 
     /// Set the region for the builder
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// fn region_override() -> Option<Region> {
     ///     // ...
@@ -62,7 +62,7 @@ impl Builder {
 
     /// Set the credentials provider for the builder
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
     /// use aws_types::config::Config;
@@ -83,7 +83,7 @@ impl Builder {
 
     /// Set the credentials provider for the builder
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
     /// use aws_types::config::Config;

--- a/aws/rust-runtime/aws-types/src/os_shim_internal.rs
+++ b/aws/rust-runtime/aws-types/src/os_shim_internal.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 ///
 /// Simple abstraction enabling in-memory mocking of the file system
 ///
-/// # Example
+/// # Examples
 /// Construct a file system which delegates to `std::fs`:
 /// ```rust
 /// let fs = aws_types::os_shim_internal::Fs::real();
@@ -166,7 +166,7 @@ impl Env {
 
     /// Create a fake process environment from a slice of tuples.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use aws_types::os_shim_internal::Env;
     /// let mock_env = Env::from_slice(&[

--- a/rust-runtime/smithy-async/src/future/now_or_later.rs
+++ b/rust-runtime/smithy-async/src/future/now_or_later.rs
@@ -12,7 +12,7 @@
 //! Typically, this is used when creating a manual async trait. In this case, it's critical that the
 //! lifetime is captured to enable interop with the async-trait macro.
 //!
-//! # Example
+//! # Examples
 //!
 //! ```rust
 //! mod future {

--- a/rust-runtime/smithy-http/src/byte_stream.rs
+++ b/rust-runtime/smithy-http/src/byte_stream.rs
@@ -7,7 +7,7 @@
 //! When the SDK returns streaming binary data, the inner Http Body is wrapped in [ByteStream](crate::byte_stream::ByteStream). ByteStream provides misuse-resistant
 //! primitives to make it easier to handle common patterns with streaming data.
 //!
-//! ## Examples:
+//! # Examples
 //!
 //! ### Writing a ByteStream into a file:
 //! ```rust
@@ -241,7 +241,7 @@ impl ByteStream {
     ///
     /// Furthermore, a partial write MAY seek in the file and resume from the previous location.
     ///
-    /// # Example
+    /// # Examples
     /// ```rust
     /// use smithy_http::byte_stream::ByteStream;
     /// use std::path::Path;

--- a/rust-runtime/smithy-http/src/pin_util.rs
+++ b/rust-runtime/smithy-http/src/pin_util.rs
@@ -5,7 +5,7 @@
 
 /// Pins a value on the stack.
 ///
-/// # Example
+/// # Examples
 ///
 /// ```rust
 /// # use core::pin::Pin;

--- a/rust-runtime/smithy-http/src/property_bag.rs
+++ b/rust-runtime/smithy-http/src/property_bag.rs
@@ -68,7 +68,7 @@ impl PropertyBag {
     ///
     /// If a value of this type already existed, it will be returned.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
@@ -95,7 +95,7 @@ impl PropertyBag {
 
     /// Get a reference to a type previously inserted on this `PropertyBag`.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
@@ -113,7 +113,7 @@ impl PropertyBag {
 
     /// Get a mutable reference to a type previously inserted on this `PropertyBag`.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
@@ -133,7 +133,7 @@ impl PropertyBag {
     ///
     /// If a value of this type existed, it will be returned.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;
@@ -153,7 +153,7 @@ impl PropertyBag {
 
     /// Clear the `PropertyBag` of all inserted extensions.
     ///
-    /// # Example
+    /// # Examples
     ///
     /// ```
     /// # use smithy_http::property_bag::PropertyBag;

--- a/rust-runtime/smithy-xml/src/encode.rs
+++ b/rust-runtime/smithy-xml/src/encode.rs
@@ -32,7 +32,7 @@ impl Display for Error {
 /// Furthermore, once `const panic` stabilizes, we'll be able to make an invalid XmlName a compiler
 /// error.
 ///
-/// ## Example
+/// # Examples
 /// ```rust
 /// use smithy_xml::encode::XmlWriter;
 /// let mut s = String::new();


### PR DESCRIPTION
## Motivation and Context
Reading through the aws-config docs, I came across some inaccuracies & confusing wording.

## Description
- Cleanup aws-config docs
- replace `# Example` with `# Examples` to comply with the doc style RFC

no changelog.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
