### PR TITLE
Update MSRV to 1.54.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 name: CI
 
 env:
-  rust_version: 1.53.0
+  rust_version: 1.54.0
   rust_toolchain_components: clippy,rustfmt
   java_version: 11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ vNext (Month Day, Year)
 
 **New this week**
 
+- Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
 - Generated structs now have accessor methods for their members (smithy-rs#842)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 vNext (Month Day, Year)
 =======================
+- Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
 
 v0.27.0-alpha.2 (November 9th, 2021)
 =======================
@@ -9,7 +10,6 @@ v0.27.0-alpha.2 (November 9th, 2021)
 
 **New this week**
 
-- Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
 - Generated structs now have accessor methods for their members (smithy-rs#842)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ pre-commit install
      * `./gradlew :aws:sdk:assemble`: Generate (but do not test / compile etc.) a fresh SDK into `sdk/build/aws-sdk`
      * `./gradlew :aws:sdk:test`: Generate & run all tests for a fresh SDK
      * `./gradlew :aws:sdk:{cargoCheck, cargoTest, cargoDocs, cargoClippy}`: Generate & run specified cargo command.
-* `codegen`: Whitelabel Smithy code generation
-* `codegen-test`: Smithy protocol test generation & integration tests for Smithy whitelabel code
+* `codegen`: Whitelabel Smithy client code generation
+* `codegen-test`: Smithy protocol test generation & integration tests for Smithy client whitelabel code
 * [`design`](design): Design documentation. See the [design/README.md](design/README.md) for details about building / viewing.
+* `codegen-server`: Whitelabel Smithy server code generation
+* `codegen-server-test`: Smithy protocol test generation & integration tests for Smithy server whitelabel code

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -7,6 +7,7 @@ vNext (Month Day, Year)
 
 **New this week**
 
+- Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
 - Model structs now have accessor methods for their members (smithy-rs#842)

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -434,13 +434,13 @@ async fn build_provider_chain(
     factory: &NamedProviderFactory,
     profile_override: Option<&str>,
 ) -> Result<ProviderChain, ProfileFileError> {
-    let profile_set = super::parser::load(&fs, &env).await.map_err(|err| {
+    let profile_set = super::parser::load(fs, env).await.map_err(|err| {
         tracing::warn!(err = %err, "failed to parse profile");
         ProfileFileError::CouldNotParseProfile(err)
     })?;
     let repr = repr::resolve_chain(&profile_set, profile_override)?;
     tracing::info!(chain = ?repr, "constructed abstract provider from config file");
-    exec::ProviderChain::from_repr(fs.clone(), connector, region.region().await, repr, &factory)
+    exec::ProviderChain::from_repr(fs.clone(), connector, region.region().await, repr, factory)
 }
 
 #[cfg(test)]

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -79,7 +79,7 @@ impl ProviderChain {
     }
 
     pub fn chain(&self) -> &[AssumeRoleProvider] {
-        &self.chain.as_slice()
+        self.chain.as_slice()
     }
 }
 

--- a/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
@@ -35,7 +35,7 @@ impl<'a> ProfileChain<'a> {
     }
 
     pub fn chain(&self) -> &[RoleArn<'a>] {
-        &self.chain.as_slice()
+        self.chain.as_slice()
     }
 }
 
@@ -133,15 +133,15 @@ pub fn resolve_chain<'a>(
                 next: source_profile_name.to_string(),
             });
         }
-        visited_profiles.push(&source_profile_name);
+        visited_profiles.push(source_profile_name);
         // After the first item in the chain, we will prioritize static credentials if they exist
         if visited_profiles.len() > 1 {
-            let try_static = static_creds_from_profile(&profile);
+            let try_static = static_creds_from_profile(profile);
             if let Ok(static_credentials) = try_static {
                 break BaseProvider::AccessKey(static_credentials);
             }
         }
-        let next_profile = match chain_provider(&profile) {
+        let next_profile = match chain_provider(profile) {
             // this provider wasn't a chain provider, reload it as a base provider
             None => {
                 break base_provider(profile).map_err(|err| {
@@ -206,7 +206,7 @@ enum NextProfile<'a> {
 }
 
 fn chain_provider(profile: &Profile) -> Option<Result<(RoleArn, NextProfile), ProfileFileError>> {
-    let role_provider = role_arn_from_profile(&profile)?;
+    let role_provider = role_arn_from_profile(profile)?;
     let (source_profile, credential_source) = (
         profile.get(role::SOURCE_PROFILE),
         profile.get(role::CREDENTIAL_SOURCE),

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -67,7 +67,7 @@ pub use self::parse::ProfileParseError;
 /// aws_access_key_id = 456
 /// ```
 pub async fn load(fs: &Fs, env: &Env) -> Result<ProfileSet, ProfileParseError> {
-    let source = source::load(&env, &fs).await;
+    let source = source::load(env, fs).await;
     ProfileSet::parse(source)
 }
 
@@ -247,7 +247,7 @@ mod test {
             profile: "default".into(),
         };
         let profile_set = ProfileSet::parse(source).expect("empty profiles are valid");
-        assert_eq!(profile_set.is_empty(), true);
+        assert!(profile_set.is_empty());
     }
 
     /// Run all tests from the fuzzing corpus to validate coverage

--- a/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
@@ -112,7 +112,7 @@ pub fn merge_in(base: &mut ProfileSet, raw_profile_set: RawProfileSet, kind: Fil
 
 fn merge_into_base<'a>(target: &mut Profile, profile: HashMap<&str, Cow<'a, str>>) {
     for (k, v) in profile {
-        match validate_identifier(&k) {
+        match validate_identifier(k) {
             Ok(k) => {
                 target
                     .properties

--- a/aws/rust-runtime/aws-config/src/profile/parser/parse.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/parse.rs
@@ -280,7 +280,7 @@ fn prepare_line(line: &str, comments_need_whitespace: bool) -> &str {
     }
     comment_idx
         .map(|idx| &line[..idx])
-        .unwrap_or(&line)
+        .unwrap_or(line)
         // trimming the comment might result in more whitespace that needs to be handled
         .trim_matches(WHITESPACE)
 }

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -53,11 +53,11 @@ impl FileKind {
 
 /// Load a [Source](Source) from a given environment and filesystem.
 pub async fn load(proc_env: &os_shim_internal::Env, fs: &os_shim_internal::Fs) -> Source {
-    let home = home_dir(&proc_env, Os::real());
-    let config = load_config_file(FileKind::Config, &home, &fs, &proc_env)
+    let home = home_dir(proc_env, Os::real());
+    let config = load_config_file(FileKind::Config, &home, fs, proc_env)
         .instrument(tracing::info_span!("load_config_file"))
         .await;
-    let credentials = load_config_file(FileKind::Credentials, &home, &fs, &proc_env)
+    let credentials = load_config_file(FileKind::Credentials, &home, fs, proc_env)
         .instrument(tracing::info_span!("load_credentials_file"))
         .await;
 

--- a/aws/rust-runtime/aws-config/src/profile/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/retry_config.rs
@@ -131,7 +131,7 @@ impl ProfileFileRetryConfigProvider {
         };
 
         let retry_mode = match selected_profile.get("retry_mode") {
-            Some(retry_mode) => match RetryMode::from_str(&retry_mode) {
+            Some(retry_mode) => match RetryMode::from_str(retry_mode) {
                 Ok(retry_mode) => Some(retry_mode),
                 Err(retry_mode_err) => {
                     return Err(RetryConfigErr::InvalidRetryMode {

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -50,7 +50,7 @@ impl Default for HttpConnector {
     fn default() -> Self {
         Self::ConnectorFn(Arc::new(
             |settings: &HttpSettings, sleep: Option<Arc<dyn AsyncSleep>>| {
-                default_connector(&settings, sleep)
+                default_connector(settings, sleep)
             },
         ))
     }
@@ -64,7 +64,7 @@ impl HttpConnector {
     ) -> Option<DynConnector> {
         match self {
             HttpConnector::Prebuilt(conn) => conn.clone(),
-            HttpConnector::ConnectorFn(func) => func(&settings, sleep),
+            HttpConnector::ConnectorFn(func) => func(settings, sleep),
             #[cfg(feature = "tcp-connector")]
             HttpConnector::TcpConnector(connection) => Some(DynConnector::new(
                 aws_smithy_client::hyper_ext::Adapter::builder()

--- a/aws/rust-runtime/aws-endpoint/src/partition/mod.rs
+++ b/aws/rust-runtime/aws-endpoint/src/partition/mod.rs
@@ -156,7 +156,7 @@ impl ResolveAwsEndpoint for Partition {
             Regionalized::Regionalized => Some(region),
         };
         let endpoint_for_region = resolved_region
-            .and_then(|region| self.endpoints.get(&region))
+            .and_then(|region| self.endpoints.get(region))
             .unwrap_or(&self.default_endpoint);
         endpoint_for_region.resolve_endpoint(region)
     }

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -125,7 +125,7 @@ impl MapRequest for SigV4SigningStage {
 
             let signature = self
                 .signer
-                .sign(&operation_config, &request_config, &creds, &mut req)
+                .sign(operation_config, &request_config, &creds, &mut req)
                 .map_err(|err| SigningStageError::SigningFailure(err))?;
             config.insert(signature);
             Ok(req)

--- a/aws/rust-runtime/aws-sigv4/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sigv4/src/event_stream.rs
@@ -56,7 +56,7 @@ fn calculate_string_to_sign(
 ) -> Vec<u8> {
     // Event Stream string to sign format is documented here:
     // https://docs.aws.amazon.com/transcribe/latest/dg/how-streaming.html
-    let date_time_str = format_date_time(&date_time);
+    let date_time_str = format_date_time(date_time);
     let date_str = format_date(&date_time.date());
 
     let mut sts: Vec<u8> = Vec::new();

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -82,7 +82,7 @@ impl<'a> SignatureValues<'a> {
 
     pub(super) fn as_headers(&self) -> Option<&HeaderValues<'_>> {
         match self {
-            SignatureValues::Headers(values) => Some(&values),
+            SignatureValues::Headers(values) => Some(values),
             _ => None,
         }
     }
@@ -194,14 +194,14 @@ impl<'a> CanonicalRequest<'a> {
             // Using append instead of insert means this will not clobber headers that have the same lowercased name
             canonical_headers.append(
                 HeaderName::from_str(&name.as_str().to_lowercase())?,
-                normalize_header_value(&value),
+                normalize_header_value(value),
             );
         }
 
         Self::insert_host_header(&mut canonical_headers, req.uri());
 
         if params.settings.signature_location == SignatureLocation::Headers {
-            Self::insert_date_header(&mut canonical_headers, &date_time);
+            Self::insert_date_header(&mut canonical_headers, date_time);
 
             if let Some(security_token) = params.security_token {
                 let mut sec_header = HeaderValue::from_str(security_token)?;
@@ -210,7 +210,7 @@ impl<'a> CanonicalRequest<'a> {
             }
 
             if params.settings.payload_checksum_kind == PayloadChecksumKind::XAmzSha256 {
-                let header = HeaderValue::from_str(&payload_hash)?;
+                let header = HeaderValue::from_str(payload_hash)?;
                 canonical_headers.insert(header::X_AMZ_CONTENT_SHA_256, header);
             }
         }
@@ -454,7 +454,7 @@ impl PartialOrd for CanonicalHeaderName {
 
 impl Ord for CanonicalHeaderName {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.as_str().cmp(&other.0.as_str())
+        self.0.as_str().cmp(other.0.as_str())
     }
 }
 
@@ -508,7 +508,7 @@ impl<'a> TryFrom<&'a str> for StringToSign<'a> {
     type Error = Error;
     fn try_from(s: &'a str) -> Result<Self, Self::Error> {
         let lines = s.lines().collect::<Vec<&str>>();
-        let date = parse_date_time(&lines[1])?;
+        let date = parse_date_time(lines[1])?;
         let scope: SigningScope<'_> = TryFrom::try_from(lines[2])?;
         let hashed_creq = &lines[3];
 

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -184,17 +184,17 @@ fn calculate_signing_params<'a>(
     let encoded_creq = &sha256_hex_string(creq.to_string().as_bytes());
     let sts = StringToSign::new(
         params.date_time,
-        &params.region,
-        &params.service_name,
+        params.region,
+        params.service_name,
         encoded_creq,
     );
     let signing_key = generate_signing_key(
-        &params.secret_key,
+        params.secret_key,
         params.date_time.date(),
-        &params.region,
-        &params.service_name,
+        params.region,
+        params.service_name,
     );
-    let signature = calculate_signature(signing_key, &sts.to_string().as_bytes());
+    let signature = calculate_signature(signing_key, sts.to_string().as_bytes());
 
     let values = creq.values.into_query_params().expect("signing with query");
     let mut signing_params = vec![
@@ -247,7 +247,7 @@ fn calculate_signing_headers<'a>(
         params.region,
         params.service_name,
     );
-    let signature = calculate_signature(signing_key, &sts.to_string().as_bytes());
+    let signature = calculate_signature(signing_key, sts.to_string().as_bytes());
 
     // Step 4: https://docs.aws.amazon.com/en_pv/general/latest/gr/sigv4-add-signature-to-request.html
     let values = creq.values.as_headers().expect("signing with headers");

--- a/aws/rust-runtime/aws-sigv4/src/http_request/url_escape.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/url_escape.rs
@@ -33,5 +33,5 @@ const BASE_SET: &AsciiSet = &CONTROLS
     .add(b'%');
 
 pub(super) fn percent_encode(value: &str) -> String {
-    percent_encoding::percent_encode(&value.as_bytes(), BASE_SET).to_string()
+    percent_encoding::percent_encode(value.as_bytes(), BASE_SET).to_string()
 }

--- a/aws/rust-runtime/aws-sigv4/src/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/sign.rs
@@ -40,7 +40,7 @@ pub fn generate_signing_key(
     // kSigning = HMAC(kService, "aws4_request")
 
     let secret = format!("AWS4{}", secret);
-    let secret = hmac::Key::new(hmac::HMAC_SHA256, &secret.as_bytes());
+    let secret = hmac::Key::new(hmac::HMAC_SHA256, secret.as_bytes());
     let tag = hmac::sign(&secret, format_date(&date).as_bytes());
 
     // sign region

--- a/aws/sdk/examples/dynamodb/src/bin/crud.rs
+++ b/aws/sdk/examples/dynamodb/src/bin/crud.rs
@@ -371,7 +371,7 @@ async fn wait_for_ready_table(
         .table_name(table_name)
         .build()
         .expect("valid input")
-        .make_operation(&conf)
+        .make_operation(conf)
         .await
         .expect("valid operation");
     let waiting_policy = WaitForReadyTable {

--- a/aws/sdk/examples/dynamodb/src/bin/movies.rs
+++ b/aws/sdk/examples/dynamodb/src/bin/movies.rs
@@ -263,7 +263,7 @@ async fn wait_for_ready_table(
         .table_name(table_name)
         .build()
         .expect("valid input")
-        .make_operation(&conf)
+        .make_operation(conf)
         .await
         .expect("valid operation");
     let waiting_policy = WaitForReadyTable {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -91,7 +91,7 @@ class UnionGenerator(
                 rust("/// Tries to convert the enum instance into [`$variantName`](#T::$variantName), extracting the inner #D.", unionSymbol, memberSymbol)
                 rust("/// Returns `Err(&Self)` if it can't be converted.")
                 rustBlock("pub fn as_$funcNamePart(&self) -> std::result::Result<&#T, &Self>", memberSymbol) {
-                    rust("if let ${unionSymbol.name}::$variantName(val) = &self { Ok(&val) } else { Err(&self) }")
+                    rust("if let ${unionSymbol.name}::$variantName(val) = &self { Ok(val) } else { Err(self) }")
                 }
                 rust("/// Returns true if this is a [`$variantName`](#T::$variantName).", unionSymbol)
                 rustBlock("pub fn is_$funcNamePart(&self) -> bool") {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RequestBindingGenerator.kt
@@ -365,7 +365,7 @@ class RequestBindingGenerator(
                     listForEach(outerTarget, field) { innerField, targetId ->
                         val target = model.expectShape(targetId)
                         rust(
-                            "query.push_kv(${param.locationName.dq()}, &${
+                            "query.push_kv(${param.locationName.dq()}, ${
                             paramFmtFun(writer, target, memberShape, innerField)
                             });"
                         )
@@ -383,14 +383,14 @@ class RequestBindingGenerator(
         return when {
             target.isStringShape -> {
                 val func = writer.format(RuntimeType.QueryFormat(runtimeConfig, "fmt_string"))
-                "$func(&$targetName)"
+                "&$func(&$targetName)"
             }
             target.isTimestampShape -> {
                 val timestampFormat =
                     index.determineTimestampFormat(member, HttpBinding.Location.QUERY, defaultTimestampFormat)
                 val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, timestampFormat)
                 val func = writer.format(RuntimeType.QueryFormat(runtimeConfig, "fmt_timestamp"))
-                "$func($targetName, ${writer.format(timestampFormatType)})"
+                "&$func($targetName, ${writer.format(timestampFormatType)})"
             }
             target.isListShape || target.isMemberShape -> {
                 throw IllegalArgumentException("lists should be handled at a higher level")
@@ -426,7 +426,7 @@ class RequestBindingGenerator(
                     index.determineTimestampFormat(member, HttpBinding.Location.LABEL, defaultTimestampFormat)
                 val timestampFormatType = RuntimeType.TimestampFormat(runtimeConfig, timestampFormat)
                 val func = format(RuntimeType.LabelFormat(runtimeConfig, "fmt_timestamp"))
-                rust("let $outputVar = $func(&$input, ${format(timestampFormatType)});")
+                rust("let $outputVar = $func($input, ${format(timestampFormatType)});")
             }
             else -> {
                 rust(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -116,7 +116,7 @@ class ResponseBindingGenerator(
             ) {
                 rust(
                     """
-                    let headers = #T::headers_for_prefix(&header_map, ${binding.locationName.dq()});
+                    let headers = #T::headers_for_prefix(header_map, ${binding.locationName.dq()});
                     let out: std::result::Result<_, _> = headers.map(|(key, header_name)| {
                         let values = header_map.get_all(header_name);
                         #T(values.iter()).map(|v| (key.to_string(), v.unwrap()))
@@ -224,7 +224,7 @@ class ResponseBindingGenerator(
                 is StructureShape, is UnionShape -> this.structuredHandler("body")
                 is StringShape -> {
                     rustTemplate(
-                        "let body_str = std::str::from_utf8(&body).map_err(#{error_symbol}::unhandled)?;",
+                        "let body_str = std::str::from_utf8(body).map_err(#{error_symbol}::unhandled)?;",
                         "error_symbol" to errorSymbol
                     )
                     if (targetShape.hasTrait<EnumTrait>()) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -69,7 +69,7 @@ open class MakeOperationGenerator(
         val takesOwnership = bodyGenerator.bodyMetadata(shape).takesOwnership
         val mut = customizations.any { it.mutSelf() }
         val consumes = customizations.any { it.consumesSelf() } || takesOwnership
-        val self = "self".letIf(mut) { "mut $it" }.letIf(!consumes) { "&$it" }
+        val self = "self".letIf(mut) { "mut $it" }.letIf(!consumes) { "$it" }
         val fnType = if (public) "pub async fn" else "async fn"
 
         implBlockWriter.docs("Consumes the builder and constructs an Operation<#D>", outputSymbol)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -69,7 +69,7 @@ open class MakeOperationGenerator(
         val takesOwnership = bodyGenerator.bodyMetadata(shape).takesOwnership
         val mut = customizations.any { it.mutSelf() }
         val consumes = customizations.any { it.consumesSelf() } || takesOwnership
-        val self = "self".letIf(mut) { "mut $it" }.letIf(!consumes) { "$it" }
+        val self = "self".letIf(mut) { "mut $it" }
         val fnType = if (public) "pub async fn" else "async fn"
 
         implBlockWriter.docs("Consumes the builder and constructs an Operation<#D>", outputSymbol)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -69,11 +69,12 @@ open class MakeOperationGenerator(
         val takesOwnership = bodyGenerator.bodyMetadata(shape).takesOwnership
         val mut = customizations.any { it.mutSelf() }
         val consumes = customizations.any { it.consumesSelf() } || takesOwnership
-        val self = "self".letIf(mut) { "mut $it" }
+        val self = "self".letIf(mut) { "mut $it" }.letIf(!consumes) { "&$it" }
         val fnType = if (public) "pub async fn" else "async fn"
 
         implBlockWriter.docs("Consumes the builder and constructs an Operation<#D>", outputSymbol)
-        implBlockWriter.rust("##[allow(clippy::let_and_return)]") // For codegen simplicity, allow `let x = ...; x`
+        Attribute.Custom("allow(clippy::let_and_return)").render(implBlockWriter) // For codegen simplicity, allow `let x = ...; x`
+        Attribute.Custom("allow(clippy::needless_borrow)").render(implBlockWriter) // Allows builders that don’t consume the input borrow
         implBlockWriter.rustBlockTemplate(
             "$fnType $functionName($self, _config: &#{config}::Config) -> $returnType",
             *codegenScope

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -587,13 +587,13 @@ class HttpBoundProtocolBodyGenerator(
 
                 // JSON serialize the structure or union targeted
                 rust(
-                    "#T(&$payloadName)?",
+                    "#T($payloadName)?",
                     serializer.payloadSerializer(member)
                 )
             }
             is DocumentShape -> {
                 rust(
-                    "#T(&$payloadName)?",
+                    "#T($payloadName)?",
                     serializer.documentSerializer(),
                 )
             }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
@@ -110,7 +110,7 @@ class EventStreamUnmarshallerGenerator(
                 """,
                 *codegenScope
             ) {
-                rustTemplate("let response_headers = #{expect_fns}::parse_response_headers(&message)?;", *codegenScope)
+                rustTemplate("let response_headers = #{expect_fns}::parse_response_headers(message)?;", *codegenScope)
                 rustBlock("match response_headers.message_type.as_str()") {
                     rustBlock("\"event\" => ") {
                         renderUnmarshallEvent()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -127,7 +127,7 @@ class XmlBindingTraitSerializerGenerator(
                         """,
                         *codegenScope
                     )
-                    serializeStructure(inputShape, xmlMembers, Ctx.Element("root", "&input"))
+                    serializeStructure(inputShape, xmlMembers, Ctx.Element("root", "input"))
                 }
                 rustTemplate("Ok(#{SdkBody}::from(out))", *codegenScope)
             }
@@ -165,9 +165,9 @@ class XmlBindingTraitSerializerGenerator(
                         is StructureShape -> serializeStructure(
                             target,
                             XmlMemberIndex.fromMembers(target.members().toList()),
-                            Ctx.Element("root", "&input")
+                            Ctx.Element("root", "input")
                         )
-                        is UnionShape -> serializeUnion(target, Ctx.Element("root", "&input"))
+                        is UnionShape -> serializeUnion(target, Ctx.Element("root", "input"))
                         else -> throw IllegalStateException("xml payloadSerializer only supports structs and unions")
                     }
                 }
@@ -314,7 +314,7 @@ class XmlBindingTraitSerializerGenerator(
                 rust("Ok(())")
             }
         }
-        rust("#T(&${ctx.input}, ${ctx.elementWriter})?", structureSerializer)
+        rust("#T(${ctx.input}, ${ctx.elementWriter})?", structureSerializer)
     }
 
     private fun RustWriter.serializeUnion(unionShape: UnionShape, ctx: Ctx.Element) {
@@ -347,7 +347,7 @@ class XmlBindingTraitSerializerGenerator(
                 rust("Ok(())")
             }
         }
-        rust("#T(&${ctx.input}, ${ctx.elementWriter})?", structureSerializer)
+        rust("#T(${ctx.input}, ${ctx.elementWriter})?", structureSerializer)
     }
 
     private fun RustWriter.serializeList(listShape: CollectionShape, ctx: Ctx.Scope) {

--- a/rust-runtime/aws-smithy-async/src/rt/sleep.rs
+++ b/rust-runtime/aws-smithy-async/src/rt/sleep.rs
@@ -24,7 +24,7 @@ where
     T: ?Sized,
 {
     fn sleep(&self, duration: Duration) -> Sleep {
-        T::sleep(&self, duration)
+        T::sleep(self, duration)
     }
 }
 
@@ -34,7 +34,7 @@ where
     T: ?Sized,
 {
     fn sleep(&self, duration: Duration) -> Sleep {
-        T::sleep(&self, duration)
+        T::sleep(self, duration)
     }
 }
 

--- a/rust-runtime/aws-smithy-http/src/endpoint.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint.rs
@@ -92,7 +92,7 @@ impl Endpoint {
         let new_uri = Uri::builder()
             .authority(authority)
             .scheme(scheme.clone())
-            .path_and_query(Self::merge_paths(&self.uri, &uri).as_ref())
+            .path_and_query(Self::merge_paths(&self.uri, uri).as_ref())
             .build()
             .expect("valid uri");
         *uri = new_uri;
@@ -107,9 +107,9 @@ impl Endpoint {
         if endpoint_path.is_empty() {
             Cow::Borrowed(uri_path_and_query)
         } else {
-            let ep_no_slash = endpoint_path.strip_suffix("/").unwrap_or(endpoint_path);
+            let ep_no_slash = endpoint_path.strip_suffix('/').unwrap_or(endpoint_path);
             let uri_path_no_slash = uri_path_and_query
-                .strip_prefix("/")
+                .strip_prefix('/')
                 .unwrap_or(uri_path_and_query);
             Cow::Owned(format!("{}/{}", ep_no_slash, uri_path_no_slash))
         }

--- a/rust-runtime/aws-smithy-http/src/header.rs
+++ b/rust-runtime/aws-smithy-http/src/header.rs
@@ -114,7 +114,7 @@ fn read_many<T>(
     for header in values {
         let mut header = header.as_bytes();
         while !header.is_empty() {
-            let (v, next) = read_one(&header, &f)?;
+            let (v, next) = read_one(header, &f)?;
             out.push(v);
             header = next;
         }
@@ -183,7 +183,7 @@ fn split_at_delim(s: &[u8]) -> (&[u8], &[u8]) {
 
 fn then_delim(s: &[u8]) -> Result<&[u8], ParseError> {
     if s.is_empty() {
-        Ok(&s)
+        Ok(s)
     } else if s.starts_with(b",") {
         Ok(&s[1..])
     } else {

--- a/rust-runtime/aws-smithy-http/src/label.rs
+++ b/rust-runtime/aws-smithy-http/src/label.rs
@@ -14,7 +14,7 @@ const GREEDY: &AsciiSet = &BASE_SET.remove(b'/');
 
 pub fn fmt_string<T: AsRef<str>>(t: T, greedy: bool) -> String {
     let uri_set = if greedy { GREEDY } else { BASE_SET };
-    percent_encoding::utf8_percent_encode(t.as_ref(), &uri_set).to_string()
+    percent_encoding::utf8_percent_encode(t.as_ref(), uri_set).to_string()
 }
 
 pub fn fmt_timestamp(t: &Instant, format: aws_smithy_types::instant::Format) -> String {

--- a/rust-runtime/aws-smithy-json/src/deserialize.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize.rs
@@ -324,7 +324,7 @@ impl<'a> JsonTokenIterator<'a> {
             offset,
             value: if floating {
                 Number::Float(
-                    f64::from_str(&number_str)
+                    f64::from_str(number_str)
                         .map_err(|_| self.error_at(start, InvalidNumber))
                         .and_then(|f| {
                             must_be_finite(f).map_err(|_| self.error_at(start, InvalidNumber))
@@ -342,7 +342,7 @@ impl<'a> JsonTokenIterator<'a> {
                 }
             } else {
                 Number::PosInt(
-                    u64::from_str(&number_str).map_err(|_| self.error_at(start, InvalidNumber))?,
+                    u64::from_str(number_str).map_err(|_| self.error_at(start, InvalidNumber))?,
                 )
             },
         })

--- a/rust-runtime/aws-smithy-json/src/serialize.rs
+++ b/rust-runtime/aws-smithy-json/src/serialize.rs
@@ -51,7 +51,7 @@ impl<'a> JsonValueWriter<'a> {
                 }
                 object.finish();
             }
-            Document::String(value) => self.string(&value),
+            Document::String(value) => self.string(value),
         }
     }
 

--- a/rust-runtime/aws-smithy-types/src/instant/format.rs
+++ b/rust-runtime/aws-smithy-types/src/instant/format.rs
@@ -331,7 +331,7 @@ pub(crate) mod rfc3339 {
     pub(crate) fn read(s: &str) -> Result<(Instant, &str), DateParseError> {
         let delim = s.find('Z').map(|idx| idx + 1).unwrap_or_else(|| s.len());
         let (head, rest) = s.split_at(delim);
-        Ok((parse(head)?, &rest))
+        Ok((parse(head)?, rest))
     }
 
     /// Format an [Instant] in the RFC-3339 date format

--- a/rust-runtime/aws-smithy-types/src/instant/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/instant/mod.rs
@@ -221,9 +221,9 @@ impl Instant {
     /// Formats the `Instant` to a string using the given `format`.
     pub fn fmt(&self, format: Format) -> String {
         match format {
-            Format::DateTime => format::rfc3339::format(&self),
-            Format::EpochSeconds => format::epoch_seconds::format(&self),
-            Format::HttpDate => format::http_date::format(&self),
+            Format::DateTime => format::rfc3339::format(self),
+            Format::EpochSeconds => format::epoch_seconds::format(self),
+            Format::HttpDate => format::http_date::format(self),
         }
     }
 }

--- a/rust-runtime/aws-smithy-xml/src/unescape.rs
+++ b/rust-runtime/aws-smithy-xml/src/unescape.rs
@@ -43,7 +43,7 @@ pub fn unescape(s: &str) -> Result<Cow<str>, XmlError> {
                         // e.g. &#xD;
                         let (entity, radix) = if let Some(entity) = entity.strip_prefix("#x") {
                             (entity, 16)
-                        } else if let Some(entity) = entity.strip_prefix("#") {
+                        } else if let Some(entity) = entity.strip_prefix('#') {
                             // e.g. &#123;
                             (entity, 10)
                         } else {
@@ -51,7 +51,7 @@ pub fn unescape(s: &str) -> Result<Cow<str>, XmlError> {
                                 esc: entity.to_string(),
                             });
                         };
-                        let char_code = u32::from_str_radix(&entity, radix).map_err(|_| {
+                        let char_code = u32::from_str_radix(entity, radix).map_err(|_| {
                             XmlError::InvalidEscape {
                                 esc: format!(
                                     "Expected numeric escape in base {}; got: {}",

--- a/rust-runtime/inlineable/src/json_errors.rs
+++ b/rust-runtime/inlineable/src/json_errors.rs
@@ -21,13 +21,13 @@ fn sanitize_error_code(error_code: &str) -> &str {
     // Trim a trailing URL from the error code, beginning with a `:`
     let error_code = match error_code.find(':') {
         Some(idx) => &error_code[..idx],
-        None => &error_code,
+        None => error_code,
     };
 
     // Trim a prefixing namespace from the error code, beginning with a `#`
     match error_code.find('#') {
         Some(idx) => &error_code[idx + 1..],
-        None => &error_code,
+        None => error_code,
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
The codegen-server project will soon depend on `axum 0.3`, which requires MSRV 1.54.0.
This will allow us to implement `FromRequest` / `IntoResponse` axum traits.

Moving to 1.54.0 requires some changes to make clippy happy, especially around references that get immediately derefenced by the compiler. This required updates on both `rust-runtime` and `codegen`.

## Testing
Tested locally and waiting for CI to run.

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
