### PR TITLE
Fix S3 Control signing

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -51,6 +51,7 @@ Several breaking changes around `aws_smithy_types::Instant` were introduced by s
 
 **New this week**
 - Conversions from `aws_smithy_types::DateTime` to `OffsetDateTime` from the `time` crate are now available from the `aws-smithy-types-convert` crate. (smithy-rs#849)
+- :bug: Fixed signing problem with S3 Control (smithy-rs#858, aws-sd-rust#291)
 
 v0.0.25-alpha (November 11th, 2021)
 ===================================

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -130,13 +130,14 @@ class SigV4SigningConfig(
     }
 }
 
-fun needsAmzSha256(service: ServiceShape) = when {
-    service.id == ShapeId.from("com.amazonaws.s3#AmazonS3") -> true
+fun needsAmzSha256(service: ServiceShape) = when (service.id) {
+    ShapeId.from("com.amazonaws.s3#AmazonS3") -> true
+    ShapeId.from("com.amazonaws.s3control#AWSS3ControlServiceV20180820") -> true
     else -> false
 }
 
-fun disableDoubleEncode(service: ServiceShape) = when {
-    service.id == ShapeId.from("com.amazonaws.s3#AmazonS3") -> true
+fun disableDoubleEncode(service: ServiceShape) = when (service.id) {
+    ShapeId.from("com.amazonaws.s3#AmazonS3") -> true
     else -> false
 }
 

--- a/aws/sdk/gradle.properties
+++ b/aws/sdk/gradle.properties
@@ -30,6 +30,7 @@ aws.services.smoketest=\
     +polly,\
     +qldbsession,\
     +s3,\
+    +s3control,\
     +sts,\
     +transcribestreaming
 

--- a/aws/sdk/integration-tests/Cargo.toml
+++ b/aws/sdk/integration-tests/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "polly",
     "qldbsession",
     "s3",
+    "s3control",
     "sts",
     "transcribestreaming",
     "glacier"

--- a/aws/sdk/integration-tests/s3control/Cargo.toml
+++ b/aws/sdk/integration-tests/s3control/Cargo.toml
@@ -1,0 +1,22 @@
+# This Cargo.toml is unused in generated code. It exists solely to enable these tests to compile in-situ
+[package]
+name = "s3control-tests"
+version = "0.1.0"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-sdk-s3control = { path = "../../build/aws-sdk/sdk/s3control" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+tracing-subscriber = "0.2.18"
+
+[dev-dependencies]
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+bytes = "1"
+http = "0.2.3"
+serde_json = "1"
+tokio  = { version = "1", features = ["full"]}

--- a/aws/sdk/integration-tests/s3control/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3control/tests/signing-it.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_http::user_agent::AwsUserAgent;
+use aws_sdk_s3control as s3control;
+use aws_smithy_client::test_connection::TestConnection;
+use aws_smithy_http::body::SdkBody;
+use s3control::operation::ListAccessPoints;
+use s3control::{Credentials, Region};
+use std::time::{Duration, UNIX_EPOCH};
+
+#[tokio::test]
+async fn test_signer() -> Result<(), s3control::Error> {
+    let creds = Credentials::from_keys(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+    );
+    let conf = s3control::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let conn = TestConnection::new(vec![(
+        http::Request::builder()
+            .header("authorization",
+                    "AWS4-HMAC-SHA256 Credential=ANOTREAL/20211112/us-east-1/s3/aws4_request, \
+                    SignedHeaders=host;x-amz-account-id;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, \
+                    Signature=ac58c2246428af711ab7bca30c704a2b6a5fd7451cf83f3bceff177f1636e277")
+            .uri("https://test-bucket.s3-control.us-east-1.amazonaws.com/v20180820/accesspoint")
+            .body(SdkBody::empty())
+            .unwrap(),
+        http::Response::builder().status(200).body("").unwrap(),
+    )]);
+    let client = aws_hyper::Client::new(conn.clone());
+    let mut op = ListAccessPoints::builder()
+        .account_id("test-bucket")
+        .build()
+        .unwrap()
+        .make_operation(&conf)
+        .await
+        .unwrap();
+    op.properties_mut()
+        .insert(UNIX_EPOCH + Duration::from_secs(1636751225));
+    op.properties_mut().insert(AwsUserAgent::for_tests());
+
+    client.call(op).await.expect_err("empty response");
+    conn.assert_requests_match(&[]);
+    Ok(())
+}


### PR DESCRIPTION
## Motivation and Context
This addresses the issue found in https://github.com/awslabs/aws-sdk-rust/issues/291.

## Testing
- Manually ran the S3 Control ListAccessPoints operation to verify it succeeds.
- Added an integration test for the signing.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
