### PR TITLE
Improve generated documentation

### DIFF
--- a/aws/rust-runtime/aws-inlineable/src/presigning.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+//! Presigned request types and configuration.
+
 /// Presigning config and builder
 pub mod config {
     use std::fmt;

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -24,6 +24,7 @@ val DECORATORS = listOf(
     AwsFluentClientDecorator(),
     CrateLicenseDecorator(),
     SharedConfigDecorator(),
+    ServiceConfigDecorator(),
     AwsPresigningDecorator(),
     AwsReadmeDecorator(),
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -84,6 +84,7 @@ class EndpointConfigCustomization(private val codegenContext: CodegenContext, pr
             ServiceConfig.BuilderImpl ->
                 rust(
                     """
+                    /// Sets the endpoint resolver to use when making requests.
                     pub fn endpoint_resolver(mut self, endpoint_resolver: impl #T + 'static) -> Self {
                         self.endpoint_resolver = Some(::std::sync::Arc::new(endpoint_resolver));
                         self

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -47,7 +47,13 @@ class AwsFluentClientDecorator : RustCodegenDecorator {
     override fun extras(codegenContext: CodegenContext, rustCrate: RustCrate) {
         val types = Types(codegenContext.runtimeConfig)
         val module = RustMetadata(additionalAttributes = listOf(Attribute.Cfg.feature("client")), public = true)
-        rustCrate.withModule(RustModule("client", module)) { writer ->
+        rustCrate.withModule(
+            RustModule(
+                "client",
+                module,
+                documentation = "Client and fluent builders for calling the service."
+            )
+        ) { writer ->
             FluentClientGenerator(
                 codegenContext,
                 includeSmithyGenericClientDocs = false,
@@ -92,6 +98,7 @@ private class AwsFluentClientExtensions(private val types: Types) {
         writer.rustBlock("impl<C> Client<C, aws_hyper::AwsMiddleware, smithy_client::retry::Standard>") {
             rustTemplate(
                 """
+                /// Creates a client with the given service config and connector override.
                 pub fn from_conf_conn(conf: crate::Config, conn: C) -> Self {
                     let retry_config = conf.retry_config.as_ref().cloned().unwrap_or_default();
                     let client = #{aws_hyper}::Client::new(conn).with_retry_config(retry_config.into());
@@ -104,11 +111,13 @@ private class AwsFluentClientExtensions(private val types: Types) {
         writer.rustBlock("impl Client<smithy_client::erase::DynConnector, aws_hyper::AwsMiddleware, smithy_client::retry::Standard>") {
             rustTemplate(
                 """
+                /// Creates a new client from a shared config.
                 ##[cfg(any(feature = "rustls", feature = "native-tls"))]
                 pub fn new(config: &#{aws_types}::config::Config) -> Self {
                     Self::from_conf(config.into())
                 }
 
+                /// Creates a new client from a service config.
                 ##[cfg(any(feature = "rustls", feature = "native-tls"))]
                 pub fn from_conf(conf: crate::Config) -> Self {
                     let retry_config = conf.retry_config.as_ref().cloned().unwrap_or_default();

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -16,17 +16,7 @@ import software.amazon.smithy.model.shapes.ToShapeId
 import software.amazon.smithy.model.traits.HttpQueryTrait
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.model.transform.ModelTransformer
-import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
-import software.amazon.smithy.rust.codegen.rustlang.Feature
-import software.amazon.smithy.rust.codegen.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.rustlang.Writable
-import software.amazon.smithy.rust.codegen.rustlang.asType
-import software.amazon.smithy.rust.codegen.rustlang.rust
-import software.amazon.smithy.rust.codegen.rustlang.rustBlock
-import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
-import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.rustlang.withBlock
-import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.rustlang.*
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
@@ -180,15 +170,9 @@ class AwsInputPresignedMethod(
             ).generateMakeOperation(this, syntheticOp, section.customizations)
         }
 
+        documentPresignedMethod()
         rustBlockTemplate(
             """
-            /// Creates a presigned request for this operation. The credentials provider from the `config`
-            /// will be used to generate the request's signature, and the `presigning_config` provides additional
-            /// presigning-specific config values, such as the amount of time the request should be valid for after
-            /// creation.
-            ///
-            /// Presigned requests can be given to other users or applications to access a resource or perform
-            /// an operation without having access to the AWS security credentials.
             ##[cfg(feature = "client")]
             pub async fn presigned(
                 self,
@@ -263,6 +247,7 @@ class AwsPresignedFluentBuilderMethod(
 
     override fun section(section: FluentClientSection): Writable = writable {
         if (section is FluentClientSection.FluentBuilderImpl && section.operationShape.hasTrait(PresignableTrait::class.java)) {
+            documentPresignedMethod()
             rustBlockTemplate(
                 """
                 pub async fn presigned(
@@ -353,4 +338,18 @@ class MoveDocumentMembersToQueryParamsTransform(
             }
         }
     }
+}
+
+private fun RustWriter.documentPresignedMethod() {
+    docs(
+        """
+        Creates a presigned request for this operation. The credentials provider from the `config`
+        will be used to generate the request's signature, and the `presigning_config` provides additional
+        presigning-specific config values, such as the amount of time the request should be valid for after
+        creation.
+        
+        Presigned requests can be given to other users or applications to access a resource or perform
+        an operation without having access to the AWS security credentials.
+        """
+    )
 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -77,6 +77,7 @@ class CredentialProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomizati
                         self
                     }
 
+                    /// Set the credentials provider for this service
                     pub fn set_credentials_provider(&mut self, credentials_provider: Option<#{credentials}::SharedCredentialsProvider>) -> &mut Self {
                         self.credentials_provider = credentials_provider;
                         self

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -108,11 +108,12 @@ class RegionProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomization()
             ServiceConfig.BuilderImpl ->
                 rustTemplate(
                     """
-            pub fn region(mut self, region: impl Into<Option<#{Region}>>) -> Self {
-                self.region = region.into();
-                self
-            }
-            """,
+                    /// Sets the AWS region to use when making requests.
+                    pub fn region(mut self, region: impl Into<Option<#{Region}>>) -> Self {
+                        self.region = region.into();
+                        self
+                    }
+                    """,
                     *codegenScope
                 )
             ServiceConfig.BuilderBuild -> rustTemplate(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/ServiceConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/ServiceConfigDecorator.kt
@@ -1,0 +1,46 @@
+package software.amazon.smithy.rustsdk
+
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.docs
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.smithy.generators.config.ServiceConfig
+
+class ServiceConfigDecorator : RustCodegenDecorator {
+    override val name: String = "ServiceConfigGenerator"
+    override val order: Byte = 0
+
+    override fun configCustomizations(
+        codegenContext: CodegenContext,
+        baseCustomizations: List<ConfigCustomization>
+    ): List<ConfigCustomization> = baseCustomizations + SharedConfigDocsCustomization()
+}
+
+class SharedConfigDocsCustomization : ConfigCustomization() {
+    override fun section(section: ServiceConfig): Writable {
+        return if (section is ServiceConfig.ConfigStructAdditionalDocs) {
+            writable {
+                docs(
+                    """
+                    Service configuration allows for customization of endpoints, region, credentials providers,
+                    and retry configuration. Generally, it is constructed automatically for you from a shared
+                    configuration loaded by the `aws-config` crate. For example:
+                    
+                    ```ignore
+                    // Load a shared config from the environment
+                    let shared_config = aws_config::from_env().load().await;
+                    // The client constructor automatically converts the shared config into the service config
+                    let client = Client::new(&shared_config);
+                    ```
+                    
+                    The service config can also be constructed manually using its builder.
+                    """
+                )
+            }
+        } else {
+            writable {}
+        }
+    }
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SharedConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SharedConfigDecorator.kt
@@ -73,10 +73,11 @@ class NewFromShared(runtimeConfig: RuntimeConfig) : ConfigCustomization() {
             ServiceConfig.ConfigImpl -> writable {
                 rustTemplate(
                     """
+                    /// Creates a new service config from a shared config.
                     pub fn new(config: &#{Config}) -> Self {
                         Builder::from(config).build()
                     }
-                """,
+                    """,
                     *codegenScope
                 )
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustModule.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustModule.kt
@@ -5,27 +5,25 @@
 
 package software.amazon.smithy.rust.codegen.rustlang
 
-data class RustModule(val name: String, val rustMetadata: RustMetadata) {
+data class RustModule(val name: String, val rustMetadata: RustMetadata, val documentation: String?) {
     fun render(writer: RustWriter) {
+        documentation?.let { docs -> writer.docs(docs) }
         rustMetadata.render(writer)
         writer.write("mod $name;")
     }
 
     companion object {
-        fun default(name: String, public: Boolean): RustModule {
-            // TODO: figure out how to enable this, but only for real services (protocol tests don't have documentation)
-            /*val attributes = if (public) {
-                listOf(Custom("deny(missing_docs)"))
-            } else {
-                listOf()
-            }*/
-            return RustModule(name, RustMetadata(public = public))
+        fun default(name: String, public: Boolean, documentation: String? = null): RustModule {
+            return RustModule(name, RustMetadata(public = public), documentation)
         }
 
-        fun public(name: String): RustModule = default(name, public = true)
-        fun private(name: String): RustModule = default(name, public = false)
+        fun public(name: String, documentation: String? = null): RustModule =
+            default(name, public = true, documentation = documentation)
 
-        val Config = public("config")
-        val Error = public("error")
+        fun private(name: String, documentation: String? = null): RustModule =
+            default(name, public = false, documentation = documentation)
+
+        val Config = public("config", documentation = "Configuration for the service.")
+        val Error = public("error", documentation = "Errors that can occur when calling the service.")
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
@@ -142,8 +142,14 @@ open class RustCrate(
 /**
  * Allowlist of modules that will be exposed publicly in generated crates
  */
-val DefaultPublicModules =
-    setOf("error", "operation", "model", "input", "output", "config").map { it to RustModule.default(it, true) }.toMap()
+val DefaultPublicModules = setOf(
+    RustModule.public("error", documentation = "All error types that operations can return."),
+    RustModule.public("operation", documentation = "All operations that this crate can perform."),
+    RustModule.public("model", documentation = "Data structures used by operation inputs/outputs."),
+    RustModule.public("input", documentation = "Input structures for operations."),
+    RustModule.public("output", documentation = "Output structures for operations."),
+    RustModule.public("config", documentation = "Client configuration."),
+).associateBy { it.name }
 
 /**
  * Finalize all the writers by:

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/CrateVersionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/CrateVersionGenerator.kt
@@ -16,7 +16,12 @@ import software.amazon.smithy.rust.codegen.smithy.generators.LibRsSection
 class CrateVersionGenerator : LibRsCustomization() {
     override fun section(section: LibRsSection) = writable {
         when (section) {
-            is LibRsSection.Body -> rust("""pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");""")
+            is LibRsSection.Body -> rust(
+                """
+                /// Crate version number.
+                pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+                """
+            )
         }
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -148,6 +148,7 @@ class BuilderGenerator(
         // Render a `set_foo` method. This is useful as a target for code generation, because the argument type
         // is the same as the resulting member type, and is always optional.
         val inputType = outerType.asOptional()
+        writer.documentShape(member, model)
         writer.rustBlock("pub fn ${member.setterName()}(mut self, input: ${inputType.render(true)}) -> Self") {
             rust("self.$memberName = input; self")
         }
@@ -182,8 +183,8 @@ class BuilderGenerator(
                 // Render a context-aware builder method for certain types, eg. a method for vectors that automatically
                 // appends
                 when (coreType) {
-                    is RustType.Vec -> renderVecHelper(memberName, coreType)
-                    is RustType.HashMap -> renderMapHelper(memberName, coreType)
+                    is RustType.Vec -> renderVecHelper(member, memberName, coreType)
+                    is RustType.HashMap -> renderMapHelper(member, memberName, coreType)
                     else -> renderBuilderMemberFn(this, coreType, member, memberName, memberSymbol)
                 }
 
@@ -193,7 +194,12 @@ class BuilderGenerator(
         }
     }
 
-    private fun RustWriter.renderVecHelper(memberName: String, coreType: RustType.Vec) {
+    private fun RustWriter.renderVecHelper(member: MemberShape, memberName: String, coreType: RustType.Vec) {
+        docs("Appends an item to `$memberName`.")
+        rust("///")
+        docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        rust("///")
+        documentShape(member, model, autoSuppressMissingDocs = false)
         rustBlock("pub fn $memberName(mut self, input: impl Into<${coreType.member.render(true)}>) -> Self") {
             rust(
                 """
@@ -206,7 +212,12 @@ class BuilderGenerator(
         }
     }
 
-    private fun RustWriter.renderMapHelper(memberName: String, coreType: RustType.HashMap) {
+    private fun RustWriter.renderMapHelper(member: MemberShape, memberName: String, coreType: RustType.HashMap) {
+        docs("Adds a key-value pair to `$memberName`.")
+        rust("///")
+        docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        rust("///")
+        documentShape(member, model, autoSuppressMissingDocs = false)
         rustBlock(
             "pub fn $memberName(mut self, k: impl Into<${coreType.key.render(true)}>, v: impl Into<${
             coreType.member.render(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EnumGenerator.kt
@@ -44,7 +44,6 @@ internal class EnumMemberModel(private val definition: EnumDefinition, private v
             name.renamedFrom?.let { renamedFrom ->
                 "`::$renamedFrom` has been renamed to `::${name.name}`."
             }
-
         )
     }
 
@@ -57,11 +56,17 @@ internal class EnumMemberModel(private val definition: EnumDefinition, private v
 }
 
 private fun RustWriter.docWithNote(doc: String?, note: String?) {
-    doc?.also { docs(escape(it)) }
-    note?.also {
-        // Add a blank line between the docs and the note to visually differentiate
-        doc?.also { write("///") }
-        docs("**NOTE:** $it")
+    if (doc.isNullOrBlank() && note.isNullOrBlank()) {
+        // If the model doesn't have any documentation for the shape, then suppress the missing docs lint
+        // since the lack of documentation is a modeling issue rather than a codegen issue.
+        rust("##[allow(missing_docs)] // documentation missing in model")
+    } else {
+        doc?.also { docs(escape(it)) }
+        note?.also {
+            // Add a blank line between the docs and the note to visually differentiate
+            doc?.also { write("///") }
+            docs("**NOTE:** $it")
+        }
     }
 }
 
@@ -111,11 +116,13 @@ class EnumGenerator(
         meta.render(writer)
         writer.write("struct $enumName(String);")
         writer.rustBlock("impl $enumName") {
-            writer.rustBlock("pub fn as_str(&self) -> &str") {
+            rust("/// Returns the `&str` value of the enum member.")
+            rustBlock("pub fn as_str(&self) -> &str") {
                 write("&self.0")
             }
 
-            writer.rustBlock("pub fn $Values() -> &'static [&'static str]") {
+            rust("/// Returns all the `&str` representations of the enum members.")
+            rustBlock("pub fn $Values() -> &'static [&'static str]") {
                 withBlock("&[", "]") {
                     val memberList = sortedMembers.joinToString(", ") { it.value.doubleQuote() }
                     write(memberList)
@@ -151,6 +158,7 @@ class EnumGenerator(
 
     private fun implBlock() {
         writer.rustBlock("impl $enumName") {
+            rust("/// Returns the `&str` value of the enum member.")
             writer.rustBlock("pub fn as_str(&self) -> &str") {
                 writer.rustBlock("match self") {
                     sortedMembers.forEach { member ->
@@ -160,6 +168,7 @@ class EnumGenerator(
                 }
             }
 
+            rust("/// Returns all the `&str` representations of the enum members.")
             writer.rustBlock("pub fn $Values() -> &'static [&'static str]") {
                 withBlock("&[", "]") {
                     val memberList = sortedMembers.joinToString(", ") { it.value.doubleQuote() }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -20,6 +20,7 @@ class FluentClientCore(private val model: Model) {
         docs("Appends an item to `${member.memberName}`.")
         rust("///")
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        rust("///")
         documentShape(member, model)
         rustBlock("pub fn $memberName(mut self, inp: impl Into<${coreType.member.render(true)}>) -> Self") {
             rust(
@@ -35,6 +36,7 @@ class FluentClientCore(private val model: Model) {
         docs("Adds a key-value pair to `${member.memberName}`.")
         rust("///")
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
+        rust("///")
         documentShape(member, model)
         val k = coreType.key
         val v = coreType.member

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/LibRsGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/LibRsGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.escape
+import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.smithy.RustSettings
 import software.amazon.smithy.rust.codegen.smithy.customize.NamedSectionGenerator
 import software.amazon.smithy.rust.codegen.smithy.customize.Section
@@ -32,6 +33,7 @@ class LibRsGenerator(
     fun render(writer: RustWriter) {
         writer.first {
             customizations.forEach { it.section(LibRsSection.Attributes)(this) }
+            rust("##![warn(missing_docs)]")
 
             val libraryDocs = settings.getService(model).getTrait<DocumentationTrait>()?.value ?: settings.moduleName
             docs(escape(libraryDocs), newlinePrefix = "//! ")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -31,6 +31,8 @@ class UnionGenerator(
     }
 
     private fun renderUnion() {
+        writer.documentShape(shape, model)
+
         val unionSymbol = symbolProvider.toSymbol(shape)
         val containerMeta = unionSymbol.expectRustMetadata()
         containerMeta.render(writer)
@@ -51,9 +53,12 @@ class UnionGenerator(
                 if (sortedMembers.size == 1) {
                     Attribute.Custom("allow(irrefutable_let_patterns)").render(this)
                 }
+                rust("/// Tries to convert the enum instance into its `${unionSymbol.name}` variant.")
+                rust("/// Returns `Err(&Self) if it can't be converted.` ")
                 rustBlock("pub fn as_$funcNamePart(&self) -> std::result::Result<&#T, &Self>", memberSymbol) {
                     rust("if let ${unionSymbol.name}::$variantName(val) = &self { Ok(&val) } else { Err(&self) }")
                 }
+                rust("/// Returns true if the enum instance is the `${unionSymbol.name}` variant.")
                 rustBlock("pub fn is_$funcNamePart(&self) -> bool") {
                     rust("self.as_$funcNamePart().is_ok()")
                 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
@@ -27,17 +27,18 @@ class IdempotencyTokenProviderCustomization : NamedSectionGenerator<ServiceConfi
             ServiceConfig.BuilderImpl -> writable {
                 rust(
                     """
-            pub fn make_token(mut self, make_token: impl Into<#T::IdempotencyTokenProvider>) -> Self {
-                self.make_token = Some(make_token.into());
-                self
-            }
-            """,
+                    pub fn make_token(mut self, make_token: impl Into<#T::IdempotencyTokenProvider>) -> Self {
+                        self.make_token = Some(make_token.into());
+                        self
+                    }
+                    """,
                     RuntimeType.IdempotencyToken
                 )
             }
             ServiceConfig.BuilderBuild -> writable {
                 rust("make_token: self.make_token.unwrap_or_else(#T::default_provider),", RuntimeType.IdempotencyToken)
             }
+            else -> writable { }
         }
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGenerator.kt
@@ -10,10 +10,7 @@ import software.amazon.smithy.model.knowledge.OperationIndex
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.traits.IdempotencyTokenTrait
-import software.amazon.smithy.rust.codegen.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.rustlang.raw
-import software.amazon.smithy.rust.codegen.rustlang.rustBlock
-import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.*
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.smithy.customize.NamedSectionGenerator
 import software.amazon.smithy.rust.codegen.smithy.customize.Section
@@ -42,11 +39,18 @@ import software.amazon.smithy.rust.codegen.util.hasTrait
  * ```
  */
 sealed class ServiceConfig(name: String) : Section(name) {
-    /** Struct definition of `Config`. Fields should end with `,`
-     *  eg. `foo: Box<u64>,`
-     **/
+    /**
+     * Additional documentation comments for the `Config` struct.
+     */
+    object ConfigStructAdditionalDocs : ServiceConfig("ConfigStructAdditionalDocs")
+
+    /**
+     * Struct definition of `Config`. Fields should end with `,` (eg. `foo: Box<u64>,`)
+     */
     object ConfigStruct : ServiceConfig("ConfigStruct")
-    /** impl block of `Config`. (eg. to add functions)
+
+    /**
+     * impl block of `Config`. (eg. to add functions)
      * eg.
      * ```kotlin
      * rust("pub fn is_cross_region() -> bool { true }")
@@ -56,14 +60,17 @@ sealed class ServiceConfig(name: String) : Section(name) {
 
     /** Struct definition of `ConfigBuilder` **/
     object BuilderStruct : ServiceConfig("BuilderStruct")
+
     /** impl block of `ConfigBuilder` **/
     object BuilderImpl : ServiceConfig("BuilderImpl")
-    /** Convert from a field in the builder to the final field in config
+
+    /**
+     * Convert from a field in the builder to the final field in config
      *  eg.
      *  ```kotlin
      *  rust("""my_field: my_field.unwrap_or_else(||"default")""")
      *  ```
-     **/
+     */
     object BuilderBuild : ServiceConfig("BuilderBuild")
 }
 
@@ -106,6 +113,10 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
     }
 
     fun render(writer: RustWriter) {
+        writer.docs("Service config.\n")
+        customizations.forEach {
+            it.section(ServiceConfig.ConfigStructAdditionalDocs)(writer)
+        }
         writer.rustBlock("pub struct Config") {
             customizations.forEach {
                 it.section(ServiceConfig.ConfigStruct)(this)
@@ -127,6 +138,7 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
         writer.rustBlock("impl Config") {
             rustTemplate(
                 """
+                /// Constructs a config builder.
                 pub fn builder() -> Builder { Builder::default() }
                 """
             )
@@ -135,6 +147,7 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
             }
         }
 
+        writer.docs("Builder for creating a `Config`.")
         writer.raw("#[derive(Default)]")
         writer.rustBlock("pub struct Builder") {
             customizations.forEach {
@@ -142,10 +155,12 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
             }
         }
         writer.rustBlock("impl Builder") {
+            docs("Constructs a config builder.")
             rustTemplate("pub fn new() -> Self { Self::default() }")
             customizations.forEach {
                 it.section(ServiceConfig.BuilderImpl)(this)
             }
+            docs("Builds a `Config`.")
             rustBlock("pub fn build(self) -> Config") {
                 rustBlock("Config") {
                     customizations.forEach {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/ErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/ErrorGenerator.kt
@@ -78,13 +78,15 @@ class ErrorGenerator(
         writer.rustBlock("impl ${symbol.name}") {
             val retryKindWriteable = shape.modeledRetryKind(error)?.writable(symbolProvider.config().runtimeConfig)
             if (retryKindWriteable != null) {
+                rust("/// Returns `Some(${errorKindT.name})` if the error is retryable. Otherwise, returns `None`.")
                 rustBlock("pub fn retryable_error_kind(&self) -> #T", errorKindT) {
                     retryKindWriteable(this)
                 }
             }
             rust(
                 """
-            pub fn message(&self) -> Option<&str> { $message }
+                /// Returns the error message.
+                pub fn message(&self) -> Option<&str> { $message }
                 """
             )
         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGenerator.kt
@@ -13,6 +13,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
@@ -21,7 +22,7 @@ import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
 
 /**
- * Each service defines it's own "top-level" error combining all possible errors that a service can emit.
+ * Each service defines its own "top-level" error combining all possible errors that a service can emit.
  *
  * Every service error is convertible into this top level error, which enables (if desired) authoring a single error handling
  * path. Eg:
@@ -98,15 +99,18 @@ class TopLevelErrorGenerator(codegenContext: CodegenContext, private val operati
     }
 
     private fun RustWriter.renderDefinition() {
+        rust("/// All possible error types for this service.")
         RustMetadata(
             additionalAttributes = listOf(Attribute.NonExhaustive),
             public = true
         ).withDerives(RuntimeType.Debug).render(this)
         rustBlock("enum Error") {
             allErrors.forEach { error ->
+                documentShape(error, model)
                 val sym = symbolProvider.toSymbol(error)
                 rust("${sym.name}(#T),", sym)
             }
+            rust("/// An unhandled error occurred.")
             rust("Unhandled(Box<dyn #T + Send + Sync + 'static>)", RuntimeType.StdError)
         }
     }

--- a/rust-runtime/smithy-types/src/base64.rs
+++ b/rust-runtime/smithy-types/src/base64.rs
@@ -81,10 +81,14 @@ pub fn decode<T: AsRef<str>>(input: T) -> Result<Vec<u8>, DecodeError> {
     decode_inner(input.as_ref())
 }
 
+/// Failure to decode a base64 value.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DecodeError {
+    /// Encountered an invalid byte.
     InvalidByte,
+    /// Encountered an invalid base64 padding value.
     InvalidPadding,
+    /// Input wasn't long enough to be a valid base64 value.
     InvalidLength,
 }
 

--- a/rust-runtime/smithy-types/src/instant/mod.rs
+++ b/rust-runtime/smithy-types/src/instant/mod.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+//! Instant value for representing Smithy timestamps.
+
 use crate::instant::format::DateParseError;
 use chrono::{DateTime, NaiveDateTime, Utc};
 use num_integer::div_mod_floor;
@@ -19,6 +21,10 @@ const NANOS_PER_MILLI: u32 = 1_000_000;
 
 /* ANCHOR: instant */
 
+/// Instant in time.
+///
+/// Instant in time represented as seconds and sub-second nanos since
+/// the Unix epoch (January 1, 1970 at midnight UTC/GMT).
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Instant {
     seconds: i64,
@@ -28,6 +34,7 @@ pub struct Instant {
 /* ANCHOR_END: instant */
 
 impl Instant {
+    /// Creates an `Instant` from a number of seconds since the Unix epoch.
     pub fn from_epoch_seconds(epoch_seconds: i64) -> Self {
         Instant {
             seconds: epoch_seconds,
@@ -35,11 +42,31 @@ impl Instant {
         }
     }
 
+    /// Creates an `Instant` from a number of seconds and a fractional second since the Unix epoch.
+    ///
+    /// # Example
+    /// ```
+    /// # use smithy_types::Instant;
+    /// assert_eq!(
+    ///     Instant::from_secs_and_nanos(1, 500_000_000u32),
+    ///     Instant::from_fractional_seconds(1, 0.5),
+    /// );
+    /// ```
     pub fn from_fractional_seconds(epoch_seconds: i64, fraction: f64) -> Self {
         let subsecond_nanos = (fraction * 1_000_000_000_f64) as u32;
         Instant::from_secs_and_nanos(epoch_seconds, subsecond_nanos)
     }
 
+    /// Creates an `Instant` from a number of seconds and sub-second nanos since the Unix epoch.
+    ///
+    /// # Example
+    /// ```
+    /// # use smithy_types::Instant;
+    /// assert_eq!(
+    ///     Instant::from_fractional_seconds(1, 0.5),
+    ///     Instant::from_secs_and_nanos(1, 500_000_000u32),
+    /// );
+    /// ```
     pub fn from_secs_and_nanos(seconds: i64, subsecond_nanos: u32) -> Self {
         if subsecond_nanos >= 1_000_000_000 {
             panic!("{} is > 1_000_000_000", subsecond_nanos)
@@ -50,12 +77,23 @@ impl Instant {
         }
     }
 
+    /// Creates an `Instant` from an `f64` representing the number of seconds since the Unix epoch.
+    ///
+    /// # Example
+    /// ```
+    /// # use smithy_types::Instant;
+    /// assert_eq!(
+    ///     Instant::from_fractional_seconds(1, 0.5),
+    ///     Instant::from_f64(1.5),
+    /// );
+    /// ```
     pub fn from_f64(epoch_seconds: f64) -> Self {
         let seconds = epoch_seconds.floor() as i64;
         let rem = epoch_seconds - epoch_seconds.floor();
         Instant::from_fractional_seconds(seconds, rem)
     }
 
+    /// Creates an `Instant` from a [`SystemTime`].
     pub fn from_system_time(system_time: SystemTime) -> Self {
         let duration = system_time
             .duration_since(UNIX_EPOCH)
@@ -66,6 +104,7 @@ impl Instant {
         }
     }
 
+    /// Parses an `Instant` from a string using the given `format`.
     pub fn from_str(s: &str, format: Format) -> Result<Self, DateParseError> {
         match format {
             Format::DateTime => format::rfc3339::parse(s),
@@ -99,6 +138,7 @@ impl Instant {
         }
     }
 
+    /// Converts the `Instant` to a chrono `DateTime<Utc>`.
     #[cfg(feature = "chrono-conversions")]
     pub fn to_chrono(self) -> DateTime<Utc> {
         self.to_chrono_internal()
@@ -127,18 +167,26 @@ impl Instant {
         }
     }
 
+    /// Returns true if sub-second nanos is greater than zero.
     pub fn has_nanos(&self) -> bool {
         self.subsecond_nanos != 0
     }
 
+    /// Returns the `Instant` value as an `f64` representing the seconds since the Unix epoch.
     pub fn epoch_fractional_seconds(&self) -> f64 {
         self.seconds as f64 + self.subsecond_nanos as f64 / 1_000_000_000_f64
     }
 
+    /// Returns the epoch seconds component of the `Instant`.
+    /// # Note
+    /// This does not include the sub-second nanos.
     pub fn epoch_seconds(&self) -> i64 {
         self.seconds
     }
 
+    /// Returns the sub-second nanos component of the `Instant`.
+    /// # Note
+    /// This does not include the number of seconds since the epoch.
     pub fn epoch_subsecond_nanos(&self) -> u32 {
         self.subsecond_nanos
     }
@@ -170,6 +218,7 @@ impl Instant {
         Instant::from_secs_and_nanos(seconds, millis as u32 * NANOS_PER_MILLI)
     }
 
+    /// Formats the `Instant` to a string using the given `format`.
     pub fn fmt(&self, format: Format) -> String {
         match format {
             Format::DateTime => format::rfc3339::format(&self),
@@ -186,6 +235,7 @@ impl Instant {
     }
 }
 
+/// Failure to convert an `Instant` to or from another type.
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct ConversionError(&'static str);
@@ -212,10 +262,14 @@ impl From<DateTime<chrono::FixedOffset>> for Instant {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+/// Formats for representing an `Instant` in the Smithy protocols.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Format {
+    /// RFC-3339 Date Time.
     DateTime,
+    /// Date format used by the HTTP `Date` header, specified in RFC-7231.
     HttpDate,
+    /// Number of seconds since the Unix epoch formatted as a floating point.
     EpochSeconds,
 }
 


### PR DESCRIPTION
## Description
A lot of generated code was missing documentation. This PR fills in all missing docs for generated SDK crates, and also fills in missing docs on the `smithy-types` crate that is partially re-exported by SDK crates.

## Testing
- Manually inspected compiled docs.
- Automated detection of missing docs with a lint.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
