### PR TITLE
Add server operation registry and router

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/OperationRegistryGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/OperationRegistryGenerator.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.rustlang.*
+import software.amazon.smithy.rust.codegen.server.smithy.protocols.ServerHttpProtocolGenerator
+import software.amazon.smithy.rust.codegen.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.RequestSpecModule
+import software.amazon.smithy.rust.codegen.smithy.generators.error.errorSymbol
+import software.amazon.smithy.rust.codegen.smithy.protocols.HttpBindingResolver
+import software.amazon.smithy.rust.codegen.smithy.protocols.HttpTraitHttpBindingResolver
+import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolContentTypes
+import software.amazon.smithy.rust.codegen.util.inputShape
+import software.amazon.smithy.rust.codegen.util.outputShape
+import software.amazon.smithy.rust.codegen.util.toSnakeCase
+
+/**
+ * OperationRegistryGenerator
+ */
+class OperationRegistryGenerator(
+    codegenContext: CodegenContext,
+    private val operations: List<OperationShape>,
+) {
+    private val serverCrate = "aws_smithy_http_server"
+    private val service = codegenContext.serviceShape
+    private val model = codegenContext.model
+    private val symbolProvider = codegenContext.symbolProvider
+    private val operationNames = operations.map { symbolProvider.toSymbol(it).name.toSnakeCase() }
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val codegenScope = arrayOf(
+        "Router" to RuntimeType.Router(runtimeConfig),
+    )
+    private val httpBindingResolver: HttpBindingResolver =
+        HttpTraitHttpBindingResolver(codegenContext.model, ProtocolContentTypes.consistent("application/json"))
+
+    fun render(writer: RustWriter) {
+        Attribute.Derives(setOf(RuntimeType.Debug, RuntimeType.DeriveBuilder)).render(writer)
+        Attribute.Custom("builder(pattern = \"owned\")").render(writer)
+        // Generic arguments of the `OperationRegistryBuilder<Fun0, Fut0, ..., FunN, FutN>`.
+        val operationsGenericArguments = operations.mapIndexed { i, _ -> "Fun$i, Fut$i"}.joinToString()
+        val operationRegistryName = "${service.getContextualName(service)}OperationRegistry<${operationsGenericArguments}>"
+        writer.rustBlock("""
+            pub struct $operationRegistryName
+            where
+                ${operationsTraitBounds()}
+            """.trimIndent()) {
+            val members = operationNames
+                .mapIndexed { i, operationName -> "$operationName: Fun$i" }
+                .joinToString(separator = ",\n")
+            rust(members)
+        }
+
+        writer.rustBlockTemplate("""
+            impl<${operationsGenericArguments}> From<$operationRegistryName> for #{Router}
+            where
+                ${operationsTraitBounds()}
+            """.trimIndent(), *codegenScope) {
+            rustBlock("fn from(registry: ${operationRegistryName}) -> Self") {
+                val operationInOutWrappers = operations.map {
+                    val operationName = symbolProvider.toSymbol(it).name
+                    Pair("crate::operation::$operationName${ServerHttpProtocolGenerator.OPERATION_INPUT_WRAPPER_SUFFIX}",
+                    "crate::operation::$operationName${ServerHttpProtocolGenerator.OPERATION_OUTPUT_WRAPPER_SUFFIX}")
+                }
+                val requestSpecsVarNames = operationNames.map { "${it}_request_spec" }
+                val routes = requestSpecsVarNames.zip(operationNames).zip(operationInOutWrappers) { (requestSpecVarName, operationName), (inputWrapper, outputWrapper) ->
+                    ".route($requestSpecVarName, $serverCrate::routing::operation_handler::operation::<_, _, $inputWrapper, _, $outputWrapper>(registry.$operationName))"
+                }.joinToString(separator = "\n")
+
+                val requestSpecs = requestSpecsVarNames.zip(operations) { requestSpecVarName, operation ->
+                    "let $requestSpecVarName = ${operation.requestSpec()};"
+                }.joinToString(separator = "\n")
+                rustTemplate("""
+                    $requestSpecs
+                    #{Router}::new()
+                        $routes
+                    """.trimIndent(), *codegenScope)
+            }
+        }
+    }
+
+    private fun operationsTraitBounds(): String = operations
+        .mapIndexed { i, operation ->
+            val outputType = if (operation.errors.isNotEmpty()) {
+                "Result<${symbolProvider.toSymbol(operation.outputShape(model)).fullName}, ${operation.errorSymbol(symbolProvider).fullyQualifiedName()}>"
+            } else {
+                symbolProvider.toSymbol(operation.outputShape(model)).fullName
+            }
+            """
+            Fun$i: FnOnce(${symbolProvider.toSymbol(operation.inputShape(model))}) -> Fut$i + Clone + Send + Sync + 'static,
+            Fut$i: std::future::Future<Output = $outputType> + Send
+            """.trimIndent()
+        }.joinToString(separator = ",\n")
+
+    private fun OperationShape.requestSpec(): String {
+        val httpTrait = httpBindingResolver.httpTrait(this)
+        val namespace = RequestSpecModule(runtimeConfig).fullyQualifiedName()
+
+        // TODO Support the `endpoint` trait: https://awslabs.github.io/smithy/1.0/spec/core/endpoint-traits.html#endpoint-trait
+
+        val pathSegments = httpTrait.uri.segments.map {
+            "$namespace::PathSegment::" +
+                if (it.isGreedyLabel) "Greedy"
+                else if (it.isLabel) "Label"
+                else "Literal(String::from(\"${it.content}\"))"
+        }
+        val querySegments = httpTrait.uri.queryLiterals.map {
+            "$namespace::QuerySegment::" +
+                if (it.value == "") "Key(String::from(\"${it.key}\"))"
+                else "KeyValue(String::from(\"${it.key}\"), String::from(\"${it.value}\"))"
+        }
+
+        return """
+            $namespace::RequestSpec::new(
+                http::Method::${httpTrait.method},
+                $namespace::UriSpec {
+                    host_prefix: None,
+                    path_and_query: $namespace::PathAndQuerySpec {
+                        path_segments: $namespace::PathSpec::from_vector_unchecked(vec![${pathSegments.joinToString()}]),
+                        query_segments: $namespace::QuerySpec::from_vector_unchecked(vec![${querySegments.joinToString()}])
+                    }
+                }
+            )""".trimIndent()
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -36,7 +36,7 @@ class ServerServiceGenerator(
      */
     fun render() {
         val operations = index.getContainedOperations(context.serviceShape).sortedBy { it.id }
-        operations.map { operation ->
+        for (operation in operations) {
             rustCrate.useShapeWriter(operation) { operationWriter ->
                 protocolGenerator.serverRenderOperation(
                     operationWriter,
@@ -53,6 +53,10 @@ class ServerServiceGenerator(
                         .render(writer)
                 }
             }
+        }
+        rustCrate.withModule(RustModule.public("operation_registry", "A registry of your service's operations.")) { writer ->
+            OperationRegistryGenerator(context, operations)
+                .render(writer)
         }
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -192,6 +192,7 @@ data class CargoDependency(
         val Axum: CargoDependency = CargoDependency("axum", CratesIo("0.3"))
         val Bytes: CargoDependency = CargoDependency("bytes", CratesIo("1"))
         val BytesUtils: CargoDependency = CargoDependency("bytes-utils", CratesIo("0.1.1"))
+        val DeriveBuilder = CargoDependency("derive_builder", CratesIo("0.10"))
         val FastRand: CargoDependency = CargoDependency("fastrand", CratesIo("1"))
         val Hex: CargoDependency = CargoDependency("hex", CratesIo("0.4.3"))
         val HttpBody: CargoDependency = CargoDependency("http-body", CratesIo("0.4"))
@@ -213,7 +214,6 @@ data class CargoDependency(
         fun SmithyEventStream(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("eventstream")
         fun SmithyHttp(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http")
         fun SmithyHttpServer(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http-server")
-        fun SmithyHttpTower(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http-tower")
         fun SmithyProtocolTestHelpers(runtimeConfig: RuntimeConfig) =
             runtimeConfig.runtimeCrate("protocol-test").copy(scope = DependencyScope.Dev)
         fun smithyJson(runtimeConfig: RuntimeConfig): CargoDependency = runtimeConfig.runtimeCrate("json")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -317,7 +317,6 @@ sealed class Attribute {
         val container: Boolean = false
     ) : Attribute() {
         override fun render(writer: RustWriter) {
-
             val bang = if (container) "!" else ""
             writer.raw("#$bang[$annotation]")
             symbols.forEach {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -176,6 +176,13 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
         val PartialEq = std.member("cmp::PartialEq")
         val StdError = RuntimeType("Error", dependency = null, namespace = "std::error")
         val String = RuntimeType("String", dependency = null, namespace = "std::string")
+        val DeriveBuilder = RuntimeType("Builder", dependency = CargoDependency.DeriveBuilder, namespace = "derive_builder")
+
+        fun RequestSpecModule(runtimeConfig: RuntimeConfig) =
+            RuntimeType("request_spec", CargoDependency.SmithyHttpServer(runtimeConfig), "${runtimeConfig.crateSrcPrefix}_http_server::routing")
+
+        fun Router(runtimeConfig: RuntimeConfig) =
+            RuntimeType("Router", CargoDependency.SmithyHttpServer(runtimeConfig), "${runtimeConfig.crateSrcPrefix}_http_server::routing")
 
         fun DateTime(runtimeConfig: RuntimeConfig) =
             RuntimeType("DateTime", CargoDependency.SmithyTypes(runtimeConfig), "${runtimeConfig.crateSrcPrefix}_types")

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 keywords = ["smithy", "framework", "web", "api", "aws"]
 categories = ["asynchronous", "web-programming", "api-bindings"]
 description = """
-HTTP server runtime and utilities.
+Server runtime for Smithy Rust Server Framework.
 
 NOTE: THIS IS HIGHLY EXPERIMENTAL AND SHOULD NOT BE USED YET.
 """
@@ -20,11 +20,19 @@ aws-smithy-http = { path = "../aws-smithy-http" }
 aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-json = { path = "../aws-smithy-json" }
 axum = { version = "0.3", features = [ "http1", "http2", "headers", "mime", "tower-log" ], default-features = false }
+async-trait = "0.1"
 bytes = "1.1"
+futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["server", "http1", "http2", "tcp"] }
 mime = "0.3"
+pin-project = "1.0"
+regex = "1.0"
+serde_urlencoded = "0.7"
+thiserror = "1"
+tokio = { version = "1.0", features = ["full"] }
+tower = { version = "0.4" }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/rust-runtime/aws-smithy-http-server/src/clone_box_service.rs
+++ b/rust-runtime/aws-smithy-http-server/src/clone_box_service.rs
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use futures_util::future::BoxFuture;
+use std::task::{Context, Poll};
+use tower::{Service, ServiceExt};
+
+/// A `Clone + Send` boxed `Service`
+pub(crate) struct CloneBoxService<T, U, E>(
+    Box<dyn CloneService<T, Response = U, Error = E, Future = BoxFuture<'static, Result<U, E>>> + Send>,
+);
+
+impl<T, U, E> CloneBoxService<T, U, E> {
+    pub(crate) fn new<S>(inner: S) -> Self
+    where
+        S: Service<T, Response = U, Error = E> + Clone + Send + 'static,
+        S::Future: Send + 'static,
+    {
+        let inner = inner.map_future(|f| Box::pin(f) as _);
+        CloneBoxService(Box::new(inner))
+    }
+}
+
+impl<T, U, E> Service<T> for CloneBoxService<T, U, E> {
+    type Response = U;
+    type Error = E;
+    type Future = BoxFuture<'static, Result<U, E>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
+        self.0.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, request: T) -> Self::Future {
+        self.0.call(request)
+    }
+}
+
+impl<T, U, E> Clone for CloneBoxService<T, U, E> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone_box())
+    }
+}
+
+trait CloneService<R>: Service<R> {
+    fn clone_box(
+        &self,
+    ) -> Box<dyn CloneService<R, Response = Self::Response, Error = Self::Error, Future = Self::Future> + Send>;
+}
+
+impl<R, T> CloneService<R> for T
+where
+    T: Service<R> + Send + Clone + 'static,
+{
+    fn clone_box(
+        &self,
+    ) -> Box<dyn CloneService<R, Response = T::Response, Error = T::Error, Future = T::Future> + Send> {
+        Box::new(self.clone())
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/error.rs
@@ -37,14 +37,14 @@
 use crate::BoxError;
 use std::{error::Error as StdError, fmt};
 
-/// Errors that can happen when using `aws-smithy-http-server`.
+/// Errors that can happen when using `aws-smithy-server`.
 #[derive(Debug)]
 pub struct Error {
-    pub inner: BoxError,
+    inner: BoxError,
 }
 
 impl Error {
-    pub fn new(error: impl Into<BoxError>) -> Self {
+    pub(crate) fn new(error: impl Into<BoxError>) -> Self {
         Self { inner: error.into() }
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/handler/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/handler/mod.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+// This code was copied and then modified from Tokio's Axum.
+
+/* Copyright (c) 2021 Tower Contributors
+ *
+ * Permission is hereby granted, free of charge, to any
+ * person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the
+ * Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice
+ * shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ * ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+ * SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+//! Async functions that can be used to handle requests.
+//!
+//! For a function to be used as a handler it must implement the [`Handler`] trait.
+//! We provide blanket implementations for functions that:
+//!
+//! - Are `async fn`s.
+//! - Take one argument that can be converted (via [`std::convert::Into`]) into a type that
+//!   implements [`FromRequest`].
+//! - Returns a type that can be converted (via [`std::convert::Into`]) into a type that implements
+//!   [`IntoResponse`].
+//! - If a closure is used it must implement `Clone + Send` and be
+//!   `'static`.
+//! - Returns a future that is `Send`. The most common way to accidentally make a
+//!   future `!Send` is to hold a `!Send` type across an await.
+
+use async_trait::async_trait;
+use axum::extract::{FromRequest, RequestParts};
+use axum::response::IntoResponse;
+use http::{Request, Response};
+use std::future::Future;
+
+use crate::body::{box_body, BoxBody};
+
+pub(crate) mod sealed {
+    #![allow(unreachable_pub, missing_docs, missing_debug_implementations)]
+
+    pub trait HiddenTrait {}
+    pub struct Hidden;
+    impl HiddenTrait for Hidden {}
+}
+
+#[async_trait]
+pub trait Handler<B, T, I, O>: Clone + Send + Sized + 'static {
+    #[doc(hidden)]
+    type Sealed: sealed::HiddenTrait;
+
+    async fn call(self, req: Request<B>) -> Response<BoxBody>;
+}
+
+#[async_trait]
+#[allow(non_snake_case)]
+impl<F, Fut, B, Res, T, I, O> Handler<B, T, I, Res> for F
+where
+    F: FnOnce(I) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = O> + Send,
+    B: Send + 'static,
+    Res: From<O>,
+    Res: IntoResponse,
+    I: From<T> + Send,
+    T: FromRequest<B> + Send,
+{
+    type Sealed = sealed::Hidden;
+
+    async fn call(self, req: Request<B>) -> Response<BoxBody> {
+        let mut req = RequestParts::new(req);
+
+        let wrapper = match T::from_request(&mut req).await {
+            Ok(value) => value,
+            Err(rejection) => return rejection.into_response().map(box_body),
+        };
+
+        let input_inner: I = wrapper.into();
+
+        let output_inner: O = self(input_inner).await;
+
+        let res: Res = output_inner.into();
+
+        res.into_response().map(box_body)
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -5,21 +5,30 @@
 
 //! HTTP server runtime and utilities, loosely based on Axum.
 
-#![cfg_attr(docsrs, feature(doc_cfg))]
-
 #[macro_use]
 pub(crate) mod macros;
 
-mod body;
-mod error;
+pub mod body;
+mod clone_box_service;
+pub mod error;
+mod handler;
 
+// Only the code-generated operation registry should instantiate routers.
+// We therefore hide it in the documentation.
+#[doc(hidden)]
+pub mod routing;
+
+#[doc(hidden)]
 pub mod protocols;
 pub mod rejection;
 
 #[doc(inline)]
-pub use self::body::{box_body, Body, BoxBody, HttpBody};
+pub use self::body::{Body, BoxBody, HttpBody};
 #[doc(inline)]
 pub use self::error::Error;
 
 /// Alias for a type-erased error type.
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
+
+#[cfg(test)]
+mod test_helpers;

--- a/rust-runtime/aws-smithy-http-server/src/routing/future.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/future.rs
@@ -32,35 +32,31 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! HTTP body utilities.
+//! Future types.
 
-use crate::BoxError;
-use crate::Error;
+use crate::body::BoxBody;
+use futures_util::future::Either;
+use http::{Request, Response};
+use std::{convert::Infallible, future::ready};
+use tower::util::Oneshot;
 
-#[doc(no_inline)]
-pub use http_body::{Body as HttpBody, Empty, Full};
+pub use super::{into_make_service::IntoMakeService, route::RouteFuture};
 
-#[doc(no_inline)]
-pub use hyper::body::Body;
+type OneshotRoute<B> = Oneshot<super::Route<B>, Request<B>>;
+type ReadyResponse = std::future::Ready<Result<Response<BoxBody>, Infallible>>;
 
-#[doc(no_inline)]
-pub use bytes::Bytes;
-
-/// A boxed [`Body`] trait object.
-///
-/// This is used as the response body type for applications. Its
-/// necessary to unify multiple response bodies types into one.
-pub type BoxBody = http_body::combinators::UnsyncBoxBody<Bytes, Error>;
-
-/// Convert a [`http_body::Body`] into a [`BoxBody`].
-pub fn box_body<B>(body: B) -> BoxBody
-where
-    B: http_body::Body<Data = Bytes> + Send + 'static,
-    B::Error: Into<BoxError>,
-{
-    body.map_err(Error::new).boxed_unsync()
+opaque_future! {
+    /// Response future for [`Router`](super::Router).
+    pub type RouterFuture<B> =
+        futures_util::future::Either<OneshotRoute<B>, ReadyResponse>;
 }
 
-pub(crate) fn empty() -> BoxBody {
-    box_body(http_body::Empty::new())
+impl<B> RouterFuture<B> {
+    pub(super) fn from_oneshot(future: Oneshot<super::Route<B>, Request<B>>) -> Self {
+        Self::new(Either::Left(future))
+    }
+
+    pub(super) fn from_response(response: Response<BoxBody>) -> Self {
+        Self::new(Either::Right(ready(Ok(response))))
+    }
 }

--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -1,0 +1,264 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! An HTTP router that adheres to the [Smithy specification].
+//!
+//! The router is a [`tower::Service`] that routes incoming requests to other `Service`s
+//! based on the requests' URI and HTTP method.
+//! It currently does not support Smithy's [endpoint trait].
+//!
+//! **This router should not be used directly**; it should only be used by generated code from the
+//! Smithy model.
+//!
+//! [Smithy specification]: https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#http-trait
+//! [endpoint trait]: https://awslabs.github.io/smithy/1.0/spec/core/endpoint-traits.html#endpoint-trait
+
+use self::{future::RouterFuture, request_spec::RequestSpec};
+use crate::body::{Body, BoxBody};
+use http::{Request, Response, StatusCode};
+use std::{
+    convert::Infallible,
+    task::{Context, Poll},
+};
+use tower::{Service, ServiceExt};
+
+pub mod future;
+mod into_make_service;
+pub mod operation_handler;
+pub mod request_spec;
+mod route;
+
+pub use self::{into_make_service::IntoMakeService, route::Route};
+
+#[derive(Debug)]
+pub struct Router<B = Body> {
+    routes: Vec<Route<B>>,
+}
+
+impl<B> Clone for Router<B> {
+    fn clone(&self) -> Self {
+        Self { routes: self.routes.clone() }
+    }
+}
+
+impl<B> Default for Router<B>
+where
+    B: Send + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<B> Router<B>
+where
+    B: Send + 'static,
+{
+    /// Create a new `Router`.
+    ///
+    /// Unless you add additional routes this will respond to `404 Not Found` to
+    /// all requests.
+    pub fn new() -> Self {
+        Self { routes: Default::default() }
+    }
+
+    /// Add a route to the router.
+    pub fn route<T>(mut self, request_spec: RequestSpec, svc: T) -> Self
+    where
+        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible> + Clone + Send + 'static,
+        T::Future: Send + 'static,
+    {
+        self.routes.push(Route::new(svc, request_spec));
+        self
+    }
+
+    /// Convert this router into a [`MakeService`], that is a [`Service`] whose
+    /// response is another service.
+    ///
+    /// This is useful when running your application with hyper's
+    /// [`Server`](hyper::server::Server).
+    ///
+    /// [`MakeService`]: tower::make::MakeService
+    pub fn into_make_service(self) -> IntoMakeService<Self> {
+        IntoMakeService::new(self)
+    }
+}
+
+impl<B> Service<Request<B>> for Router<B>
+where
+    B: Send + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = RouterFuture<B>;
+
+    #[inline]
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let mut method_not_allowed = false;
+
+        for route in &self.routes {
+            match route.matches(&req) {
+                request_spec::Match::Yes => {
+                    return RouterFuture::from_oneshot(route.clone().oneshot(req));
+                }
+                request_spec::Match::MethodNotAllowed => method_not_allowed = true,
+                // Continue looping to see if another route matches.
+                request_spec::Match::No => continue,
+            }
+        }
+
+        let status_code = if method_not_allowed { StatusCode::METHOD_NOT_ALLOWED } else { StatusCode::NOT_FOUND };
+        RouterFuture::from_response(Response::builder().status(status_code).body(crate::body::empty()).unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{body::box_body, routing::request_spec::*};
+    use futures_util::Future;
+    use http::Method;
+    use std::pin::Pin;
+
+    /// Helper function to build a `Request`. Used in other test modules.
+    pub fn req(method: &Method, uri: &str) -> Request<()> {
+        Request::builder().method(method).uri(uri).body(()).unwrap()
+    }
+
+    /// A service that returns its name and the request's URI in the response body.
+    #[derive(Clone)]
+    struct NamedEchoUriService(String);
+
+    impl<B> Service<Request<B>> for NamedEchoUriService {
+        type Response = Response<BoxBody>;
+        type Error = Infallible;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        #[inline]
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        #[inline]
+        fn call(&mut self, req: Request<B>) -> Self::Future {
+            let body = box_body(Body::from(format!("{} :: {}", self.0, String::from(req.uri().to_string()))));
+            let fut = async { Ok(Response::builder().status(&http::StatusCode::OK).body(body).unwrap()) };
+            Box::pin(fut)
+        }
+    }
+
+    // Returns a `Response`'s body as a `String`, without consuming the response.
+    async fn get_body_as_str<B>(res: &mut Response<B>) -> String
+    where
+        B: http_body::Body + std::marker::Unpin,
+        B::Error: std::fmt::Debug,
+    {
+        let body_mut = res.body_mut();
+        let body_bytes = hyper::body::to_bytes(body_mut).await.unwrap();
+        String::from(std::str::from_utf8(&body_bytes).unwrap())
+    }
+
+    // This test is a rewrite of `mux.spec.ts`.
+    // https://github.com/awslabs/smithy-typescript/blob/fbf97a9bf4c1d8cf7f285ea7c24e1f0ef280142a/smithy-typescript-ssdk-libs/server-common/src/httpbinding/mux.spec.ts
+    #[tokio::test]
+    async fn simple_routing() {
+        let request_specs: Vec<(RequestSpec, &str)> = vec![
+            (
+                RequestSpec::from_parts(
+                    Method::GET,
+                    vec![PathSegment::Literal(String::from("a")), PathSegment::Label, PathSegment::Label],
+                    vec![],
+                ),
+                "A",
+            ),
+            (
+                RequestSpec::from_parts(
+                    Method::GET,
+                    vec![
+                        PathSegment::Literal(String::from("mg")),
+                        PathSegment::Greedy,
+                        PathSegment::Literal(String::from("z")),
+                    ],
+                    vec![],
+                ),
+                "MiddleGreedy",
+            ),
+            (
+                RequestSpec::from_parts(
+                    Method::DELETE,
+                    vec![],
+                    vec![
+                        QuerySegment::KeyValue(String::from("foo"), String::from("bar")),
+                        QuerySegment::Key(String::from("baz")),
+                    ],
+                ),
+                "Delete",
+            ),
+            (
+                RequestSpec::from_parts(
+                    Method::POST,
+                    vec![PathSegment::Literal(String::from("query_key_only"))],
+                    vec![QuerySegment::Key(String::from("foo"))],
+                ),
+                "QueryKeyOnly",
+            ),
+        ];
+
+        let mut router = Router::new();
+        for (spec, svc_name) in request_specs {
+            let svc = NamedEchoUriService(String::from(svc_name));
+            router = router.route(spec, svc.clone());
+        }
+
+        let hits = vec![
+            ("A", Method::GET, "/a/b/c"),
+            ("MiddleGreedy", Method::GET, "/mg/a/z"),
+            ("MiddleGreedy", Method::GET, "/mg/a/b/c/d/z?abc=def"),
+            ("Delete", Method::DELETE, "/?foo=bar&baz=quux"),
+            ("Delete", Method::DELETE, "/?foo=bar&baz"),
+            ("Delete", Method::DELETE, "/?foo=bar&baz=&"),
+            ("Delete", Method::DELETE, "/?foo=bar&baz=quux&baz=grault"),
+            ("QueryKeyOnly", Method::POST, "/query_key_only?foo=bar"),
+            ("QueryKeyOnly", Method::POST, "/query_key_only?foo"),
+            ("QueryKeyOnly", Method::POST, "/query_key_only?foo="),
+            ("QueryKeyOnly", Method::POST, "/query_key_only?foo=&"),
+        ];
+        for (svc_name, method, uri) in &hits {
+            let mut res = router.call(req(method, uri)).await.unwrap();
+            let actual_body = get_body_as_str(&mut res).await;
+
+            assert_eq!(format!("{} :: {}", svc_name, uri), actual_body);
+        }
+
+        for (_, _, uri) in hits {
+            let res = router.call(req(&Method::PATCH, uri)).await.unwrap();
+            assert_eq!(StatusCode::METHOD_NOT_ALLOWED, res.status());
+        }
+
+        let misses = vec![
+            (Method::GET, "/a"),
+            (Method::GET, "/a/b"),
+            (Method::GET, "/mg"),
+            (Method::GET, "/mg/q"),
+            (Method::GET, "/mg/z"),
+            (Method::GET, "/mg/a/b/z/c"),
+            (Method::DELETE, "/?foo=bar"),
+            (Method::DELETE, "/?foo=bar"),
+            (Method::DELETE, "/?baz=quux"),
+            (Method::POST, "/query_key_only?baz=quux"),
+            (Method::GET, "/"),
+            (Method::POST, "/"),
+        ];
+        for (method, miss) in misses {
+            let res = router.call(req(&method, miss)).await.unwrap();
+            assert_eq!(StatusCode::NOT_FOUND, res.status());
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/routing/operation_handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/operation_handler.rs
@@ -1,0 +1,62 @@
+use crate::{body::BoxBody, handler::Handler};
+use futures_util::{
+    future::{BoxFuture, Map},
+    FutureExt,
+};
+use http::{Request, Response};
+use std::{
+    convert::Infallible,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+use tower::Service;
+
+/// Struct that holds a handler, that is, a function provided by the user that implements the
+/// Smithy operation.
+pub struct OperationHandler<H, B, T, I, Res> {
+    handler: H,
+    #[allow(clippy::type_complexity)]
+    _marker: PhantomData<fn() -> (B, T, I, Res)>,
+}
+
+impl<H, B, T, I, Res> Clone for OperationHandler<H, B, T, I, Res>
+where
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self { handler: self.handler.clone(), _marker: PhantomData }
+    }
+}
+
+/// Construct an [`OperationHandler`] out of a function implementing the operation.
+pub fn operation<H, B, T, I, Res>(handler: H) -> OperationHandler<H, B, T, I, Res> {
+    OperationHandler { handler, _marker: PhantomData }
+}
+
+impl<H, B, T, I, Res> Service<Request<B>> for OperationHandler<H, B, T, I, Res>
+where
+    H: Handler<B, T, I, Res>,
+    B: Send + 'static,
+{
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = OperationHandlerFuture;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        let future = Handler::call(self.handler.clone(), req).map(Ok::<_, Infallible> as _);
+        OperationHandlerFuture::new(future)
+    }
+}
+
+type WrapResultInResponseFn = fn(Response<BoxBody>) -> Result<Response<BoxBody>, Infallible>;
+
+opaque_future! {
+    /// Response future for [`OperationHandler`].
+    pub type OperationHandlerFuture =
+        Map<BoxFuture<'static, Response<BoxBody>>, WrapResultInResponseFn>;
+}

--- a/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
@@ -1,0 +1,265 @@
+use http::Request;
+use regex::Regex;
+
+#[derive(Debug, Clone)]
+pub enum PathSegment {
+    Literal(String),
+    Label,
+    Greedy,
+}
+
+#[derive(Debug, Clone)]
+pub enum QuerySegment {
+    Key(String),
+    KeyValue(String, String),
+}
+
+#[derive(Debug, Clone)]
+pub enum HostPrefixSegment {
+    Literal(String),
+    Label,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PathSpec(Vec<PathSegment>);
+
+impl PathSpec {
+    pub fn from_vector_unchecked(path_segments: Vec<PathSegment>) -> Self {
+        PathSpec(path_segments)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct QuerySpec(Vec<QuerySegment>);
+
+impl QuerySpec {
+    pub fn from_vector_unchecked(query_segments: Vec<QuerySegment>) -> Self {
+        QuerySpec(query_segments)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PathAndQuerySpec {
+    pub path_segments: PathSpec,
+    pub query_segments: QuerySpec,
+}
+
+#[derive(Debug, Clone)]
+pub struct UriSpec {
+    pub host_prefix: Option<Vec<HostPrefixSegment>>,
+    pub path_and_query: PathAndQuerySpec,
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestSpec {
+    method: http::Method,
+    uri_spec: UriSpec,
+    uri_path_regex: Regex,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Match {
+    /// The request matches the URI pattern spec.
+    Yes,
+    /// The request matches the URI pattern spec, but the wrong HTTP method was used. `405 Method
+    /// Not Allowed` should be returned in the response.
+    MethodNotAllowed,
+    /// The request does not match the URI pattern spec. `404 Not Found` should be returned in the
+    /// response.
+    No,
+}
+
+impl From<&PathSpec> for Regex {
+    fn from(uri_path_spec: &PathSpec) -> Self {
+        let sep = "/+";
+        let re = uri_path_spec
+            .0
+            .iter()
+            .map(|segment_spec| match segment_spec {
+                PathSegment::Literal(literal) => literal,
+                // TODO URL spec says it should be ASCII but this regex accepts UTF-8:
+                // https://github.com/awslabs/smithy/issues/975
+                PathSegment::Label => "[^/]+",
+                PathSegment::Greedy => ".*",
+            })
+            .fold(String::new(), |a, b| a + sep + b);
+
+        Regex::new(&format!("{}$", re)).unwrap()
+    }
+}
+
+impl RequestSpec {
+    pub fn new(method: http::Method, uri_spec: UriSpec) -> Self {
+        let uri_path_regex = (&uri_spec.path_and_query.path_segments).into();
+        RequestSpec { method, uri_spec, uri_path_regex }
+    }
+
+    pub(super) fn matches<B>(&self, req: &Request<B>) -> Match {
+        if let Some(_host_prefix) = &self.uri_spec.host_prefix {
+            todo!("Look at host prefix");
+        }
+
+        if !self.uri_path_regex.is_match(req.uri().path()) {
+            return Match::No;
+        }
+
+        if self.uri_spec.path_and_query.query_segments.0.is_empty() {
+            if self.method == req.method() {
+                return Match::Yes;
+            } else {
+                return Match::MethodNotAllowed;
+            }
+        }
+
+        match req.uri().query() {
+            Some(query) => {
+                // We can't use `HashMap<&str, &str>` because a query string key can appear more
+                // than once e.g. `/?foo=bar&foo=baz`. We _could_ use a multiset e.g. the `hashbag`
+                // crate.
+                let res = serde_urlencoded::from_str::<Vec<(&str, &str)>>(query);
+
+                match res {
+                    Err(_) => Match::No,
+                    Ok(query_map) => {
+                        for query_segment in self.uri_spec.path_and_query.query_segments.0.iter() {
+                            match query_segment {
+                                QuerySegment::Key(key) => {
+                                    if !query_map.iter().any(|(k, _v)| k == key) {
+                                        return Match::No;
+                                    }
+                                }
+                                QuerySegment::KeyValue(key, expected_value) => {
+                                    let mut it = query_map.iter().filter(|(k, _v)| k == key).peekable();
+                                    if it.peek().is_none() {
+                                        return Match::No;
+                                    }
+
+                                    // The query key appears more than once. All of its values must
+                                    // coincide and be equal to the expected value.
+                                    if it.any(|(_k, v)| v != expected_value) {
+                                        return Match::No;
+                                    }
+                                }
+                            }
+                        }
+
+                        if self.method == req.method() {
+                            Match::Yes
+                        } else {
+                            Match::MethodNotAllowed
+                        }
+                    }
+                }
+            }
+            None => Match::No,
+        }
+    }
+
+    // Helper function to build a `RequestSpec`.
+    #[cfg(test)]
+    pub fn from_parts(
+        method: http::Method,
+        path_segments: Vec<PathSegment>,
+        query_segments: Vec<QuerySegment>,
+    ) -> Self {
+        Self::new(
+            method,
+            UriSpec {
+                host_prefix: None,
+                path_and_query: PathAndQuerySpec {
+                    path_segments: PathSpec::from_vector_unchecked(path_segments),
+                    query_segments: QuerySpec::from_vector_unchecked(query_segments),
+                },
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::req;
+    use super::*;
+    use http::Method;
+
+    #[test]
+    fn greedy_labels_match_greedily() {
+        let spec = RequestSpec::from_parts(
+            Method::GET,
+            vec![
+                PathSegment::Literal(String::from("mg")),
+                PathSegment::Greedy,
+                PathSegment::Literal(String::from("z")),
+            ],
+            vec![],
+        );
+
+        let hits = vec![
+            (Method::GET, "/mg/a/z"),
+            (Method::GET, "/mg/z/z"),
+            (Method::GET, "/mg/a/z/b/z"),
+            (Method::GET, "/mg/a/z/z/z"),
+        ];
+        for (method, uri) in &hits {
+            assert_eq!(Match::Yes, spec.matches(&req(method, uri)));
+        }
+    }
+
+    #[test]
+    fn repeated_query_keys() {
+        let spec = RequestSpec::from_parts(Method::DELETE, vec![], vec![QuerySegment::Key(String::from("foo"))]);
+
+        let hits = vec![
+            (Method::DELETE, "/?foo=bar&foo=bar"),
+            (Method::DELETE, "/?foo=bar&foo=baz"),
+            (Method::DELETE, "/?foo&foo"),
+        ];
+        for (method, uri) in &hits {
+            assert_eq!(Match::Yes, spec.matches(&req(method, uri)));
+        }
+    }
+
+    fn key_value_spec() -> RequestSpec {
+        RequestSpec::from_parts(
+            Method::DELETE,
+            vec![],
+            vec![QuerySegment::KeyValue(String::from("foo"), String::from("bar"))],
+        )
+    }
+
+    #[test]
+    fn repeated_query_keys_same_values_match() {
+        assert_eq!(Match::Yes, key_value_spec().matches(&req(&Method::DELETE, "/?foo=bar&foo=bar")));
+    }
+
+    #[test]
+    fn repeated_query_keys_distinct_values_does_not_match() {
+        assert_eq!(Match::No, key_value_spec().matches(&req(&Method::DELETE, "/?foo=bar&foo=baz")));
+    }
+
+    fn ab_spec() -> RequestSpec {
+        RequestSpec::from_parts(
+            Method::GET,
+            vec![PathSegment::Literal(String::from("a")), PathSegment::Literal(String::from("b"))],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn empty_segments_in_the_middle_dont_matter() {
+        let hits = vec![(Method::GET, "/a/b"), (Method::GET, "/a//b"), (Method::GET, "//////a//b")];
+        for (method, uri) in &hits {
+            assert_eq!(Match::Yes, ab_spec().matches(&req(method, uri)));
+        }
+    }
+
+    // The rationale is that `/index` points to the `index` resource, but `/index/` points to "the
+    // default resource under `index`", for example `/index/index.html`, so trailing slashes at the
+    // end of URIs _do_ matter.
+    #[test]
+    fn empty_segments_at_the_end_do_matter() {
+        let misses = vec![(Method::GET, "/a/b/"), (Method::GET, "/a/b//"), (Method::GET, "//a//b////")];
+        for (method, uri) in &misses {
+            assert_eq!(Match::No, ab_spec().matches(&req(method, uri)));
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/routing/route.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/route.rs
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+// This code was copied and then modified from Tokio's Axum.
+
+/* Copyright (c) 2021 Tower Contributors
+ *
+ * Permission is hereby granted, free of charge, to any
+ * person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the
+ * Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice
+ * shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ * ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+ * SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+use crate::{
+    body::{Body, BoxBody},
+    clone_box_service::CloneBoxService,
+};
+use http::{Request, Response};
+use pin_project::pin_project;
+use std::{
+    convert::Infallible,
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::Service;
+use tower::{util::Oneshot, ServiceExt};
+
+use super::request_spec::{Match, RequestSpec};
+
+/// How routes are stored inside a [`Router`](super::Router).
+pub struct Route<B = Body> {
+    service: CloneBoxService<Request<B>, Response<BoxBody>, Infallible>,
+    request_spec: RequestSpec,
+}
+
+impl<B> Route<B> {
+    pub(super) fn new<T>(svc: T, request_spec: RequestSpec) -> Self
+    where
+        T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible> + Clone + Send + 'static,
+        T::Future: Send + 'static,
+    {
+        Self { service: CloneBoxService::new(svc), request_spec }
+    }
+
+    pub(super) fn matches(&self, req: &Request<B>) -> Match {
+        self.request_spec.matches(req)
+    }
+}
+
+impl<ReqBody> Clone for Route<ReqBody> {
+    fn clone(&self) -> Self {
+        Self { service: self.service.clone(), request_spec: self.request_spec.clone() }
+    }
+}
+
+impl<ReqBody> fmt::Debug for Route<ReqBody> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Route").finish()
+    }
+}
+
+impl<B> Service<Request<B>> for Route<B> {
+    type Response = Response<BoxBody>;
+    type Error = Infallible;
+    type Future = RouteFuture<B>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        RouteFuture::new(self.service.clone().oneshot(req))
+    }
+}
+
+/// Response future for [`Route`].
+#[pin_project]
+pub struct RouteFuture<B> {
+    #[pin]
+    future: Oneshot<CloneBoxService<Request<B>, Response<BoxBody>, Infallible>, Request<B>>,
+}
+
+impl<B> RouteFuture<B> {
+    pub(crate) fn new(future: Oneshot<CloneBoxService<Request<B>, Response<BoxBody>, Infallible>, Request<B>>) -> Self {
+        RouteFuture { future }
+    }
+}
+
+impl<B> Future for RouteFuture<B> {
+    type Output = Result<Response<BoxBody>, Infallible>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.project().future.poll(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn traits() {
+        use crate::test_helpers::*;
+
+        assert_send::<Route<()>>();
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/test_helpers.rs
+++ b/rust-runtime/aws-smithy-http-server/src/test_helpers.rs
@@ -1,0 +1,2 @@
+pub(crate) fn assert_send<T: Send>() {}
+pub(crate) fn assert_sync<T: Sync>() {}


### PR DESCRIPTION
This commit adds two things:
1. A runtime router implementing `tower`'s [`Service`](https://docs.rs/tower-service/0.3.1/tower_service/trait.Service.html) that adheres to [Smithy's `http` trait specification](https://awslabs.github.io/smithy/1.0/spec/core/http-traits.html#http-trait), that is linear in the number of registered routes.
2. A code-generated "operation registry" that allows service implementers to provide Rust functions and declare them as the handlers for their service's operations.

The framework will receive HTTP requests from the server and route them to the corresponding operation handler.

---

~~The PR is far from being mergeable, but it builds. I also want to gather feedback, especially for `OperationRegistry.kt`.~~ PR is now mergeable.

Another PR implementing `axum`'s `FromRequest` and `IntoResponse` for operations needs to be merged first, ~~on which @crisidev is currently working.~~ which was done on #839.