### PR TITLE
update: Ensure service stack is Send + Sync

### DIFF
--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -184,7 +184,6 @@ where
     ) -> Result<SdkSuccess<T>, SdkError<E>>
     where
         O: Send + Sync,
-        // E: Send + Sync,
         Retry: Send + Sync,
         R::Policy: bounds::SmithyRetryPolicy<O, T, E, Retry>,
         // This bound is not _technically_ inferred by all the previous bounds, but in practice it

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -32,7 +32,10 @@ use tracing::Instrument;
 /// Implementors are essentially "policy factories" that can produce a new instance of a retry
 /// policy mechanism for each request, which allows both shared global state _and_ per-request
 /// local state.
-pub trait NewRequestPolicy {
+pub trait NewRequestPolicy
+where
+    Self::Policy: Send + Sync,
+{
     /// The type of the per-request policy mechanism.
     type Policy;
 
@@ -292,7 +295,7 @@ where
     Handler: Clone,
     R: ClassifyResponse<SdkSuccess<T>, SdkError<E>>,
 {
-    type Future = Pin<Box<dyn Future<Output = Self> + Send>>;
+    type Future = Pin<Box<dyn Future<Output = Self> + Send + Sync>>;
 
     fn retry(
         &self,
@@ -321,7 +324,7 @@ where
     }
 }
 
-fn check_send_sync<T: Send>(t: T) -> T {
+fn check_send_sync<T: Send + Sync>(t: T) -> T {
     t
 }
 


### PR DESCRIPTION
update: ensure service stack is send + sync

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
these types need to be send and sync

## Description
<!--- Describe your changes in detail -->
add compile-time checks for send and sync

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
These don't change functionality

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
