### PR TITLE
Runtime and client codegen support for improved server protocol dispatcher

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -201,6 +201,7 @@ data class CargoDependency(
         fun SmithyClient(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("client")
         fun SmithyEventStream(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("eventstream")
         fun SmithyHttp(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http")
+        fun SmithyHttpServer(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http-server")
         fun SmithyHttpTower(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http-tower")
 
         fun SmithyProtocolTestHelpers(runtimeConfig: RuntimeConfig) =

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -272,23 +272,6 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
             namespace = "aws_smithy_http::response"
         )
 
-        fun parseHttpRequest(runtimeConfig: RuntimeConfig) = RuntimeType(
-            "ParseHttpRequest",
-            dependency = CargoDependency.SmithyHttpServer(runtimeConfig),
-            namespace = "aws_smithy_http_server::request"
-        )
-
-        fun serializeHttpResponse(runtimeConfig: RuntimeConfig) = RuntimeType(
-            "SerializeHttpResponse",
-            dependency = CargoDependency.SmithyHttpServer(runtimeConfig),
-            namespace = "aws_smithy_http_server::response"
-        )
-
-        fun serializeHttpError(runtimeConfig: RuntimeConfig) = RuntimeType(
-            "SerializeHttpError",
-            dependency = CargoDependency.SmithyHttpServer(runtimeConfig),
-            namespace = "aws_smithy_http_server::response"
-        )
         val Bytes = RuntimeType("Bytes", dependency = CargoDependency.Bytes, namespace = "bytes")
 
         fun forInlineDependency(inlineDependency: InlineDependency) =

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -266,12 +266,29 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
         fun sdkBody(runtimeConfig: RuntimeConfig): RuntimeType =
             RuntimeType("SdkBody", dependency = CargoDependency.SmithyHttp(runtimeConfig), "aws_smithy_http::body")
 
-        fun parseStrict(runtimeConfig: RuntimeConfig) = RuntimeType(
+        fun parseStrictResponse(runtimeConfig: RuntimeConfig) = RuntimeType(
             "ParseStrictResponse",
             dependency = CargoDependency.SmithyHttp(runtimeConfig),
             namespace = "aws_smithy_http::response"
         )
 
+        fun parseHttpRequest(runtimeConfig: RuntimeConfig) = RuntimeType(
+            "ParseHttpRequest",
+            dependency = CargoDependency.SmithyHttpServer(runtimeConfig),
+            namespace = "aws_smithy_http_server::request"
+        )
+
+        fun serializeHttpResponse(runtimeConfig: RuntimeConfig) = RuntimeType(
+            "SerializeHttpResponse",
+            dependency = CargoDependency.SmithyHttpServer(runtimeConfig),
+            namespace = "aws_smithy_http_server::response"
+        )
+
+        fun serializeHttpError(runtimeConfig: RuntimeConfig) = RuntimeType(
+            "SerializeHttpError",
+            dependency = CargoDependency.SmithyHttpServer(runtimeConfig),
+            namespace = "aws_smithy_http_server::response"
+        )
         val Bytes = RuntimeType("Bytes", dependency = CargoDependency.Bytes, namespace = "bytes")
 
         fun forInlineDependency(inlineDependency: InlineDependency) =

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -46,10 +46,16 @@ import software.amazon.smithy.rust.codegen.util.toSnakeCase
 import java.util.logging.Logger
 
 data class ProtocolSupport(
+    /* Client support */
     val requestSerialization: Boolean,
     val requestBodySerialization: Boolean,
     val responseDeserialization: Boolean,
-    val errorDeserialization: Boolean
+    val errorDeserialization: Boolean,
+    /* Server support */
+    val requestDeserialization: Boolean,
+    val requestBodyDeserialization: Boolean,
+    val responseSerialization: Boolean,
+    val errorSerialization: Boolean
 )
 
 /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsJson.kt
@@ -48,10 +48,16 @@ class AwsJsonFactory(private val version: AwsJsonVersion) : ProtocolGeneratorFac
     override fun transformModel(model: Model): Model = model
 
     override fun support(): ProtocolSupport = ProtocolSupport(
+        /* Client support */
         requestSerialization = true,
         requestBodySerialization = true,
         responseDeserialization = true,
-        errorDeserialization = true
+        errorDeserialization = true,
+        /* Server support */
+        requestDeserialization = false,
+        requestBodyDeserialization = false,
+        responseSerialization = false,
+        errorSerialization = false
     )
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
@@ -36,10 +36,16 @@ class AwsQueryFactory : ProtocolGeneratorFactory<HttpBoundProtocolGenerator> {
 
     override fun support(): ProtocolSupport {
         return ProtocolSupport(
+            /* Client support */
             requestSerialization = true,
             requestBodySerialization = true,
             responseDeserialization = true,
             errorDeserialization = true,
+            /* Server support */
+            requestDeserialization = false,
+            requestBodyDeserialization = false,
+            responseSerialization = false,
+            errorSerialization = false
         )
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
@@ -33,10 +33,16 @@ class Ec2QueryFactory : ProtocolGeneratorFactory<HttpBoundProtocolGenerator> {
 
     override fun support(): ProtocolSupport {
         return ProtocolSupport(
+            /* Client support */
             requestSerialization = true,
             requestBodySerialization = true,
             responseDeserialization = true,
             errorDeserialization = true,
+            /* Server support */
+            requestDeserialization = false,
+            requestBodyDeserialization = false,
+            responseSerialization = false,
+            errorSerialization = false
         )
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -67,7 +67,7 @@ class HttpBoundProtocolGenerator(
     HttpBoundProtocolTraitImplGenerator(codegenContext, protocol),
 )
 
-private class HttpBoundProtocolTraitImplGenerator(
+class HttpBoundProtocolTraitImplGenerator(
     private val codegenContext: CodegenContext,
     private val protocol: Protocol,
 ) : ProtocolTraitImplGenerator {
@@ -78,7 +78,7 @@ private class HttpBoundProtocolTraitImplGenerator(
     private val operationDeserModule = RustModule.private("operation_deser")
 
     private val codegenScope = arrayOf(
-        "ParseStrict" to RuntimeType.parseStrict(runtimeConfig),
+        "ParseStrict" to RuntimeType.parseStrictResponse(runtimeConfig),
         "ParseResponse" to RuntimeType.parseResponse(runtimeConfig),
         "http" to RuntimeType.http,
         "operation" to RuntimeType.operationModule(runtimeConfig),
@@ -160,7 +160,7 @@ private class HttpBoundProtocolTraitImplGenerator(
         )
     }
 
-    private fun parseError(operationShape: OperationShape): RuntimeType {
+    fun parseError(operationShape: OperationShape): RuntimeType {
         val fnName = "parse_${operationShape.id.name.toSnakeCase()}_error"
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
@@ -258,7 +258,7 @@ private class HttpBoundProtocolTraitImplGenerator(
         }
     }
 
-    private fun parseResponse(operationShape: OperationShape): RuntimeType {
+    fun parseResponse(operationShape: OperationShape): RuntimeType {
         val fnName = "parse_${operationShape.id.name.toSnakeCase()}_response"
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
@@ -416,7 +416,7 @@ class HttpBoundProtocolBodyGenerator(
     private val operationSerModule = RustModule.private("operation_ser")
 
     private val codegenScope = arrayOf(
-        "ParseStrict" to RuntimeType.parseStrict(runtimeConfig),
+        "ParseStrict" to RuntimeType.parseStrictResponse(runtimeConfig),
         "ParseResponse" to RuntimeType.parseResponse(runtimeConfig),
         "http" to RuntimeType.http,
         "hyper" to CargoDependency.HyperWithStream.asType(),

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestJson.kt
@@ -30,10 +30,16 @@ class RestJsonFactory : ProtocolGeneratorFactory<HttpBoundProtocolGenerator> {
 
     override fun support(): ProtocolSupport {
         return ProtocolSupport(
+            /* Client support */
             requestSerialization = true,
             requestBodySerialization = true,
             responseDeserialization = true,
-            errorDeserialization = true
+            errorDeserialization = true,
+            /* Server support */
+            requestDeserialization = false,
+            requestBodyDeserialization = false,
+            responseSerialization = false,
+            errorSerialization = false
         )
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -34,10 +34,16 @@ class RestXmlFactory(private val generator: (CodegenContext) -> Protocol = { Res
 
     override fun support(): ProtocolSupport {
         return ProtocolSupport(
+            /* Client support */
             requestSerialization = true,
             requestBodySerialization = true,
             responseDeserialization = true,
-            errorDeserialization = true
+            errorDeserialization = true,
+            /* Server support */
+            requestDeserialization = false,
+            requestBodyDeserialization = false,
+            responseSerialization = false,
+            errorSerialization = false
         )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -59,7 +59,7 @@ private class TestProtocolTraitImplGenerator(
                             ${operationWriter.escape(correctResponse)}
                         }
                     }""",
-            "parse_strict" to RuntimeType.parseStrict(codegenContext.runtimeConfig),
+            "parse_strict" to RuntimeType.parseStrictResponse(codegenContext.runtimeConfig),
             "output" to symbolProvider.toSymbol(operationShape.outputShape(codegenContext.model)),
             "error" to operationShape.errorSymbol(symbolProvider),
             "response" to RuntimeType.Http("Response"),
@@ -119,7 +119,7 @@ private class TestProtocolFactory(
     override fun transformModel(model: Model): Model = model
 
     override fun support(): ProtocolSupport {
-        return ProtocolSupport(true, true, true, true)
+        return ProtocolSupport(true, true, true, true, false, false, false, false)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ smithy.rs.runtime.crate.version=0.27.0-alpha
 kotlin.code.style=official
 
 # codegen
-smithyVersion=1.12.0
+smithyVersion=1.13.0
 
 # kotlin
 kotlinVersion=1.4.21

--- a/rust-runtime/Cargo.toml
+++ b/rust-runtime/Cargo.toml
@@ -11,5 +11,6 @@ members = [
     "aws-smithy-protocol-test",
     "aws-smithy-query",
     "aws-smithy-types",
-    "aws-smithy-xml"
+    "aws-smithy-xml",
+    "aws-smithy-http-server"
 ]

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "aws-smithy-http-server"
 version = "0.1.0"
-authors = ["Matteo Bigoi <matbigoi@amazon.com>", "David Pérez <davidpz@amazon.com>"]
+authors = ["Smithy Rust Server <smithy-rs-server@amazon.com>"]
 edition = "2018"
 description = """
 Server traits and utilities used by the code generator.
+
+NOTE: THIS IS HIGHLY EXPERIMENTAL AND SHOULD NOT BE USED YET.
 """
+# until this is not stable, it is not publishable.
+publish = false
 
 [dependencies]
 aws-smithy-http = { path = "../aws-smithy-http" }

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aws-smithy-http-server"
 version = "0.1.0"
-authors = ["Matteo Bigoi <matbigoi@amazon.com>", "David Perez <davidpz@amazon.com>"]
+authors = ["Matteo Bigoi <matbigoi@amazon.com>", "David Pérez <davidpz@amazon.com>"]
 edition = "2018"
 description = """
 Server traits and utilities used by the code generator.

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "aws-smithy-http-server"
+version = "0.1.0"
+authors = ["Matteo Bigoi <matbigoi@amazon.com>", "David Perez <davidpz@amazon.com>"]
+edition = "2018"
+description = """
+Server traits and utilities used by the code generator.
+"""
+
+[dependencies]
+aws-smithy-http = { path = "../aws-smithy-http" }
+bytes = "1.1"
+http = "0.2"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -1,0 +1,9 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+pub mod request;
+pub mod response;

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -20,10 +20,10 @@ pub trait ParseHttpRequest {
     /// Input type of the HttpRequest
     ///
     /// For request/response style operations, this is typically something like:
-    /// `Result<OperationInput, OperationInputError>`
+    /// `Result<OperationInput, Error>`
     ///
     /// For streaming operations, this is something like:
-    /// `Result<EventStream<OperationEvent>>, OperationStreamingError>`
+    /// `Result<EventStream<OperationEvent>>, Error>`
     type Input;
 
     /// Parse an HTTP request without reading the body. If the body must be provided to proceed,

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! Parse HTTP request trait
+
+use aws_smithy_http::body::SdkBody;
+use bytes::Bytes;
+
+/// `ParseHttpRequest` is a generic trait for parsing structured data from HTTP requests.
+///
+/// It is designed to be flexible, because `Input` is unconstrained, it can be used to support
+/// event streams, regular request-response style operations, as well as any other HTTP-based
+/// protocol that we manage to come up with.
+///
+/// It also enables this critical and core trait to avoid being async, and it makes code that uses
+/// the trait easier to test.
+pub trait ParseHttpRequest {
+    /// Input type of the HttpRequest
+    ///
+    /// For request/response style operations, this is typically something like:
+    /// `Result<OperationInput, OperationInputError>`
+    ///
+    /// For streaming operations, this is something like:
+    /// `Result<EventStream<OperationEvent>>, OperationStreamingError>`
+    type Input;
+
+    /// Parse an HTTP request without reading the body. If the body must be provided to proceed,
+    /// return `None`
+    ///
+    /// This exists to serve APIs like S3::GetObject where the body is passed directly into the
+    /// response and consumed by the client. However, even in the case of S3::GetObject, errors
+    /// require reading the entire body.
+    ///
+    /// This also facilitates `EventStream` and other streaming HTTP protocols by enabling the
+    /// handler to take ownership of the HTTP request directly.
+    ///
+    /// Currently `parse_unloaded` operates on a borrowed HTTP request to enable
+    /// the caller to provide a raw HTTP response to the caller for inspection after the response is
+    /// returned. For EventStream-like use cases, the caller can use `mem::swap` to replace
+    /// the streaming body with an empty body as long as the body implements default.
+    ///
+    /// We should consider if this is too limiting & if this should take an owned response instead.
+    fn parse_unloaded(&self, request: &mut http::Request<SdkBody>) -> Option<Self::Input>;
+
+    /// Parse an HTTP request from a fully loaded body. This is for standard request/response style
+    /// APIs like RestJson1.
+    ///
+    /// Using an explicit body type of Bytes here is a conscious decision—If you _really_ need
+    /// to precisely control how the data is loaded into memory (eg. by using `bytes::Buf`), implement
+    /// your handler in `parse_unloaded`.
+    ///
+    /// Production code will never call `parse_loaded` without first calling `parse_unloaded`. However,
+    /// in tests it may be easier to use `parse_loaded` directly. It is OK to panic in `parse_loaded`
+    /// if `parse_unloaded` will never return `None`, however, it may make your code easier to test if an
+    /// implementation is provided.
+    fn parse_loaded(&self, request: &http::Request<Bytes>) -> Self::Input;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bytes::Bytes;
+    use std::mem;
+
+    #[test]
+    fn support_non_streaming_body() {
+        pub struct S3GetObject {
+            pub body: Bytes,
+        }
+
+        struct S3GetObjectParser;
+
+        impl ParseHttpRequest for S3GetObjectParser {
+            type Input = S3GetObject;
+
+            fn parse_unloaded(&self, _request: &mut http::Request<SdkBody>) -> Option<Self::Input> {
+                None
+            }
+
+            fn parse_loaded(&self, request: &http::Request<Bytes>) -> Self::Input {
+                S3GetObject {
+                    body: request.body().clone(),
+                }
+            }
+        }
+    }
+    #[test]
+    fn supports_streaming_body() {
+        pub struct S3GetObject {
+            pub body: SdkBody,
+        }
+
+        struct S3GetObjectParser;
+
+        impl ParseHttpRequest for S3GetObjectParser {
+            type Input = S3GetObject;
+
+            fn parse_unloaded(&self, request: &mut http::Request<SdkBody>) -> Option<Self::Input> {
+                // For responses that pass on the body, use mem::take to leave behind an empty body
+                let body = mem::replace(request.body_mut(), SdkBody::taken());
+                Some(S3GetObject { body })
+            }
+
+            fn parse_loaded(&self, _request: &http::Request<Bytes>) -> Self::Input {
+                unimplemented!()
+            }
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -39,9 +39,9 @@ pub trait ParseHttpRequest {
     /// Currently `parse_unloaded` operates on a borrowed HTTP request to enable
     /// the caller to provide a raw HTTP response to the caller for inspection after the response is
     /// returned. For EventStream-like use cases, the caller can use `mem::swap` to replace
-    /// the streaming body with an empty body as long as the body implements default.
+    /// the streaming body with an empty body as long as the body implements `std::default::Default`.
     ///
-    /// We should consider if this is too limiting & if this should take an owned response instead.
+    /// We should consider if this is too limiting and if this should take an owned request instead.
     fn parse_unloaded(&self, request: &mut http::Request<SdkBody>) -> Option<Self::Input>;
 
     /// Parse an HTTP request from a fully loaded body. This is for standard request/response style

--- a/rust-runtime/aws-smithy-http-server/src/response.rs
+++ b/rust-runtime/aws-smithy-http-server/src/response.rs
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+//! Serialize HTTP response and error traits
+
+/// `SerializeHttpResponse` is a generic trait for serializing structured data into HTTP responses.
+///
+/// It is designed to be flexible, because `Output` and `Struct` are unconstrained, it can be used to support
+/// event streams, regular request-response style operations, as well as any other HTTP-based
+/// protocol that we manage to come up with.
+///
+/// It also enables this critical and core trait to avoid being async, and it makes code that uses
+/// the trait easier to test.
+///
+/// TODO: streaming and not-fully loaded body serialization is no developed yet
+pub trait SerializeHttpResponse {
+    /// Struct instance to be serialized into the HTTP body
+    ///
+    /// For request/response style operations, this is typically something like:
+    /// `OperationOutput`
+    type Struct;
+    /// HTTP response output
+    ///
+    /// For request/response style operations, this is typically something like:
+    /// `Result<ResponseBytes>, Error>`
+    type Output;
+
+    /// Serialize an HTTP response from a fully loaded body. This is for standard request/response style
+    /// APIs like RestJson1.
+    fn serialize(&self, output: &Self::Struct) -> Self::Output;
+}
+
+/// `SerializeHttpError` is a generic trait for serializing structured errors into HTTP responses.
+///
+/// It is designed to be flexible, because `Output` and `Struct` are unconstrained, it can be used to support
+/// event streams, regular request-response style operations, as well as any other HTTP-based
+/// protocol that we manage to come up with.
+///
+/// It also enables this critical and core trait to avoid being async, and it makes code that uses
+/// the trait easier to test.
+///
+/// TODO: streaming and not-fully loaded body serialization is no developed yet
+pub trait SerializeHttpError {
+    /// Struct instance to be serialized into the HTTP body
+    ///
+    /// For request/response style operations, this is typically something like:
+    /// `OperationError`
+    type Struct;
+    /// HTTP response output
+    ///
+    /// For request/response style operations, this is typically something like:
+    /// `Result<ResponseBytes>, Error>`
+    type Output;
+
+    /// Serialize an HTTP response from a fully loaded body. This is for standard request/response style
+    /// APIs like RestJson1.
+    fn serialize(&self, error: &Self::Struct) -> Self::Output;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bytes::Bytes;
+
+    #[test]
+    fn support_non_streaming_body() {
+        pub struct S3GetObject {
+            pub body: Bytes,
+        }
+
+        #[allow(dead_code)]
+        pub enum S3Error {
+            Something,
+        }
+
+        impl S3Error {
+            fn as_bytes(&self) -> Bytes {
+                match self {
+                    S3Error::Something => Bytes::from_static(b"something"),
+                }
+            }
+        }
+
+        struct S3GetObjectParser;
+
+        impl SerializeHttpResponse for S3GetObjectParser {
+            type Struct = S3GetObject;
+            type Output = http::Response<bytes::Bytes>;
+
+            fn serialize(&self, output: &Self::Struct) -> Self::Output {
+                http::Response::builder().body(output.body.clone()).unwrap()
+            }
+        }
+
+        impl SerializeHttpError for S3GetObjectParser {
+            type Struct = S3Error;
+            type Output = http::Response<bytes::Bytes>;
+
+            fn serialize(&self, error: &Self::Struct) -> Self::Output {
+                http::Response::builder().body(error.as_bytes()).unwrap()
+            }
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/response.rs
+++ b/rust-runtime/aws-smithy-http-server/src/response.rs
@@ -23,11 +23,11 @@ pub trait SerializeHttpResponse {
     /// HTTP response output
     ///
     /// For request/response style operations, this is typically something like:
-    /// `Result<ResponseBytes>, Error>`
+    /// `Result<ResponseBytes, Error>`
     type Output;
 
     /// Serialize an HTTP response from a fully loaded body. This is for standard request/response style
-    /// APIs like RestJson1.
+    /// protocols like RestJson1.
     fn serialize(&self, output: &Self::Struct) -> Self::Output;
 }
 
@@ -40,7 +40,7 @@ pub trait SerializeHttpResponse {
 /// It also enables this critical and core trait to avoid being async, and it makes code that uses
 /// the trait easier to test.
 ///
-/// TODO: streaming and not-fully loaded body serialization is no developed yet
+/// TODO: streaming and not-fully loaded body serialization is not developed yet
 pub trait SerializeHttpError {
     /// Struct instance to be serialized into the HTTP body
     ///
@@ -50,11 +50,11 @@ pub trait SerializeHttpError {
     /// HTTP response output
     ///
     /// For request/response style operations, this is typically something like:
-    /// `Result<ResponseBytes>, Error>`
+    /// `Result<ResponseBytes, Error>`
     type Output;
 
     /// Serialize an HTTP response from a fully loaded body. This is for standard request/response style
-    /// APIs like RestJson1.
+    /// protocols like RestJson1.
     fn serialize(&self, error: &Self::Struct) -> Self::Output;
 }
 


### PR DESCRIPTION
## Motivation and Context
We are changing how the HTTP protocol operation generation is done in server-codegen. It will mimic how the client-codegen works, but delegating the protocol specifics to their implementations and dispatching them through a protocol loader.

This is the first PR, adding a Rust runtime defining the server operation traits and adapts the client codegen allowing server configurations to the ProtocolSupport and changing the visibility of HttpBoundProtocolGenerator methods to allow server-codegen to use them (will be needed mostly for testing).

This can be reviewed as I'll be waiting to merge this before submitting the dispatcher implementation. 

## Description
Implement Rust runtime defining the traits used by the server to build operations
parsers/serializers:
  * ParseHttpRequest
  * SerializeHttpResponse
  * SerializeHttpError

Refactor ProtocolSupport to allow server configurations:
  * requestDeserialization (bool)
  * requestBodyDeserialization (bool)
  * responseSerialization(bool)
  * errorSerialization(bool)

Change visibility of HttpBoundProtocolGenerator methods to allow to use
them in the server generator

## Testing
Tested on CI

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
