### PR TITLE
[bugfix] header trimming truncated length-1 headers

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -10,6 +10,7 @@ vNext (Month Day, Year)
 - Fix epoch seconds date-time parsing bug in `aws-smithy-types` (smithy-rs#834)
 - Omit trailing zeros from fraction when formatting HTTP dates in `aws-smithy-types` (smithy-rs#834)
 - Model structs now have accessor methods for their members (smithy-rs#842)
+- :bug: Fix bug that caused signing to fail for requests where the body length was <=9. (smithy-rs#845)
 
 v0.0.23-alpha (November 3rd, 2021)
 ==================================

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -153,6 +153,7 @@ pub fn sign<'a>(
     request: SignableRequest<'a>,
     params: &'a SigningParams<'a>,
 ) -> Result<SigningOutput<SigningInstructions>, Error> {
+    tracing::trace!(request = ?request, params = ?params, "signing request");
     match params.settings.signature_location {
         SignatureLocation::Headers => {
             let (signing_headers, signature) =

--- a/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
+++ b/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
@@ -15,6 +15,7 @@ const NAUGHTY_STRINGS: &str = include_str!("blns/blns.txt");
 // // A useful way to find leaks in the signing system that requires an actual S3 bucket to test with
 // // If you want to use this, update the credentials to be your credentials and change the bucket name
 // // to your bucket
+// // NOTE: this won't actually succeed, you'll get a 400 back from S3 because the headers are too long.
 // #[tokio::test]
 // async fn test_metadata_field_against_naughty_strings_list() -> Result<(), aws_sdk_s3::Error> {
 //     // re-add `aws-config = { path = "../../build/aws-sdk/aws-config" }` to this project's Cargo.toml
@@ -95,7 +96,7 @@ async fn test_s3_signer_with_naughty_string_metadata() -> Result<(), aws_sdk_s3:
 
     // This is a snapshot test taken from a known working test result
     let snapshot_signature =
-        "Signature=849f8737d8e8239a349d74af5b2c1d24be43a199e591bd2fc9db7d8a62f49d71";
+        "Signature=8dfa41f2db599a9fba53393b0ae5da646e5e452fa3685f7a1487d6eade5ec5c8";
     assert!(
         auth_header
             .to_str()


### PR DESCRIPTION
## Motivation and Context
`dynamodb.list_tables()` (and every other operation that emits a body with length <= 9) was broken because single-character strings were being omitted from headers during signing.

## Description
Fix `trim_all` to work on single character strings. Add test.

## Testing
- [x] Unit test
- [x] Validate that `list_tables()` works again 
## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
