### PR TITLE
docs: fixed examples url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ vNext (Month Day, Year)
 
 **TODO Next Release:**
 - Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
-- Fixed links to Usage Examples
+- Fixed links to Usage Examples (smithy-rs#862, @floric)
 
 **Breaking Changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vNext (Month Day, Year)
 
 **TODO Next Release:**
 - Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
+- Fixed links to Usage Examples
 
 **Breaking Changes**
 

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,7 +1,7 @@
 vNext (Month Day, Year)
 =======================
 - Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
-- Fixed links to Usage Examples
+- Fixed links to Usage Examples (smithy-rs#862, @floric)
 
 **Breaking Changes**
 

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,6 +1,7 @@
 vNext (Month Day, Year)
 =======================
 - Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
+- Fixed links to Usage Examples
 
 **Breaking Changes**
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
@@ -55,7 +55,7 @@ class AwsReadmeDecorator : RustCodegenDecorator {
                     ## Getting Started
 
                     > Examples are available for many services and operations, check out the
-                    > [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples).
+                    > [examples folder in GitHub](https://github.com/awslabs/aws-sdk-rust/tree/main/examples).
 
                     The SDK provides one crate per AWS service. You must add [Tokio](https://crates.io/crates/tokio)
                     as a dependency within your Rust project to execute asynchronous code. To add `$moduleName` to
@@ -79,7 +79,7 @@ class AwsReadmeDecorator : RustCodegenDecorator {
                     * [GitHub discussions](https://github.com/awslabs/aws-sdk-rust/discussions) - For ideas, RFCs & general questions
                     * [GitHub issues](https://github.com/awslabs/aws-sdk-rust/issues/new/choose) – For bug reports & feature requests
                     * [Generated Docs (latest version)](https://awslabs.github.io/aws-sdk-rust/)
-                    * [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples)
+                    * [Usage examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples)
 
                     ## License
 


### PR DESCRIPTION
## Motivation and Context

This change fixes the broken reference links to the examples folder for each subproject.

## Description

I changed the link to the usage examples from `https://github.com/awslabs/aws-sdk-rust/tree/main/sdk/examples` to `https://github.com/awslabs/aws-sdk-rust/tree/main/examples`.

## Checklist
- [x] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
