### PR TITLE
Smithy 1.13

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3/tests/signing-it.rs
@@ -23,7 +23,7 @@ async fn test_signer() -> Result<(), aws_sdk_s3::Error> {
         .build();
     let conn = TestConnection::new(vec![(
         http::Request::builder()
-            .header("authorization", "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210618/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=c55fb770a89c535e56b502f8c949766c7bde7cfc84f89d2b7761d13b8e82234c")
+            .header("authorization", "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210618/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=6233614b69271e15db079287874a654183916e509909b5719b00cd8d5f31299e")
             .uri("https://s3.us-east-1.amazonaws.com/test-bucket?list-type=2&prefix=prefix~")
             .body(SdkBody::empty())
             .unwrap(),

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -147,8 +147,9 @@ open class MakeOperationGenerator(
         val contentType = httpBindingResolver.requestContentType(operationShape)
         httpBindingGenerator.renderUpdateHttpBuilder(writer)
         writer.inRequestBuilderBaseFn(inputShape) {
+            Attribute.AllowUnusedMut.render(this)
             writer.rust("let mut builder = update_http_builder(input, #T::new())?;", RuntimeType.HttpRequestBuilder)
-            val additionalHeaders = listOf("content-type" to contentType) + protocol.additionalHeaders(operationShape)
+            val additionalHeaders = listOfNotNull(contentType?.let { "content-type" to it }) + protocol.additionalHeaders(operationShape)
             for (header in additionalHeaders) {
                 writer.rustTemplate(
                     """

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
@@ -144,15 +144,15 @@ open class ProtocolGenerator(
                 if (needsContentLength(operationShape)) {
                     rustTemplate(
                         """
-                    let mut builder = builder;
-                    if let Some(content_length) = body.content_length() {
-                        builder = #{header_util}::set_header_if_absent(
-                                    builder,
-                                    #{http}::header::CONTENT_LENGTH,
-                                    content_length
-                        );
-                    }
-                    """,
+                        let mut builder = builder;
+                        if let Some(content_length) = body.content_length() {
+                            builder = #{header_util}::set_header_if_absent(
+                                        builder,
+                                        #{http}::header::CONTENT_LENGTH,
+                                        content_length
+                            );
+                        }
+                        """,
                         *codegenScope
                     )
                 }
@@ -193,7 +193,8 @@ open class ProtocolGenerator(
     }
 
     private fun needsContentLength(operationShape: OperationShape): Boolean {
-        return protocol.httpBindingResolver.requestBindings(operationShape).any { it.location == HttpLocation.DOCUMENT || it.location == HttpLocation.PAYLOAD }
+        return protocol.httpBindingResolver.requestBindings(operationShape)
+            .any { it.location == HttpLocation.DOCUMENT || it.location == HttpLocation.PAYLOAD }
     }
 
     private fun renderTypeAliases(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
@@ -24,6 +24,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.BuilderGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.FluentClientGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.implBlock
 import software.amazon.smithy.rust.codegen.smithy.generators.operationBuildError
+import software.amazon.smithy.rust.codegen.smithy.protocols.HttpLocation
 import software.amazon.smithy.rust.codegen.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.util.inputShape
 
@@ -137,11 +138,13 @@ open class ProtocolGenerator(
             )
             makeOperationGenerator.generateMakeOperation(this, operationShape, customizations)
             rustBlockTemplate(
-                "fn assemble(mut builder: #{RequestBuilder}, body: #{SdkBody}) -> #{Request}<#{SdkBody}>",
+                "fn assemble(builder: #{RequestBuilder}, body: #{SdkBody}) -> #{Request}<#{SdkBody}>",
                 *codegenScope
             ) {
-                rustTemplate(
-                    """
+                if (needsContentLength(operationShape)) {
+                    rustTemplate(
+                        """
+                    let mut builder = builder;
                     if let Some(content_length) = body.content_length() {
                         builder = #{header_util}::set_header_if_absent(
                                     builder,
@@ -149,10 +152,11 @@ open class ProtocolGenerator(
                                     content_length
                         );
                     }
-                    builder.body(body).expect("should be valid request")
                     """,
-                    *codegenScope
-                )
+                        *codegenScope
+                    )
+                }
+                rust("""builder.body(body).expect("should be valid request")""")
             }
 
             // pub fn builder() -> ... { }
@@ -186,6 +190,10 @@ open class ProtocolGenerator(
             writeCustomizations(customizations, OperationSection.OperationImplBlock(customizations))
         }
         traitGenerator.generateTraitImpls(operationWriter, operationShape)
+    }
+
+    private fun needsContentLength(operationShape: OperationShape): Boolean {
+        return protocol.httpBindingResolver.requestBindings(operationShape).any { it.location == HttpLocation.DOCUMENT || it.location == HttpLocation.PAYLOAD }
     }
 
     private fun renderTypeAliases(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -442,10 +442,7 @@ class ProtocolTestGenerator(
         private val RestXml = "aws.protocoltests.restxml#RestXml"
         private val AwsQuery = "aws.protocoltests.query#AwsQuery"
         private val Ec2Query = "aws.protocoltests.ec2#AwsEc2"
-        private val ExpectFail = setOf<FailingTest>(
-            // this is a buggy test, will be fixed in 1.13
-            FailingTest(RestJson, "RestJsonNoInputAndOutput", Action.Request)
-        )
+        private val ExpectFail = setOf<FailingTest>()
         private val RunOnly: Set<String>? = null
 
         // These tests are not even attempted to be generated, either because they will not compile

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
@@ -135,9 +135,8 @@ class HttpTraitHttpBindingResolver(
     ): TimestampFormatTrait.Format =
         httpIndex.determineTimestampFormat(memberShape, location, defaultTimestampFormat)
 
-    override fun requestContentType(operationShape: OperationShape): String? {
-        return httpIndex.determineRequestContentType(operationShape, contentTypes.requestDocument).orNull()
-    }
+    override fun requestContentType(operationShape: OperationShape): String? =
+        httpIndex.determineRequestContentType(operationShape, contentTypes.requestDocument).orNull()
 
     override fun responseContentType(operationShape: OperationShape): String? =
         httpIndex.determineResponseContentType(operationShape, contentTypes.responseDocument).orNull()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
@@ -85,22 +85,18 @@ interface HttpBindingResolver {
     /**
      * Determines the request content type for given [operationShape].
      */
-    fun requestContentType(operationShape: OperationShape): String
+    fun requestContentType(operationShape: OperationShape): String?
 
     /**
      * Determines the response content type for given [operationShape].
      */
-    fun responseContentType(operationShape: OperationShape): String
+    fun responseContentType(operationShape: OperationShape): String?
 }
 
 /**
  * Content types a protocol uses.
  */
 data class ProtocolContentTypes(
-    /** Default request content type when the shape isn't, for example, a Blob */
-    val requestDefault: String,
-    /** Default response content type when the shape isn't, for example, a Blob */
-    val responseDefault: String,
     /** Request content type override for when the shape is a Document */
     val requestDocument: String? = null,
     /** Response content type override for when the shape is a Document */
@@ -139,13 +135,12 @@ class HttpTraitHttpBindingResolver(
     ): TimestampFormatTrait.Format =
         httpIndex.determineTimestampFormat(memberShape, location, defaultTimestampFormat)
 
-    override fun requestContentType(operationShape: OperationShape): String =
-        httpIndex.determineRequestContentType(operationShape, contentTypes.requestDocument)
-            .orElse(contentTypes.requestDefault)
+    override fun requestContentType(operationShape: OperationShape): String? {
+        return httpIndex.determineRequestContentType(operationShape, contentTypes.requestDocument).orNull()
+    }
 
-    override fun responseContentType(operationShape: OperationShape): String =
-        httpIndex.determineResponseContentType(operationShape, contentTypes.responseDocument)
-            .orElse(contentTypes.responseDefault)
+    override fun responseContentType(operationShape: OperationShape): String? =
+        httpIndex.determineResponseContentType(operationShape, contentTypes.responseDocument).orNull()
 
     // Sort the members after extracting them from the map to have a consistent order
     private fun mappedBindings(bindings: Map<String, HttpBinding>): List<HttpBindingDescriptor> =

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBindingResolver.kt
@@ -101,10 +101,12 @@ data class ProtocolContentTypes(
     val requestDocument: String? = null,
     /** Response content type override for when the shape is a Document */
     val responseDocument: String? = null,
+    /** EventStream content type */
+    val eventStreamContentType: String? = null
 ) {
     companion object {
         /** Create an instance of [ProtocolContentTypes] where all content types are the same */
-        fun consistent(type: String) = ProtocolContentTypes(type, type)
+        fun consistent(type: String) = ProtocolContentTypes(type, type, type)
     }
 }
 
@@ -136,10 +138,10 @@ class HttpTraitHttpBindingResolver(
         httpIndex.determineTimestampFormat(memberShape, location, defaultTimestampFormat)
 
     override fun requestContentType(operationShape: OperationShape): String? =
-        httpIndex.determineRequestContentType(operationShape, contentTypes.requestDocument).orNull()
+        httpIndex.determineRequestContentType(operationShape, contentTypes.requestDocument, contentTypes.eventStreamContentType).orNull()
 
     override fun responseContentType(operationShape: OperationShape): String? =
-        httpIndex.determineResponseContentType(operationShape, contentTypes.responseDocument).orNull()
+        httpIndex.determineResponseContentType(operationShape, contentTypes.responseDocument, contentTypes.eventStreamContentType).orNull()
 
     // Sort the members after extracting them from the map to have a consistent order
     private fun mappedBindings(bindings: Map<String, HttpBinding>): List<HttpBindingDescriptor> =

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -184,6 +184,18 @@ class JsonSerializerGenerator(
         }
     }
 
+    override fun unsetStructure(structure: StructureShape): RuntimeType {
+        return RuntimeType.forInlineFun("rest_json_unsetpayload", operationSerModule) { writer ->
+            writer.rustTemplate(
+                """
+                pub fn rest_json_unsetpayload() -> std::vec::Vec<u8> {
+                    b"{}"[..].into()
+                }
+            """
+            )
+        }
+    }
+
     override fun operationSerializer(operationShape: OperationShape): RuntimeType? {
         // Don't generate an operation JSON serializer if there is no JSON body
         val httpDocumentMembers = httpBindingResolver.requestMembers(operationShape, HttpLocation.DOCUMENT)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -191,7 +191,7 @@ class JsonSerializerGenerator(
                 pub fn rest_json_unsetpayload() -> std::vec::Vec<u8> {
                     b"{}"[..].into()
                 }
-            """
+                """
             )
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/QuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/QuerySerializerGenerator.kt
@@ -109,6 +109,10 @@ abstract class QuerySerializerGenerator(codegenContext: CodegenContext) : Struct
         TODO("$protocolName doesn't support payload serialization yet")
     }
 
+    override fun unsetStructure(structure: StructureShape): RuntimeType {
+        TODO("AwsQuery doesn't support payload serialization")
+    }
+
     override fun operationSerializer(operationShape: OperationShape): RuntimeType? {
         val fnName = symbolProvider.serializeFunctionName(operationShape)
         val inputShape = operationShape.inputShape(model)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/StructuredDataSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/StructuredDataSerializerGenerator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.smithy.protocols.serialize
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 
 interface StructuredDataSerializerGenerator {
@@ -20,6 +21,11 @@ interface StructuredDataSerializerGenerator {
      * ```
      */
     fun payloadSerializer(member: MemberShape): RuntimeType
+
+    /**
+     * Generate the correct data when attempting to serialize a structure that is unset
+     */
+    fun unsetStructure(structure: StructureShape): RuntimeType
 
     /**
      * Generate a serializer for an operation input.

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -177,6 +177,19 @@ class XmlBindingTraitSerializerGenerator(
         }
     }
 
+    override fun unsetStructure(structure: StructureShape): RuntimeType {
+        val fnName = "rest_xml_unset_payload"
+        return RuntimeType.forInlineFun(fnName, operationSerModule) { writer ->
+            writer.rustTemplate(
+                """
+                pub fn $fnName() -> std::vec::Vec<u8> {
+                    vec![]
+                }
+            """
+            )
+        }
+    }
+
     override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
         TODO("Not yet implemented")
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -185,7 +185,7 @@ class XmlBindingTraitSerializerGenerator(
                 pub fn $fnName() -> std::vec::Vec<u8> {
                     vec![]
                 }
-            """
+                """
             )
         }
     }
@@ -232,7 +232,10 @@ class XmlBindingTraitSerializerGenerator(
                 rust("$input.as_ref()")
             }
             is BooleanShape, is NumberShape -> {
-                rust("#T::from(${autoDeref(input)}).encode()", CargoDependency.SmithyTypes(runtimeConfig).asType().member("primitive::Encoder"))
+                rust(
+                    "#T::from(${autoDeref(input)}).encode()",
+                    CargoDependency.SmithyTypes(runtimeConfig).asType().member("primitive::Encoder")
+                )
             }
             is BlobShape -> rust("#T($input.as_ref()).as_ref()", RuntimeType.Base64Encode(runtimeConfig))
             is TimestampShape -> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ smithy.rs.runtime.crate.version=0.27.0-alpha
 kotlin.code.style=official
 
 # codegen
-smithyVersion=1.12.0
+smithyVersion=1.13.0
 
 # kotlin
 kotlinVersion=1.4.21

--- a/rust-runtime/aws-smithy-async/src/rt/sleep.rs
+++ b/rust-runtime/aws-smithy-async/src/rt/sleep.rs
@@ -65,7 +65,7 @@ impl Future for Sleep {
 /// Implementation of [`AsyncSleep`] for Tokio.
 #[non_exhaustive]
 #[cfg(feature = "rt-tokio")]
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub struct TokioSleep;
 
 #[cfg(feature = "rt-tokio")]

--- a/rust-runtime/aws-smithy-async/src/rt/sleep.rs
+++ b/rust-runtime/aws-smithy-async/src/rt/sleep.rs
@@ -65,7 +65,7 @@ impl Future for Sleep {
 /// Implementation of [`AsyncSleep`] for Tokio.
 #[non_exhaustive]
 #[cfg(feature = "rt-tokio")]
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default)]
 pub struct TokioSleep;
 
 #[cfg(feature = "rt-tokio")]


### PR DESCRIPTION
## Motivation and Context
Upgrade to Smithy 1.13. The new release is breaking CI because the CLI version is being autodiscovered.

## Description
The Smith 1.13 upgrade adds new restJson protocol tests. These demonstrated two issues:

1. We were not properly using the http binding index to compute content types. We should not have fallen back to a default content type—instead we need to use exactly what is given. We were also using the index incorrectly: `document` in the context of the index refers to anything in the HTTP body, _not_ the Smithy document type.
2. We were sending `Content-Length: 0` even when no HTTP body was modeled.
3. We were sending an empty body for structures targeted `@httpPayload` trait in restJson. We should instead be sending on an empty JSON body: `{}`.

## Testing
- [x] Protocol tests
- [ ] Manually review codegen diff

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
