### PR TITLE
Generate simpler operation error types for the server

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/CombinedErrorGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/CombinedErrorGenerator.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.OperationIndex
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.rust.codegen.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.documentShape
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.util.toSnakeCase
+
+/**
+ * For a given Operation ([this]), return the symbol referring to the unified error. This can be used
+ * if you, e.g. want to return a unified error from a function:
+ *
+ * ```kotlin
+ * rustWriter.rustBlock("fn get_error() -> #T", operation.errorSymbol(symbolProvider)) {
+ *     write("todo!() // function body")
+ * }
+ * ```
+ */
+fun OperationShape.errorSymbol(symbolProvider: SymbolProvider): RuntimeType {
+    val symbol = symbolProvider.toSymbol(this)
+    return RuntimeType("${symbol.name}Error", null, "crate::error")
+}
+
+/**
+ * Generates a unified error enum for [operation]. [ErrorGenerator] handles generating the individual variants,
+ * but we must still combine those variants into an enum covering all possible errors for a given operation.
+ */
+class CombinedErrorGenerator(
+    private val model: Model,
+    private val symbolProvider: RustSymbolProvider,
+    private val operation: OperationShape
+) {
+    private val operationIndex = OperationIndex.of(model)
+
+    fun render(writer: RustWriter) {
+        val errors = operationIndex.getErrors(operation)
+        val operationSymbol = symbolProvider.toSymbol(operation)
+        val symbol = operation.errorSymbol(symbolProvider)
+        val meta = RustMetadata(
+            derives = Attribute.Derives(setOf(RuntimeType.Debug)),
+            public = true
+        )
+
+        writer.rust("/// Error type for the `${operationSymbol.name}` operation.")
+        writer.rust("/// Each variant represents an error that can occur for the `${operationSymbol.name}` operation.")
+        meta.render(writer)
+        writer.rustBlock("enum ${symbol.name}") {
+            errors.forEach { errorVariant ->
+                documentShape(errorVariant, model)
+                val errorVariantSymbol = symbolProvider.toSymbol(errorVariant)
+                write("${errorVariantSymbol.name}(#T),", errorVariantSymbol)
+            }
+        }
+
+        writer.rustBlock("impl #T for ${symbol.name}", RuntimeType.stdfmt.member("Display")) {
+            rustBlock("fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result") {
+                delegateToVariants {
+                    writable { rust("_inner.fmt(f)") }
+                }
+            }
+        }
+
+        writer.rustBlock("impl ${symbol.name}") {
+            errors.forEach { error ->
+                val errorSymbol = symbolProvider.toSymbol(error)
+                val fnName = errorSymbol.name.toSnakeCase()
+                writer.rust("/// Returns `true` if the error kind is `${symbol.name}::${errorSymbol.name}`.")
+                writer.rustBlock("pub fn is_$fnName(&self) -> bool") {
+                    rust("matches!(&self, ${symbol.name}::${errorSymbol.name}(_))")
+                }
+            }
+        }
+
+        writer.rustBlock("impl #T for ${symbol.name}", RuntimeType.StdError) {
+            rustBlock("fn source(&self) -> Option<&(dyn #T + 'static)>", RuntimeType.StdError) {
+                delegateToVariants {
+                    writable {
+                        when (it) {
+                            is VariantMatch.Modeled -> rust("Some(_inner)")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    sealed class VariantMatch(name: String) : Section(name) {
+        data class Modeled(val symbol: Symbol, val shape: Shape) : VariantMatch("Modeled")
+    }
+
+    /**
+     * Generates code to delegate behavior to the variants, for example:
+     *
+     * ```rust
+     *  match &self {
+     *      GreetingWithErrorsError::InvalidGreeting(_inner) => inner.fmt(f),
+     *      GreetingWithErrorsError::ComplexError(_inner) => inner.fmt(f),
+     *      GreetingWithErrorsError::FooError(_inner) => inner.fmt(f),
+     *      GreetingWithErrorsError::Unhandled(_inner) => _inner.fmt(f),
+     *  }
+     *  ```
+     *
+     * [handler] is passed an instance of [VariantMatch]—a [writable] should be returned containing the content to be
+     * written for this variant.
+     *
+     *  The field will always be bound as `_inner`.
+     */
+    private fun RustWriter.delegateToVariants(
+        handler: (VariantMatch) -> Writable
+    ) {
+        val errors = operationIndex.getErrors(operation)
+        val symbol = operation.errorSymbol(symbolProvider)
+        rustBlock("match &self") {
+            errors.forEach {
+                val errorSymbol = symbolProvider.toSymbol(it)
+                rust("""${symbol.name}::${errorSymbol.name}(_inner) => """)
+                handler(VariantMatch.Modeled(errorSymbol, it))(this)
+                write(",")
+            }
+        }
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.Ser
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.smithy.generators.error.errorSymbol
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
 
@@ -32,7 +33,6 @@ class ServerServiceGenerator(
     /**
      * Render Service Specific code. Code will end up in different files via [useShapeWriter]. See `SymbolVisitor.kt`
      * which assigns a symbol location to each shape.
-     *
      */
     fun render() {
         val operations = index.getContainedOperations(context.serviceShape).sortedBy { it.id }
@@ -46,9 +46,12 @@ class ServerServiceGenerator(
                 ServerProtocolTestGenerator(context, protocolSupport, operation, operationWriter)
                     .render()
             }
-            rustCrate.withModule(RustModule.Error) { writer ->
-                ServerCombinedErrorGenerator(context.model, context.symbolProvider, operation)
-                    .render(writer)
+
+            if (operation.errors.isNotEmpty()) {
+                rustCrate.withModule(RustModule.Error) { writer ->
+                    ServerCombinedErrorGenerator(context.model, context.symbolProvider, operation)
+                        .render(writer)
+                }
             }
         }
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -11,8 +11,6 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.Ser
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
-import software.amazon.smithy.rust.codegen.smithy.generators.error.CombinedErrorGenerator
-import software.amazon.smithy.rust.codegen.smithy.generators.error.TopLevelErrorGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
 
@@ -49,7 +47,7 @@ class ServerServiceGenerator(
                     .render()
             }
             rustCrate.withModule(RustModule.Error) { writer ->
-                CombinedErrorGenerator(context.model, context.symbolProvider, operation)
+                ServerCombinedErrorGenerator(context.model, context.symbolProvider, operation)
                     .render(writer)
             }
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -53,7 +53,5 @@ class ServerServiceGenerator(
                     .render(writer)
             }
         }
-
-        TopLevelErrorGenerator(context, operations).render(rustCrate)
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -93,7 +93,7 @@ class ServerProtocolTestGenerator(
             val testCases = error.getTrait<HttpResponseTestsTrait>()?.testCases.orEmpty()
             testCases.map { TestCase.ResponseTest(it, error) }
         }
-        val allTests: List<TestCase> = (requestTests + responseTests + errorTests).filterMatching()
+        val allTests: List<TestCase> = (requestTests + errorTests).filterMatching()
         if (allTests.isNotEmpty()) {
             val operationName = operationSymbol.name
             val testModuleName = "server_${operationName.toSnakeCase()}_test"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -7,8 +7,6 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators.protocol
 
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.knowledge.OperationIndex
-import software.amazon.smithy.model.shapes.DoubleShape
-import software.amazon.smithy.model.shapes.FloatShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.ErrorTrait
@@ -33,13 +31,10 @@ import software.amazon.smithy.rust.codegen.server.smithy.protocols.HttpServerTra
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.generators.Instantiator
-import software.amazon.smithy.rust.codegen.smithy.generators.error.errorSymbol
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.getTrait
-import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
-import software.amazon.smithy.rust.codegen.util.isStreaming
 import software.amazon.smithy.rust.codegen.util.orNull
 import software.amazon.smithy.rust.codegen.util.outputShape
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
@@ -93,7 +88,7 @@ class ServerProtocolTestGenerator(
             val testCases = error.getTrait<HttpResponseTestsTrait>()?.testCases.orEmpty()
             testCases.map { TestCase.ResponseTest(it, error) }
         }
-        val allTests: List<TestCase> = (requestTests + errorTests).filterMatching()
+        val allTests: List<TestCase> = (requestTests + responseTests + errorTests).filterMatching()
         if (allTests.isNotEmpty()) {
             val operationName = operationSymbol.name
             val testModuleName = "server_${operationName.toSnakeCase()}_test"


### PR DESCRIPTION
Currently, operation error types are designed to be used by clients.
Clients need to cope with a large scale of possible errors, including
unmodeled errors and errors coming from different layers of the stack.
On the other hand, all operation server errors should be related to
business logic; we want all of them to be correctly modeled and have
compilation fail if any of them is not properly handled.

This commit revamps error generation by the `rust-server-codegen`
plugin, generating a simple Rust enum type for each fallible operation,
holding one variant per modeled error.

Closes #780.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
