### PR TITLE
update: require that unmarshaller used to create a Receiver is Send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+vNext (Month, Day, Year)
+=======================
+
+- Update `Recevier`s to be `Send` (aws-sdk-rust#224)
+
 v0.23 (September 14th, 2021)
 =======================
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 vNext (Month, Day, Year)
 =======================
 
-- Update `Recevier`s to be `Send` (aws-sdk-rust#224)
+- Update `Receiver`s to be `Send` (aws-sdk-rust#224)
 
 v0.23 (September 14th, 2021)
 =======================

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,3 +1,8 @@
+vNext (Month Day, Year)
+=======================
+
+- Update `Recevier`s to be `Send` (aws-sdk-rust#224)
+
 v0.0.18-alpha (September 14th, 2021)
 =======================
 - :tada: Add support for `OpenSearch` service & bring in other model updates (#todo)

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,7 +1,7 @@
 vNext (Month Day, Year)
 =======================
 
-- Update `Recevier`s to be `Send` (aws-sdk-rust#224)
+- Update `Receiver`s to be `Send` (aws-sdk-rust#224)
 
 v0.0.18-alpha (September 14th, 2021)
 =======================

--- a/rust-runtime/smithy-http/src/event_stream.rs
+++ b/rust-runtime/smithy-http/src/event_stream.rs
@@ -413,6 +413,13 @@ mod tests {
         );
     }
 
+    fn assert_send<T: Send>() {}
+
+    #[tokio::test]
+    async fn receiver_is_send() {
+        assert_send::<Receiver::<(), ()>>();
+    }
+
     #[derive(Debug)]
     struct TestServiceError;
     impl std::fmt::Display for TestServiceError {

--- a/rust-runtime/smithy-http/src/event_stream.rs
+++ b/rust-runtime/smithy-http/src/event_stream.rs
@@ -417,7 +417,7 @@ mod tests {
 
     #[tokio::test]
     async fn receiver_is_send() {
-        assert_send::<Receiver::<(), ()>>();
+        assert_send::<Receiver<(), ()>>();
     }
 
     #[derive(Debug)]

--- a/rust-runtime/smithy-http/src/event_stream.rs
+++ b/rust-runtime/smithy-http/src/event_stream.rs
@@ -138,7 +138,7 @@ where
 /// Receives Smithy-modeled messages out of an Event Stream.
 #[derive(Debug)]
 pub struct Receiver<T, E> {
-    unmarshaller: Box<dyn UnmarshallMessage<Output = T, Error = E>>,
+    unmarshaller: Box<dyn UnmarshallMessage<Output = T, Error = E> + Send>,
     decoder: MessageFrameDecoder,
     buffer: SegmentedBuf<Bytes>,
     body: SdkBody,
@@ -153,7 +153,7 @@ pub struct Receiver<T, E> {
 impl<T, E> Receiver<T, E> {
     /// Creates a new `Receiver` with the given message unmarshaller and SDK body.
     pub fn new(
-        unmarshaller: impl UnmarshallMessage<Output = T, Error = E> + 'static,
+        unmarshaller: impl UnmarshallMessage<Output = T, Error = E> + Send + 'static,
         body: SdkBody,
     ) -> Self {
         Receiver {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes https://github.com/awslabs/aws-sdk-rust/issues/224

## Description
<!--- Describe your changes in detail -->
This PR updates the smithy message `Receiver<T, E>` to require that it be created with a `Send` `UnmarshallMessage`. Without this change, the Future generated by `Recevier::recv` would not be `Send`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this locally with the example code provided in https://github.com/awslabs/aws-sdk-rust/issues/224

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
