### PR TITLE
Add credential provider for assuming roles via STS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 - Add `TimeSource` to `aws_types::os_shim_internal` (#701)
 - User agent construction is now `const fn` (#701)
 - Update event stream `Receiver`s to be `Send` (#702, #aws-sdk-rust#224)
+- Add `sts::AssumeRoleProvider` to `aws-config` (#703, aws-sdk-rust#3)
 
 v0.23 (September 14th, 2021)
 =======================

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -3,6 +3,7 @@ vNext (Month Day, Year)
 **New This Week**
 - Add IMDS client to `aws-config`
 - Update event stream `Receiver`s to be `Send` (aws-sdk-rust#224)
+- Add `sts::AssumeRoleProvider` to `aws-config` (#703, aws-sdk-rust#3)
 
 v0.0.18-alpha (September 14th, 2021)
 =======================

--- a/aws/rust-runtime/aws-config/src/environment/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/environment/credentials.rs
@@ -16,7 +16,7 @@ use aws_types::{credentials, Credentials};
 /// - `AWS_ACCESS_KEY_ID`
 /// - `AWS_SECRET_ACCESS_KEY` with fallback to `SECRET_ACCESS_KEY`
 /// - `AWS_SESSION_TOKEN`
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EnvironmentVariableCredentialsProvider {
     env: Env,
 }

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -59,7 +59,7 @@ pub mod meta;
 pub mod profile;
 
 #[cfg(feature = "sts")]
-mod sts;
+pub mod sts;
 
 #[cfg(test)]
 mod test_case;

--- a/aws/rust-runtime/aws-config/src/sts.rs
+++ b/aws/rust-runtime/aws-config/src/sts.rs
@@ -3,14 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-pub mod util {
+//! Credential provider augmentation through the AWS Security Token Service (STS).
+
+mod assume_role;
+pub use assume_role::{AssumeRoleProvider, AssumeRoleProviderBuilder};
+
+pub(crate) mod util {
     use aws_sdk_sts::model::Credentials as StsCredentials;
     use aws_types::credentials::{self, CredentialsError};
     use aws_types::Credentials as AwsCredentials;
     use std::time::{SystemTime, UNIX_EPOCH};
 
     /// Convert STS credentials to aws_auth::Credentials
-    pub fn into_credentials(
+    pub(crate) fn into_credentials(
         sts_credentials: Option<StsCredentials>,
         provider_name: &'static str,
     ) -> credentials::Result {
@@ -42,7 +47,7 @@ pub mod util {
     /// STS Assume Role providers MUST assign a name to their generated session. When a user does not
     /// provide a name for the session, the provider will choose a name composed of a base + a timestamp,
     /// eg. `profile-file-provider-123456789`
-    pub fn default_session_name(base: &str) -> String {
+    pub(crate) fn default_session_name(base: &str) -> String {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("post epoch");

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -1,0 +1,206 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! Assume credentials for a role through the AWS Security Token Service (STS).
+
+use aws_sdk_sts::error::AssumeRoleErrorKind;
+use aws_sdk_sts::operation::AssumeRole;
+use aws_types::credentials::{
+    self, future, CredentialsError, ProvideCredentials, SharedCredentialsProvider,
+};
+use aws_types::region::Region;
+
+use tracing::Instrument;
+
+/// Credentials provider that uses credentials provided by another provider to assume a role
+/// through the AWS Security Token Service (STS).
+///
+/// When asked to provide credentials, this provider will first invoke the inner credentials
+/// provider to get AWS credentials for STS. Then, it will call STS to get assumed credentials for
+/// the desired role.
+///
+/// # Examples
+/// ```rust
+/// use aws_config::sts::{AssumeRoleProvider};
+/// use aws_types::{Credentials, region::Region};
+/// use aws_config::environment;
+/// use aws_config::environment::credentials::EnvironmentVariableCredentialsProvider;
+/// use std::sync::Arc;
+///
+/// let provider = AssumeRoleProvider::builder("arn:aws:iam::123456789012:role/demo")
+///   .region(Region::from_static("us-east-2"))
+///   .session_name("testAR")
+///   .build(Arc::new(EnvironmentVariableCredentialsProvider::new()) as Arc<_>);
+/// ```
+#[derive(Debug)]
+pub struct AssumeRoleProvider {
+    sts: aws_hyper::StandardClient,
+    conf: aws_sdk_sts::Config,
+    op: aws_sdk_sts::input::AssumeRoleInput,
+}
+
+impl AssumeRoleProvider {
+    /// Build a new role-assuming provider for the given role.
+    ///
+    /// The `role` argument should take the form an Amazon Resource Name (ARN) like
+    ///
+    /// ```text
+    /// arn:aws:iam::123456789012:role/example
+    /// ```
+    pub fn builder(role: impl Into<String>) -> AssumeRoleProviderBuilder {
+        AssumeRoleProviderBuilder::new(role.into())
+    }
+}
+
+/// A builder for [`AssumeRoleProvider`].
+///
+/// Construct one through [`AssumeRoleProvider::builder`].
+pub struct AssumeRoleProviderBuilder {
+    role_arn: String,
+    external_id: Option<String>,
+    session_name: Option<String>,
+    region: Option<Region>,
+    connection: Option<smithy_client::erase::DynConnector>,
+}
+
+impl AssumeRoleProviderBuilder {
+    /// Start a new assume role builder for the given role.
+    ///
+    /// The `role` argument should take the form an Amazon Resource Name (ARN) like
+    ///
+    /// ```text
+    /// arn:aws:iam::123456789012:role/example
+    /// ```
+    pub fn new(role: impl Into<String>) -> Self {
+        Self {
+            role_arn: role.into(),
+            external_id: None,
+            session_name: None,
+            region: None,
+            connection: None,
+        }
+    }
+
+    /// Set a unique identifier that might be required when you assume a role in another account.
+    ///
+    /// If the administrator of the account to which the role belongs provided you with an external
+    /// ID, then provide that value in this parameter. The value can be any string, such as a
+    /// passphrase or account number.
+    pub fn external_id(mut self, id: impl Into<String>) -> Self {
+        self.external_id = Some(id.into());
+        self
+    }
+
+    /// Set an identifier for the assumed role session.
+    ///
+    /// Use the role session name to uniquely identify a session when the same role is assumed by
+    /// different principals or for different reasons. In cross-account scenarios, the role session
+    /// name is visible to, and can be logged by the account that owns the role. The role session
+    /// name is also used in the ARN of the assumed role principal.
+    pub fn session_name(mut self, name: impl Into<String>) -> Self {
+        self.session_name = Some(name.into());
+        self
+    }
+
+    /// Set the region to assume the role in.
+    ///
+    /// This dictates which STS endpoint the AssumeRole action is invoked on.
+    pub fn region(mut self, region: Region) -> Self {
+        self.region = Some(region);
+        self
+    }
+
+    /// Set the backing connection to use when talking to STS.
+    pub fn connection(mut self, conn: impl smithy_client::bounds::SmithyConnector) -> Self {
+        self.connection = Some(smithy_client::erase::DynConnector::new(conn));
+        self
+    }
+
+    /// Build a credentials provider for this role authorized by the given `provider`.
+    pub fn build(self, provider: impl Into<SharedCredentialsProvider>) -> AssumeRoleProvider {
+        let config = aws_sdk_sts::Config::builder()
+            .credentials_provider(provider.into())
+            .region(self.region.clone())
+            .build();
+
+        let client = if let Some(conn) = self.connection {
+            aws_hyper::Client::new(conn)
+        } else {
+            aws_hyper::Client::https()
+        };
+
+        let session_name = self
+            .session_name
+            .unwrap_or_else(|| super::util::default_session_name("assume-role-provider"));
+
+        let operation = AssumeRole::builder()
+            .set_role_arn(Some(self.role_arn))
+            .set_external_id(self.external_id)
+            .set_role_session_name(Some(session_name))
+            .build()
+            .expect("operation is valid");
+
+        AssumeRoleProvider {
+            sts: client,
+            conf: config,
+            op: operation,
+        }
+    }
+}
+
+impl AssumeRoleProvider {
+    #[tracing::instrument(
+        name = "assume_role",
+        level = "info",
+        skip(self),
+        fields(op = ?self.op)
+    )]
+    async fn credentials(&self) -> credentials::Result {
+        tracing::info!("assuming role");
+
+        tracing::debug!("retrieving assumed credentials");
+        let op = self
+            .op
+            .clone()
+            .make_operation(&self.conf)
+            .expect("valid operation");
+
+        let assumed = self.sts.call(op).in_current_span().await;
+        match assumed {
+            Ok(assumed) => {
+                tracing::debug!(
+                    access_key_id = ?assumed.credentials.as_ref().map(|c| &c.access_key_id),
+                    "obtained assumed credentials"
+                );
+                super::util::into_credentials(assumed.credentials, "AssumeRoleProvider")
+            }
+            Err(aws_hyper::SdkError::ServiceError { err, raw }) => {
+                match err.kind {
+                    AssumeRoleErrorKind::RegionDisabledException(_)
+                    | AssumeRoleErrorKind::MalformedPolicyDocumentException(_) => {
+                        return Err(CredentialsError::InvalidConfiguration(
+                            aws_hyper::SdkError::ServiceError { err, raw }.into(),
+                        ))
+                    }
+                    _ => {}
+                }
+                tracing::warn!(error = ?err.message(), "sts refused to grant assume role");
+                Err(CredentialsError::ProviderError(
+                    aws_hyper::SdkError::ServiceError { err, raw }.into(),
+                ))
+            }
+            Err(err) => Err(CredentialsError::ProviderError(err.into())),
+        }
+    }
+}
+
+impl ProvideCredentials for AssumeRoleProvider {
+    fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials
+    where
+        Self: 'a,
+    {
+        future::ProvideCredentials::new(self.credentials())
+    }
+}


### PR DESCRIPTION
## Motivation and Context

This adds a simple `ProvideCredentials` implementation that assumes a role through the AWS Security Token Service (STS) using credentials provided by another provider. This, in turn, enables users to access other SDK API through permissions they have been granted on other accounts, rather than just through their own account. This was previously only possible through careful configuration of the credentials profile file, which is inconvenient for programmatic access.

Will address https://github.com/awslabs/aws-sdk-rust/issues/3.

## Description

Adds the `AssumeRoleProvider` type under the now-public `sts` module, which wraps an inner credentials provider `P`. The user provides the ARN for the role to assume, as well as a temporary session name, and `AssumeRoleProvider` attempts to pull credentials for that role using the credentials provided by `P`.

## Testing

I set up two AWS accounts, A and B, with one role each (RA and RB respectively).

I set the trust relationships policy for RA to be
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "",
      "Effect": "Allow",
      "Principal": {
        "AWS": "arn:aws:iam::B:role/RB"
      },
      "Action": "sts:AssumeRole"
    }
  ]
}
```

I set the access policy for RB to be
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Action": "sts:AssumeRole",
            "Resource": "arn:aws:iam::A:role/RA"
        }
    ]
}
```

I also granted RA access to particular AWS service (say, Foo) that RB did not have access to.

I then checked that RB indeed did not have access to Foo:

```rust
use aws_config::default_provider::credentials::default_provider;
use aws_types::credentials::ProvideCredentials;
use aws_types::region::Region;

let mut config = aws_foo::Config::builder();
let provider = Arc::new(default_provider().await) as Arc<dyn ProvideCredentials + 'static>;
config.credentials_provider(provider);

// ... construct aws_foo::Client and attempt to invoke a method
```

That call failed as expected. I then added the `AssumeRoleProvider`:

```rust
use aws_config::default_provider::credentials::default_provider;
use aws_config::sts::AssumeRoleProvider;
use aws_types::credentials::ProvideCredentials;
use aws_types::region::Region;

let mut config = aws_foo::Config::builder();
let provider = Arc::new(default_provider().await) as Arc<dyn ProvideCredentials + 'static>;
let provider = AssumeRoleProvider::new(
    provider,
    "arn:aws:iam::A:role/RA",
    Region::from_static("us-east-2"), // same as config.region() set elsewhere
    "testing",
);
config.credentials_provider(provider);

// ... construct aws_foo::Client and attempt to invoke a method
```

And the call succeeded. Logs indicate that STS was contacted and provided the credentials for the assumed role.

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
