### PR TITLE
create a common history for generated code branches

### DIFF
--- a/.github/workflows/codegen-preview.yml
+++ b/.github/workflows/codegen-preview.yml
@@ -71,7 +71,7 @@ jobs:
       id: branch_output
     - uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"
-      if: ${{ env.GITHUB_HEAD_REF }} != null
+      if: ${{ env.GITHUB_HEAD_REF != null }}
       with:
         script: |
           await github.rest.issues.createComment({

--- a/tools/mk-generated.sh
+++ b/tools/mk-generated.sh
@@ -19,12 +19,12 @@ set -e
 	current_branch="${gh_branch:-$(git rev-parse --abbrev-ref HEAD)}"
 	echo "Current branch resolved to: $current_branch"
 	gen_branch="__generated-$current_branch"
-	git branch -D "$gen_branch" || echo "no branch named $gen_branch yet"
 	repo_root=$(git rev-parse --show-toplevel)
 	cd "$repo_root" && ./gradlew :aws:sdk:assemble
 	target="$(mktemp -d)"
 	mv "$repo_root"/aws/sdk/build/aws-sdk "$target"
-	git checkout --orphan "$gen_branch"
+	# checkout and reset $gen_branch to be based on the __generated__ history
+	git checkout -B "$gen_branch" __generated__
 	cd "$repo_root" && git rm -rf .
 	rm -rf "$repo_root/aws-sdk"
 	mv "$target"/aws-sdk "$repo_root"/.


### PR DESCRIPTION
## Motivation and Context
Generated code diffs aren't currently working as they should because they lack a common history

## Description
Base generated code branches on the orphan branch `__generated__` which was pushed manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
