### PR TITLE
Fix docs on union converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ vNext (Month Day, Year)
 - `moduleDescription` in `smithy-build.json` settings is now optional
 - Upgrade to Smithy 1.12
 - `hyper::Error(IncompleteMessage)` will now be retried (smithy-rs#815)
+- Fix generated docs on unions. (smithy-rs#826)
 
 v0.27 (October 20th, 2021)
 ==========================

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 - :bug: Fix `native-tls` feature in `aws-config` (aws-sdk-rust#265, smithy-rs#803)
 - Add example to aws-sig-auth for generating an IAM Token for RDS (smithy-rs#811, aws-sdk-rust#147)
 - :bug: `hyper::Error(IncompleteMessage)` will now be retried (smithy-rs#815)
+- :bug: Fix generated docs on unions like `dynamodb::AttributeValue`. (smithy-rs#826)
 
 **Breaking Changes**
 - `<operation>.make_operation(&config)` is now an `async` function for all operations. Code should be updated to call `.await`. This will only impact users using the low-level API. (smithy-rs#797)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -112,6 +112,22 @@ sealed class RustType {
     data class Opaque(override val name: kotlin.String, override val namespace: kotlin.String? = null) : RustType()
 }
 
+/**
+ * Return the fully qualified name of this type NOT including generic type parameters, references, etc.
+ *
+ * - To generate something like `std::collections::HashMap`, use this function.
+ * - To generate something like `std::collections::HashMap<String, String>`, use [render]
+ */
+fun RustType.qualifiedName(): String {
+    val namespace = this.namespace?.let { "$it::" } ?: ""
+    return "$namespace$name"
+}
+
+/**
+ * Render this type, including references and generic parameters.
+ * - To generate something like `std::collections::HashMap<String, String>`, use this function
+ * - To generate something like `std::collections::HashMap`, use [qualifiedName]
+ */
 fun RustType.render(fullyQualified: Boolean = true): String {
     val namespace = if (fullyQualified) {
         this.namespace?.let { "$it::" } ?: ""

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -397,7 +397,7 @@ class RustWriter private constructor(
     inner class RustDocLinker : BiFunction<Any, String, String> {
         override fun apply(t: Any, u: String): String {
             return when (t) {
-                is Symbol -> "[`${t.name}`](${t.fullName})"
+                is Symbol -> "[`${t.name}`](${t.rustType().qualifiedName()})"
                 else -> throw CodegenException("Invalid type provided to RustDocLinker ($t) expected Symbol")
             }
         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -53,7 +53,7 @@ class UnionGenerator(
                 if (sortedMembers.size == 1) {
                     Attribute.Custom("allow(irrefutable_let_patterns)").render(this)
                 }
-                rust("/// Tries to convert the enum instance into [`$variantName`](#T::$variantName).", unionSymbol)
+                rust("/// Tries to convert the enum instance into [`$variantName`](#T::$variantName), extracting the inner #D.", unionSymbol, memberSymbol)
                 rust("/// Returns `Err(&Self)` if it can't be converted.")
                 rustBlock("pub fn as_$funcNamePart(&self) -> std::result::Result<&#T, &Self>", memberSymbol) {
                     rust("if let ${unionSymbol.name}::$variantName(val) = &self { Ok(&val) } else { Err(&self) }")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -47,8 +47,8 @@ class UnionGenerator(
         writer.rustBlock("impl ${unionSymbol.name}") {
             sortedMembers.forEach { member ->
                 val memberSymbol = symbolProvider.toSymbol(member)
-                val variantName = symbolProvider.toMemberName(member).toPascalCase()
-                val funcNamePart = variantName.toSnakeCase()
+                val variantName = member.memberName.toPascalCase()
+                val funcNamePart = member.memberName.toSnakeCase()
 
                 if (sortedMembers.size == 1) {
                     Attribute.Custom("allow(irrefutable_let_patterns)").render(this)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -47,18 +47,18 @@ class UnionGenerator(
         writer.rustBlock("impl ${unionSymbol.name}") {
             sortedMembers.forEach { member ->
                 val memberSymbol = symbolProvider.toSymbol(member)
-                val funcNamePart = member.memberName.toSnakeCase()
-                val variantName = member.memberName.toPascalCase()
+                val variantName = symbolProvider.toMemberName(member).toPascalCase()
+                val funcNamePart = variantName.toSnakeCase()
 
                 if (sortedMembers.size == 1) {
                     Attribute.Custom("allow(irrefutable_let_patterns)").render(this)
                 }
-                rust("/// Tries to convert the enum instance into its #D variant.", unionSymbol)
-                rust("/// Returns `Err(&Self) if it can't be converted.` ")
+                rust("/// Tries to convert the enum instance into [`$variantName`](#T::$variantName).", unionSymbol)
+                rust("/// Returns `Err(&Self)` if it can't be converted.")
                 rustBlock("pub fn as_$funcNamePart(&self) -> std::result::Result<&#T, &Self>", memberSymbol) {
                     rust("if let ${unionSymbol.name}::$variantName(val) = &self { Ok(&val) } else { Err(&self) }")
                 }
-                rust("/// Returns true if the enum instance is the `${unionSymbol.name}` variant.")
+                rust("/// Returns true if this is a [`$variantName`](#T::$variantName).", unionSymbol)
                 rustBlock("pub fn is_$funcNamePart(&self) -> bool") {
                     rust("self.as_$funcNamePart().is_ok()")
                 }


### PR DESCRIPTION
## Motivation and Context
Documentation on unions is currently buggy and linking to wrong thing:

<img width="1057" alt="Screen Shot 2021-11-02 at 2 40 16 PM" src="https://user-images.githubusercontent.com/492903/139925528-a47c284b-6190-4cfc-a620-a9316a94ba6a.png">

## Description
Fix the generated docs for unions

## Testing

<img width="1052" alt="Screen Shot 2021-11-02 at 2 39 53 PM" src="https://user-images.githubusercontent.com/492903/139925576-83eaf205-702d-4432-bcf8-ebf931e3982f.png">

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable
- [x] I have reviewed the generated code diff
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
