### PR TITLE
fix: accidental ser instead of deser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 vNext (Month Day, Year)
 =======================
-...
+
+**New this week**
+
+- :bug: Re-add missing deserialization operations that were missing because of a typo in `HttpBoundProtocolGenerator.kt`
 
 v0.25 (October 7th, 2021)
 =========================

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -76,6 +76,7 @@ private class HttpBoundProtocolTraitImplGenerator(
     private val runtimeConfig = codegenContext.runtimeConfig
     private val httpBindingResolver = protocol.httpBindingResolver
     private val operationSerModule = RustModule.private("operation_ser")
+    private val operationDeserModule = RustModule.private("operation_deser")
 
     private val codegenScope = arrayOf(
         "ParseStrict" to RuntimeType.parseStrict(runtimeConfig),
@@ -165,7 +166,7 @@ private class HttpBoundProtocolTraitImplGenerator(
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = operationShape.errorSymbol(symbolProvider)
-        return RuntimeType.forInlineFun(fnName, operationSerModule) {
+        return RuntimeType.forInlineFun(fnName, operationDeserModule) {
             Attribute.Custom("allow(clippy::unnecessary_wraps)").render(it)
             it.rustBlockTemplate(
                 "pub fn $fnName(response: &#{http}::Response<#{Bytes}>) -> std::result::Result<#{O}, #{E}>",
@@ -237,7 +238,7 @@ private class HttpBoundProtocolTraitImplGenerator(
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = operationShape.errorSymbol(symbolProvider)
-        return RuntimeType.forInlineFun(fnName, operationSerModule) {
+        return RuntimeType.forInlineFun(fnName, operationDeserModule) {
             Attribute.Custom("allow(clippy::unnecessary_wraps)").render(it)
             it.rustBlockTemplate(
                 "pub fn $fnName(op_response: &mut #{operation}::Response) -> std::result::Result<#{O}, #{E}>",
@@ -263,7 +264,7 @@ private class HttpBoundProtocolTraitImplGenerator(
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = operationShape.errorSymbol(symbolProvider)
-        return RuntimeType.forInlineFun(fnName, operationSerModule) {
+        return RuntimeType.forInlineFun(fnName, operationDeserModule) {
             Attribute.Custom("allow(clippy::unnecessary_wraps)").render(it)
             it.rustBlockTemplate(
                 "pub fn $fnName(response: &#{http}::Response<#{Bytes}>) -> std::result::Result<#{O}, #{E}>",


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Deserialization implementations were accidentally removed in [this PR](https://github.com/awslabs/smithy-rs/pull/731/files#diff-63f738d47ba11bfed015686d832e5d46c8522ec5aed5e3d65b2b53d6c5f6fe2bR343)

## Description
<!--- Describe your changes in detail -->
This fixes the 3 specific lines that were referencing a serialization module to instead reference the deserialization module

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `./gradlew -Paws.fullsdk=true :aws:sdk:clean && ./gradlew -Paws.services=+acm :aws:sdk:assemble` and looked at the generated code to very that the `operation_deser.rs` files were being generated

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
