### PR TITLE
Refactored Application Auto Scaling code example

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -9,6 +9,7 @@ vNext (Month Day, Year)
 **New This Week**
 
 - :tada: Add presigned request support and examples for S3 GetObject and PutObject (smithy-rs#731)
+- - Refactored Application Auto Scaling code example by moving operation out of main and into a separate function.
 
 v0.0.19-alpha (September 24th, 2021)
 ====================================

--- a/aws/sdk/examples/applicationautoscaling/Cargo.toml
+++ b/aws/sdk/examples/applicationautoscaling/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "applicationautoscaling"
+name = "applicationautoscaling-code-examples"
 version = "0.1.0"
-authors = ["John DiSanti <jdisanti@amazon.com>"]
+authors = ["John DiSanti <jdisanti@amazon.com>, Doug Schwartz <dougsch@amazon.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 aws-config = { path = "../../build/aws-sdk/aws-config" }
-applicationautoscaling = { package = "aws-sdk-applicationautoscaling", path = "../../build/aws-sdk/applicationautoscaling" }
+aws-sdk-applicationautoscaling = { package = "aws-sdk-applicationautoscaling", path = "../../build/aws-sdk/applicationautoscaling" }
 aws-types = { path = "../../build/aws-sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }

--- a/aws/sdk/examples/applicationautoscaling/src/bin/describe-scaling-policies.rs
+++ b/aws/sdk/examples/applicationautoscaling/src/bin/describe-scaling-policies.rs
@@ -3,23 +3,43 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use applicationautoscaling::model::ServiceNamespace;
-use applicationautoscaling::{Client, Error, Region};
 use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_applicationautoscaling::model::ServiceNamespace;
+use aws_sdk_applicationautoscaling::{Client, Error, Region, PKG_VERSION};
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Opt {
-    /// The region
+    /// The AWS Region.
     #[structopt(short, long)]
     region: Option<String>,
 
-    /// Whether to display additional information
+    /// Whether to display additional information.
     #[structopt(short, long)]
     verbose: bool,
 }
 
-/// Lists your Amazon Cognito identities
+// Lists the Application Auto Scaling policies.
+async fn show_policies(
+    client: &aws_sdk_applicationautoscaling::Client,
+) -> Result<(), aws_sdk_applicationautoscaling::Error> {
+    let response = client
+        .describe_scaling_policies()
+        .service_namespace(ServiceNamespace::Ec2)
+        .send()
+        .await?;
+    if let Some(policies) = response.scaling_policies {
+        println!("Auto Scaling Policies:");
+        for policy in policies {
+            println!("{:?}\n", policy);
+        }
+    }
+    println!("Next token: {:?}", response.next_token);
+
+    Ok(())
+}
+
+/// Lists your Application Auto Scaling policies in the Region.
 /// # Arguments
 ///
 /// * `[-r REGION]` - The region containing the buckets.
@@ -38,10 +58,7 @@ async fn main() -> Result<(), Error> {
     let shared_config = aws_config::from_env().region(region_provider).load().await;
 
     if verbose {
-        println!(
-            "Application Auto Scaling client version: {}",
-            applicationautoscaling::PKG_VERSION
-        );
+        println!("Application Auto Scaling client version: {}", PKG_VERSION);
         println!(
             "Region:                                  {:?}",
             shared_config.region().unwrap()
@@ -51,18 +68,7 @@ async fn main() -> Result<(), Error> {
 
     let client = Client::new(&shared_config);
 
-    let response = client
-        .describe_scaling_policies()
-        .service_namespace(ServiceNamespace::Ec2)
-        .send()
-        .await?;
-    if let Some(policies) = response.scaling_policies {
-        println!("Auto Scaling Policies:");
-        for policy in policies {
-            println!("{:?}\n", policy);
-        }
-    }
-    println!("Next token: {:?}", response.next_token);
+    show_policies(&client).await.unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
Moved **describe_scaling_policies** operation of main and into separate function.

## Motivation and Context
This change facilitates exposing the function for an AWS SDK docs topic.

## Description
Moved the client call to **describe_scaling_policies** to the **show_policies** function.

## Testing
Tested using clippy; ran against alpha 0.0.19 bits.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
