### PR TITLE
Refactored API Gateway code example 

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -9,6 +9,7 @@ vNext (Month Day, Year)
 **New This Week**
 
 - :tada: Add presigned request support and examples for S3 GetObject and PutObject (smithy-rs#731)
+- Refactored API Gateway code example by moving operation out of main and into a separate function.
 
 v0.0.19-alpha (September 24th, 2021)
 ====================================

--- a/aws/sdk/examples/apigateway/src/bin/get_rest_apis.rs
+++ b/aws/sdk/examples/apigateway/src/bin/get_rest_apis.rs
@@ -18,6 +18,28 @@ struct Opt {
     verbose: bool,
 }
 
+// Displays the Amazon API Gateway REST APIs in the Region.
+async fn show_apis(client: &aws_sdk_apigateway::Client) -> Result<(), aws_sdk_apigateway::Error> {
+    let resp = client.get_rest_apis().send().await?;
+
+    for api in resp.items.unwrap_or_default() {
+        println!("ID:          {}", api.id.as_deref().unwrap_or_default());
+        println!("Name:        {}", api.name.as_deref().unwrap_or_default());
+        println!(
+            "Description: {}",
+            api.description.as_deref().unwrap_or_default()
+        );
+        println!(
+            "Version:     {}",
+            api.version.as_deref().unwrap_or_default()
+        );
+        println!("Created:     {}", api.created_date.unwrap().to_chrono());
+        println!();
+    }
+
+    Ok(())
+}
+
 /// Displays information about the Amazon API Gateway REST APIs in the Region.
 ///
 /// # Arguments
@@ -49,22 +71,7 @@ async fn main() -> Result<(), Error> {
     let shared_config = aws_config::from_env().region(region_provider).load().await;
     let client = Client::new(&shared_config);
 
-    let resp = client.get_rest_apis().send().await?;
-
-    for api in resp.items.unwrap_or_default() {
-        println!("ID:          {}", api.id.as_deref().unwrap_or_default());
-        println!("Name:        {}", api.name.as_deref().unwrap_or_default());
-        println!(
-            "Description: {}",
-            api.description.as_deref().unwrap_or_default()
-        );
-        println!(
-            "Version:     {}",
-            api.version.as_deref().unwrap_or_default()
-        );
-        println!("Created:     {}", api.created_date.unwrap().to_chrono());
-        println!();
-    }
+    show_apis(&client).await.unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
Moved **get_rest_apis** operation out of main and into a separate function.

## Motivation and Context
This change facilitates exposing the function for an AWS SDK docs topic.

## Description
Moved the client call to **get_rest_apis** to the **show_apis** function.

## Testing
Tested using clippy; ran against alpha 0.0.19 bits.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
