### PR TITLE
Prepare `v0.28.0-alpha` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 vNext (Month Day, Year)
 =======================
 
+v0.28.0-alpha (November 11th, 2021)
+===================================
+
+No changes since last release except for version bumping since older versions
+of the AWS SDK were failing to compile with the `0.27.0-alpha.2` version chosen
+for the previous release.
+
 v0.27.0-alpha.2 (November 9th, 2021)
 =======================
 **Breaking Changes**

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+*                      @awslabs/rust-sdk-owners
+/codegen-server/       @awslabs/smithy-rs-server
+/codegen-server-test/  @awslabs/smithy-rs-server

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,6 +1,13 @@
 vNext (Month Day, Year)
 =======================
 
+v0.0.25-alpha (November 11th, 2021)
+===================================
+
+No changes since last release except for version bumping since older versions
+of the AWS SDK were failing to compile with the `0.27.0-alpha.2` version chosen
+for some of the supporting crates.
+
 v0.0.24-alpha (November 9th, 2021)
 ==================================
 **Breaking Changes**

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@
 
 # Version number to use for the generated SDK
 # Note: these must always be full 3-segment semver versions
-aws.sdk.version=0.0.24-alpha
+aws.sdk.version=0.0.25-alpha
 
 # Version number to use for the generated runtime crates
-smithy.rs.runtime.crate.version=0.27.0-alpha.2
+smithy.rs.runtime.crate.version=0.28.0-alpha
 
 kotlin.code.style=official
 


### PR DESCRIPTION
This is in response to the compile failures we've seen with the older versions of the AWS SDK pulling in the later versions of the Smithy runtime crates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
