### PR TITLE
fix(signing): Fix duplicate content-length header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 vNext (Month Day, Year)
 =======================
 
+**New This Week**
+- :bug: Fixes issue where `Content-Length` header could be duplicated leading to signing failure (aws-sdk-rust#220, smithy-rs#697)
+
 v0.22 (September 2nd, 2021)
 ===========================
 

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,6 +1,9 @@
 vNext (Month Day, Year)
 =======================
 
+**New This Week**
+- :bug: Fixes issue where `Content-Length` header could be duplicated leading to signing failure (aws-sdk-rust#220, smithy-rs#697)
+
 v0.0.17-alpha (September 2nd, 2021)
 ===================================
 

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -22,6 +22,7 @@ http-body = { version = "0.4", optional = true }
 percent-encoding = { version = "2.1", optional = true }
 ring = "0.16"
 smithy-eventstream = { path = "../../../rust-runtime/smithy-eventstream", optional = true }
+tracing = "0.1"
 
 [dev-dependencies]
 bytes = "1"

--- a/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
@@ -129,6 +129,7 @@ pub fn calculate_signing_headers<'a, B>(
     } = params;
     let (creq, extra_headers) =
         CanonicalRequest::from(request, body, settings, *date_time, *security_token)?;
+    tracing::trace!(canonical_request = %creq);
 
     // Step 2: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-create-string-to-sign.html.
     let encoded_creq = &sha256_hex_string(creq.to_string().as_bytes());

--- a/aws/sdk/aws-models/s3-tests.smithy
+++ b/aws/sdk/aws-models/s3-tests.smithy
@@ -156,7 +156,7 @@ apply CreateMultipartUpload @httpRequestTests([
 
 apply PutObject @httpRequestTests([
     {
-        id: "DontSendMultipleContentTypeHeaders",
+        id: "DontSendDuplicateContentType",
         documentation: "This test validates that if a content-type is specified, that only one content-type header is sent",
         method: "PUT",
         protocol: "aws.protocols#restXml",
@@ -166,6 +166,20 @@ apply PutObject @httpRequestTests([
             Bucket: "test-bucket",
             Key: "test-key",
             ContentType: "text/html"
+        }
+    },
+    {
+        id: "DontSendDuplicateContentLength",
+        documentation: "This test validates that if a content-length is specified, that only one content-length header is sent",
+        method: "PUT",
+        protocol: "aws.protocols#restXml",
+        uri: "/test-bucket/test-key",
+        headers: { "content-length": "2" },
+        params: {
+            Bucket: "test-bucket",
+            Key: "test-key",
+            ContentLength: 2,
+            Body: "ab"
         }
     }
 ])

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -477,8 +477,13 @@ class HttpBoundProtocolGenerator(
             for (header in additionalHeaders) {
                 rustTemplate(
                     """
-                    builder = #{header_util}::set_header_if_absent(builder, ${header.first.dq()}, ${header.second.dq()});
+                    builder = #{header_util}::set_header_if_absent(
+                                builder,
+                                #{http}::header::HeaderName::from_static(${header.first.dq()}),
+                                ${header.second.dq()}
+                    );
                     """,
+                    "http" to RuntimeType.http,
                     "header_util" to CargoDependency.SmithyHttp(runtimeConfig).asType().member("header")
 
                 )


### PR DESCRIPTION
## Motivation and Context
If `content_length` was set explicitly, we were erroneously duplicating it for non-streaming bodies. 
aws-sdk-rust#220

## Description
- Uses `set_header_if_absent` to avoid double setting content length
- Adds a trace level log of the canonical request during signing
- Adds an additional protocol test that fails prior to this change

## Testing
- [x] Additional protocol test added.

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
