### PR TITLE
Add accessor methods to generated structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 vNext (Month Day, Year)
 =======================
 
+**Breaking Changes**
+
+- Members named `builder` on model structs were renamed to `builder_value` so that their accessors don't conflict with the existing `builder()` methods (smithy-rs#842)
+
 **New this week**
 
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
+- Generated structs now have accessor methods for their members (smithy-rs#842)
 
 v0.27.0-alpha.1 (November 3rd, 2021)
 ====================================

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,6 +1,10 @@
 vNext (Month Day, Year)
 =======================
 
+**Breaking Changes**
+
+- Members named `builder` on model structs were renamed to `builder_value` so that their accessors don't conflict with the existing `builder()` methods (smithy-rs#842)
+
 **New this week**
 
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
+- Model structs now have accessor methods for their members (smithy-rs#842)
 
 v0.0.23-alpha (November 3rd, 2021)
 ==================================

--- a/aws/sdk/examples/apigateway/src/bin/get_rest_apis.rs
+++ b/aws/sdk/examples/apigateway/src/bin/get_rest_apis.rs
@@ -22,18 +22,12 @@ struct Opt {
 async fn show_apis(client: &Client) -> Result<(), Error> {
     let resp = client.get_rest_apis().send().await?;
 
-    for api in resp.items.unwrap_or_default() {
-        println!("ID:          {}", api.id.as_deref().unwrap_or_default());
-        println!("Name:        {}", api.name.as_deref().unwrap_or_default());
-        println!(
-            "Description: {}",
-            api.description.as_deref().unwrap_or_default()
-        );
-        println!(
-            "Version:     {}",
-            api.version.as_deref().unwrap_or_default()
-        );
-        println!("Created:     {}", api.created_date.unwrap().to_chrono());
+    for api in resp.items().unwrap_or_default() {
+        println!("ID:          {}", api.id().unwrap_or_default());
+        println!("Name:        {}", api.name().unwrap_or_default());
+        println!("Description: {}", api.description().unwrap_or_default());
+        println!("Version:     {}", api.version().unwrap_or_default());
+        println!("Created:     {}", api.created_date().unwrap().to_chrono());
         println!();
     }
 

--- a/aws/sdk/examples/s3/src/bin/list-buckets.rs
+++ b/aws/sdk/examples/s3/src/bin/list-buckets.rs
@@ -47,11 +47,11 @@ async fn main() -> Result<(), Error> {
     }
 
     let resp = client.list_buckets().send().await?;
-    let buckets = resp.buckets.unwrap_or_default();
+    let buckets = resp.buckets().unwrap_or_default();
     let num_buckets = buckets.len();
 
-    for bucket in &buckets {
-        println!("{}", bucket.name.as_deref().unwrap_or_default());
+    for bucket in buckets {
+        println!("{}", bucket.name().unwrap_or_default());
     }
 
     println!();

--- a/aws/sdk/examples/s3/src/bin/list-object-versions.rs
+++ b/aws/sdk/examples/s3/src/bin/list-object-versions.rs
@@ -58,12 +58,9 @@ async fn main() -> Result<(), Error> {
 
     let resp = client.list_object_versions().bucket(&bucket).send().await?;
 
-    for version in resp.versions.unwrap_or_default() {
-        println!(" {}", version.key.as_deref().unwrap_or_default());
-        println!(
-            "  version ID: {}",
-            version.version_id.as_deref().unwrap_or_default()
-        );
+    for version in resp.versions().unwrap_or_default() {
+        println!(" {}", version.key().unwrap_or_default());
+        println!("  version ID: {}", version.version_id().unwrap_or_default());
     }
 
     Ok(())

--- a/aws/sdk/examples/s3/src/bin/list-objects.rs
+++ b/aws/sdk/examples/s3/src/bin/list-objects.rs
@@ -60,8 +60,8 @@ async fn main() -> Result<(), Error> {
 
     println!("Objects:");
 
-    for object in resp.contents.unwrap_or_default() {
-        println!("  {}", object.key.as_deref().unwrap_or_default());
+    for object in resp.contents().unwrap_or_default() {
+        println!("  {}", object.key().unwrap_or_default());
     }
 
     Ok(())

--- a/aws/sdk/examples/s3/src/bin/select-object-content.rs
+++ b/aws/sdk/examples/s3/src/bin/select-object-content.rs
@@ -96,17 +96,16 @@ async fn main() -> Result<(), Error> {
                 println!(
                     "Record: {}",
                     records
-                        .payload
-                        .as_ref()
+                        .payload()
                         .map(|p| std::str::from_utf8(p.as_ref()).unwrap())
                         .unwrap_or("")
                 );
             }
             SelectObjectContentEventStream::Stats(stats) => {
-                println!("Stats: {:?}", stats.details.unwrap());
+                println!("Stats: {:?}", stats.details().unwrap());
             }
             SelectObjectContentEventStream::Progress(progress) => {
-                println!("Progress: {:?}", progress.details.unwrap());
+                println!("Progress: {:?}", progress.details().unwrap());
             }
             SelectObjectContentEventStream::Cont(_) => {
                 println!("Continuation Event");

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustReservedWords.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustReservedWords.kt
@@ -33,6 +33,7 @@ class RustReservedWordSymbolProvider(private val base: RustSymbolProvider, priva
         return when (val container = model.expectShape(shape.container)) {
             is StructureShape -> when (baseName) {
                 "build" -> "build_value"
+                "builder" -> "builder_value"
                 "default" -> "default_value"
                 "send" -> "send_value"
                 // To avoid conflicts with the `make_operation` and `presigned` functions on generated inputs

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -172,6 +172,45 @@ fun RustType.asOptional(): RustType = when (this) {
     else -> RustType.Option(this)
 }
 
+/** Converts type to a reference */
+fun RustType.asRef(): RustType = when (this) {
+    is RustType.Reference -> this
+    is RustType.Option -> RustType.Option(member.asRef())
+    else -> RustType.Reference(null, this)
+}
+
+/** Converts type to its Deref target */
+fun RustType.asDeref(): RustType = when (this) {
+    is RustType.Option -> if (member.isDeref()) {
+        RustType.Option(member.asDeref().asRef())
+    } else {
+        this
+    }
+    is RustType.Box -> RustType.Reference(null, member)
+    is RustType.String -> RustType.Opaque("str")
+    is RustType.Vec -> RustType.Slice(member)
+    else -> this
+}
+
+/** Returns true if the type implements Deref */
+fun RustType.isDeref(): Boolean = when (this) {
+    is RustType.Box -> true
+    is RustType.String -> true
+    is RustType.Vec -> true
+    else -> false
+}
+
+/** Returns true if the type implements Copy */
+fun RustType.isCopy(): Boolean = when (this) {
+    is RustType.Float -> true
+    is RustType.Integer -> true
+    is RustType.Reference -> true
+    is RustType.Bool -> true
+    is RustType.Slice -> true
+    is RustType.Option -> this.member.isCopy()
+    else -> false
+}
+
 /**
  * Meta information about a Rust construction (field, struct, or enum)
  */

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -172,14 +172,27 @@ fun RustType.asOptional(): RustType = when (this) {
     else -> RustType.Option(this)
 }
 
-/** Converts type to a reference */
+/**
+ * Converts type to a reference
+ *
+ * For example:
+ * - `String` -> `&String`
+ * - `Option<T>` -> `Option<&T>`
+ */
 fun RustType.asRef(): RustType = when (this) {
     is RustType.Reference -> this
     is RustType.Option -> RustType.Option(member.asRef())
     else -> RustType.Reference(null, this)
 }
 
-/** Converts type to its Deref target */
+/**
+ * Converts type to its Deref target
+ *
+ * For example:
+ * - `String` -> `str`
+ * - `Option<String>` -> `Option<&str>`
+ * - `Box<Something>` -> `&Something`
+ */
 fun RustType.asDeref(): RustType = when (this) {
     is RustType.Option -> if (member.isDeref()) {
         RustType.Option(member.asDeref().asRef())

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -121,6 +121,9 @@ class StructureGenerator(
     }
 
     private fun renderStructureImpl() {
+        if (members.isEmpty()) {
+            return
+        }
         writer.rustBlock("impl $name") {
             // Render field accessor methods
             forEachMember { member, memberName, memberSymbol ->

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.smithy.generators
 
+import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
@@ -14,7 +15,12 @@ import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.SensitiveTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asDeref
+import software.amazon.smithy.rust.codegen.rustlang.asRef
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
+import software.amazon.smithy.rust.codegen.rustlang.isCopy
+import software.amazon.smithy.rust.codegen.rustlang.isDeref
+import software.amazon.smithy.rust.codegen.rustlang.render
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
@@ -52,10 +58,11 @@ class StructureGenerator(
 ) {
     private val members: List<MemberShape> = shape.allMembers.values.toList()
     private val name = symbolProvider.toSymbol(shape).name
+    private val errorTrait = shape.getTrait<ErrorTrait>()
 
     fun render() {
         renderStructure()
-        shape.getTrait<ErrorTrait>()?.also { errorTrait ->
+        errorTrait?.also { errorTrait ->
             ErrorGenerator(symbolProvider, writer, shape, errorTrait).render()
         }
     }
@@ -113,6 +120,39 @@ class StructureGenerator(
         }
     }
 
+    private fun renderStructureImpl() {
+        writer.rustBlock("impl $name") {
+            // Render field accessor methods
+            forEachMember { member, memberName, memberSymbol ->
+                // Let the ErrorGenerator render the error message accessor if this is an error struct
+                if (errorTrait == null || memberName != "message") {
+                    renderMemberDoc(member, memberSymbol)
+                    val memberType = memberSymbol.rustType()
+                    val returnType = if (memberType.isCopy()) {
+                        memberType
+                    } else if (memberType is RustType.Option && memberType.member.isDeref()) {
+                        memberType.asDeref()
+                    } else {
+                        memberType.asRef()
+                    }
+                    rustBlock("pub fn $memberName(&self) -> ${returnType.render()}") {
+                        if (memberType.isCopy()) {
+                            rust("self.$memberName")
+                        } else if (memberType is RustType.Option && memberType.member.isDeref()) {
+                            rust("self.$memberName.as_deref()")
+                        } else if (memberType is RustType.Option) {
+                            rust("self.$memberName.as_ref()")
+                        } else if (memberType.isDeref()) {
+                            rust("self.$memberName.deref()")
+                        } else {
+                            rust("&self.$memberName")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private fun renderStructure() {
         val symbol = symbolProvider.toSymbol(shape)
         val containerMeta = symbol.expectRustMetadata()
@@ -121,20 +161,31 @@ class StructureGenerator(
         containerMeta.copy(derives = withoutDebug).render(writer)
 
         writer.rustBlock("struct $name ${lifetimeDeclaration()}") {
-            members.forEach { member ->
-                val memberName = symbolProvider.toMemberName(member)
-                val memberSymbol = symbolProvider.toSymbol(member)
-                writer.documentShape(
-                    member,
-                    model,
-                    note = memberSymbol.renamedFrom()
-                        ?.let { oldName -> "This member has been renamed from `$oldName`." }
-                )
+            forEachMember { member, memberName, memberSymbol ->
+                renderMemberDoc(member, memberSymbol)
                 memberSymbol.expectRustMetadata().render(this)
                 write("$memberName: #T,", symbolProvider.toSymbol(member))
             }
         }
 
+        renderStructureImpl()
         renderDebugImpl()
+    }
+
+    private fun RustWriter.forEachMember(block: RustWriter.(MemberShape, String, Symbol) -> Unit) {
+        members.forEach { member ->
+            val memberName = symbolProvider.toMemberName(member)
+            val memberSymbol = symbolProvider.toSymbol(member)
+            block(member, memberName, memberSymbol)
+        }
+    }
+
+    private fun RustWriter.renderMemberDoc(member: MemberShape, memberSymbol: Symbol) {
+        documentShape(
+            member,
+            model,
+            note = memberSymbol.renamedFrom()
+                ?.let { oldName -> "This member has been renamed from `$oldName`." }
+        )
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/StructureGenerator.kt
@@ -131,24 +131,18 @@ class StructureGenerator(
                 if (errorTrait == null || memberName != "message") {
                     renderMemberDoc(member, memberSymbol)
                     val memberType = memberSymbol.rustType()
-                    val returnType = if (memberType.isCopy()) {
-                        memberType
-                    } else if (memberType is RustType.Option && memberType.member.isDeref()) {
-                        memberType.asDeref()
-                    } else {
-                        memberType.asRef()
+                    val returnType = when {
+                        memberType.isCopy() -> memberType
+                        memberType is RustType.Option && memberType.member.isDeref() -> memberType.asDeref()
+                        else -> memberType.asRef()
                     }
                     rustBlock("pub fn $memberName(&self) -> ${returnType.render()}") {
-                        if (memberType.isCopy()) {
-                            rust("self.$memberName")
-                        } else if (memberType is RustType.Option && memberType.member.isDeref()) {
-                            rust("self.$memberName.as_deref()")
-                        } else if (memberType is RustType.Option) {
-                            rust("self.$memberName.as_ref()")
-                        } else if (memberType.isDeref()) {
-                            rust("self.$memberName.deref()")
-                        } else {
-                            rust("&self.$memberName")
+                        when {
+                            memberType.isCopy() -> rust("self.$memberName")
+                            memberType is RustType.Option && memberType.member.isDeref() -> rust("self.$memberName.as_deref()")
+                            memberType is RustType.Option -> rust("self.$memberName.as_ref()")
+                            memberType.isDeref() -> rust("self.$memberName.deref()")
+                            else -> rust("&self.$memberName")
                         }
                     }
                 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -244,6 +244,9 @@ class StructureGeneratorTest {
             )
         val provider = testSymbolProvider(testModel)
         val project = TestWorkspace.testProject(provider)
+        println("file:///" + project.baseDir + "/src/lib.rs")
+        println("file:///" + project.baseDir + "/src/model.rs")
+
         project.useShapeWriter(inner) { writer ->
             writer.withModule("model") {
                 StructureGenerator(testModel, provider, writer, testModel.lookup("test#One")).render()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -232,6 +232,9 @@ class StructureGeneratorTest {
                     fieldDouble: Double,
                     fieldPrimitiveDouble: PrimitiveDouble,
                     two: Two,
+                    build: Integer,
+                    builder: Integer,
+                    default: Integer,
                 }
 
                 structure Two {
@@ -269,6 +272,9 @@ class StructureGeneratorTest {
                     let _: Option<f64> = one.field_double();
                     let _: f64 = one.field_primitive_double();
                     let _: Option<&crate::model::Two> = one.two();
+                    let _: Option<i32> = one.build_value();
+                    let _: Option<i32> = one.builder_value();
+                    let _: Option<i32> = one.default_value();
                     """
                 )
             }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -13,8 +13,10 @@ import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.raw
+import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.generators.StructureGenerator
+import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.testutil.compileAndTest
@@ -24,7 +26,8 @@ import software.amazon.smithy.rust.codegen.util.lookup
 
 class StructureGeneratorTest {
     companion object {
-        val model = """
+        val model =
+            """
             namespace com.test
             @documentation("this documents the shape")
             structure MyStruct {
@@ -34,7 +37,7 @@ class StructureGeneratorTest {
                baz: Integer,
                ts: Timestamp,
                inner: Inner,
-               byteValue: Byte
+               byteValue: Byte,
             }
 
             // Intentionally empty
@@ -62,7 +65,7 @@ class StructureGeneratorTest {
             structure StructWithDoc {
                 doc: Document
             }
-        """.asSmithyModel()
+            """.asSmithyModel()
         val struct = model.lookup<StructureShape>("com.test#MyStruct")
         val structWithDoc = model.lookup<StructureShape>("com.test#StructWithDoc")
         val inner = model.lookup<StructureShape>("com.test#Inner")
@@ -200,5 +203,83 @@ class StructureGeneratorTest {
             };
             """
         )
+    }
+
+    @Test
+    fun `it generates accessor methods`() {
+        val testModel =
+            RecursiveShapeBoxer.transform(
+                """
+                namespace test
+
+                structure One {
+                    fieldString: String,
+                    fieldBlob: Blob,
+                    fieldTimestamp: Timestamp,
+                    fieldDocument: Document,
+                    fieldBoolean: Boolean,
+                    fieldPrimitiveBoolean: PrimitiveBoolean,
+                    fieldByte: Byte,
+                    fieldPrimitiveByte: PrimitiveByte,
+                    fieldShort: Short,
+                    fieldPrimitiveShort: PrimitiveShort,
+                    fieldInteger: Integer,
+                    fieldPrimitiveInteger: PrimitiveInteger,
+                    fieldLong: Long,
+                    fieldPrimitiveLong: PrimitiveLong,
+                    fieldFloat: Float,
+                    fieldPrimitiveFloat: PrimitiveFloat,
+                    fieldDouble: Double,
+                    fieldPrimitiveDouble: PrimitiveDouble,
+                    two: Two,
+                }
+
+                structure Two {
+                    one: One,
+                }
+                """.asSmithyModel()
+            )
+        val provider = testSymbolProvider(testModel)
+        val project = TestWorkspace.testProject(provider)
+        project.useShapeWriter(inner) { writer ->
+            writer.withModule("model") {
+                StructureGenerator(testModel, provider, writer, testModel.lookup("test#One")).render()
+                StructureGenerator(testModel, provider, writer, testModel.lookup("test#Two")).render()
+            }
+
+            writer.rustBlock("fn compile_test_one(one: &crate::model::One)") {
+                rust(
+                    """
+                    let _: Option<&str> = one.field_string();
+                    let _: Option<&aws_smithy_types::Blob> = one.field_blob();
+                    let _: Option<&aws_smithy_types::instant::Instant> = one.field_timestamp();
+                    let _: Option<&aws_smithy_types::Document> = one.field_document();
+                    let _: Option<bool> = one.field_boolean();
+                    let _: bool = one.field_primitive_boolean();
+                    let _: Option<i8> = one.field_byte();
+                    let _: i8 = one.field_primitive_byte();
+                    let _: Option<i16> = one.field_short();
+                    let _: i16 = one.field_primitive_short();
+                    let _: Option<i32> = one.field_integer();
+                    let _: i32 = one.field_primitive_integer();
+                    let _: Option<i64> = one.field_long();
+                    let _: i64 = one.field_primitive_long();
+                    let _: Option<f32> = one.field_float();
+                    let _: f32 = one.field_primitive_float();
+                    let _: Option<f64> = one.field_double();
+                    let _: f64 = one.field_primitive_double();
+                    let _: Option<&crate::model::Two> = one.two();
+                    """
+                )
+            }
+            writer.rustBlock("fn compile_test_two(two: &crate::model::Two)") {
+                rust(
+                    """
+                    let _: Option<&crate::model::One> = two.one();
+                    """
+                )
+            }
+        }
+        project.compileAndTest()
     }
 }


### PR DESCRIPTION
## Motivation and Context
By having accessors rather than direct access to struct members, we will have a lot more flexibility with how data is stored in the structs.

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
