### PR TITLE
fix(codegen): Fix bug triggered by operation input/output naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vNext (Month Day, Year)
 
 **New This Week**
 - :bug: Fixes issue where `Content-Length` header could be duplicated leading to signing failure (aws-sdk-rust#220, smithy-rs#697)
+- :bug: Fixes naming collision during generation of model shapes that collide with `<operationname>Input` and `<operationname>Output` (#799)
 
 v0.22 (September 2nd, 2021)
 ===========================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ vNext (Month Day, Year)
 
 **New This Week**
 - :bug: Fixes issue where `Content-Length` header could be duplicated leading to signing failure (aws-sdk-rust#220, smithy-rs#697)
-- :bug: Fixes naming collision during generation of model shapes that collide with `<operationname>Input` and `<operationname>Output` (#799)
+- :bug: Fixes naming collision during generation of model shapes that collide with `<operationname>Input` and `<operationname>Output` (#699)
 
 v0.22 (September 2nd, 2021)
 ===========================

--- a/codegen-test/model/rest-xml-extras.smithy
+++ b/codegen-test/model/rest-xml-extras.smithy
@@ -19,8 +19,21 @@ service RestXmlExtras {
         PrimitiveIntOpXml,
         ChecksumRequired,
         StringHeader,
+        CreateFoo,
     ]
 }
+
+/// This operation triggers a name collision between the synthetic `CreateFooInput` and `CreateFooInput`
+@http(uri: "/reused-input", method: "POST")
+operation CreateFoo {
+    input: CreateFooRequest,
+}
+
+structure CreateFooRequest {
+    input: CreateFooInput
+}
+
+structure CreateFooInput {}
 
 @httpRequestTests([{
     id: "RestXmlSerPrimitiveIntUnset",

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -60,7 +60,7 @@ class StructureGenerator(
     }
 
     companion object {
-        /** Returns whether or not a structure shape requires a fallible builder to be generated. */
+        /** Returns whether a structure shape requires a fallible builder to be generated. */
         fun fallibleBuilder(structureShape: StructureShape, symbolProvider: SymbolProvider): Boolean =
             // All inputs should have fallible builders in case a new required field is added in the future
             structureShape.hasTrait<SyntheticInputTrait>() ||

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamer.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.SetShape
 import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
@@ -44,14 +45,18 @@ fun RustSymbolProvider.serializeFunctionName(shape: Shape): String = shapeFuncti
  */
 fun RustSymbolProvider.deserializeFunctionName(shape: Shape): String = shapeFunctionName("deser", shape)
 
+fun ShapeId.toRustIdentifier(): String {
+    return this.namespace.replace(".", "_").toSnakeCase() + this.name.toSnakeCase()
+}
+
 private fun RustSymbolProvider.shapeFunctionName(prefix: String, shape: Shape): String {
-    val symbolNameSnakeCase = toSymbol(shape).name.toSnakeCase()
+    val symbolNameSnakeCase = toSymbol(shape).fullName.replace("::", "_").toSnakeCase()
     return prefix + "_" + when (shape) {
-        is ListShape -> "list_${shape.id.name.toSnakeCase()}"
-        is MapShape -> "map_${shape.id.name.toSnakeCase()}"
-        is MemberShape -> "member_${shape.container.name.toSnakeCase()}_${shape.memberName.toSnakeCase()}"
+        is ListShape -> "list_${shape.id.toRustIdentifier()}"
+        is MapShape -> "map_${shape.id.toRustIdentifier()}"
+        is MemberShape -> "member_${shape.container.toRustIdentifier()}_${shape.memberName.toSnakeCase()}"
         is OperationShape -> "operation_$symbolNameSnakeCase"
-        is SetShape -> "set_${shape.id.name.toSnakeCase()}"
+        is SetShape -> "set_${shape.id.toRustIdentifier()}"
         is StructureShape -> "structure_$symbolNameSnakeCase"
         is UnionShape -> "union_$symbolNameSnakeCase"
         else -> TODO("SerializerFunctionNamer.name: $shape")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamer.kt
@@ -46,7 +46,7 @@ fun RustSymbolProvider.serializeFunctionName(shape: Shape): String = shapeFuncti
 fun RustSymbolProvider.deserializeFunctionName(shape: Shape): String = shapeFunctionName("deser", shape)
 
 fun ShapeId.toRustIdentifier(): String {
-    return this.namespace.replace(".", "_").toSnakeCase() + this.name.toSnakeCase()
+    return "${namespace.replace(".", "_").toSnakeCase()}_${name.toSnakeCase()}"
 }
 
 private fun RustSymbolProvider.shapeFunctionName(prefix: String, shape: Shape): String {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -434,7 +434,13 @@ class XmlBindingTraitParserGenerator(
                 }
                 withBlock("Ok(builder.build()", ")") {
                     if (StructureGenerator.fallibleBuilder(shape, symbolProvider)) {
-                        rustTemplate(""".map_err(|_|{XmlError}::custom("missing field"))?""", *codegenScope)
+                        // NOTE:(rcoh) This branch is unreachable given the current nullability rules.
+                        // Only synthetic inputs can have fallible builders, but synthetic inputs can never be parsed
+                        // (because they're inputs, only outputs will be parsed!)
+
+                        // I'm leaving this branch here so that the binding trait parser generator would work for a server
+                        // side implementation in the future.
+                        rustTemplate(""".map_err(|_|#{XmlError}::custom("missing field"))?""", *codegenScope)
                     }
                 }
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Smithy.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/util/Smithy.kt
@@ -47,32 +47,37 @@ fun MemberShape.isStreaming(model: Model) = this.getMemberTrait(model, Streaming
 fun UnionShape.isEventStream(): Boolean {
     return hasTrait(StreamingTrait::class.java)
 }
+
 fun MemberShape.isEventStream(model: Model): Boolean {
     return (model.expectShape(target) as? UnionShape)?.isEventStream() ?: false
 }
+
 fun MemberShape.isInputEventStream(model: Model): Boolean {
     return isEventStream(model) && model.expectShape(container).hasTrait<SyntheticInputTrait>()
 }
+
 fun MemberShape.isOutputEventStream(model: Model): Boolean {
     return isEventStream(model) && model.expectShape(container).hasTrait<SyntheticInputTrait>()
 }
+
 private fun Shape.hasEventStreamMember(model: Model): Boolean {
     return members().any { it.isEventStream(model) }
 }
+
 fun OperationShape.isInputEventStream(model: Model): Boolean {
     return input.map { id -> model.expectShape(id).hasEventStreamMember(model) }.orElse(false)
 }
+
 fun OperationShape.isOutputEventStream(model: Model): Boolean {
     return output.map { id -> model.expectShape(id).hasEventStreamMember(model) }.orElse(false)
 }
+
 fun OperationShape.isEventStream(model: Model): Boolean {
     return isInputEventStream(model) || isOutputEventStream(model)
 }
+
 fun ServiceShape.hasEventStreamOperations(model: Model): Boolean = operations.any { id ->
-    // Don't assume all of the looked up operation ids are operation shapes. Our
-    // synthetic input/output structure shapes can have the same name as an operation,
-    // as is the case with `kinesisanalytics`.
-    model.getShape(id).orNull()?.let { it is OperationShape && it.isEventStream(model) } ?: false
+    model.expectShape(id, OperationShape::class.java).isEventStream(model)
 }
 
 /*

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/EventStreamSymbolProviderTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/EventStreamSymbolProviderTest.kt
@@ -44,8 +44,8 @@ class EventStreamSymbolProviderTest {
         val provider = EventStreamSymbolProvider(TestRuntimeConfig, SymbolVisitor(model, service, DefaultConfig), model)
 
         // Look up the synthetic input/output rather than the original input/output
-        val inputStream = model.expectShape(ShapeId.from("test#TestOperationInput\$inputStream")) as MemberShape
-        val outputStream = model.expectShape(ShapeId.from("test#TestOperationOutput\$outputStream")) as MemberShape
+        val inputStream = model.expectShape(ShapeId.from("test.synthetic#TestOperationInput\$inputStream")) as MemberShape
+        val outputStream = model.expectShape(ShapeId.from("test.synthetic#TestOperationOutput\$outputStream")) as MemberShape
 
         val inputType = provider.toSymbol(inputStream).rustType()
         val outputType = provider.toSymbol(outputStream).rustType()
@@ -80,8 +80,8 @@ class EventStreamSymbolProviderTest {
         val provider = EventStreamSymbolProvider(TestRuntimeConfig, SymbolVisitor(model, service, DefaultConfig), model)
 
         // Look up the synthetic input/output rather than the original input/output
-        val inputStream = model.expectShape(ShapeId.from("test#TestOperationInput\$inputStream")) as MemberShape
-        val outputStream = model.expectShape(ShapeId.from("test#TestOperationOutput\$outputStream")) as MemberShape
+        val inputStream = model.expectShape(ShapeId.from("test.synthetic#TestOperationInput\$inputStream")) as MemberShape
+        val outputStream = model.expectShape(ShapeId.from("test.synthetic#TestOperationOutput\$outputStream")) as MemberShape
 
         val inputType = provider.toSymbol(inputStream).rustType()
         val outputType = provider.toSymbol(outputStream).rustType()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/StreamingShapeSymbolProviderTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/StreamingShapeSymbolProviderTest.kt
@@ -36,8 +36,8 @@ internal class StreamingShapeSymbolProviderTest {
         // "doing the right thing"
         val modelWithOperationTraits = OperationNormalizer.transform(model)
         val symbolProvider = testSymbolProvider(modelWithOperationTraits)
-        symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test#GenerateSpeechOutput\$data")).name shouldBe ("byte_stream::ByteStream")
-        symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test#GenerateSpeechInput\$data")).name shouldBe ("byte_stream::ByteStream")
+        symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechOutput\$data")).name shouldBe ("byte_stream::ByteStream")
+        symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechInput\$data")).name shouldBe ("byte_stream::ByteStream")
     }
 
     @Test
@@ -45,8 +45,8 @@ internal class StreamingShapeSymbolProviderTest {
         val modelWithOperationTraits = OperationNormalizer.transform(model)
         val symbolProvider = testSymbolProvider(modelWithOperationTraits)
 
-        val outputSymbol = symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test#GenerateSpeechOutput\$data"))
-        val inputSymbol = symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test#GenerateSpeechInput\$data"))
+        val outputSymbol = symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechOutput\$data"))
+        val inputSymbol = symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechInput\$data"))
         // Ensure that users don't need to set an input
         outputSymbol.defaultValue() shouldBe Default.RustDefault
         inputSymbol.defaultValue() shouldBe Default.RustDefault

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamerTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamerTest.kt
@@ -102,13 +102,13 @@ class InlineFunctionNamerTest {
             symbolProvider.deserializeFunctionName(testModel.lookup(shapeId)) shouldBe "deser_$suffix"
         }
 
-        test("test#Op1", "operation_op1")
-        test("test#SomeList1", "list_some_list1")
-        test("test#SomeMap1", "map_some_map1")
-        test("test#SomeSet1", "set_some_set1")
-        test("test#SomeStruct1", "structure_some_struct1")
-        test("test#SomeUnion1", "union_some_union1")
-        test("test#SomeStruct1\$some_string", "member_some_struct1_some_string")
+        test("test#Op1", "operation_crate_operation_op1")
+        test("test#SomeList1", "list_test_some_list1")
+        test("test#SomeMap1", "map_test_some_map1")
+        test("test#SomeSet1", "set_test_some_set1")
+        test("test#SomeStruct1", "structure_crate_model_some_struct1")
+        test("test#SomeUnion1", "union_crate_model_some_union1")
+        test("test#SomeStruct1\$some_string", "member_test_some_struct1_some_string")
     }
 
     @Test

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/OperationNormalizerTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/OperationNormalizerTest.kt
@@ -86,4 +86,32 @@ internal class OperationNormalizerTest {
         testSymbolProvider(modified).toSymbol(outputShape).name shouldBe "MyOpOutput"
         outputShape.memberNames shouldBe listOf("v")
     }
+
+    @Test
+    fun `synthetics should not collide with other operations`() {
+        val model = """
+            namespace test
+
+            structure DeleteApplicationRequest {}
+            structure DeleteApplicationResponse {}
+
+            operation DeleteApplication {
+                input: DeleteApplicationRequest,
+                output: DeleteApplicationResponse,
+            }
+
+            structure DeleteApplicationOutputRequest {}
+            structure DeleteApplicationOutputResponse {}
+
+            operation DeleteApplicationOutput {
+                input: DeleteApplicationOutputRequest,
+                output: DeleteApplicationOutputResponse,
+            }
+        """.asSmithyModel()
+
+        (model.expectShape(ShapeId.from("test#DeleteApplicationOutput")) is OperationShape) shouldBe true
+
+        val modified = OperationNormalizer.transform(model)
+        (modified.expectShape(ShapeId.from("test#DeleteApplicationOutput")) is OperationShape) shouldBe true
+    }
 }


### PR DESCRIPTION
-[ ] Tier-2 check passed
- Fixes #662 
## Motivation and Context
During codegeneration, synthetic copies of input & output shapes are created. However, due to a Smithy shape id conflict, these
shapes were overwriting existing shapes in the model instead of creating new shapes.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
This lead to a number of bugs exposed by the new s3control model. A minimal example of this model is included as a test in rest-xml-extras.

This commit augments the namespace of synthetic shapes to exist in the `synthetic` Smithy namespace, removing the conflict. After this bug was fixed, a subsequent bug in the serializer function naming was exposed where two shapes with the same name but in different modules generated a conflicting serializer.
<!--- Describe your changes in detail -->

## Testing


Tests:
- [x] new s3control model compiles
- [x] test case added to rest-xml-extras
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
