### PR TITLE
Add pre-commit hook to fix code gen block quote indentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,13 @@ repos:
   - id: check-yaml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+- repo: local
+  hooks:
+  - id: kotlin-block-quotes
+    name: Kotlin Block Quotes
+    entry: ./.pre-commit-hooks/kotlin-block-quotes.py
+    language: python
+    files: ^.*\.kt$
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
   rev: v1.6.1
   hooks:

--- a/.pre-commit-hooks/kotlin-block-quotes.py
+++ b/.pre-commit-hooks/kotlin-block-quotes.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+#
+# Script for pre-commit that fixes Kotlin block quote indentation
+# for Smithy codegen, where the actual whitespace in the block quotes
+# doesn't actually matter.
+#
+# In anticipation that the script isn't perfect, it will not change any
+# file if non-indentation changes were made. Instead, it fails and says
+# where the ambiguous code is so that it can be touched up manually.
+#
+# To run unit tests, run this script directly with the `--self-test` arg.
+# To test against the repository, run `pre-commit run --all --verbose`.
+#
+import re
+import sys
+import unittest
+from enum import Enum
+
+INDENT_SIZE = 4
+
+# Chops of any line comment
+def without_line_comment(line):
+    line_comment_start = line.find("//")
+    if line_comment_start != -1:
+        return line[:line_comment_start]
+    return line
+
+def _calc_block_comment(line, direction):
+    regex = "(" + re.escape("/*") + "|" + re.escape("*/") + "|" + re.escape("//") + ")"
+    tokens = [m.string[m.start(0):m.end(0)] for m in re.finditer(regex, line)]
+    depth = 0
+    for token in tokens:
+        if direction > 0 and token == "//" and depth == 0:
+            break
+        elif token == "/*":
+            depth += direction
+        elif token == "*/":
+            depth -= direction
+    return depth > 0
+
+# Returns True if the line starts a block comment
+def starts_block_comment(line):
+    return _calc_block_comment(line, 1)
+
+# Returns True if the line ends a block comment
+def ends_block_comment(line):
+    return _calc_block_comment(line, -1)
+
+# Returns True if the line starts or ends a block quote (depending on state)
+def starts_or_ends_block_quote(line, inside_block_quotes):
+    regex = "(" + re.escape('"""') + "|" + re.escape("//") + ")"
+    tokens = [m.string[m.start(0):m.end(0)] for m in re.finditer(regex, line)]
+    start_value = inside_block_quotes
+    for token in tokens:
+        if not inside_block_quotes and token == "//":
+            break
+        elif token == '"""':
+            inside_block_quotes = not inside_block_quotes
+    return start_value != inside_block_quotes
+
+# Returns the indentation of a line
+def line_indent(line):
+    indent = re.search("[^\s]", line)
+    if indent != None:
+        return indent.start(0)
+    else:
+        return 0
+
+# Changes the indentation of a line
+def adjust_indent(line, indent):
+    old_indent = re.search("[^\s]", line)
+    if old_indent == None:
+        return line
+    line = line[old_indent.start(0):]
+    return (" " * indent) + line
+
+# Parser state.
+class State(Enum):
+    Default = 0 # Just started, or not inside a block comment or block quote
+    InsideBlockComment = 1
+    InsideBlockQuote = 2
+
+# Fixes block quote indentation and returns True if changes were made
+def fix_lines(lines):
+    state = State.Default
+    changed = []
+    correct_indent = 0
+    correct_end_indent = 0
+    first_inner_indent = None
+
+    for index, line in enumerate(lines):
+        # Look for block quotes or block comments
+        if state == State.Default:
+            if starts_block_comment(line):
+                state = State.InsideBlockComment
+            elif starts_or_ends_block_quote(line, inside_block_quotes = False):
+                state = State.InsideBlockQuote
+                correct_end_indent = line_indent(line)
+                # Determine correct block comment indentation once one is found
+                if line.lstrip().startswith('"""'):
+                    correct_indent = line_indent(line)
+                else:
+                    correct_indent = line_indent(line) + INDENT_SIZE
+                first_inner_indent = None
+
+        # Skip all lines inside of block comments
+        elif state == State.InsideBlockComment:
+            if ends_block_comment(line):
+                state = State.Default
+
+        # Format block quotes
+        elif state == State.InsideBlockQuote:
+            current_indent = line_indent(line)
+            # Track the first line's indentation inside of the block quote
+            # so that relative indentation can be preserved.
+            if first_inner_indent == None:
+                first_inner_indent = current_indent
+            # Handle the end of the block quote
+            if starts_or_ends_block_quote(line, inside_block_quotes = True):
+                if line.lstrip().startswith('"""') and current_indent != correct_end_indent:
+                    lines[index] = adjust_indent(line, correct_end_indent)
+                    changed.append(index + 1)
+                state = State.Default
+            else:
+                # Handle lines in the middle of the block quote
+                indent_relative_to_first = max(0, current_indent - first_inner_indent)
+                adjusted_indent = correct_indent + indent_relative_to_first
+                if current_indent != adjusted_indent:
+                    lines[index] = adjust_indent(line, adjusted_indent)
+                    changed.append(index + 1)
+
+    return changed
+
+# Determines if the changes made were only to indentation
+def only_changed_indentation(lines_before, lines_after):
+    if len(lines_before) != len(lines_after):
+        return False
+    for index in range(0, len(lines_before)):
+        if lines_before[index].lstrip() != lines_after[index].lstrip():
+            return False
+    return True
+
+# Fixes the indentation in a file, and returns True if the file was changed
+def fix_file(file_name):
+    lines = []
+    with open(file_name, "r") as file:
+        lines = file.readlines()
+    old_lines = lines[:]
+    changed_line_numbers = fix_lines(lines)
+    if len(changed_line_numbers) > 0 and old_lines != lines:
+        # This script isn't perfect, so if anything other than whitespace changed,
+        # then bail to avoid losing any code changes.
+        if not only_changed_indentation(old_lines, lines):
+            print("ERROR: `" + file_name + "`: Block quote indentation is wrong on lines " + str(changed_line_numbers) + \
+                ". The pre-commit script can't fix it automatically in this instance.")
+            sys.exit(1)
+        else:
+            text = "".join(lines)
+            with open(file_name, "w") as file:
+                file.write(text)
+            print("INFO: Fixed indentation in `" + file_name + "`.")
+            return True
+    else:
+        print("INFO: `" + file_name + "` is fine.")
+        return False
+
+class SelfTest(unittest.TestCase):
+    def test_starts_block_comment(self):
+        assert(not starts_block_comment(""))
+        assert(not starts_block_comment("foo"))
+        assert(not starts_block_comment("/* false */"))
+        assert(not starts_block_comment("    /* false */"))
+        assert(not starts_block_comment("    /* false */ asdf"))
+        assert(not starts_block_comment("  asdf  /* false */ asdf"))
+        assert(not starts_block_comment("    /* false */ /* false */"))
+        assert(not starts_block_comment("    /* false /* false */ */"))
+        assert(not starts_block_comment("    /* false /* false /* false */ */ */"))
+        assert(not starts_block_comment("   false */"))
+        assert(not starts_block_comment("/* false //*/"))
+        assert(not starts_block_comment("    /* false /* false /* false */ */ // */"))
+        assert(not starts_block_comment("// /* false"))
+        assert(starts_block_comment("    /* true *"))
+        assert(starts_block_comment("    /* true */ /*"))
+        assert(starts_block_comment("    /* true /* true /* true */ */"))
+
+    def test_ends_block_comment(self):
+        assert(not ends_block_comment(""))
+        assert(ends_block_comment("*/"))
+        assert(ends_block_comment("// */"))
+        assert(ends_block_comment("  */ asdf"))
+        assert(ends_block_comment("  asdf */ asdf"))
+        assert(not ends_block_comment(" /* asdf */ asdf"))
+        assert(not ends_block_comment("    /* true */ /*"))
+        assert(not ends_block_comment("    /* true /* true /* true */ */"))
+
+    def test_starts_or_ends_block_quote(self):
+        assert(not starts_or_ends_block_quote("", False))
+        assert(not starts_or_ends_block_quote('  """foo "bar" baz"""', False))
+        assert(not starts_or_ends_block_quote('  """foo "bar" baz""" test """foo"""', False))
+        assert(starts_or_ends_block_quote('  """foo "bar" baz""" test """foo', False))
+        assert(starts_or_ends_block_quote('"""', False))
+
+        assert(not starts_or_ends_block_quote('// """', False))
+        assert(starts_or_ends_block_quote('"""//""" """', False))
+        assert(not starts_or_ends_block_quote('"""//"""', False))
+
+        assert(starts_or_ends_block_quote('// """', True))
+        assert(starts_or_ends_block_quote('"""//""" """', True))
+        assert(starts_or_ends_block_quote('"""//"""', True))
+
+    def test_line_indent(self):
+        self.assertEqual(line_indent(""), 0)
+        self.assertEqual(line_indent("   "), 0)
+        self.assertEqual(line_indent("   foo"), 3)
+        self.assertEqual(line_indent("   foo bar"), 3)
+
+    def test_adjust_indent(self):
+        self.assertEqual(adjust_indent("", 3), "")
+        self.assertEqual(adjust_indent("foo", 3), "   foo")
+        self.assertEqual(adjust_indent(" foo", 3), "   foo")
+
+    def test_only_changed_indentation(self):
+        assert(only_changed_indentation(["foo"], ["foo"]))
+        assert(only_changed_indentation(["foo"], ["    foo"]))
+        assert(not only_changed_indentation(["foo"], ["oo"]))
+        assert(not only_changed_indentation(["foo"], ["foo", "bar"]))
+        assert(not only_changed_indentation(["foo", "bar"], ["foo"]))
+        assert(not only_changed_indentation(["  foo"], ["  oo"]))
+
+    def fix_lines_test_case(self, expected, input, lines_changed):
+        actual_lines_changed = fix_lines(input)
+        self.assertEqual(expected, input)
+        self.assertEqual(lines_changed, actual_lines_changed)
+
+    def test_fix_lines(self):
+        self.fix_lines_test_case( \
+            expected = ['  """', '  if something {', '      foo();', '  }', '  """'], \
+            input = ['  """', '  if something {', '      foo();', '  }', '"""'], \
+            lines_changed = [5] \
+        )
+        self.fix_lines_test_case( \
+            expected = ['  foo = """', '      asdf', '  """'], \
+            input = ['  foo = """', '    asdf', '    """'], \
+            lines_changed = [2, 3] \
+        )
+        self.fix_lines_test_case( \
+            expected = ['  foo = """', '      // asdf', '  //"""'], \
+            input = ['  foo = """', '      // asdf', '  //"""'], \
+            lines_changed = [] \
+        )
+        self.fix_lines_test_case( \
+            expected = ['    """', '    asdf {', '        asdf', '    }', '    """'], \
+            input = ['    """', '  asdf {', '      asdf', '  }', '"""'], \
+            lines_changed = [2, 3, 4, 5] \
+        )
+
+def main():
+    # Run unit tests if given `--self-test` argument
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        sys.argv.pop()
+        unittest.main()
+    else:
+        file_names = sys.argv[1:]
+        status = 0
+        for file_name in file_names:
+            if fix_file(file_name):
+                status = 1
+        sys.exit(status)
+
+if __name__ == "__main__":
+    main()

--- a/.pre-commit-hooks/kotlin-block-quotes.py
+++ b/.pre-commit-hooks/kotlin-block-quotes.py
@@ -80,7 +80,7 @@ class State(Enum):
     InsideBlockComment = 1
     InsideBlockQuote = 2
 
-# Fixes block quote indentation and returns True if changes were made
+# Fixes block quote indentation and returns a list of line numbers changed
 def fix_lines(lines):
     state = State.Default
     changed = []

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -96,11 +96,11 @@ class EndpointConfigCustomization(private val codegenContext: CodegenContext, pr
             ServiceConfig.BuilderBuild -> {
                 val resolverGenerator = EndpointResolverGenerator(codegenContext, endpointData)
                 rust(
-                    """endpoint_resolver: self.endpoint_resolver.unwrap_or_else(||
-                                ::std::sync::Arc::new(
-                                    #T()
-                                )
-                         ),""",
+                    """
+                    endpoint_resolver: self.endpoint_resolver.unwrap_or_else(||
+                        ::std::sync::Arc::new(#T())
+                    ),
+                    """,
                     resolverGenerator.resolver(),
                 )
             }
@@ -118,8 +118,8 @@ class EndpointResolverFeature(private val runtimeConfig: RuntimeConfig, private 
             is OperationSection.MutateRequest -> writable {
                 rust(
                     """
-                #T::set_endpoint_resolver(&mut ${section.request}.properties_mut(), ${section.config}.endpoint_resolver.clone());
-                """,
+                    #T::set_endpoint_resolver(&mut ${section.request}.properties_mut(), ${section.config}.endpoint_resolver.clone());
+                    """,
                     runtimeConfig.awsEndpointDependency().asType()
                 )
             }
@@ -335,7 +335,7 @@ class EndpointResolverGenerator(codegenContext: CodegenContext, private val endp
             rustTemplate(
                 """
                 #{CredentialScope}::builder()
-            """,
+                """,
                 *codegenScope
             )
             objectNode.getStringMember("service").map {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
@@ -52,38 +52,38 @@ class AwsReadmeDecorator : RustCodegenDecorator {
                 """.trimIndent() +
                     "\n\n$description\n\n" +
                     """
-                ## Getting Started
+                    ## Getting Started
 
-                > Examples are available for many services and operations, check out the
-                > [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+                    > Examples are available for many services and operations, check out the
+                    > [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
 
-                The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
-                as a dependency within your Rust project to execute asynchronous code. To add `$moduleName` to
-                your project, add the following to your **Cargo.toml** file:
+                    The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
+                    as a dependency within your Rust project to execute asynchronous code. To add `$moduleName` to
+                    your project, add the following to your **Cargo.toml** file:
 
-                ```toml
-                [dependencies]
-                aws-config = "${codegenContext.settings.moduleVersion}"
-                $moduleName = "${codegenContext.settings.moduleVersion}"
-                tokio = { version = "1", features = ["full"] }
-                ```
+                    ```toml
+                    [dependencies]
+                    aws-config = "${codegenContext.settings.moduleVersion}"
+                    $moduleName = "${codegenContext.settings.moduleVersion}"
+                    tokio = { version = "1", features = ["full"] }
+                    ```
 
-                ## Using the SDK
+                    ## Using the SDK
 
-                Until the SDK is released, we will be adding information about using the SDK to the
-                [Guide](https://github.com/awslabs/aws-sdk-rust/blob/main/Guide.md). Feel free to suggest
-                additional sections for the guide by opening an issue and describing what you are trying to do.
+                    Until the SDK is released, we will be adding information about using the SDK to the
+                    [Guide](https://github.com/awslabs/aws-sdk-rust/blob/main/Guide.md). Feel free to suggest
+                    additional sections for the guide by opening an issue and describing what you are trying to do.
 
-                ## Getting Help
+                    ## Getting Help
 
-                * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
-                * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
-                * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-                * [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+                    * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
+                    * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
+                    * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
+                    * [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
 
-                ## License
+                    ## License
 
-                This project is licensed under the Apache-2.0 License.
+                    This project is licensed under the Apache-2.0 License.
                     """.trimIndent()
             )
         }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -131,10 +131,10 @@ class RegionConfigPlugin : OperationCustomization() {
                 // Allow the region to be late-inserted via another method
                 rust(
                     """
-                if let Some(region) = &${section.config}.region {
-                    ${section.request}.properties_mut().insert(region.clone());
-                }
-                """
+                    if let Some(region) = &${section.config}.region {
+                        ${section.request}.properties_mut().insert(region.clone());
+                    }
+                    """
                 )
             }
             else -> emptySection

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SharedConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SharedConfigDecorator.kt
@@ -57,7 +57,7 @@ class SharedConfigDecorator : RustCodegenDecorator {
                         Builder::from(config).build()
                     }
                 }
-            """,
+                """,
                 *codegenScope
             )
         }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/TreeHashHeader.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/TreeHashHeader.kt
@@ -43,10 +43,10 @@ class TreeHashHeader(private val runtimeConfig: RuntimeConfig) : OperationCustom
                 }
                 rustTemplate(
                     """
-                        #{glacier_checksums}::add_checksum_treehash(
-                            &mut ${section.request}
-                        ).await.map_err(|e|#{BuildError}::Other(e.into()))?;
-                        """,
+                    #{glacier_checksums}::add_checksum_treehash(
+                        &mut ${section.request}
+                    ).await.map_err(|e|#{BuildError}::Other(e.into()))?;
+                    """,
                     "glacier_checksums" to glacierChecksums, "BuildError" to runtimeConfig.operationBuildError()
                 )
             }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecoratorTest.kt
@@ -44,21 +44,21 @@ class AwsPresigningDecoratorTest {
 
     private fun testOperation(namespace: String, name: String): Model =
         """
-            namespace $namespace
-            use aws.protocols#restJson1
+        namespace $namespace
+        use aws.protocols#restJson1
 
-            @restJson1
-            service TestService {
-                version: "2019-12-16",
-                operations: ["$name"],
-            }
+        @restJson1
+        service TestService {
+            version: "2019-12-16",
+            operations: ["$name"],
+        }
 
-            operation $name {
-                input: ${name}InputOutput,
-                output: ${name}InputOutput,
-            }
-            structure ${name}InputOutput {
-            }
+        operation $name {
+            input: ${name}InputOutput,
+            output: ${name}InputOutput,
+        }
+        structure ${name}InputOutput {
+        }
         """.asSmithyModel()
 }
 

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointConfigCustomizationTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointConfigCustomizationTest.kt
@@ -20,21 +20,21 @@ import software.amazon.smithy.rust.codegen.util.lookup
 internal class EndpointConfigCustomizationTest {
 
     private val model = """
-    namespace test
-    @aws.api#service(sdkId: "Test", endpointPrefix: "service-with-prefix")
-    service TestService {
-        version: "123"
-    }
+        namespace test
+        @aws.api#service(sdkId: "Test", endpointPrefix: "service-with-prefix")
+        service TestService {
+            version: "123"
+        }
 
-    @aws.api#service(sdkId: "Test", endpointPrefix: "iam")
-    service NoRegions {
-        version: "123"
-    }
+        @aws.api#service(sdkId: "Test", endpointPrefix: "iam")
+        service NoRegions {
+            version: "123"
+        }
 
-    @aws.api#service(sdkId: "Test")
-    service NoEndpointPrefix {
-        version: "123"
-    }
+        @aws.api#service(sdkId: "Test")
+        service NoEndpointPrefix {
+            version: "123"
+        }
     """.asSmithyModel()
 
     private val endpointConfig = """
@@ -94,7 +94,7 @@ internal class EndpointConfigCustomizationTest {
               }
             }
         }]
-    }
+        }
     """.let { ObjectNode.parse(it).expectObjectNode() }
 
     fun endpointCustomization(service: String) =
@@ -133,7 +133,7 @@ internal class EndpointConfigCustomizationTest {
                 let mut uri = Uri::from_static("/?k=v");
                 endpoint.set_endpoint(&mut uri, None);
                 assert_eq!(uri, Uri::from_static("https://access-analyzer-fips.ca-central-1.amazonaws.com/?k=v"));
-            """
+                """
             )
         }
         project.compileAndTest()
@@ -162,7 +162,7 @@ internal class EndpointConfigCustomizationTest {
                 let mut uri = Uri::from_static("/?k=v");
                 endpoint.set_endpoint(&mut uri, None);
                 assert_eq!(uri, Uri::from_static("https://iam-fips.amazonaws.com/?k=v"));
-            """
+                """
             )
         }
         println("file:///" + project.baseDir + "/src/aws_endpoint.rs")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/CodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/CodegenVisitor.kt
@@ -292,63 +292,63 @@ class CodegenVisitor(context: PluginContext, private val codegenDecorator: RustC
     private fun renderSerdeError(writer: RustWriter) {
         writer.rust(
             """
-                ##[derive(Debug)]
-                pub enum Error {
-                    Generic(std::borrow::Cow<'static, str>),
-                    DeserializeJson(aws_smithy_json::deserialize::Error),
-                    DeserializeHeader(aws_smithy_http::header::ParseError),
-                    DeserializeLabel(std::string::String),
-                    BuildInput(aws_smithy_http::operation::BuildError),
-                    BuildResponse(http::Error),
-                    SmithyType(aws_smithy_types::Error),
-                }
+            ##[derive(Debug)]
+            pub enum Error {
+                Generic(std::borrow::Cow<'static, str>),
+                DeserializeJson(aws_smithy_json::deserialize::Error),
+                DeserializeHeader(aws_smithy_http::header::ParseError),
+                DeserializeLabel(std::string::String),
+                BuildInput(aws_smithy_http::operation::BuildError),
+                BuildResponse(http::Error),
+                SmithyType(aws_smithy_types::Error),
+            }
 
-                impl Error {
-                    ##[allow(dead_code)]
-                    pub fn generic(msg: &'static str) -> Self {
-                        Self::Generic(msg.into())
+            impl Error {
+                ##[allow(dead_code)]
+                pub fn generic(msg: &'static str) -> Self {
+                    Self::Generic(msg.into())
+                }
+            }
+
+            impl From<aws_smithy_json::deserialize::Error> for Error {
+                fn from(err: aws_smithy_json::deserialize::Error) -> Self {
+                    Self::DeserializeJson(err)
+                }
+            }
+
+            impl From<aws_smithy_http::header::ParseError> for Error {
+                fn from(err: aws_smithy_http::header::ParseError) -> Self {
+                    Self::DeserializeHeader(err)
+                }
+            }
+
+            impl From<aws_smithy_http::operation::BuildError> for Error {
+                fn from(err: aws_smithy_http::operation::BuildError) -> Self {
+                    Self::BuildInput(err)
+                }
+            }
+
+            impl From<aws_smithy_types::Error> for Error {
+                fn from(err: aws_smithy_types::Error) -> Self {
+                    Self::SmithyType(err)
+                }
+            }
+
+            impl std::fmt::Display for Error {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    match *self {
+                        Self::Generic(ref msg) => write!(f, "serde error: {}", msg),
+                        Self::DeserializeJson(ref err) => write!(f, "json parse error: {}", err),
+                        Self::DeserializeHeader(ref err) => write!(f, "header parse error: {}", err),
+                        Self::DeserializeLabel(ref msg) => write!(f, "label parse error: {}", msg),
+                        Self::BuildInput(ref err) => write!(f, "json payload error: {}", err),
+                        Self::BuildResponse(ref err) => write!(f, "http response error: {}", err),
+                        Self::SmithyType(ref err) => write!(f, "type error: {}", err),
                     }
                 }
+            }
 
-                impl From<aws_smithy_json::deserialize::Error> for Error {
-                    fn from(err: aws_smithy_json::deserialize::Error) -> Self {
-                        Self::DeserializeJson(err)
-                    }
-                }
-
-                impl From<aws_smithy_http::header::ParseError> for Error {
-                    fn from(err: aws_smithy_http::header::ParseError) -> Self {
-                        Self::DeserializeHeader(err)
-                    }
-                }
-
-                impl From<aws_smithy_http::operation::BuildError> for Error {
-                    fn from(err: aws_smithy_http::operation::BuildError) -> Self {
-                        Self::BuildInput(err)
-                    }
-                }
-
-                impl From<aws_smithy_types::Error> for Error {
-                    fn from(err: aws_smithy_types::Error) -> Self {
-                        Self::SmithyType(err)
-                    }
-                }
-
-                impl std::fmt::Display for Error {
-                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                        match *self {
-                            Self::Generic(ref msg) => write!(f, "serde error: {}", msg),
-                            Self::DeserializeJson(ref err) => write!(f, "json parse error: {}", err),
-                            Self::DeserializeHeader(ref err) => write!(f, "header parse error: {}", err),
-                            Self::DeserializeLabel(ref msg) => write!(f, "label parse error: {}", msg),
-                            Self::BuildInput(ref err) => write!(f, "json payload error: {}", err),
-                            Self::BuildResponse(ref err) => write!(f, "http response error: {}", err),
-                            Self::SmithyType(ref err) => write!(f, "type error: {}", err),
-                        }
-                    }
-                }
-
-                impl std::error::Error for Error {}
+            impl std::error::Error for Error {}
             """.trimIndent()
         )
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -198,14 +198,14 @@ class ProtocolTestGenerator(
                     let mut http_request = http_request;
                     let ep = #T::endpoint::Endpoint::mutable(#T::Uri::from_static(${withScheme.dq()}));
                     ep.set_endpoint(http_request.uri_mut(), parts.acquire().get());
-                """,
+                    """,
                     CargoDependency.SmithyHttp(codegenContext.runtimeConfig).asType(), CargoDependency.Http.asType()
                 )
             }
             rust(
                 """
-                    assert_eq!(http_request.method(), ${method.dq()});
-                    assert_eq!(http_request.uri().path(), ${uri.dq()});
+                assert_eq!(http_request.method(), ${method.dq()});
+                assert_eq!(http_request.uri().path(), ${uri.dq()});
                 """
             )
             resolvedHost.orNull()?.also { host ->
@@ -276,7 +276,7 @@ class ProtocolTestGenerator(
             use #{parse_http_response};
             let parser = #{op}::new();
             let parsed = parser.parse_loaded(&http_response);
-        """,
+            """,
             "op" to operationSymbol,
             "parse_http_response" to CargoDependency.SmithyHttp(codegenContext.runtimeConfig).asType()
                 .member("response::ParseHttpResponse"),
@@ -298,8 +298,8 @@ class ProtocolTestGenerator(
                 if (member.isStreaming(codegenContext.model)) {
                     rust(
                         """assert_eq!(
-                                        parsed.$memberName.collect().await.unwrap().into_bytes(),
-                                        expected_output.$memberName.collect().await.unwrap().into_bytes()
+                        parsed.$memberName.collect().await.unwrap().into_bytes(),
+                        expected_output.$memberName.collect().await.unwrap().into_bytes()
                                     );"""
                     )
                 } else {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/RestJson1.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/RestJson1.kt
@@ -109,10 +109,10 @@ class RestJson1HttpSerializerGenerator(
                     HttpLocation.RESPONSE_CODE -> {
                         rustTemplate(
                             """
-                                let status = output.${it.memberName.toLowerCase()}
-                                    .ok_or(#{JsonSerdeError}::generic(${(it.member.memberName + " missing or empty").dq()}))?;
-                                let http_status: u16 = #{Convert}::TryFrom::<i32>::try_from(status)
-                                    .map_err(|_| #{JsonSerdeError}::generic(${("invalid status code").dq()}))?;
+                            let status = output.${it.memberName.toLowerCase()}
+                                .ok_or(#{JsonSerdeError}::generic(${(it.member.memberName + " missing or empty").dq()}))?;
+                            let http_status: u16 = #{Convert}::TryFrom::<i32>::try_from(status)
+                                .map_err(|_| #{JsonSerdeError}::generic(${("invalid status code").dq()}))?;
                             """.trimIndent(),
                             *codegenScope,
                         )
@@ -128,8 +128,8 @@ class RestJson1HttpSerializerGenerator(
             }
             rustTemplate(
                 """
-                    response.body(#{Bytes}::from(payload))
-                        .map_err(#{JsonSerdeError}::BuildResponse)
+                response.body(#{Bytes}::from(payload))
+                    .map_err(#{JsonSerdeError}::BuildResponse)
                 """.trimIndent(),
                 *codegenScope,
             )
@@ -158,17 +158,17 @@ class RestJson1HttpSerializerGenerator(
                     rustBlock("#TKind::${variantSymbol.name}($data) =>", errorSymbol) {
                         rust(
                             """
-                                #T(&$data)?;
-                                object.key(${"code".dq()}).string(${httpBindingResolver.errorCode(variantShape).dq()});
+                            #T(&$data)?;
+                            object.key(${"code".dq()}).string(${httpBindingResolver.errorCode(variantShape).dq()});
                             """.trimIndent(),
                             serializerSymbol
                         )
                         if (variantShape.errorMessageMember() != null) {
                             rust(
                                 """
-                                    if let Some(message) = $data.message() {
-                                        object.key(${"message".dq()}).string(message);
-                                    }
+                                if let Some(message) = $data.message() {
+                                    object.key(${"message".dq()}).string(message);
+                                }
                                 """.trimIndent()
                             )
                         }
@@ -191,10 +191,10 @@ class RestJson1HttpSerializerGenerator(
                 }
                 rust(
                     """
-                        #TKind::Unhandled(_) => {
-                            object.key(${"code".dq()}).string(${"Unhandled".dq()});
-                            response = response.status(500);
-                        }
+                    #TKind::Unhandled(_) => {
+                        object.key(${"code".dq()}).string(${"Unhandled".dq()});
+                        response = response.status(500);
+                    }
                     """.trimIndent(),
                     errorSymbol
                 )
@@ -202,8 +202,8 @@ class RestJson1HttpSerializerGenerator(
             rust("object.finish();")
             rustTemplate(
                 """
-                    response.body(#{Bytes}::from(out))
-                        .map_err(#{JsonSerdeError}::BuildResponse)
+                response.body(#{Bytes}::from(out))
+                    .map_err(#{JsonSerdeError}::BuildResponse)
                 """.trimIndent(),
                 *codegenScope
             )
@@ -325,9 +325,9 @@ class RestJson1HttpDeserializerGenerator(
         with(writer) {
             rustTemplate(
                 """
-                    #{Static}::lazy_static! {
-                        static ref RE: #{Regex}::Regex = #{Regex}::Regex::new("$pattern").unwrap();
-                    }
+                #{Static}::lazy_static! {
+                    static ref RE: #{Regex}::Regex = #{Regex}::Regex::new("$pattern").unwrap();
+                }
                 """.trimIndent(),
                 *codegenScope,
             )
@@ -336,11 +336,11 @@ class RestJson1HttpDeserializerGenerator(
                     val deserializer = generateDeserializeLabelFn(it)
                     rustTemplate(
                         """
-                            if let Some(m) = captures.name("${it.locationName}") {
-                                input = input.${it.member.setterName()}(
-                                    #{deserializer}(m.as_str())?
-                                );
-                            }
+                        if let Some(m) = captures.name("${it.locationName}") {
+                            input = input.${it.member.setterName()}(
+                                #{deserializer}(m.as_str())?
+                            );
+                        }
                         """.trimIndent(),
                         "deserializer" to deserializer,
                         "E" to errorShape,
@@ -360,7 +360,7 @@ class RestJson1HttpDeserializerGenerator(
         val deserializer = httpBindingGenerator.generateDeserializeHeaderFn(binding)
         writer.rust(
             """
-                #T(request.headers())?
+            #T(request.headers())?
             """.trimIndent(),
             deserializer,
         )
@@ -387,10 +387,10 @@ class RestJson1HttpDeserializerGenerator(
             ) {
                 rustTemplate(
                     """
-                        let value = #{PercentEncoding}::percent_decode_str(value)
-                            .decode_utf8()
-                            .map_err(|err| #{JsonSerdeError}::DeserializeLabel(err.to_string()))?;
-                        Ok(Some(value.into_owned()))
+                    let value = #{PercentEncoding}::percent_decode_str(value)
+                        .decode_utf8()
+                        .map_err(|err| #{JsonSerdeError}::DeserializeLabel(err.to_string()))?;
+                    Ok(Some(value.into_owned()))
                     """.trimIndent(),
                     *codegenScope,
                 )
@@ -416,12 +416,12 @@ class RestJson1HttpDeserializerGenerator(
             ) {
                 rustTemplate(
                     """
-                        let value = #{PercentEncoding}::percent_decode_str(value)
-                            .decode_utf8()
-                            .map_err(|err| #{JsonSerdeError}::DeserializeLabel(err.to_string()))?;
-                        let value = #{Instant}::Instant::from_str(&value, #{format})
-                            .map_err(|err| #{JsonSerdeError}::DeserializeLabel(err.to_string()))?;
-                        Ok(Some(value))
+                    let value = #{PercentEncoding}::percent_decode_str(value)
+                        .decode_utf8()
+                        .map_err(|err| #{JsonSerdeError}::DeserializeLabel(err.to_string()))?;
+                    let value = #{Instant}::Instant::from_str(&value, #{format})
+                        .map_err(|err| #{JsonSerdeError}::DeserializeLabel(err.to_string()))?;
+                    Ok(Some(value))
                     """.trimIndent(),
                     *codegenScope,
                     "format" to timestampFormatType,
@@ -441,9 +441,9 @@ class RestJson1HttpDeserializerGenerator(
             ) {
                 rustTemplate(
                     """
-                        let value = #{FromStr}::from_str(value)
-                            .map_err(|_| #{JsonSerdeError}::DeserializeLabel(${"label parse error".dq()}.to_string()))?;
-                        Ok(Some(value))
+                    let value = #{FromStr}::from_str(value)
+                        .map_err(|_| #{JsonSerdeError}::DeserializeLabel(${"label parse error".dq()}.to_string()))?;
+                    Ok(Some(value))
                     """.trimIndent(),
                     *codegenScope,
                 )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/HttpChecksumRequiredGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/HttpChecksumRequiredGenerator.kt
@@ -51,7 +51,7 @@ class HttpChecksumRequiredGenerator(
                         );
                         Result::<_, #{BuildError}>::Ok(req)
                     })?;
-                """,
+                    """,
                     "md5" to CargoDependency.Md5.asType(),
                     "http" to CargoDependency.Http.asType(),
                     "base64_encode" to RuntimeType.Base64Encode(codegenContext.runtimeConfig),

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/IdempotencyTokenGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/IdempotencyTokenGenerator.kt
@@ -30,10 +30,10 @@ class IdempotencyTokenGenerator(codegenContext: CodegenContext, private val oper
             is OperationSection.MutateInput -> writable {
                 rust(
                     """
-                if ${section.input}.$memberName.is_none() {
-                    ${section.input}.$memberName = Some(${section.config}.make_token.make_idempotency_token());
-                }
-                """
+                    if ${section.input}.$memberName.is_none() {
+                        ${section.input}.$memberName = Some(${section.config}.make_token.make_idempotency_token());
+                    }
+                    """
                 )
             }
             else -> emptySection

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/RetryConfigDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/RetryConfigDecorator.kt
@@ -100,42 +100,42 @@ class RetryConfigProviderConfig(codegenContext: CodegenContext) : ConfigCustomiz
             ServiceConfig.BuilderImpl ->
                 rustTemplate(
                     """
-            /// Set the retry_config for the builder
-            ///
-            /// ## Examples
-            /// ```rust
-            /// use $moduleUseName::config::Config;
-            /// use #{RetryConfig};
-            ///
-            /// let retry_config = RetryConfig::new().with_max_attempts(5);
-            /// let config = Config::builder().retry_config(retry_config).build();
-            /// ```
-            pub fn retry_config(mut self, retry_config: #{RetryConfig}) -> Self {
-                self.set_retry_config(Some(retry_config));
-                self
-            }
+                    /// Set the retry_config for the builder
+                    ///
+                    /// ## Examples
+                    /// ```rust
+                    /// use $moduleUseName::config::Config;
+                    /// use #{RetryConfig};
+                    ///
+                    /// let retry_config = RetryConfig::new().with_max_attempts(5);
+                    /// let config = Config::builder().retry_config(retry_config).build();
+                    /// ```
+                    pub fn retry_config(mut self, retry_config: #{RetryConfig}) -> Self {
+                        self.set_retry_config(Some(retry_config));
+                        self
+                    }
 
-            /// Set the retry_config for the builder
-            ///
-            /// ## Examples
-            /// ```rust
-            /// use $moduleUseName::config::{Builder, Config};
-            /// use #{RetryConfig};
-            ///
-            /// fn disable_retries(builder: &mut Builder) {
-            ///     let retry_config = RetryConfig::new().with_max_attempts(1);
-            ///     builder.set_retry_config(Some(retry_config));
-            /// }
-            ///
-            /// let mut builder = Config::builder();
-            /// disable_retries(&mut builder);
-            /// let config = builder.build();
-            /// ```
-            pub fn set_retry_config(&mut self, retry_config: Option<#{RetryConfig}>) -> &mut Self {
-                self.retry_config = retry_config;
-                self
-            }
-            """,
+                    /// Set the retry_config for the builder
+                    ///
+                    /// ## Examples
+                    /// ```rust
+                    /// use $moduleUseName::config::{Builder, Config};
+                    /// use #{RetryConfig};
+                    ///
+                    /// fn disable_retries(builder: &mut Builder) {
+                    ///     let retry_config = RetryConfig::new().with_max_attempts(1);
+                    ///     builder.set_retry_config(Some(retry_config));
+                    /// }
+                    ///
+                    /// let mut builder = Config::builder();
+                    /// disable_retries(&mut builder);
+                    /// let config = builder.build();
+                    /// ```
+                    pub fn set_retry_config(&mut self, retry_config: Option<#{RetryConfig}>) -> &mut Self {
+                        self.retry_config = retry_config;
+                        self
+                    }
+                    """,
                     *codegenScope
                 )
             ServiceConfig.BuilderBuild -> rustTemplate(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EndpointTraitBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EndpointTraitBindingGenerator.kt
@@ -78,10 +78,10 @@ class EndpointTraitBindings(
                     }
                     rust(
                         """
-                    if $field.is_empty() {
-                        return Err($invalidFieldError)
-                    }
-                    """
+                        if $field.is_empty() {
+                            return Err($invalidFieldError)
+                        }
+                        """
                     )
                     "${label.content} = $field"
                 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -27,7 +27,7 @@ class FluentClientCore(private val model: Model) {
                 """
                 self.inner = self.inner.$memberName(inp);
                 self
-            """
+                """
             )
         }
     }
@@ -46,7 +46,7 @@ class FluentClientCore(private val model: Model) {
                 """
                 self.inner = self.inner.$memberName(k, v);
                 self
-            """
+                """
             )
         }
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
@@ -197,7 +197,7 @@ class RequestBindingGenerator(
                     builder = builder.header(header_name, header_value);
                 }
 
-            """,
+                """,
                 "build_error" to runtimeConfig.operationBuildError()
             )
         }
@@ -232,7 +232,7 @@ class RequestBindingGenerator(
                         }, err)}
                         })?;
                         builder = builder.header(${httpBinding.locationName.dq()}, header_value);
-                    """,
+                        """,
                         "build_error" to runtimeConfig.operationBuildError()
                     )
                 }
@@ -437,9 +437,9 @@ class RequestBindingGenerator(
         }
         rust(
             """
-                if $outputVar.is_empty() {
-                    return Err(${buildError()})
-                }
+            if $outputVar.is_empty() {
+                return Err(${buildError()})
+            }
             """
         )
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -287,11 +287,13 @@ class ResponseBindingGenerator(
             )
             if (coreShape.hasTrait<MediaTypeTrait>()) {
                 rustTemplate(
-                    """let $parsedValue: std::result::Result<Vec<_>, _> = $parsedValue
+                    """
+                    let $parsedValue: std::result::Result<Vec<_>, _> = $parsedValue
                         .iter().map(|s|
                             #{base_64_decode}(s).map_err(|_|#{header}::ParseError::new_with_message("failed to decode base64"))
                             .and_then(|bytes|String::from_utf8(bytes).map_err(|_|#{header}::ParseError::new_with_message("base64 encoded data was not valid utf-8")))
-                        ).collect();""",
+                        ).collect();
+                    """,
                     "base_64_decode" to RuntimeType.Base64Decode(runtimeConfig),
                     "header" to headerUtil
                 )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
@@ -213,9 +213,9 @@ open class ProtocolGenerator(
 
         inputWriter.rust(
             """
-                ##[doc(hidden)] pub type ${inputPrefix}OperationOutputAlias = $operationTypeOutput;
-                ##[doc(hidden)] pub type ${inputPrefix}OperationRetryAlias = $operationTypeRetry;
-                """
+            ##[doc(hidden)] pub type ${inputPrefix}OperationOutputAlias = $operationTypeOutput;
+            ##[doc(hidden)] pub type ${inputPrefix}OperationRetryAlias = $operationTypeRetry;
+            """
         )
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -188,14 +188,14 @@ class ProtocolTestGenerator(
                     let mut http_request = http_request;
                     let ep = #T::endpoint::Endpoint::mutable(#T::Uri::from_static(${withScheme.dq()}));
                     ep.set_endpoint(http_request.uri_mut(), parts.acquire().get());
-                """,
+                    """,
                     CargoDependency.SmithyHttp(codegenContext.runtimeConfig).asType(), CargoDependency.Http.asType()
                 )
             }
             rust(
                 """
-                    assert_eq!(http_request.method(), ${method.dq()});
-                    assert_eq!(http_request.uri().path(), ${uri.dq()});
+                assert_eq!(http_request.method(), ${method.dq()});
+                assert_eq!(http_request.uri().path(), ${uri.dq()});
                 """
             )
             resolvedHost.orNull()?.also { host ->
@@ -258,9 +258,9 @@ class ProtocolTestGenerator(
         }
         rust(
             """
-                .status(${testCase.code})
-                .body(#T::from(${testCase.body.orNull()?.dq()?.replace("#", "##") ?: "vec![]"}))
-                .unwrap();
+            .status(${testCase.code})
+            .body(#T::from(${testCase.body.orNull()?.dq()?.replace("#", "##") ?: "vec![]"}))
+            .unwrap();
             """,
             RuntimeType.sdkBody(runtimeConfig = codegenContext.runtimeConfig)
         )
@@ -278,7 +278,7 @@ class ProtocolTestGenerator(
                 let http_response = http_response.map(|body|#{bytes}::copy_from_slice(body.bytes().unwrap()));
                 <#{op} as #{parse_http_response}>::parse_loaded(&parser, &http_response)
             });
-        """,
+            """,
             "op" to operationSymbol,
             "bytes" to RuntimeType.Bytes,
             "parse_http_response" to CargoDependency.SmithyHttp(codegenContext.runtimeConfig).asType()
@@ -300,10 +300,12 @@ class ProtocolTestGenerator(
                 val memberName = codegenContext.symbolProvider.toMemberName(member)
                 if (member.isStreaming(codegenContext.model)) {
                     rust(
-                        """assert_eq!(
+                        """
+                        assert_eq!(
                                         parsed.$memberName.collect().await.unwrap().into_bytes(),
                                         expected_output.$memberName.collect().await.unwrap().into_bytes()
-                                    );"""
+                                    );
+                        """
                     )
                 } else {
                     when (codegenContext.model.expectShape(member.target)) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -139,20 +139,20 @@ private class HttpBoundProtocolTraitImplGenerator(
         val successCode = httpBindingResolver.httpTrait(operationShape).code
         rustTemplate(
             """
-                impl #{ParseResponse} for $operationName {
-                    type Output = std::result::Result<#{O}, #{E}>;
-                    fn parse_unloaded(&self, response: &mut #{operation}::Response) -> Option<Self::Output> {
-                        // This is an error, defer to the non-streaming parser
-                        if !response.http().status().is_success() && response.http().status().as_u16() != $successCode {
-                            return None;
-                        }
-                        Some(#{parse_streaming_response}(response))
+            impl #{ParseResponse} for $operationName {
+                type Output = std::result::Result<#{O}, #{E}>;
+                fn parse_unloaded(&self, response: &mut #{operation}::Response) -> Option<Self::Output> {
+                    // This is an error, defer to the non-streaming parser
+                    if !response.http().status().is_success() && response.http().status().as_u16() != $successCode {
+                        return None;
                     }
-                    fn parse_loaded(&self, response: &#{http}::Response<#{Bytes}>) -> Self::Output {
-                        // if streaming, we only hit this case if its an error
-                        #{parse_error}(response)
-                    }
+                    Some(#{parse_streaming_response}(response))
                 }
+                fn parse_loaded(&self, response: &#{http}::Response<#{Bytes}>) -> Self::Output {
+                    // if streaming, we only hit this case if its an error
+                    #{parse_error}(response)
+                }
+            }
             """,
             "O" to outputSymbol,
             "E" to operationShape.errorSymbol(symbolProvider),
@@ -348,8 +348,8 @@ private class HttpBoundProtocolTraitImplGenerator(
                 val fnName = httpBindingGenerator.generateDeserializeHeaderFn(binding)
                 rust(
                     """
-                        #T(response.headers())
-                            .map_err(|_|#T::unhandled("Failed to parse ${member.memberName} from header `${binding.locationName}"))?
+                    #T(response.headers())
+                        .map_err(|_|#T::unhandled("Failed to parse ${member.memberName} from header `${binding.locationName}"))?
                     """,
                     fnName, errorSymbol
                 )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -186,7 +186,7 @@ class JsonParserGenerator(
                     data
                 }
             }
-        """
+            """
         )
     }
 
@@ -484,8 +484,8 @@ class JsonParserGenerator(
         rustBlockTemplate("match tokens.next().transpose()?", *codegenScope) {
             rustBlockTemplate(
                 """
-                    Some(#{Token}::ValueNull { .. }) => Ok(None),
-                    Some(#{Token}::Start${StringUtils.capitalize(objectOrArray)} { .. }) =>
+                Some(#{Token}::ValueNull { .. }) => Ok(None),
+                Some(#{Token}::Start${StringUtils.capitalize(objectOrArray)} { .. }) =>
                 """,
                 *codegenScope
             ) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -356,9 +356,11 @@ class XmlBindingTraitParserGenerator(
     private fun RustWriter.parseAttributeMember(memberShape: MemberShape, ctx: Ctx) {
         rustBlock("") {
             rustTemplate(
-                """let s = ${ctx.tag}
+                """
+                let s = ${ctx.tag}
                     .start_el()
-                    .attr(${memberShape.xmlName().toString().dq()});""",
+                    .attr(${memberShape.xmlName().toString().dq()});
+                """,
                 *codegenScope
             )
             rustBlock("match s") {
@@ -389,11 +391,11 @@ class XmlBindingTraitParserGenerator(
                         case(member) {
                             val current =
                                 """
-                                    (match base.take() {
-                                        None => None,
-                                        Some(${format(symbol)}::$variantName(inner)) => Some(inner),
-                                        Some(_) => return Err(#{XmlError}::custom("mixed variants"))
-                                    })
+                                (match base.take() {
+                                    None => None,
+                                    Some(${format(symbol)}::$variantName(inner)) => Some(inner),
+                                    Some(_) => return Err(#{XmlError}::custom("mixed variants"))
+                                })
                                 """
                             withBlock("let tmp =", ";") {
                                 parseMember(member, ctx.copy(accum = current.trim()))
@@ -516,10 +518,10 @@ class XmlBindingTraitParserGenerator(
             val accum = ctx.accum ?: throw CodegenException("need accum to parse flat map")
             rustTemplate(
                 """
-            let mut $map = $accum.unwrap_or_default();
-            #{decoder}(&mut tag, &mut $map)?;
-            $map
-            """,
+                let mut $map = $accum.unwrap_or_default();
+                #{decoder}(&mut tag, &mut $map)?;
+                $map
+                """,
                 *codegenScope,
                 "decoder" to entryDecoder
             )
@@ -555,11 +557,11 @@ class XmlBindingTraitParserGenerator(
 
                 rustTemplate(
                     """
-                let k = k.ok_or_else(||#{XmlError}::custom("missing key map entry"))?;
-                let v = v.ok_or_else(||#{XmlError}::custom("missing value map entry"))?;
-                out.insert(k, v);
-                Ok(())
-                        """,
+                    let k = k.ok_or_else(||#{XmlError}::custom("missing key map entry"))?;
+                    let v = v.ok_or_else(||#{XmlError}::custom("missing value map entry"))?;
+                    out.insert(k, v);
+                    Ok(())
+                    """,
                     *codegenScope
                 )
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/Rust.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/Rust.kt
@@ -165,10 +165,10 @@ class TestWriterDelegator(fileManifest: FileManifest, symbolProvider: RustSymbol
  */
 fun TestWriterDelegator.compileAndTest(runClippy: Boolean = false) {
     val stubModel = """
-    namespace fake
-    service Fake {
-        version: "123"
-    }
+        namespace fake
+        service Fake {
+            version: "123"
+        }
     """.asSmithyModel()
     this.finalize(
         rustSettings(stubModel),
@@ -258,14 +258,14 @@ private fun String.intoCrate(
     val tempDir = TestWorkspace.subproject()
     // TODO: unify this with CargoTomlGenerator
     val cargoToml = """
-    [package]
-    name = ${tempDir.nameWithoutExtension.dq()}
-    version = "0.0.1"
-    authors = ["rcoh@amazon.com"]
-    edition = "2018"
+        [package]
+        name = ${tempDir.nameWithoutExtension.dq()}
+        version = "0.0.1"
+        authors = ["rcoh@amazon.com"]
+        edition = "2018"
 
-    [dependencies]
-    ${deps.joinToString("\n") { it.toString() }}
+        [dependencies]
+        ${deps.joinToString("\n") { it.toString() }}
     """.trimIndent()
     tempDir.resolve("Cargo.toml").writeText(cargoToml)
     tempDir.resolve("src").mkdirs()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/TestConfigCustomization.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/TestConfigCustomization.kt
@@ -26,12 +26,12 @@ fun stubCustomization(name: String): ConfigCustomization {
                             self.$name = Some($name);
                         self
                     }
-                """
+                    """
                 )
                 ServiceConfig.BuilderBuild -> rust(
                     """
                     $name: self.$name.unwrap_or(123),
-                """
+                    """
                 )
             }
         }
@@ -64,7 +64,7 @@ fun stubConfigProject(customization: ConfigCustomization, project: TestWriterDel
             fn assert_send_sync<T: Send + Sync>() {}
             assert_send_sync::<Config>();
 
-        """
+            """
         )
     }
     return project

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/EnumGeneratorTest.kt
@@ -157,15 +157,15 @@ class EnumGeneratorTest {
         @Test
         fun `unnamed enums are implement eq and hash`() {
             val model = """
-            namespace test
-            @enum([
-            {
-                value: "Foo",
-            },
-            {
-                value: "Bar",
-            }])
-            string FooEnum
+                namespace test
+                @enum([
+                {
+                    value: "Foo",
+                },
+                {
+                    value: "Bar",
+                }])
+                string FooEnum
             """.asSmithyModel()
             val shape: StringShape = model.lookup("test#FooEnum")
             val trait = shape.expectTrait<EnumTrait>()
@@ -185,25 +185,25 @@ class EnumGeneratorTest {
         @Test
         fun `it generates unamed enums`() {
             val model = """
-            namespace test
-            @enum([
-                {
-                    value: "Foo",
-                },
-                {
-                    value: "Baz",
-                },
-                {
-                    value: "Bar",
-                },
-                {
-                    value: "1",
-                },
-                {
-                    value: "0",
-                },
-            ])
-            string FooEnum
+                namespace test
+                @enum([
+                    {
+                        value: "Foo",
+                    },
+                    {
+                        value: "Baz",
+                    },
+                    {
+                        value: "Bar",
+                    },
+                    {
+                        value: "1",
+                    },
+                    {
+                        value: "0",
+                    },
+                ])
+                string FooEnum
             """.asSmithyModel()
             val shape: StringShape = model.lookup("test#FooEnum")
             val trait = shape.expectTrait<EnumTrait>()
@@ -266,9 +266,9 @@ class EnumGeneratorTest {
 
             rendered shouldContain
                 """
-                    /// Some top-level documentation.
-                    ///
-                    /// _Note: `SomeEnum::Unknown` has been renamed to `::UnknownValue`._
+                /// Some top-level documentation.
+                ///
+                /// _Note: `SomeEnum::Unknown` has been renamed to `::UnknownValue`._
                 """.trimIndent()
         }
 
@@ -292,7 +292,7 @@ class EnumGeneratorTest {
 
             rendered shouldContain
                 """
-                    /// Some top-level documentation.
+                /// Some top-level documentation.
                 """.trimIndent()
         }
     }
@@ -300,13 +300,13 @@ class EnumGeneratorTest {
     @Test
     fun `it handles variants that clash with Rust reserved words`() {
         val model = """
-                namespace test
-                @enum([
-                    { name: "Known", value: "Known" },
-                    { name: "Self", value: "other" },
-                ])
-                string SomeEnum
-            """.asSmithyModel()
+            namespace test
+            @enum([
+                { name: "Known", value: "Known" },
+                { name: "Self", value: "other" },
+            ])
+            string SomeEnum
+        """.asSmithyModel()
 
         val shape: StringShape = model.lookup("test#SomeEnum")
         val trait = shape.expectTrait<EnumTrait>()
@@ -316,9 +316,9 @@ class EnumGeneratorTest {
 
         writer.compileAndTest(
             """
-                assert_eq!(SomeEnum::from("other"), SomeEnum::SelfValue);
-                assert_eq!(SomeEnum::from("SomethingNew"), SomeEnum::Unknown("SomethingNew".into()));
-                """
+            assert_eq!(SomeEnum::from("other"), SomeEnum::SelfValue);
+            assert_eq!(SomeEnum::from("SomethingNew"), SomeEnum::Unknown("SomethingNew".into()));
+            """
         )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -25,43 +25,43 @@ import software.amazon.smithy.rust.codegen.util.lookup
 class StructureGeneratorTest {
     companion object {
         val model = """
-        namespace com.test
-        @documentation("this documents the shape")
-        structure MyStruct {
-           foo: String,
-           @documentation("This *is* documentation about the member.")
-           bar: PrimitiveInteger,
-           baz: Integer,
-           ts: Timestamp,
-           inner: Inner,
-           byteValue: Byte
-        }
+            namespace com.test
+            @documentation("this documents the shape")
+            structure MyStruct {
+               foo: String,
+               @documentation("This *is* documentation about the member.")
+               bar: PrimitiveInteger,
+               baz: Integer,
+               ts: Timestamp,
+               inner: Inner,
+               byteValue: Byte
+            }
 
-        // Intentionally empty
-        structure Inner {
-        }
+            // Intentionally empty
+            structure Inner {
+            }
 
-        @error("server")
-        @retryable
-        structure MyError {
-            message: String
-        }
+            @error("server")
+            @retryable
+            structure MyError {
+                message: String
+            }
 
-        @sensitive
-        string SecretKey
-
-        structure Credentials {
-            username: String,
             @sensitive
-            password: String,
+            string SecretKey
 
-            // test that sensitive can be applied directly to a member or to the shape
-            secretKey: SecretKey
-        }
+            structure Credentials {
+                username: String,
+                @sensitive
+                password: String,
 
-        structure StructWithDoc {
-            doc: Document
-        }
+                // test that sensitive can be applied directly to a member or to the shape
+                secretKey: SecretKey
+            }
+
+            structure StructWithDoc {
+                doc: Document
+            }
         """.asSmithyModel()
         val struct = model.lookup<StructureShape>("com.test#MyStruct")
         val structWithDoc = model.lookup<StructureShape>("com.test#StructWithDoc")
@@ -111,7 +111,7 @@ class StructureGeneratorTest {
                     """
                     let s: Option<crate::structs::MyStruct> = None;
                     s.map(|i|println!("{:?}, {:?}", i.ts, i.byte_value));
-                """
+                    """
                 )
             }
         }
@@ -128,7 +128,7 @@ class StructureGeneratorTest {
             """
             let err = MyError { message: None };
             assert_eq!(err.retryable_error_kind(), aws_smithy_types::retry::ErrorKind::ServerError);
-        """
+            """
         )
     }
 
@@ -146,7 +146,7 @@ class StructureGeneratorTest {
                 secret_key: Some("don't leak me".to_owned())
             };
             assert_eq!(format!("{:?}", creds), "Credentials { username: Some(\"not_redacted\"), password: \"*** Sensitive Data Redacted ***\", secret_key: \"*** Sensitive Data Redacted ***\" }");
-        """
+            """
         )
         writer.compileAndTest()
     }
@@ -154,19 +154,19 @@ class StructureGeneratorTest {
     @Test
     fun `attach docs to everything`() {
         val model = """
-        namespace com.test
-        @documentation("inner doc")
-        structure Inner { }
+            namespace com.test
+            @documentation("inner doc")
+            structure Inner { }
 
-        @documentation("shape doc")
-        structure MyStruct {
-           @documentation("member doc")
-           member: String,
+            @documentation("shape doc")
+            structure MyStruct {
+               @documentation("member doc")
+               member: String,
 
-           @documentation("specific docs")
-           nested: Inner,
+               @documentation("specific docs")
+               nested: Inner,
 
-           nested2: Inner
+               nested2: Inner
         }""".asSmithyModel()
         val provider = testSymbolProvider(model)
         val writer = RustWriter.root()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/RequestBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/RequestBindingGeneratorTest.kt
@@ -30,78 +30,78 @@ import software.amazon.smithy.rust.codegen.util.expectTrait
 
 class RequestBindingGeneratorTest {
     private val baseModel = """
-            namespace smithy.example
+        namespace smithy.example
 
-            @idempotent
-            @http(method: "PUT", uri: "/{bucketName}/{key}", code: 200)
-            operation PutObject {
-                input: PutObjectRequest
-            }
+        @idempotent
+        @http(method: "PUT", uri: "/{bucketName}/{key}", code: 200)
+        operation PutObject {
+            input: PutObjectRequest
+        }
 
-            list Extras {
-                member: Integer
-            }
+        list Extras {
+            member: Integer
+        }
 
-            list Dates {
-                member: Timestamp
-            }
+        list Dates {
+            member: Timestamp
+        }
 
-            @mediaType("video/quicktime")
-            string Video
+        @mediaType("video/quicktime")
+        string Video
 
-            map StringMap {
-                key: String,
-                value: String
-            }
+        map StringMap {
+            key: String,
+            value: String
+        }
 
-            structure PutObjectRequest {
-                // Sent in the URI label named "key".
-                @required
-                @httpLabel
-                key: Timestamp,
+        structure PutObjectRequest {
+            // Sent in the URI label named "key".
+            @required
+            @httpLabel
+            key: Timestamp,
 
-                // Sent in the URI label named "bucketName".
-                @required
-                @httpLabel
-                bucketName: String,
+            // Sent in the URI label named "bucketName".
+            @required
+            @httpLabel
+            bucketName: String,
 
-                // Sent in the X-Dates header
-                @httpHeader("X-Dates")
-                dateHeaderList: Dates,
+            // Sent in the X-Dates header
+            @httpHeader("X-Dates")
+            dateHeaderList: Dates,
 
-                @httpHeader("X-Ints")
-                intList: Extras,
+            @httpHeader("X-Ints")
+            intList: Extras,
 
-                @httpHeader("X-MediaType")
-                mediaType: Video,
+            @httpHeader("X-MediaType")
+            mediaType: Video,
 
-                // Sent in the query string as paramName
-                @httpQuery("paramName")
-                someValue: String,
+            // Sent in the query string as paramName
+            @httpQuery("paramName")
+            someValue: String,
 
-                @httpQuery("primitive")
-                primitive: PrimitiveInteger,
+            @httpQuery("primitive")
+            primitive: PrimitiveInteger,
 
-                @httpQuery("enabled")
-                enabled: PrimitiveBoolean,
+            @httpQuery("enabled")
+            enabled: PrimitiveBoolean,
 
-                @httpQuery("hello")
-                extras: Extras,
+            @httpQuery("hello")
+            extras: Extras,
 
-                // Sent in the body
-                data: Blob,
+            // Sent in the body
+            data: Blob,
 
-                // Sent in the body
-                additional: String,
+            // Sent in the body
+            additional: String,
 
-                @httpPrefixHeaders("X-Prefix-")
-                prefix: StringMap,
+            @httpPrefixHeaders("X-Prefix-")
+            prefix: StringMap,
 
-                @sensitive
-                @httpHeader("stringHeader")
-                stringHeader: String
-            }
-        """.asSmithyModel()
+            @sensitive
+            @httpHeader("stringHeader")
+            stringHeader: String
+        }
+    """.asSmithyModel()
     private val model = OperationNormalizer.transform(baseModel)
 
     private val operationShape = model.expectShape(ShapeId.from("smithy.example#PutObject"), OperationShape::class.java)
@@ -236,7 +236,7 @@ class RequestBindingGeneratorTest {
 
             let prefix_header = http_request.headers().get_all("X-Prefix-k").iter().map(|hv|std::str::from_utf8(hv.as_ref()).unwrap()).collect::<Vec<_>>();
             assert_eq!(prefix_header, vec!["😹"])
-        """
+            """
         )
     }
 
@@ -246,16 +246,16 @@ class RequestBindingGeneratorTest {
         renderOperation(writer)
         writer.compileAndTest(
             """
-        use std::collections::HashMap;
-        let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
-        let inp = PutObjectInput::builder()
-            .bucket_name("buk")
-            .key(ts.clone())
-            .prefix("😹".to_string(), "😹".to_string())
-            .build().unwrap();
-        let err = inp.test_request_builder_base().expect_err("can't make a header out of a cat emoji");
-        assert_eq!(format!("{}", err), "Invalid field in input: prefix (Details: `😹` cannot be used as a header name: invalid HTTP header name)");
-        """
+            use std::collections::HashMap;
+            let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                .bucket_name("buk")
+                .key(ts.clone())
+                .prefix("😹".to_string(), "😹".to_string())
+                .build().unwrap();
+            let err = inp.test_request_builder_base().expect_err("can't make a header out of a cat emoji");
+            assert_eq!(format!("{}", err), "Invalid field in input: prefix (Details: `😹` cannot be used as a header name: invalid HTTP header name)");
+            """
         )
     }
 
@@ -265,16 +265,16 @@ class RequestBindingGeneratorTest {
         renderOperation(writer)
         writer.compileAndTest(
             """
-        use std::collections::HashMap;
-        let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
-        let inp = PutObjectInput::builder()
-            .bucket_name("buk")
-            .key(ts.clone())
-            .prefix("valid-key".to_string(), "\n can't put a newline in a header value".to_string())
-            .build().unwrap();
-        let err = inp.test_request_builder_base().expect_err("can't make a header with a newline");
-        assert_eq!(format!("{}", err), "Invalid field in input: prefix (Details: `\n can\'t put a newline in a header value` cannot be used as a header value: failed to parse header value)");
-        """
+            use std::collections::HashMap;
+            let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                .bucket_name("buk")
+                .key(ts.clone())
+                .prefix("valid-key".to_string(), "\n can't put a newline in a header value".to_string())
+                .build().unwrap();
+            let err = inp.test_request_builder_base().expect_err("can't make a header with a newline");
+            assert_eq!(format!("{}", err), "Invalid field in input: prefix (Details: `\n can\'t put a newline in a header value` cannot be used as a header value: failed to parse header value)");
+            """
         )
     }
 
@@ -284,16 +284,16 @@ class RequestBindingGeneratorTest {
         renderOperation(writer)
         writer.compileAndTest(
             """
-        let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
-        let inp = PutObjectInput::builder()
-            .bucket_name("buk")
-            .key(ts.clone())
-            .string_header("\n is not valid")
-            .build().unwrap();
-        let err = inp.test_request_builder_base().expect_err("can't make a header with a newline");
-        // make sure we obey the sensitive trait
-        assert_eq!(format!("{}", err), "Invalid field in input: string_header (Details: `*** Sensitive Data Redacted ***` cannot be used as a header value: failed to parse header value)");
-        """
+            let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                .bucket_name("buk")
+                .key(ts.clone())
+                .string_header("\n is not valid")
+                .build().unwrap();
+            let err = inp.test_request_builder_base().expect_err("can't make a header with a newline");
+            // make sure we obey the sensitive trait
+            assert_eq!(format!("{}", err), "Invalid field in input: string_header (Details: `*** Sensitive Data Redacted ***` cannot be used as a header value: failed to parse header value)");
+            """
         )
     }
 
@@ -303,15 +303,15 @@ class RequestBindingGeneratorTest {
         renderOperation(writer)
         writer.compileAndTest(
             """
-        let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
-        let inp = PutObjectInput::builder()
-            // don't set bucket
-            // .bucket_name("buk")
-            .key(ts.clone())
-            .build().unwrap();
-        let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-        assert!(matches!(err, ${writer.format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
-        """
+            let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                // don't set bucket
+                // .bucket_name("buk")
+                .key(ts.clone())
+                .build().unwrap();
+            let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
+            assert!(matches!(err, ${writer.format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
+            """
         )
     }
 
@@ -321,15 +321,15 @@ class RequestBindingGeneratorTest {
         renderOperation(writer)
         writer.compileAndTest(
             """
-        let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
-        let inp = PutObjectInput::builder()
-            .bucket_name("buk")
-            // don't set key
-            // .key(ts.clone())
-            .build().unwrap();
-        let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-        assert!(matches!(err, ${writer.format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
-        """
+            let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                .bucket_name("buk")
+                // don't set key
+                // .key(ts.clone())
+                .build().unwrap();
+            let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
+            assert!(matches!(err, ${writer.format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
+            """
         )
     }
 
@@ -339,14 +339,14 @@ class RequestBindingGeneratorTest {
         renderOperation(writer)
         writer.compileAndTest(
             """
-        let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
-        let inp = PutObjectInput::builder()
-            .bucket_name("")
-            .key(ts.clone())
-            .build().unwrap();
-        let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-        assert!(matches!(err, ${writer.format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
-        """
+            let ts = aws_smithy_types::Instant::from_epoch_seconds(10123125);
+            let inp = PutObjectInput::builder()
+                .bucket_name("")
+                .key(ts.clone())
+                .build().unwrap();
+            let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
+            assert!(matches!(err, ${writer.format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
+            """
         )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/ResponseBindingGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/http/ResponseBindingGeneratorTest.kt
@@ -30,43 +30,43 @@ import software.amazon.smithy.rust.codegen.util.outputShape
 
 class ResponseBindingGeneratorTest {
     private val baseModel = """
-            namespace smithy.example
+        namespace smithy.example
 
-            @idempotent
-            @http(method: "PUT", uri: "/", code: 200)
-            operation PutObject {
-                output: PutObjectResponse
-            }
+        @idempotent
+        @http(method: "PUT", uri: "/", code: 200)
+        operation PutObject {
+            output: PutObjectResponse
+        }
 
-            list Extras {
-                member: Integer
-            }
+        list Extras {
+            member: Integer
+        }
 
-            list Dates {
-                member: Timestamp
-            }
+        list Dates {
+            member: Timestamp
+        }
 
-            @mediaType("video/quicktime")
-            string Video
+        @mediaType("video/quicktime")
+        string Video
 
-            structure PutObjectResponse {
-                // Sent in the X-Dates header
-                @httpHeader("X-Dates")
-                dateHeaderList: Dates,
+        structure PutObjectResponse {
+            // Sent in the X-Dates header
+            @httpHeader("X-Dates")
+            dateHeaderList: Dates,
 
-                @httpHeader("X-Ints")
-                intList: Extras,
+            @httpHeader("X-Ints")
+            intList: Extras,
 
-                @httpHeader("X-MediaType")
-                mediaType: Video,
+            @httpHeader("X-MediaType")
+            mediaType: Video,
 
-                // Sent in the body
-                data: Blob,
+            // Sent in the body
+            data: Blob,
 
-                // Sent in the body
-                additional: String,
-            }
-        """.asSmithyModel()
+            // Sent in the body
+            additional: String,
+        }
+    """.asSmithyModel()
     private val model = OperationNormalizer.transform(baseModel)
     private val operationShape = model.expectShape(ShapeId.from("smithy.example#PutObject"), OperationShape::class.java)
     private val symbolProvider = testSymbolProvider(model)
@@ -108,7 +108,7 @@ class ResponseBindingGeneratorTest {
                 assert_eq!(http_serde::deser_header_put_object_put_object_output_int_list(resp.headers()).unwrap(), Some(vec![1,2,3,4,5,6]));
                 assert_eq!(http_serde::deser_header_put_object_put_object_output_media_type(resp.headers()).expect("valid").unwrap(), "smithy-rs");
                 assert_eq!(http_serde::deser_header_put_object_put_object_output_date_header_list(resp.headers()).unwrap().unwrap().len(), 3);
-            """
+                """
             )
         }
         testProject.compileAndTest()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/rustlang/InlineDependencyTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/rustlang/InlineDependencyTest.kt
@@ -38,7 +38,7 @@ internal class InlineDependencyTest {
             use crate::idempotency_token::uuid_v4;
             let res = uuid_v4(0);
             assert_eq!(res, "00000000-0000-4000-8000-000000000000");
-        """
+            """
         )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CombinedErrorGeneratorTest.kt
@@ -19,25 +19,25 @@ internal class CombinedErrorGeneratorTest {
     @Test
     fun `generate combined error enums`() {
         val model = """
-        namespace error
-        operation Greeting {
-            errors: [InvalidGreeting, ComplexError, FooException]
-        }
+            namespace error
+            operation Greeting {
+                errors: [InvalidGreeting, ComplexError, FooException]
+            }
 
-        @error("client")
-        @retryable
-        structure InvalidGreeting {
-            message: String,
-        }
+            @error("client")
+            @retryable
+            structure InvalidGreeting {
+                message: String,
+            }
 
-        @error("server")
-        structure FooException {}
+            @error("server")
+            structure FooException {}
 
-        @error("server")
-        structure ComplexError {
-            abc: String,
-            other: Integer
-        }
+            @error("server")
+            structure ComplexError {
+                abc: String,
+                other: Integer
+            }
         """.asSmithyModel()
         val symbolProvider = testSymbolProvider(model)
         val writer = RustWriter.forModule("error")
@@ -73,7 +73,7 @@ internal class CombinedErrorGeneratorTest {
             // indicate the original name in the display output
             let error = FooError::builder().build();
             assert_eq!(format!("{}", error), "FooError [FooException]")
-        """
+            """
         )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EndpointTraitBindingsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EndpointTraitBindingsTest.kt
@@ -39,17 +39,17 @@ internal class EndpointTraitBindingsTest {
     @Test
     fun `generate endpoint prefixes`() {
         val model = """
-        namespace test
-        @readonly
-        @endpoint(hostPrefix: "{foo}a.data.")
-        operation GetStatus {
-            input: GetStatusInput,
-        }
-        structure GetStatusInput {
-            @required
-            @hostLabel
-            foo: String
-        }
+            namespace test
+            @readonly
+            @endpoint(hostPrefix: "{foo}a.data.")
+            operation GetStatus {
+                input: GetStatusInput,
+            }
+            structure GetStatusInput {
+                @required
+                @hostLabel
+                foo: String
+            }
         """.asSmithyModel()
         val operationShape: OperationShape = model.lookup("test#GetStatus")
         val sym = testSymbolProvider(model)
@@ -67,7 +67,7 @@ internal class EndpointTraitBindingsTest {
                 struct GetStatusInput {
                     foo: Option<String>
                 }
-            """
+                """
             )
             it.implBlock(model.lookup("test#GetStatusInput"), sym) {
                 it.rustBlock(
@@ -84,14 +84,14 @@ internal class EndpointTraitBindingsTest {
                 let inp = GetStatusInput { foo: Some("test_value".to_string()) };
                 let prefix = inp.endpoint_prefix().unwrap();
                 assert_eq!(prefix.as_str(), "test_valuea.data.");
-            """
+                """
             )
             it.unitTest(
                 """
-                    // not a valid URI component
+                // not a valid URI component
                 let inp = GetStatusInput { foo: Some("test value".to_string()) };
                 inp.endpoint_prefix().expect_err("invalid uri component");
-            """
+                """
             )
 
             it.unitTest(
@@ -99,7 +99,7 @@ internal class EndpointTraitBindingsTest {
                 // unset is invalid
                 let inp = GetStatusInput { foo: None };
                 inp.endpoint_prefix().expect_err("invalid uri component");
-            """
+                """
             )
 
             it.unitTest(
@@ -107,7 +107,7 @@ internal class EndpointTraitBindingsTest {
                 // empty is invalid
                 let inp = GetStatusInput { foo: Some("".to_string()) };
                 inp.endpoint_prefix().expect_err("empty label is invalid");
-            """
+                """
             )
         }
 
@@ -118,23 +118,23 @@ internal class EndpointTraitBindingsTest {
     @Test
     fun `endpoint integration test`() {
         val model = """
-        namespace com.example
-        use aws.protocols#awsJson1_0
-        @awsJson1_0
-        @aws.api#service(sdkId: "Test", endpointPrefix: "differentprefix")
-        service TestService {
-            operations: [SayHello],
-            version: "1"
-        }
-        @endpoint(hostPrefix: "test123.{greeting}.")
-        operation SayHello {
-            input: SayHelloInput
-        }
-        structure SayHelloInput {
-            @required
-            @hostLabel
-            greeting: String
-        }
+            namespace com.example
+            use aws.protocols#awsJson1_0
+            @awsJson1_0
+            @aws.api#service(sdkId: "Test", endpointPrefix: "differentprefix")
+            service TestService {
+                operations: [SayHello],
+                version: "1"
+            }
+            @endpoint(hostPrefix: "test123.{greeting}.")
+            operation SayHello {
+                input: SayHelloInput
+            }
+            structure SayHelloInput {
+                @required
+                @hostLabel
+                greeting: String
+            }
         """.asSmithyModel()
         val (ctx, testDir) = generatePluginContext(model)
         val moduleName = ctx.settings.expectStringMember("module").value.replace('-', '_')
@@ -146,22 +146,22 @@ internal class EndpointTraitBindingsTest {
                     TokioTest.render(it)
                     it.rust(
                         """
-                    async fn test_endpoint_prefix() {
-                        let conf = $moduleName::Config::builder().build();
-                        $moduleName::operation::SayHello::builder()
-                            .greeting("hey there!").build().expect("input is valid")
-                            .make_operation(&conf).await.expect_err("no spaces or exclamation points in ep prefixes");
-                        let op = $moduleName::operation::SayHello::builder()
-                            .greeting("hello")
-                            .build().expect("valid operation")
-                            .make_operation(&conf).await.expect("hello is a valid prefix");
-                        let properties = op.properties();
-                        let prefix = properties.get::<aws_smithy_http::endpoint::EndpointPrefix>()
-                            .expect("prefix should be in config")
-                            .as_str();
-                        assert_eq!(prefix, "test123.hello.");
-                    }
-                    """
+                        async fn test_endpoint_prefix() {
+                            let conf = $moduleName::Config::builder().build();
+                            $moduleName::operation::SayHello::builder()
+                                .greeting("hey there!").build().expect("input is valid")
+                                .make_operation(&conf).await.expect_err("no spaces or exclamation points in ep prefixes");
+                            let op = $moduleName::operation::SayHello::builder()
+                                .greeting("hello")
+                                .build().expect("valid operation")
+                                .make_operation(&conf).await.expect("hello is a valid prefix");
+                            let properties = op.properties();
+                            let prefix = properties.get::<aws_smithy_http::endpoint::EndpointPrefix>()
+                                .expect("prefix should be in config")
+                                .as_str();
+                            assert_eq!(prefix, "test123.hello.");
+                        }
+                        """
                     )
                 }
             }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/InstantiatorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/InstantiatorTest.kt
@@ -66,7 +66,7 @@ class InstantiatorTest {
             member: WithBox,
             value: Integer
         }
-        """.asSmithyModel().let { RecursiveShapeBoxer.transform(it) }
+    """.asSmithyModel().let { RecursiveShapeBoxer.transform(it) }
 
     private val symbolProvider = testSymbolProvider(model)
     private val runtimeConfig = TestRuntimeConfig
@@ -120,9 +120,9 @@ class InstantiatorTest {
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
         val data = Node.parse(
             """ {
-                "member": {
-                    "member": { }
-                }, "value": 10
+            "member": {
+                "member": { }
+            }, "value": 10
             }
             """.trimIndent()
         )
@@ -141,7 +141,7 @@ class InstantiatorTest {
                         member: Some(Box::new(WithBox { value: None, member: None })),
                     }))
                 });
-            """
+                """
             )
         }
         writer.compileAndTest()
@@ -153,8 +153,8 @@ class InstantiatorTest {
             """ [
             "bar",
             "foo"
-        ]
-        """
+            ]
+            """
         )
         val writer = RustWriter.forModule("lib")
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
@@ -174,8 +174,8 @@ class InstantiatorTest {
             "bar",
             "foo",
             null
-        ]
-        """
+            ]
+            """
         )
         val writer = RustWriter.forModule("lib")
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
@@ -195,8 +195,8 @@ class InstantiatorTest {
             "k1": { "map": {} },
             "k2": { "map": { "k3": {} } },
             "k3": { }
-        }
-        """
+            }
+            """
         )
         val writer = RustWriter.forModule("model")
         val sut = Instantiator(symbolProvider, model, runtimeConfig)
@@ -212,7 +212,7 @@ class InstantiatorTest {
                 assert_eq!(result.get("k1").unwrap().map.as_ref().unwrap().len(), 0);
                 assert_eq!(result.get("k2").unwrap().map.as_ref().unwrap().len(), 1);
                 assert_eq!(result.get("k3").unwrap().map, None);
-            """
+                """
             )
         }
         writer.compileAndTest(clippy = true)

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/config/ServiceConfigGeneratorTest.kt
@@ -24,26 +24,26 @@ internal class ServiceConfigGeneratorTest {
     @Test
     fun `idempotency token when used`() {
         fun model(trait: String) = """
-        namespace com.example
+            namespace com.example
 
-        use aws.protocols#restJson1
-        use smithy.test#httpRequestTests
-        use smithy.test#httpResponseTests
+            use aws.protocols#restJson1
+            use smithy.test#httpRequestTests
+            use smithy.test#httpResponseTests
 
-        @restJson1
-        service HelloService {
-            operations: [SayHello],
-            version: "1"
-        }
+            @restJson1
+            service HelloService {
+                operations: [SayHello],
+                version: "1"
+            }
 
-        operation SayHello {
-            input: IdempotentInput
-        }
+            operation SayHello {
+                input: IdempotentInput
+            }
 
-        structure IdempotentInput {
-            $trait
-            tok: String
-        }
+            structure IdempotentInput {
+                $trait
+                tok: String
+            }
         """.asSmithyModel()
 
         val withToken = model("@idempotencyToken")
@@ -101,7 +101,7 @@ internal class ServiceConfigGeneratorTest {
                 builder.config_field = Some(99);
                 let config = builder.build();
                 assert_eq!(config.config_field, 99);
-            """
+                """
             )
         }
         project.compileAndTest()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGeneratorTest.kt
@@ -19,27 +19,27 @@ internal class TopLevelErrorGeneratorTest {
     @Test
     fun `top level errors are send + sync`() {
         val model = """
-        namespace com.example
+            namespace com.example
 
-        use aws.protocols#restJson1
+            use aws.protocols#restJson1
 
-        @restJson1
-        service HelloService {
-            operations: [SayHello],
-            version: "1"
-        }
+            @restJson1
+            service HelloService {
+                operations: [SayHello],
+                version: "1"
+            }
 
-        @http(uri: "/", method: "POST")
-        operation SayHello {
-            errors: [SorryBusy, CanYouRepeatThat]
+            @http(uri: "/", method: "POST")
+            operation SayHello {
+                errors: [SorryBusy, CanYouRepeatThat]
 
-        }
+            }
 
-        @error("server")
-        structure SorryBusy { }
+            @error("server")
+            structure SorryBusy { }
 
-        @error("client")
-        structure CanYouRepeatThat { }
+            @error("client")
+            structure CanYouRepeatThat { }
         """.asSmithyModel()
 
         val (pluginContext, testDir) = generatePluginContext(model)
@@ -53,7 +53,7 @@ internal class TopLevelErrorGeneratorTest {
             fn tl_errors_are_send_sync() {
                 check_send_sync::<$moduleName::Error>()
             }
-        """
+            """
         )
         "cargo test".runCommand(testDir)
     }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -53,11 +53,11 @@ private class TestProtocolTraitImplGenerator(
     override fun generateTraitImpls(operationWriter: RustWriter, operationShape: OperationShape) {
         operationWriter.rustTemplate(
             """
-                    impl #{parse_strict} for ${operationShape.id.name}{
-                        type Output = Result<#{output}, #{error}>;
-                        fn parse(&self, response: &#{response}<#{bytes}>) -> Self::Output {
-                            ${operationWriter.escape(correctResponse)}
-                        }
+            impl #{parse_strict} for ${operationShape.id.name}{
+                type Output = Result<#{output}, #{error}>;
+                fn parse(&self, response: &#{response}<#{bytes}>) -> Self::Output {
+                    ${operationWriter.escape(correctResponse)}
+                }
                     }""",
             "parse_strict" to RuntimeType.parseStrict(codegenContext.runtimeConfig),
             "output" to symbolProvider.toSymbol(operationShape.outputShape(codegenContext.model)),

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/EventStreamTestTools.kt
@@ -168,35 +168,35 @@ object EventStreamTestModels {
             requestContentType = "application/xml",
             responseContentType = "application/xml",
             validTestStruct = """
-                        <TestStruct>
-                            <someString>hello</someString>
-                            <someInt>5</someInt>
-                        </TestStruct>
+                <TestStruct>
+                    <someString>hello</someString>
+                    <someInt>5</someInt>
+                </TestStruct>
             """.trimIndent(),
             validMessageWithNoHeaderPayloadTraits = """
-                        <MessageWithNoHeaderPayloadTraits>
-                            <someString>hello</someString>
-                            <someInt>5</someInt>
-                        </MessageWithNoHeaderPayloadTraits>
+                <MessageWithNoHeaderPayloadTraits>
+                    <someString>hello</someString>
+                    <someInt>5</someInt>
+                </MessageWithNoHeaderPayloadTraits>
             """.trimIndent(),
             validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
             validSomeError = """
-                        <ErrorResponse>
-                            <Error>
-                                <Type>SomeError</Type>
-                                <Code>SomeError</Code>
-                                <Message>some error</Message>
-                            </Error>
-                        </ErrorResponse>
+                <ErrorResponse>
+                    <Error>
+                        <Type>SomeError</Type>
+                        <Code>SomeError</Code>
+                        <Message>some error</Message>
+                    </Error>
+                </ErrorResponse>
             """.trimIndent(),
             validUnmodeledError = """
-                        <ErrorResponse>
-                            <Error>
-                                <Type>UnmodeledError</Type>
-                                <Code>UnmodeledError</Code>
-                                <Message>unmodeled error</Message>
-                            </Error>
-                        </ErrorResponse>
+                <ErrorResponse>
+                    <Error>
+                        <Type>UnmodeledError</Type>
+                        <Code>UnmodeledError</Code>
+                        <Message>unmodeled error</Message>
+                    </Error>
+                </ErrorResponse>
             """.trimIndent(),
         ) { RestXml(it) },
 
@@ -209,35 +209,35 @@ object EventStreamTestModels {
             requestContentType = "application/x-www-form-urlencoded",
             responseContentType = "text/xml",
             validTestStruct = """
-                        <TestStruct>
-                            <someString>hello</someString>
-                            <someInt>5</someInt>
-                        </TestStruct>
+                <TestStruct>
+                    <someString>hello</someString>
+                    <someInt>5</someInt>
+                </TestStruct>
             """.trimIndent(),
             validMessageWithNoHeaderPayloadTraits = """
-                        <MessageWithNoHeaderPayloadTraits>
-                            <someString>hello</someString>
-                            <someInt>5</someInt>
-                        </MessageWithNoHeaderPayloadTraits>
+                <MessageWithNoHeaderPayloadTraits>
+                    <someString>hello</someString>
+                    <someInt>5</someInt>
+                </MessageWithNoHeaderPayloadTraits>
             """.trimIndent(),
             validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
             validSomeError = """
-                        <ErrorResponse>
-                            <Error>
-                                <Type>SomeError</Type>
-                                <Code>SomeError</Code>
-                                <Message>some error</Message>
-                            </Error>
-                        </ErrorResponse>
+                <ErrorResponse>
+                    <Error>
+                        <Type>SomeError</Type>
+                        <Code>SomeError</Code>
+                        <Message>some error</Message>
+                    </Error>
+                </ErrorResponse>
             """.trimIndent(),
             validUnmodeledError = """
-                        <ErrorResponse>
-                            <Error>
-                                <Type>UnmodeledError</Type>
-                                <Code>UnmodeledError</Code>
-                                <Message>unmodeled error</Message>
-                            </Error>
-                        </ErrorResponse>
+                <ErrorResponse>
+                    <Error>
+                        <Type>UnmodeledError</Type>
+                        <Code>UnmodeledError</Code>
+                        <Message>unmodeled error</Message>
+                    </Error>
+                </ErrorResponse>
             """.trimIndent(),
         ) { AwsQueryProtocol(it) },
 
@@ -250,39 +250,39 @@ object EventStreamTestModels {
             requestContentType = "application/x-www-form-urlencoded",
             responseContentType = "text/xml",
             validTestStruct = """
-                        <TestStruct>
-                            <someString>hello</someString>
-                            <someInt>5</someInt>
-                        </TestStruct>
+                <TestStruct>
+                    <someString>hello</someString>
+                    <someInt>5</someInt>
+                </TestStruct>
             """.trimIndent(),
             validMessageWithNoHeaderPayloadTraits = """
-                        <MessageWithNoHeaderPayloadTraits>
-                            <someString>hello</someString>
-                            <someInt>5</someInt>
-                        </MessageWithNoHeaderPayloadTraits>
+                <MessageWithNoHeaderPayloadTraits>
+                    <someString>hello</someString>
+                    <someInt>5</someInt>
+                </MessageWithNoHeaderPayloadTraits>
             """.trimIndent(),
             validTestUnion = "<TestUnion><Foo>hello</Foo></TestUnion>",
             validSomeError = """
-                        <Response>
-                            <Errors>
-                                <Error>
-                                    <Type>SomeError</Type>
-                                    <Code>SomeError</Code>
-                                    <Message>some error</Message>
-                                </Error>
-                            </Errors>
-                        </Response>
+                <Response>
+                    <Errors>
+                        <Error>
+                            <Type>SomeError</Type>
+                            <Code>SomeError</Code>
+                            <Message>some error</Message>
+                        </Error>
+                    </Errors>
+                </Response>
             """.trimIndent(),
             validUnmodeledError = """
-                        <Response>
-                            <Errors>
-                                <Error>
-                                    <Type>UnmodeledError</Type>
-                                    <Code>UnmodeledError</Code>
-                                    <Message>unmodeled error</Message>
-                                </Error>
-                            </Errors>
-                        </Response>
+                <Response>
+                    <Errors>
+                        <Error>
+                            <Type>UnmodeledError</Type>
+                            <Code>UnmodeledError</Code>
+                            <Message>unmodeled error</Message>
+                        </Error>
+                    </Errors>
+                </Response>
             """.trimIndent(),
         ) { Ec2QueryProtocol(it) },
     )

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/AwsQueryParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/AwsQueryParserGeneratorTest.kt
@@ -55,16 +55,16 @@ class AwsQueryParserGeneratorTest {
             writer.unitTest(
                 name = "valid_input",
                 test = """
-                let xml = br#"
-                <SomeOperationResponse>
-                    <SomeOperationResult someAttribute="5">
-                        <someVal>Some value</someVal>
-                    </SomeOperationResult>
-                </someOperationResponse>
-                "#;
-                let output = ${writer.format(operationParser)}(xml, output::some_operation_output::Builder::default()).unwrap().build();
-                assert_eq!(output.some_attribute, Some(5));
-                assert_eq!(output.some_val, Some("Some value".to_string()));
+                    let xml = br#"
+                    <SomeOperationResponse>
+                        <SomeOperationResult someAttribute="5">
+                            <someVal>Some value</someVal>
+                        </SomeOperationResult>
+                    </someOperationResponse>
+                    "#;
+                    let output = ${writer.format(operationParser)}(xml, output::some_operation_output::Builder::default()).unwrap().build();
+                    assert_eq!(output.some_attribute, Some(5));
+                    assert_eq!(output.some_val, Some("Some value".to_string()));
                 """
             )
         }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/Ec2QueryParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/Ec2QueryParserGeneratorTest.kt
@@ -55,14 +55,14 @@ class Ec2QueryParserGeneratorTest {
             writer.unitTest(
                 name = "valid_input",
                 test = """
-                let xml = br#"
-                <SomeOperationResponse someAttribute="5">
-                    <someVal>Some value</someVal>
-                </someOperationResponse>
-                "#;
-                let output = ${writer.format(operationParser)}(xml, output::some_operation_output::Builder::default()).unwrap().build();
-                assert_eq!(output.some_attribute, Some(5));
-                assert_eq!(output.some_val, Some("Some value".to_string()));
+                    let xml = br#"
+                    <SomeOperationResponse someAttribute="5">
+                        <someVal>Some value</someVal>
+                    </someOperationResponse>
+                    "#;
+                    let output = ${writer.format(operationParser)}(xml, output::some_operation_output::Builder::default()).unwrap().build();
+                    assert_eq!(output.some_attribute, Some(5));
+                    assert_eq!(output.some_val, Some("Some value".to_string()));
                 """
             )
         }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGeneratorTest.kt
@@ -102,75 +102,75 @@ internal class XmlBindingTraitParserGeneratorTest {
             writer.unitTest(
                 name = "valid_input",
                 test = """
-                let xml = br#"<Top>
-                    <choice>
-                        <Hi>
-                            <Name>some key</Name>
-                            <Setting>
-                                <s>hello</s>
-                            </Setting>
-                        </Hi>
-                    </choice>
-                    <prefix:local>hey</prefix:local>
-                </Top>
-                "#;
-                let output = ${writer.format(operationParser)}(xml, output::op_output::Builder::default()).unwrap().build();
-                let mut map = std::collections::HashMap::new();
-                map.insert("some key".to_string(), model::Choice::S("hello".to_string()));
-                assert_eq!(output.choice, Some(model::Choice::FlatMap(map)));
-                assert_eq!(output.renamed_with_prefix.as_deref(), Some("hey"));
-            """
+                    let xml = br#"<Top>
+                        <choice>
+                            <Hi>
+                                <Name>some key</Name>
+                                <Setting>
+                                    <s>hello</s>
+                                </Setting>
+                            </Hi>
+                        </choice>
+                        <prefix:local>hey</prefix:local>
+                    </Top>
+                    "#;
+                    let output = ${writer.format(operationParser)}(xml, output::op_output::Builder::default()).unwrap().build();
+                    let mut map = std::collections::HashMap::new();
+                    map.insert("some key".to_string(), model::Choice::S("hello".to_string()));
+                    assert_eq!(output.choice, Some(model::Choice::FlatMap(map)));
+                    assert_eq!(output.renamed_with_prefix.as_deref(), Some("hey"));
+                """
             )
 
             writer.unitTest(
                 name = "ignore_extras",
                 test = """
-                let xml = br#"<Top>
-                    <notchoice>
-                        <extra/>
-                        <stuff/>
-                        <noone/>
-                        <needs>5</needs>
-                    </notchoice>
-                    <choice>
-                        <Hi>
-                            <Name>some key</Name>
-                            <Setting>
-                                <s>hello</s>
-                            </Setting>
-                        </Hi>
-                    </choice>
-                </Top>
-                "#;
-                let output = ${writer.format(operationParser)}(xml, output::op_output::Builder::default()).unwrap().build();
-                let mut map = std::collections::HashMap::new();
-                map.insert("some key".to_string(), model::Choice::S("hello".to_string()));
-                assert_eq!(output.choice, Some(model::Choice::FlatMap(map)));
-            """
+                    let xml = br#"<Top>
+                        <notchoice>
+                            <extra/>
+                            <stuff/>
+                            <noone/>
+                            <needs>5</needs>
+                        </notchoice>
+                        <choice>
+                            <Hi>
+                                <Name>some key</Name>
+                                <Setting>
+                                    <s>hello</s>
+                                </Setting>
+                            </Hi>
+                        </choice>
+                    </Top>
+                    "#;
+                    let output = ${writer.format(operationParser)}(xml, output::op_output::Builder::default()).unwrap().build();
+                    let mut map = std::collections::HashMap::new();
+                    map.insert("some key".to_string(), model::Choice::S("hello".to_string()));
+                    assert_eq!(output.choice, Some(model::Choice::FlatMap(map)));
+                """
             )
 
             writer.unitTest(
                 name = "nopanics_on_invalid",
                 test = """
-                let xml = br#"<Top>
-                    <notchoice>
-                        <extra/>
-                        <stuff/>
-                        <noone/>
-                        <needs>5</needs>
-                    </notchoice>
-                    <choice>
-                        <Hey>
-                            <Name>some key</Name>
-                            <Setting>
-                                <s>hello</s>
-                            </Setting>
-                        </Hey>
-                    </choice>
-                </Top>
-                "#;
-                ${writer.format(operationParser)}(xml, output::op_output::Builder::default()).expect_err("invalid input");
-            """
+                    let xml = br#"<Top>
+                        <notchoice>
+                            <extra/>
+                            <stuff/>
+                            <noone/>
+                            <needs>5</needs>
+                        </notchoice>
+                        <choice>
+                            <Hey>
+                                <Name>some key</Name>
+                                <Setting>
+                                    <s>hello</s>
+                                </Setting>
+                            </Hey>
+                        </choice>
+                    </Top>
+                    "#;
+                    ${writer.format(operationParser)}(xml, output::op_output::Builder::default()).expect_err("invalid input");
+                """
             )
         }
         project.withModule(RustModule.public("model")) {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
@@ -116,18 +116,18 @@ internal class XmlBindingTraitSerializerGeneratorTest {
         project.lib { writer ->
             writer.unitTest(
                 """
-                 use model::Top;
+                use model::Top;
                 let inp = crate::input::OpInput::builder().payload(
-                    Top::builder()
-                        .field("hello!")
-                        .extra(45)
-                        .recursive(Top::builder().extra(55).build())
-                        .build()
+                   Top::builder()
+                       .field("hello!")
+                       .extra(45)
+                       .recursive(Top::builder().extra(55).build())
+                       .build()
                 ).build().unwrap();
                 let serialized = ${writer.format(operationParser)}(&inp.payload.unwrap()).unwrap();
                 let output = std::str::from_utf8(&serialized).unwrap();
                 assert_eq!(output, "<Top extra=\"45\"><field>hello!</field><recursive extra=\"55\"></recursive></Top>");
-            """
+                """
             )
         }
         project.withModule(RustModule.public("model")) {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxerTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapeBoxerTest.kt
@@ -37,11 +37,11 @@ internal class RecursiveShapeBoxerTest {
     @Test
     fun `add the box trait to simple recursive shapes`() {
         val model = """
-        namespace com.example
-        structure Recursive {
-            RecursiveStruct: Recursive,
-            anotherField: Boolean
-        }
+            namespace com.example
+            structure Recursive {
+                RecursiveStruct: Recursive,
+                anotherField: Boolean
+            }
         """.asSmithyModel()
         val transformed = RecursiveShapeBoxer.transform(model)
         val member: MemberShape = transformed.lookup("com.example#Recursive\$RecursiveStruct")
@@ -51,25 +51,25 @@ internal class RecursiveShapeBoxerTest {
     @Test
     fun `add the box trait to complex structures`() {
         val model = """
-       namespace com.example
-       structure Expr {
-            left: Atom,
-            right: Atom
-       }
+            namespace com.example
+            structure Expr {
+                 left: Atom,
+                 right: Atom
+            }
 
-       union Atom {
-            add: Expr,
-            sub: Expr,
-            literal: Integer,
-            more: SecondTree
-       }
+            union Atom {
+                 add: Expr,
+                 sub: Expr,
+                 literal: Integer,
+                 more: SecondTree
+            }
 
-       structure SecondTree {
-            member: Expr,
-            otherMember: Atom,
-            third: SecondTree
-       }
-       """.asSmithyModel()
+            structure SecondTree {
+                 member: Expr,
+                 otherMember: Atom,
+                 third: SecondTree
+            }
+        """.asSmithyModel()
         val transformed = RecursiveShapeBoxer.transform(model)
         val boxed = transformed.shapes().filter { it.hasTrait<RustBoxTrait>() }.toList()
         boxed.map { it.id.toString().removePrefix("com.example#") }.toSet() shouldBe setOf(

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapesIntegrationTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/transformers/RecursiveShapesIntegrationTest.kt
@@ -23,25 +23,25 @@ class RecursiveShapesIntegrationTest {
     @Test
     fun `recursive shapes are properly boxed`() {
         val model = """
-       namespace com.example
-       structure Expr {
-            left: Atom,
-            right: Atom
-       }
+            namespace com.example
+            structure Expr {
+                 left: Atom,
+                 right: Atom
+            }
 
-       union Atom {
-            add: Expr,
-            sub: Expr,
-            literal: Integer,
-            more: SecondTree
-       }
+            union Atom {
+                 add: Expr,
+                 sub: Expr,
+                 literal: Integer,
+                 more: SecondTree
+            }
 
-       structure SecondTree {
-            member: Expr,
-            otherMember: Atom,
-            third: SecondTree
-       }
-       """.asSmithyModel()
+            structure SecondTree {
+                 member: Expr,
+                 otherMember: Atom,
+                 third: SecondTree
+            }
+        """.asSmithyModel()
         val check = { input: Model ->
             val structures = listOf("Expr", "SecondTree").map { input.lookup<StructureShape>("com.example#$it") }
             val writer = RustWriter.forModule("model")

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/util/StringsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/util/StringsTest.kt
@@ -15,7 +15,7 @@ internal class StringsTest {
         "abc".doubleQuote() shouldBe "\"abc\""
         """{"some": "json"}""".doubleQuote() shouldBe """"{\"some\": \"json\"}""""
         """{"nested": "{\"nested\": 5}"}"}""".doubleQuote() shouldBe """
-           "{\"nested\": \"{\\\"nested\\\": 5}\"}\"}"
+        "{\"nested\": \"{\\\"nested\\\": 5}\"}\"}"
         """.trimIndent().trim()
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
@@ -77,10 +77,10 @@ class RustWriterTest {
         output shouldContain "struct Test"
         output.compileAndRun(
             """
-        let test = Test { member: ${RustType.HashSet.Namespace}::${RustType.HashSet.Type}::default(), otherMember: "hello".to_string() };
-        assert_eq!(test.otherMember, "hello");
-        assert_eq!(test.member.is_empty(), true);
-         """
+            let test = Test { member: ${RustType.HashSet.Namespace}::${RustType.HashSet.Type}::default(), otherMember: "hello".to_string() };
+            assert_eq!(test.otherMember, "hello");
+            assert_eq!(test.member.is_empty(), true);
+            """
         )
     }
 
@@ -93,7 +93,7 @@ class RustWriterTest {
             |/* handle weird characters */
             |`a backtick`
             |[a link](asdf)
-        """.trimMargin()
+            """.trimMargin()
         )
         sut.rustBlock("fn main()") { }
         sut.compileAndTest()
@@ -103,8 +103,8 @@ class RustWriterTest {
     @Test
     fun `generate doc links`() {
         val model = """
-        namespace test
-        structure Foo {}
+            namespace test
+            structure Foo {}
         """.asSmithyModel()
         val shape = model.lookup<StructureShape>("test#Foo")
         val symbol = testSymbolProvider(model).toSymbol(shape)


### PR DESCRIPTION
## Motivation and Context
The block quote indentation in the Kotlin codegen is all over the place, and many PRs make changes to it. This script will keep it normalized and looking neat.

_Note: because I took a line-based approach, there are some cases where block quotes and block comments are combined on the same line that can confuse the script. I added a safeguard to bail out in this case, but I don't anticipate us doing weird stuff like this that would trigger it:_

```kotlin
foo = /* something */ """
   asdf
"""
```

If that does happen, the script won't modify the file, but will tell you to go fix it.

## Testing
- Unit tested the script
- Ran against all of smithy-rs and manually inspected the results
- Verified Ktlint is happy with the output

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
