### PR TITLE
Fix signing of UTF-8 header values

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 - Add IMDS credential provider to `aws-config` (smithy-rs#709)
 - Update event stream `Receiver`s to be `Send` (aws-sdk-rust#224)
 - Add `sts::AssumeRoleProvider` to `aws-config` (#703, aws-sdk-rust#3)
+- :bug: Fix panic when signing non-ASCII header values (smithy-rs#708, aws-sdk-rust#226)
 
 v0.0.18-alpha (September 14th, 2021)
 =======================

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -317,7 +317,12 @@ impl<'a> fmt::Display for CanonicalRequest<'a> {
             // a missing header is a bug, so we should panic.
             let value = &self.headers[&header.0];
             write!(f, "{}:", header.0.as_str())?;
-            writeln!(f, "{}", value.to_str().unwrap())?;
+            writeln!(
+                f,
+                "{}",
+                std::str::from_utf8(value.as_bytes())
+                    .expect("SDK request header values are valid UTF-8")
+            )?;
         }
         writeln!(f)?;
         // write out the signed headers

--- a/aws/rust-runtime/aws-sigv4/src/http_request/test.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/test.rs
@@ -54,7 +54,7 @@ fn test_parsed_request(name: &str, ext: &str) -> Request<Bytes> {
     }
 }
 
-pub(crate) fn make_headers_comparable(request: &mut Request<Bytes>) {
+pub(crate) fn make_headers_comparable<B>(request: &mut Request<B>) {
     for (_name, value) in request.headers_mut() {
         value.set_sensitive(false);
     }


### PR DESCRIPTION
## Motivation and Context
This fixes #708 and will fix aws-sdk-rust#226 upon release.

## Testing
- Added a unit test that reproduced the issue
- Manually tested by calling S3 PutObject with metadata that had non-ASCII characters

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
