### PR TITLE
Add operation input/output wrapper conversion functions

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -248,7 +248,7 @@ class ServerProtocolTestGenerator(
         }
         rustTemplate(
             """
-            let output = super::$operationName(output);
+            let output = super::$operationName::Output(output);
             use #{Axum}::response::IntoResponse;
             let http_response = output.into_response();
             """,


### PR DESCRIPTION
The functions allow to wrap the model types into the wrappers and unwrap
the wrappers into the model types.

The wrapper types have been made private.

## Testing

`./gradlew codegen-server-test:build`.

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [ ] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
