### PR TITLE
Fix bugs in Event Stream unmarshalling

### DIFF
--- a/rust-runtime/smithy-eventstream/src/smithy.rs
+++ b/rust-runtime/smithy-eventstream/src/smithy.rs
@@ -32,10 +32,17 @@ expect_shape_fn!(fn expect_byte_array[ByteArray] -> Blob { bytes -> Blob::new(by
 expect_shape_fn!(fn expect_string[String] -> String { value -> value.as_str().into() });
 expect_shape_fn!(fn expect_timestamp[Timestamp] -> Instant { value -> *value });
 
+#[derive(Debug)]
 pub struct ResponseHeaders<'a> {
-    pub content_type: &'a StrBytes,
+    pub content_type: Option<&'a StrBytes>,
     pub message_type: &'a StrBytes,
     pub smithy_type: &'a StrBytes,
+}
+
+impl<'a> ResponseHeaders<'a> {
+    pub fn content_type_as_str(&self) -> Option<&str> {
+        self.content_type.map(|ct| ct.as_str())
+    }
 }
 
 fn expect_header_str_value<'a>(
@@ -70,7 +77,9 @@ pub fn parse_response_headers(message: &Message) -> Result<ResponseHeaders, Erro
     }
     let message_type = expect_header_str_value(message_type, ":message-type")?;
     Ok(ResponseHeaders {
-        content_type: expect_header_str_value(content_type, ":content-type")?,
+        content_type: content_type
+            .map(|ct| expect_header_str_value(Some(ct), ":content-type"))
+            .transpose()?,
         message_type,
         smithy_type: if message_type.as_str() == "event" {
             expect_header_str_value(event_type, ":event-type")?
@@ -107,7 +116,7 @@ mod tests {
             ));
         let parsed = parse_response_headers(&message).unwrap();
         assert_eq!("Foo", parsed.smithy_type.as_str());
-        assert_eq!("application/json", parsed.content_type.as_str());
+        assert_eq!(Some("application/json"), parsed.content_type_as_str());
         assert_eq!("event", parsed.message_type.as_str());
     }
 
@@ -128,7 +137,7 @@ mod tests {
             ));
         let parsed = parse_response_headers(&message).unwrap();
         assert_eq!("BadRequestException", parsed.smithy_type.as_str());
-        assert_eq!("application/json", parsed.content_type.as_str());
+        assert_eq!(Some("application/json"), parsed.content_type_as_str());
         assert_eq!("exception", parsed.message_type.as_str());
     }
 
@@ -144,7 +153,11 @@ mod tests {
                 HeaderValue::String("exception".into()),
             ));
         let error = parse_response_headers(&message).err().unwrap().to_string();
-        assert_eq!("failed to unmarshall message: expected response to include :exception-type header, but it was missing", error);
+        assert_eq!(
+            "failed to unmarshall message: expected response to include :exception-type \
+             header, but it was missing",
+            error
+        );
     }
 
     #[test]
@@ -159,7 +172,11 @@ mod tests {
                 HeaderValue::String("event".into()),
             ));
         let error = parse_response_headers(&message).err().unwrap().to_string();
-        assert_eq!("failed to unmarshall message: expected response to include :event-type header, but it was missing", error);
+        assert_eq!(
+            "failed to unmarshall message: expected response to include :event-type \
+             header, but it was missing",
+            error
+        );
     }
 
     #[test]
@@ -173,7 +190,29 @@ mod tests {
                 ":message-type",
                 HeaderValue::String("event".into()),
             ));
+        let parsed = parse_response_headers(&message).ok().unwrap();
+        assert_eq!(None, parsed.content_type);
+        assert_eq!("Foo", parsed.smithy_type.as_str());
+        assert_eq!("event", parsed.message_type.as_str());
+    }
+
+    #[test]
+    fn content_type_wrong_type() {
+        let message = Message::new(&b"test"[..])
+            .add_header(Header::new(
+                ":event-type",
+                HeaderValue::String("Foo".into()),
+            ))
+            .add_header(Header::new(":content-type", HeaderValue::Int32(16)))
+            .add_header(Header::new(
+                ":message-type",
+                HeaderValue::String("event".into()),
+            ));
         let error = parse_response_headers(&message).err().unwrap().to_string();
-        assert_eq!("failed to unmarshall message: expected response to include :content-type header, but it was missing", error);
+        assert_eq!(
+            "failed to unmarshall message: expected response :content-type \
+             header to be string, received Int32(16)",
+            error
+        );
     }
 }

--- a/rust-runtime/smithy-http/Cargo.toml
+++ b/rust-runtime/smithy-http/Cargo.toml
@@ -35,7 +35,7 @@ async-stream = "0.3"
 futures-util = "0.3"
 hyper = { version = "0.14.5", features = ["stream"] }
 proptest = "1"
-tokio = {version = "1.6", features = ["macros", "rt", "fs", "io-util"]}
+tokio = {version = "1.6", features = ["macros", "rt", "rt-multi-thread", "fs", "io-util"]}
 tokio-stream = "0.1.5"
 tempfile = "3.2.0"
 


### PR DESCRIPTION
## Description
This PR fixes the issue reported in aws-sdk-rust#239, as well as a couple other issues identified while testing the fix for it:
- S3 Select's `Cont` event doesn't come across with a `:content-type` header, but the unmarshaller was expecting this header.
- The unmarshaller attempted to parse events that were modeled as empty structs, but S3 sends an empty payload for empty structs rather than an empty XML payload conforming to restXml.
- The event stream `Receiver` was returning that there were no more events even when it had some remaining events in its buffer.

## Testing
- Placed a large (>200 MB) CSV file in S3 and queried it with `select count(*) from s3object` to trigger the `Cont` event.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
