### PR TITLE
Rev2 of Github Pages Landing Page

### DIFF
--- a/buildSrc/src/main/kotlin/DocsLandingPage.kt
+++ b/buildSrc/src/main/kotlin/DocsLandingPage.kt
@@ -24,35 +24,31 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
         )
 
         writer.write("## AWS Services")
+        writer.write("") // empty line between header and table
         /* generate a basic markdown table */
-        writer.write("| Service | [docs.rs](https://docs.rs) | [crates.io](https://crates.io) | [Usage Examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/) |")
-        writer.write("| ------- | ------- | --------- | ------ |")
+        writer.write("| Service | Package |")
+        writer.write("| ------- | ------- |")
         awsServices.sortedBy { it.humanName }.forEach {
             writer.write(
-                "| ${it.humanName} | ${docsRs(it)} | ${cratesIo(it)} | ${
-                examples(
-                    it,
-                    project
-                )
-                }"
+                "| ${it.humanName} | ${cratesIo(it)} ${docsRs(it)} ${examples(it, project)} | "
             )
         }
     }
-    outputDir.resolve("docs.md").writeText(writer.toString())
+    outputDir.resolve("index.md").writeText(writer.toString())
 }
 
 /**
  * Generate a link to the examples for a given service
  */
 private fun examples(service: AwsService, project: Project) = if (with(service) { project.examples() }) {
-    "[Link](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/${service.module})"
+    "([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/${service.module}))"
 } else {
-    "None yet!"
+    ""
 }
 
 /**
  * Generate a link to the docs
  */
 private fun docsRs(service: AwsService) = docsRs(service.crate())
-private fun docsRs(crate: String) = "[$crate](https://docs.rs/$crate)"
+private fun docsRs(crate: String) = "([docs](https://docs.rs/$crate))"
 private fun cratesIo(service: AwsService) = "[${service.crate()}](https://crates.io/crates/${service.crate()})"

--- a/buildSrc/src/main/kotlin/DocsLandingPage.kt
+++ b/buildSrc/src/main/kotlin/DocsLandingPage.kt
@@ -29,8 +29,9 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
         writer.write("| Service | Package |")
         writer.write("| ------- | ------- |")
         awsServices.sortedBy { it.humanName }.forEach {
+            val items = listOfNotNull(cratesIo(it), docsRs(it), examples(it, project)).joinToString(" ")
             writer.write(
-                "| ${it.humanName} | ${cratesIo(it)} ${docsRs(it)} ${examples(it, project)} |"
+                "| ${it.humanName} | $items |"
             )
         }
     }
@@ -43,7 +44,7 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
 private fun examples(service: AwsService, project: Project) = if (with(service) { project.examples() }) {
     "([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/${service.module}))"
 } else {
-    ""
+    null
 }
 
 /**

--- a/buildSrc/src/main/kotlin/DocsLandingPage.kt
+++ b/buildSrc/src/main/kotlin/DocsLandingPage.kt
@@ -30,7 +30,7 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
         writer.write("| ------- | ------- |")
         awsServices.sortedBy { it.humanName }.forEach {
             writer.write(
-                "| ${it.humanName} | ${cratesIo(it)} ${docsRs(it)} ${examples(it, project)} | "
+                "| ${it.humanName} | ${cratesIo(it)} ${docsRs(it)} ${examples(it, project)} |"
             )
         }
     }

--- a/buildSrc/src/main/kotlin/DocsLandingPage.kt
+++ b/buildSrc/src/main/kotlin/DocsLandingPage.kt
@@ -19,7 +19,7 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
     with(writer) {
         write("# AWS SDK for Rust")
         write(
-            """The AWS SDK for Rust contains one crate for each AWS service, as well as ${docsRs("aws-config")},
+            """The AWS SDK for Rust contains one crate for each AWS service, as well as ${cratesIo("aws-config")} ${docsRs("aws-config")},
             |a crate implementing configuration loading such as credential providers.""".trimMargin()
         )
 
@@ -52,4 +52,5 @@ private fun examples(service: AwsService, project: Project) = if (with(service) 
  */
 private fun docsRs(service: AwsService) = docsRs(service.crate())
 private fun docsRs(crate: String) = "([docs](https://docs.rs/$crate))"
-private fun cratesIo(service: AwsService) = "[${service.crate()}](https://crates.io/crates/${service.crate()})"
+private fun cratesIo(service: AwsService) = cratesIo(service.crate())
+private fun cratesIo(crate: String) = "[$crate](https://crates.io/crates/$crate)"


### PR DESCRIPTION
## Description

- Generate `index.md` instead so it works directly with Jekyll
- Fix some bugs in table generation and generate a narrower table that doesn't need side-to-side scrolling


## Testing
- [x] verified output of github pages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
