### PR TITLE
Msrv 1.53.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 name: CI
 
 env:
-  rust_version: 1.52.1
+  rust_version: 1.53.0
   rust_toolchain_components: clippy,rustfmt
   java_version: 11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 vNext (Month Day, Year)
 =======================
+**Breaking changes**
+- :warning: MSRV increased from 1.52.1 to 1.53.0 per our 3-behind MSRV policy.
+
+**New this week**
 - :bug: Fix an issue where `smithy-xml` may have generated invalid XML (smithy-rs#719)
 
 v0.24 (September 24th, 2021)

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,5 +1,10 @@
 vNext (Month Day, Year)
 =======================
+**Breaking changes**
+- :warning: MSRV increased from 1.52.1 to 1.53.0 per our 3-behind MSRV policy.
+
+**Tasks to cut release**
+- [ ] Bump MSRV on aws-sdk-rust, then delete this line.
 
 v0.0.19-alpha (September 24th, 2021)
 ====================================

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -90,7 +90,7 @@ impl CredentialsProviderChain {
                 }
             }
         }
-        return Err(CredentialsError::CredentialsNotLoaded);
+        Err(CredentialsError::CredentialsNotLoaded)
     }
 }
 

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -151,12 +151,10 @@ pub mod named {
     }
 
     fn lower_cow(mut inp: Cow<str>) -> Cow<str> {
-        if inp.chars().all(|c| c.is_ascii_lowercase()) {
-            inp
-        } else {
+        if !inp.chars().all(|c| c.is_ascii_lowercase()) {
             inp.to_mut().make_ascii_lowercase();
-            inp
         }
+        inp
     }
 
     impl NamedProviderFactory {

--- a/rust-runtime/smithy-types/src/instant/mod.rs
+++ b/rust-runtime/smithy-types/src/instant/mod.rs
@@ -100,11 +100,11 @@ impl Instant {
     }
 
     #[cfg(feature = "chrono-conversions")]
-    pub fn to_chrono(&self) -> DateTime<Utc> {
+    pub fn to_chrono(self) -> DateTime<Utc> {
         self.to_chrono_internal()
     }
 
-    fn to_chrono_internal(&self) -> DateTime<Utc> {
+    fn to_chrono_internal(self) -> DateTime<Utc> {
         DateTime::<Utc>::from_utc(
             NaiveDateTime::from_timestamp(self.seconds, self.subsecond_nanos),
             Utc,
@@ -115,7 +115,7 @@ impl Instant {
     ///
     /// Since SystemTime cannot represent times prior to the unix epoch, if this time is before
     /// 1/1/1970, this function will return `None`.
-    pub fn to_system_time(&self) -> Option<SystemTime> {
+    pub fn to_system_time(self) -> Option<SystemTime> {
         if self.seconds < 0 {
             None
         } else {
@@ -146,7 +146,7 @@ impl Instant {
     /// Converts the `Instant` to the number of milliseconds since the Unix epoch.
     /// This is fallible since `Instant` holds more precision than an `i64`, and will
     /// return a `ConversionError` for `Instant` values that can't be converted.
-    pub fn to_epoch_millis(&self) -> Result<i64, ConversionError> {
+    pub fn to_epoch_millis(self) -> Result<i64, ConversionError> {
         let subsec_millis =
             Integer::div_floor(&i64::from(self.subsecond_nanos), &(NANOS_PER_MILLI as i64));
         if self.seconds < 0 {

--- a/rust-runtime/smithy-types/src/lib.rs
+++ b/rust-runtime/smithy-types/src/lib.rs
@@ -64,11 +64,11 @@ pub enum Number {
 macro_rules! to_num_fn {
     ($name:ident, $typ:ident) => {
         /// Converts to a `$typ`. This conversion may be lossy.
-        pub fn $name(&self) -> $typ {
+        pub fn $name(self) -> $typ {
             match self {
-                Number::PosInt(val) => *val as $typ,
-                Number::NegInt(val) => *val as $typ,
-                Number::Float(val) => *val as $typ,
+                Number::PosInt(val) => val as $typ,
+                Number::NegInt(val) => val as $typ,
+                Number::Float(val) => val as $typ,
             }
         }
     };


### PR DESCRIPTION
## Motivation and Context
Our MSRV is to remain 3 major versions behind stable.

## Description
Small fixes for clippy to upgrade to 1.53.0

## Testing
- `./gradlew :aws:sdk:cargoClippy`. We need a full SDK build prior to merging. 
## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
