### PR TITLE
Split SDK examples into a top-level directory

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
+- Moved examples into repository root (aws-sdk-rust#181, smithy-rs#843)
 
 v0.0.23-alpha (November 3rd, 2021)
 ==================================

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -32,22 +32,22 @@ dns = ["tokio/rt"]
 default = ["default-provider", "rustls", "rt-tokio", "dns", "tcp-connector"]
 
 [dependencies]
-aws-sdk-sts = { path = "../../sdk/build/aws-sdk/sts", optional = true }
-aws-smithy-async = { path = "../../sdk/build/aws-sdk/aws-smithy-async" }
-aws-smithy-client = { path = "../../sdk/build/aws-sdk/aws-smithy-client" }
-aws-smithy-types = { path = "../../sdk/build/aws-sdk/aws-smithy-types" }
-aws-types = { path = "../../sdk/build/aws-sdk/aws-types" }
+aws-sdk-sts = { path = "../../sdk/build/aws-sdk/sdk/sts", optional = true }
+aws-smithy-async = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-async" }
+aws-smithy-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-client" }
+aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
+aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["sync"], optional = true }
 tracing = { version = "0.1" }
 
 # TODO: remove when middleware stacks are moved inside of clients directly
-aws-hyper = { path = "../../sdk/build/aws-sdk/aws-hyper", optional = true }
+aws-hyper = { path = "../../sdk/build/aws-sdk/sdk/aws-hyper", optional = true }
 
 # imds
-aws-http = { path = "../../sdk/build/aws-sdk/aws-http", optional = true }
-aws-smithy-http = { path = "../../sdk/build/aws-sdk/aws-smithy-http", optional = true }
-aws-smithy-http-tower = { path = "../../sdk/build/aws-sdk/aws-smithy-http-tower", optional = true }
-aws-smithy-json = { path = "../../sdk/build/aws-sdk/aws-smithy-json", optional = true }
+aws-http = { path = "../../sdk/build/aws-sdk/sdk/aws-http", optional = true }
+aws-smithy-http = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http", optional = true }
+aws-smithy-http-tower = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http-tower", optional = true }
+aws-smithy-json = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-json", optional = true }
 bytes = "1.1.0"
 http = "0.2.4"
 tower = { version = "0.4.8", optional = true }
@@ -68,4 +68,4 @@ arbitrary = "1.0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
-aws-smithy-client = { path = "../../sdk/build/aws-sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -21,7 +21,10 @@ plugins {
 
 val smithyVersion: String by project
 
-val sdkOutputDir = buildDir.resolve("aws-sdk")
+val outputDir = buildDir.resolve("aws-sdk")
+val sdkOutputDir = outputDir.resolve("sdk")
+val examplesOutputDir = outputDir.resolve("examples")
+
 val runtimeModules = listOf(
     "aws-smithy-async",
     "aws-smithy-client",
@@ -290,13 +293,13 @@ task("relocateExamples") {
         copy {
             from(projectDir)
             include("examples/**")
-            into(sdkOutputDir)
+            into(outputDir)
             exclude("**/target")
-            filter { line -> line.replace("build/aws-sdk/", "") }
+            filter { line -> line.replace("build/aws-sdk/", "sdk/") }
         }
     }
     inputs.dir(projectDir.resolve("examples"))
-    outputs.dir(sdkOutputDir)
+    outputs.dir(outputDir)
 }
 
 /**
@@ -329,9 +332,9 @@ fun rewriteSmithyRsCrateVersion(line: String): String =
     rewriteCrateVersion(line, getProperty("smithy.rs.runtime.crate.version")!!)
 
 /** Patches a file with the result of the given `operation` being run on each line */
-fun patchFile(path: String, operation: (String) -> String) {
-    val patchedContents = File(path).readLines().joinToString("\n", transform = operation)
-    File(path).writeText(patchedContents)
+fun patchFile(path: File, operation: (String) -> String) {
+    val patchedContents = path.readLines().joinToString("\n", transform = operation)
+    path.writeText(patchedContents)
 }
 
 tasks.register<Copy>("copyAllRuntimes") {
@@ -352,7 +355,7 @@ tasks.register("relocateAwsRuntime") {
     doLast {
         // Patch the Cargo.toml files
         awsModules.forEach { moduleName ->
-            patchFile("$sdkOutputDir/$moduleName/Cargo.toml") { line ->
+            patchFile(sdkOutputDir.resolve("$moduleName/Cargo.toml")) { line ->
                 line.let(::rewritePathDependency)
                     .let(::rewriteAwsSdkCrateVersion)
             }
@@ -364,7 +367,7 @@ tasks.register("relocateRuntime") {
     doLast {
         // Patch the Cargo.toml files
         runtimeModules.forEach { moduleName ->
-            patchFile("$sdkOutputDir/$moduleName/Cargo.toml") { line ->
+            patchFile(sdkOutputDir.resolve("$moduleName/Cargo.toml")) { line ->
                 line.let(::rewriteSmithyRsCrateVersion)
             }
         }
@@ -378,23 +381,27 @@ fun generateCargoWorkspace(services: List<AwsService>): String {
         .filter { generatedModules.contains(it.name) }
         .map { "examples/${it.name}" }
 
-    val modules = services.map(AwsService::module) + runtimeModules + awsModules + examples.toList()
+    val modules = (
+        services.map(AwsService::module).map { "sdk/$it" } +
+        runtimeModules.map { "sdk/$it" } +
+        awsModules.map { "sdk/$it" } +
+        examples.toList()
+    ).sorted()
     return """
-    [workspace]
-    members = [
-        ${modules.joinToString(",") { "\"$it\"" }}
-    ]
-    """.trimIndent()
+    |[workspace]
+    |members = [${"\n"}${modules.joinToString(",\n") { "|    \"$it\"" }}
+    |]
+    """.trimMargin()
 }
 task("generateCargoWorkspace") {
     description = "generate Cargo.toml workspace file"
     doFirst {
-        sdkOutputDir.mkdirs()
-        sdkOutputDir.resolve("Cargo.toml").writeText(generateCargoWorkspace(awsServices))
+        outputDir.mkdirs()
+        outputDir.resolve("Cargo.toml").writeText(generateCargoWorkspace(awsServices))
     }
     inputs.property("servicelist", awsServices.sortedBy { it.module }.toString())
     inputs.dir(projectDir.resolve("examples"))
-    outputs.file(sdkOutputDir.resolve("Cargo.toml"))
+    outputs.file(outputDir.resolve("Cargo.toml"))
     outputs.upToDateWhen { false }
 }
 
@@ -418,7 +425,7 @@ tasks["assemble"].dependsOn("smithyBuildJar")
 tasks["assemble"].finalizedBy("finalizeSdk")
 
 tasks.register<Exec>("cargoCheck") {
-    workingDir(sdkOutputDir)
+    workingDir(outputDir)
     // disallow warnings
     environment("RUSTFLAGS", "-D warnings")
     commandLine("cargo", "check", "--lib", "--tests", "--benches")
@@ -426,7 +433,7 @@ tasks.register<Exec>("cargoCheck") {
 }
 
 tasks.register<Exec>("cargoTest") {
-    workingDir(sdkOutputDir)
+    workingDir(outputDir)
     // disallow warnings
     environment("RUSTFLAGS", "-D warnings")
     commandLine("cargo", "test")
@@ -434,7 +441,7 @@ tasks.register<Exec>("cargoTest") {
 }
 
 tasks.register<Exec>("cargoDocs") {
-    workingDir(sdkOutputDir)
+    workingDir(outputDir)
     // disallow warnings
     environment("RUSTDOCFLAGS", "-D warnings")
     commandLine("cargo", "doc", "--no-deps", "--document-private-items")
@@ -442,7 +449,7 @@ tasks.register<Exec>("cargoDocs") {
 }
 
 tasks.register<Exec>("cargoClippy") {
-    workingDir(sdkOutputDir)
+    workingDir(outputDir)
     // disallow warnings
     commandLine("cargo", "clippy", "--", "-D", "warnings")
     dependsOn("assemble")
@@ -450,10 +457,10 @@ tasks.register<Exec>("cargoClippy") {
 
 tasks.register<RunExampleTask>("runExample") {
     dependsOn("assemble")
-    outputDir = sdkOutputDir
+    outputDir = outputDir
 }
 
-// TODO: validate that the example exists. Otherwise this fails with a hiden error.
+// TODO: validate that the example exists. Otherwise this fails with a hidden error.
 open class RunExampleTask @javax.inject.Inject constructor() : Exec() {
     @Option(option = "example", description = "Example to run")
     var example: String? = null

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -295,7 +295,7 @@ task("relocateExamples") {
             include("examples/**")
             into(outputDir)
             exclude("**/target")
-            filter { line -> line.replace("build/aws-sdk/", "sdk/") }
+            filter { line -> line.replace("build/aws-sdk/sdk/", "sdk/") }
         }
     }
     inputs.dir(projectDir.resolve("examples"))
@@ -308,7 +308,7 @@ task("relocateExamples") {
  */
 fun rewritePathDependency(line: String): String {
     // some runtime crates are actually dependent on the generated bindings:
-    return line.replace("../sdk/build/aws-sdk/", "")
+    return line.replace("../sdk/build/aws-sdk/sdk/", "")
         // others use relative dependencies::
         .replace("../../rust-runtime/", "")
 }

--- a/aws/sdk/examples/apigateway/Cargo.toml
+++ b/aws/sdk/examples/apigateway/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-apigateway = { path = "../../build/aws-sdk/apigateway", package = "aws-sdk-apigateway" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-apigateway = { path = "../../build/aws-sdk/sdk/apigateway" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/applicationautoscaling/Cargo.toml
+++ b/aws/sdk/examples/applicationautoscaling/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-applicationautoscaling = { package = "aws-sdk-applicationautoscaling", path = "../../build/aws-sdk/applicationautoscaling" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-applicationautoscaling = { path = "../../build/aws-sdk/sdk/applicationautoscaling" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/autoscaling/Cargo.toml
+++ b/aws/sdk/examples/autoscaling/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-autoscaling = { path = "../../build/aws-sdk/autoscaling", package = "aws-sdk-autoscaling" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-autoscaling = { path = "../../build/aws-sdk/sdk/autoscaling" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/autoscalingplans/Cargo.toml
+++ b/aws/sdk/examples/autoscalingplans/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-autoscalingplans = { package = "aws-sdk-autoscalingplans", path = "../../build/aws-sdk/autoscalingplans" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+autoscalingplans = { package = "aws-sdk-autoscalingplans", path = "../../build/aws-sdk/sdk/autoscalingplans" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/batch/Cargo.toml
+++ b/aws/sdk/examples/batch/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-batch = { package = "aws-sdk-batch", path = "../../build/aws-sdk/batch" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+batch = { package = "aws-sdk-batch", path = "../../build/aws-sdk/sdk/batch" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/cloudformation/Cargo.toml
+++ b/aws/sdk/examples/cloudformation/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-cloudformation = { package = "aws-sdk-cloudformation", path = "../../build/aws-sdk/cloudformation" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-cloudformation = { package = "aws-sdk-cloudformation", path = "../../build/aws-sdk/sdk/cloudformation" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/cloudwatch/Cargo.toml
+++ b/aws/sdk/examples/cloudwatch/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-cloudwatch = { package = "aws-sdk-cloudwatch", path = "../../build/aws-sdk/cloudwatch" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+cloudwatch = { package = "aws-sdk-cloudwatch", path = "../../build/aws-sdk/sdk/cloudwatch" }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.2", features = ["fmt"] }

--- a/aws/sdk/examples/cloudwatchlogs/Cargo.toml
+++ b/aws/sdk/examples/cloudwatchlogs/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-cloudwatchlogs = { package = "aws-sdk-cloudwatchlogs", path = "../../build/aws-sdk/cloudwatchlogs" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+cloudwatchlogs = { package = "aws-sdk-cloudwatchlogs", path = "../../build/aws-sdk/sdk/cloudwatchlogs" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }

--- a/aws/sdk/examples/cognitoidentity/Cargo.toml
+++ b/aws/sdk/examples/cognitoidentity/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-cognitoidentity = { package = "aws-sdk-cognitoidentity", path = "../../build/aws-sdk/cognitoidentity" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+cognitoidentity = { package = "aws-sdk-cognitoidentity", path = "../../build/aws-sdk/sdk/cognitoidentity" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
 structopt = { version = "0.3", default-features = false }

--- a/aws/sdk/examples/cognitoidentityprovider/Cargo.toml
+++ b/aws/sdk/examples/cognitoidentityprovider/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-cognitoidentityprovider = { package = "aws-sdk-cognitoidentityprovider", path = "../../build/aws-sdk/cognitoidentityprovider" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-cognitoidentityprovider = { package = "aws-sdk-cognitoidentityprovider", path = "../../build/aws-sdk/sdk/cognitoidentityprovider" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/cognitosync/Cargo.toml
+++ b/aws/sdk/examples/cognitosync/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-cognitosync = { package = "aws-sdk-cognitosync", path = "../../build/aws-sdk/cognitosync" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-cognitosync = { package = "aws-sdk-cognitosync", path = "../../build/aws-sdk/sdk/cognitosync" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/config/Cargo.toml
+++ b/aws/sdk/examples/config/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-config = { package = "aws-sdk-config", path = "../../build/aws-sdk/config" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-config = { package = "aws-sdk-config", path = "../../build/aws-sdk/sdk/config" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/dynamodb/Cargo.toml
+++ b/aws/sdk/examples/dynamodb/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-http = { path = "../../build/aws-sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
-aws-sdk-dynamodb = { path = "../../build/aws-sdk/dynamodb" }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
-aws-smithy-types = { path = "../../build/aws-sdk/aws-smithy-types" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 rand = "0.8.3"
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }

--- a/aws/sdk/examples/ebs/Cargo.toml
+++ b/aws/sdk/examples/ebs/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-ebs = { package = "aws-sdk-ebs", path = "../../build/aws-sdk/ebs" }
-aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-ebs = { package = "aws-sdk-ebs", path = "../../build/aws-sdk/sdk/ebs" }
+aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/sdk/ec2" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 base64 = "0.13.0"
 sha2 = "0.9.5"

--- a/aws/sdk/examples/ec2/Cargo.toml
+++ b/aws/sdk/examples/ec2/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/sdk/ec2" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/ecr/Cargo.toml
+++ b/aws/sdk/examples/ecr/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Russell Cohen <rcoh@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-ecr = { path = "../../build/aws-sdk/ecr" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-ecr = { path = "../../build/aws-sdk/sdk/ecr" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }

--- a/aws/sdk/examples/ecs/Cargo.toml
+++ b/aws/sdk/examples/ecs/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 tokio = { version = "1", features = ["full"]}
-aws-sdk-ecs = { path = "../../build/aws-sdk/ecs" }
+aws-sdk-ecs = { path = "../../build/aws-sdk/sdk/ecs" }

--- a/aws/sdk/examples/eks/Cargo.toml
+++ b/aws/sdk/examples/eks/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Russell Cohen <rcoh@amazon.com>"]
 edition = "2018"
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"]}
-aws-types = { path = "../../build/aws-sdk/aws-types" }
-aws-sdk-eks = { path = "../../build/aws-sdk/eks" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
+aws-sdk-eks = { path = "../../build/aws-sdk/sdk/eks" }

--- a/aws/sdk/examples/iam/Cargo.toml
+++ b/aws/sdk/examples/iam/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-iam = { package = "aws-sdk-iam", path = "../../build/aws-sdk/iam" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+iam = { package = "aws-sdk-iam", path = "../../build/aws-sdk/sdk/iam" }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/kinesis/Cargo.toml
+++ b/aws/sdk/examples/kinesis/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-kinesis = { package = "aws-sdk-kinesis", path = "../../build/aws-sdk/kinesis" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+kinesis = { package = "aws-sdk-kinesis", path = "../../build/aws-sdk/sdk/kinesis" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/kms/Cargo.toml
+++ b/aws/sdk/examples/kms/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 description = "Example usage of the KMS service"
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-kms = { package = "aws-sdk-kms", path = "../../build/aws-sdk/kms" }
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+kms = { package = "aws-sdk-kms", path = "../../build/aws-sdk/sdk/kms" }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 base64 = "0.13.0"

--- a/aws/sdk/examples/lambda/Cargo.toml
+++ b/aws/sdk/examples/lambda/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/ec2" }
-lambda = { package = "aws-sdk-lambda", path = "../../build/aws-sdk/lambda" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/sdk/ec2" }
+lambda = { package = "aws-sdk-lambda", path = "../../build/aws-sdk/sdk/lambda" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/medialive/Cargo.toml
+++ b/aws/sdk/examples/medialive/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-medialive = { package = "aws-sdk-medialive", path = "../../build/aws-sdk/medialive" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+medialive = { package = "aws-sdk-medialive", path = "../../build/aws-sdk/sdk/medialive" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/mediapackage/Cargo.toml
+++ b/aws/sdk/examples/mediapackage/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-mediapackage = { package = "aws-sdk-mediapackage", path = "../../build/aws-sdk/mediapackage" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+mediapackage = { package = "aws-sdk-mediapackage", path = "../../build/aws-sdk/sdk/mediapackage" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/polly/Cargo.toml
+++ b/aws/sdk/examples/polly/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-polly = { package = "aws-sdk-polly", path = "../../build/aws-sdk/polly" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+polly = { package = "aws-sdk-polly", path = "../../build/aws-sdk/sdk/polly" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/qldb/Cargo.toml
+++ b/aws/sdk/examples/qldb/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-qldb = { package = "aws-sdk-qldb", path = "../../build/aws-sdk/qldb" }
-qldbsession = { package = "aws-sdk-qldbsession", path = "../../build/aws-sdk/qldbsession" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+qldb = { package = "aws-sdk-qldb", path = "../../build/aws-sdk/sdk/qldb" }
+qldbsession = { package = "aws-sdk-qldbsession", path = "../../build/aws-sdk/sdk/qldbsession" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/rds/Cargo.toml
+++ b/aws/sdk/examples/rds/Cargo.toml
@@ -7,9 +7,9 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-rds = {package = "aws-sdk-rds", path = "../../build/aws-sdk/rds"}
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+rds = {package = "aws-sdk-rds", path = "../../build/aws-sdk/sdk/rds"}
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = {version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/rdsdata/Cargo.toml
+++ b/aws/sdk/examples/rdsdata/Cargo.toml
@@ -7,9 +7,9 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-rdsdata = {package = "aws-sdk-rdsdata", path = "../../build/aws-sdk/rdsdata"}
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+rdsdata = {package = "aws-sdk-rdsdata", path = "../../build/aws-sdk/sdk/rdsdata"}
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = {version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/route53/Cargo.toml
+++ b/aws/sdk/examples/route53/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-route53 = { package = "aws-sdk-route53", path = "../../build/aws-sdk/route53" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+route53 = { package = "aws-sdk-route53", path = "../../build/aws-sdk/sdk/route53" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }

--- a/aws/sdk/examples/s3/Cargo.toml
+++ b/aws/sdk/examples/s3/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/s3" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 

--- a/aws/sdk/examples/sagemaker/Cargo.toml
+++ b/aws/sdk/examples/sagemaker/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-sagemaker = {package = "aws-sdk-sagemaker", path = "../../build/aws-sdk/sagemaker"}
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+sagemaker = {package = "aws-sdk-sagemaker", path = "../../build/aws-sdk/sdk/sagemaker"}
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 

--- a/aws/sdk/examples/secretsmanager/Cargo.toml
+++ b/aws/sdk/examples/secretsmanager/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 description = "Example usage of the SecretManager service"
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-secretsmanager = { package = "aws-sdk-secretsmanager", path = "../../build/aws-sdk/secretsmanager" }
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+secretsmanager = { package = "aws-sdk-secretsmanager", path = "../../build/aws-sdk/sdk/secretsmanager" }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"]}
 

--- a/aws/sdk/examples/ses/Cargo.toml
+++ b/aws/sdk/examples/ses/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Russell Cohen <rcoh@amazon.com>", "Doug Schwartz <dougsch@amazon.com
 edition = "2018"
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-ses = { package = "aws-sdk-sesv2", path = "../../build/aws-sdk/sesv2" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+ses = { package = "aws-sdk-sesv2", path = "../../build/aws-sdk/sdk/sesv2" }
 
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 

--- a/aws/sdk/examples/snowball/Cargo.toml
+++ b/aws/sdk/examples/snowball/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-snowball = { path = "../../build/aws-sdk/snowball" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-snowball = { path = "../../build/aws-sdk/sdk/snowball" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/sns/Cargo.toml
+++ b/aws/sdk/examples/sns/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-sns = { package = "aws-sdk-sns", path = "../../build/aws-sdk/sns" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-sns = { package = "aws-sdk-sns", path = "../../build/aws-sdk/sdk/sns" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/sqs/Cargo.toml
+++ b/aws/sdk/examples/sqs/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-sqs = { package = "aws-sdk-sqs", path = "../../build/aws-sdk/sqs" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+sqs = { package = "aws-sdk-sqs", path = "../../build/aws-sdk/sdk/sqs" }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/ssm/Cargo.toml
+++ b/aws/sdk/examples/ssm/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-ssm = { package = "aws-sdk-ssm", path = "../../build/aws-sdk/ssm" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+ssm = { package = "aws-sdk-ssm", path = "../../build/aws-sdk/sdk/ssm" }
 tokio = { version = "1", features = ["full"] }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 structopt = { version = "0.3", default-features = false }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }

--- a/aws/sdk/examples/telephone-game/Cargo.toml
+++ b/aws/sdk/examples/telephone-game/Cargo.toml
@@ -8,10 +8,10 @@ description = "Play a game of telephone with AWS"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-polly = { package = "aws-sdk-polly", path = "../../build/aws-sdk/polly" }
-aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/s3" }
-aws-sdk-transcribe = { package = "aws-sdk-transcribe", path = "../../build/aws-sdk/transcribe" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-polly = { package = "aws-sdk-polly", path = "../../build/aws-sdk/sdk/polly" }
+aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3" }
+aws-sdk-transcribe = { package = "aws-sdk-transcribe", path = "../../build/aws-sdk/sdk/transcribe" }
 anyhow = "1.0.44"
 clap = "2.33.3"
 rodio = "0.14.0"

--- a/aws/sdk/examples/transcribestreaming/Cargo.toml
+++ b/aws/sdk/examples/transcribestreaming/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { path = "../../build/aws-sdk/aws-config" }
-aws-sdk-transcribestreaming = { package = "aws-sdk-transcribestreaming", path = "../../build/aws-sdk/transcribestreaming" }
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-transcribestreaming = { package = "aws-sdk-transcribestreaming", path = "../../build/aws-sdk/sdk/transcribestreaming" }
 async-stream = "0.3"
 bytes = "1"
 hound = "3.4"

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -8,13 +8,13 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-http = { path = "../../build/aws-sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper" }
-aws-sdk-dynamodb = { path = "../../build/aws-sdk/dynamodb" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
-aws-smithy-types = { path = "../../build/aws-sdk/aws-smithy-types" }
-aws-types = { path = "../../build/aws-sdk/aws-types" }
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
+aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 bytes = "1"
 criterion = { version = "0.3.4" }
 futures-util = "0.3"

--- a/aws/sdk/integration-tests/glacier/Cargo.toml
+++ b/aws/sdk/integration-tests/glacier/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-glacier = { path = "../../build/aws-sdk/glacier" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-protocol-test = { path = "../../build/aws-sdk/aws-smithy-protocol-test"}
+aws-sdk-glacier = { path = "../../build/aws-sdk/sdk/glacier" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol-test"}
 tracing-subscriber = "0.2.18"
 
 [dev-dependencies]
 tokio  = { version = "1", features = ["full"]}
 http = "0.2.3"
 bytes = "1"
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
-aws-http = { path = "../../build/aws-sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-endpoint = { path = "../../build/aws-sdk/aws-endpoint" }
-aws-sdk-iam = { path = "../../build/aws-sdk/iam" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
+aws-endpoint = { path = "../../build/aws-sdk/sdk/aws-endpoint" }
+aws-sdk-iam = { path = "../../build/aws-sdk/sdk/iam" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tracing-subscriber = "0.2.18"
 
 [dev-dependencies]
 tokio  = { version = "1", features = ["full"]}
 http = "0.2.3"
 bytes = "1"
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
-aws-http = { path = "../../build/aws-sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-http = { path = "../../build/aws-sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper" }
-aws-sdk-kms = { path = "../../build/aws-sdk/kms" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
-aws-smithy-types = { path = "../../build/aws-sdk/aws-smithy-types" }
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
+aws-sdk-kms = { path = "../../build/aws-sdk/sdk/kms" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full"]}

--- a/aws/sdk/integration-tests/lambda/Cargo.toml
+++ b/aws/sdk/integration-tests/lambda/Cargo.toml
@@ -6,16 +6,16 @@ edition = "2018"
 
 [dependencies]
 async-stream = "0.3"
-aws-http = { path = "../../build/aws-sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
-aws-sdk-lambda = { path = "../../build/aws-sdk/lambda" }
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-sdk-lambda = { path = "../../build/aws-sdk/sdk/lambda" }
 base64 = "0.13"
 bytes = "1"
 futures-core = "0.3"
 http = "0.2.3"
 serde_json = "1"
-smithy-client = { path = "../../build/aws-sdk/smithy-client", features = ["test-util"] }
-smithy-eventstream = { path = "../../build/aws-sdk/smithy-eventstream" }
-smithy-http = { path = "../../build/aws-sdk/smithy-http" }
+smithy-client = { path = "../../build/aws-sdk/sdk/smithy-client", features = ["test-util"] }
+smithy-eventstream = { path = "../../build/aws-sdk/sdk/smithy-eventstream" }
+smithy-http = { path = "../../build/aws-sdk/sdk/smithy-http" }
 tokio  = { version = "1", features = ["full"]}
 tracing-subscriber = "0.2.18"

--- a/aws/sdk/integration-tests/polly/Cargo.toml
+++ b/aws/sdk/integration-tests/polly/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-polly = { path = "../../build/aws-sdk/polly" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
+aws-sdk-polly = { path = "../../build/aws-sdk/sdk/polly" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tracing-subscriber = "0.2.18"
 
 [dev-dependencies]
 tokio  = { version = "1", features = ["full"]}
 http = "0.2.3"
 bytes = "1"
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
-aws-http = { path = "../../build/aws-sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}

--- a/aws/sdk/integration-tests/qldbsession/Cargo.toml
+++ b/aws/sdk/integration-tests/qldbsession/Cargo.toml
@@ -8,12 +8,12 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-http = { path = "../../build/aws-sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper" }
-aws-sdk-qldbsession = { path = "../../build/aws-sdk/qldbsession" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
-aws-smithy-types = { path = "../../build/aws-sdk/aws-smithy-types" }
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
+aws-sdk-qldbsession = { path = "../../build/aws-sdk/sdk/qldbsession" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 http = "0.2.3"
 tokio = { version = "1", features = ["full"]}
 tracing-subscriber = "0.2.16"

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -8,14 +8,14 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-s3 = { path = "../../build/aws-sdk/s3" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
+aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tracing-subscriber = "0.2.18"
 
 [dev-dependencies]
-aws-http = { path = "../../build/aws-sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
 bytes = "1"
 http = "0.2.3"
 serde_json = "1"

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-sdk-sts = { path = "../../build/aws-sdk/sts" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
+aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tracing-subscriber = "0.2"
 
 [dev-dependencies]
 tokio  = { version = "1", features = ["full"]}
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}

--- a/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
+++ b/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 
 [dependencies]
 async-stream = "0.3"
-aws-http = { path = "../../build/aws-sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/aws-hyper"}
-aws-sdk-transcribestreaming = { path = "../../build/aws-sdk/transcribestreaming" }
-aws-smithy-client = { path = "../../build/aws-sdk/aws-smithy-client", features = ["test-util"] }
-aws-smithy-eventstream = { path = "../../build/aws-sdk/aws-smithy-eventstream" }
-aws-smithy-http = { path = "../../build/aws-sdk/aws-smithy-http" }
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-sdk-transcribestreaming = { path = "../../build/aws-sdk/sdk/transcribestreaming" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-eventstream = { path = "../../build/aws-sdk/sdk/aws-smithy-eventstream" }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 bytes = "1"
 futures-core = "0.3"
 hound = "3.4"


### PR DESCRIPTION
## Motivation and Context
This was requested in https://github.com/awslabs/aws-sdk-rust/issues/181 and will make our examples more discoverable.

## Testing
- Manually inspected the build output after running `./gradlew aws:sdk:assemble`
- Ran `./gradlew aws:sdk:cargoTest`

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
