### PR TITLE
Fix #793. Generate all input/output/error serde helpers in server codegen

### DIFF
--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -27,6 +27,11 @@ val CodegenTests = listOf(
     CodegenTest("com.amazonaws.ebs#Ebs", "ebs")
 )
 
+/**
+ * The fluent client is generated to prevent warnings in RustDoc since the client is
+ * referenced by multiple documentations.
+ * TODO: review client generation in the future.
+ */
 fun generateSmithyBuild(tests: List<CodegenTest>): String {
     val projections =
         tests.joinToString(",\n") {
@@ -35,7 +40,7 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
                 "plugins": {
                     "rust-server-codegen": {
                       "codegen": {
-                        "includeFluentClient": false
+                        "includeFluentClient": true
                       },
                       "runtimeConfig": {
                         "relativePath": "${rootProject.projectDir.absolutePath}/rust-runtime"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/RestJson1.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/RestJson1.kt
@@ -102,9 +102,6 @@ class RestJson1HttpSerializerGenerator(
             return
         }
         val serializerSymbol = jsonSerializerGenerator.serverOutputSerializer(operationShape)
-        if (serializerSymbol == null) {
-            return
-        }
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         writer.write("")
         writer.rustBlockTemplate(
@@ -169,44 +166,38 @@ class RestJson1HttpSerializerGenerator(
                     val variantSymbol = symbolProvider.toSymbol(variantShape)
                     val data = safeName("var")
                     val serializerSymbol = jsonSerializerGenerator.serverErrorSerializer(it)
-                    if (serializerSymbol != null) {
-                        rustBlock("#TKind::${variantSymbol.name}($data) =>", errorSymbol) {
+                    rustBlock("#TKind::${variantSymbol.name}($data) =>", errorSymbol) {
+                        rust(
+                            """
+                                #T(&$data)?;
+                                object.key(${"code".dq()}).string(${httpBindingResolver.errorCode(variantShape).dq()});
+                            """.trimIndent(),
+                            serializerSymbol
+                        )
+                        if (variantShape.errorMessageMember() != null) {
                             rust(
                                 """
-                                    #T(&$data)?;
-                                    object.key(${"code".dq()}).string(${httpBindingResolver.errorCode(variantShape).dq()});
-                                """.trimIndent(),
-                                serializerSymbol
-                            )
-                            if (variantShape.errorMessageMember() != null) {
-                                rust(
-                                    """
-                                        if let Some(message) = $data.message() {
-                                            object.key(${"message".dq()}).string(message);
-                                        }
-                                    """.trimIndent()
-                                )
-                            }
-                            val bindings = httpBindingResolver.errorResponseBindings(it)
-                            bindings.forEach { binding ->
-                                when (val location = binding.location) {
-                                    HttpLocation.RESPONSE_CODE, HttpLocation.DOCUMENT -> {}
-                                    else -> {
-                                        logger.warning(
-                                            "$operationShape: response serialization does not currently support $location bindings"
-                                        )
+                                    if let Some(message) = $data.message() {
+                                        object.key(${"message".dq()}).string(message);
                                     }
+                                """.trimIndent()
+                            )
+                        }
+                        val bindings = httpBindingResolver.errorResponseBindings(it)
+                        bindings.forEach { binding ->
+                            when (val location = binding.location) {
+                                HttpLocation.RESPONSE_CODE, HttpLocation.DOCUMENT -> {}
+                                else -> {
+                                    logger.warning(
+                                        "$operationShape: response serialization does not currently support $location bindings"
+                                    )
                                 }
                             }
-                            val status =
-                                variantShape.getTrait<HttpErrorTrait>()?.let { trait -> trait.code }
-                                    ?: errorTrait.defaultHttpStatusCode
-                            rust("response = response.status($status);")
                         }
-                    } else {
-                        logger.warning(
-                            "[rust-server-codegen] $variantShape: response error serialization does not contain any member"
-                        )
+                        val status =
+                            variantShape.getTrait<HttpErrorTrait>()?.let { trait -> trait.code }
+                                ?: errorTrait.defaultHttpStatusCode
+                        rust("response = response.status($status);")
                     }
                 }
                 rust(
@@ -369,9 +360,6 @@ class RestJson1HttpDeserializerGenerator(
             return
         }
         val deserializerSymbol = jsonParserGenerator.serverInputParser(operationShape)
-        if (deserializerSymbol == null) {
-            return
-        }
         val inputSymbol = symbolProvider.toSymbol(inputShape)
         writer.write("")
         writer.rustBlockTemplate(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/StructuredDataParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/StructuredDataParserGenerator.kt
@@ -66,5 +66,5 @@ interface StructuredDataParserGenerator {
      * }
      * ```
      */
-    fun serverInputParser(operationShape: OperationShape): RuntimeType?
+    fun serverInputParser(operationShape: OperationShape): RuntimeType
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -241,7 +241,7 @@ class XmlBindingTraitParserGenerator(
         TODO("Document shapes are not supported by rest XML")
     }
 
-    override fun serverInputParser(operationShape: OperationShape): RuntimeType? {
+    override fun serverInputParser(operationShape: OperationShape): RuntimeType {
         TODO("Not yet implemented")
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/AwsQuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/AwsQuerySerializerGenerator.kt
@@ -22,11 +22,11 @@ class AwsQuerySerializerGenerator(codegenContext: CodegenContext) : QuerySeriali
 
     override fun MemberShape.isFlattened(): Boolean = getTrait<XmlFlattenedTrait>() != null
 
-    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType? {
+    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
         TODO("Not yet implemented")
     }
 
-    override fun serverErrorSerializer(shape: ShapeId): RuntimeType? {
+    override fun serverErrorSerializer(shape: ShapeId): RuntimeType {
         TODO("Not yet implemented")
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGenerator.kt
@@ -25,11 +25,11 @@ class Ec2QuerySerializerGenerator(codegenContext: CodegenContext) : QuerySeriali
 
     override fun MemberShape.isFlattened(): Boolean = true
 
-    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType? {
+    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
         TODO("Not yet implemented")
     }
 
-    override fun serverErrorSerializer(shape: ShapeId): RuntimeType? {
+    override fun serverErrorSerializer(shape: ShapeId): RuntimeType {
         TODO("Not yet implemented")
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/StructuredDataSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/StructuredDataSerializerGenerator.kt
@@ -49,7 +49,7 @@ interface StructuredDataSerializerGenerator {
      * }
      * ```
      */
-    fun serverOutputSerializer(operationShape: OperationShape): RuntimeType?
+    fun serverOutputSerializer(operationShape: OperationShape): RuntimeType
 
     /**
      * Generate a serializer for a server operation error structure
@@ -59,5 +59,5 @@ interface StructuredDataSerializerGenerator {
      * }
      * ```
      */
-    fun serverErrorSerializer(shape: ShapeId): RuntimeType?
+    fun serverErrorSerializer(shape: ShapeId): RuntimeType
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -177,11 +177,11 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
-    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType? {
+    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
         TODO("Not yet implemented")
     }
 
-    override fun serverErrorSerializer(shape: ShapeId): RuntimeType? {
+    override fun serverErrorSerializer(shape: ShapeId): RuntimeType {
         TODO("Not yet implemented")
     }
 


### PR DESCRIPTION
## Motivation and Context
Fixes #793

## Description
Ensure all input/output/error serde helpers are generated in the server codegen.

## Testing
Tested locally with the integ-test suite for both server and client. Manually diffed the server generated code.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
