### PR TITLE
Add missing features to user agent formatting

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,7 +1,8 @@
 vNext (Month Day, Year)
 =======================
+
+**TODO Upon release**
 - Update README & aws-sdk-rust CI for MSRV upgrade to 1.54
-- Fixed links to Usage Examples (smithy-rs#862, @floric)
 
 **Breaking Changes**
 
@@ -51,7 +52,17 @@ Several breaking changes around `aws_smithy_types::Instant` were introduced by s
 - The `DateTime::fmt` method is now fallible and fails when a `DateTime`'s value is outside what can be represented by the desired date format.
 
 **New this week**
+
 - Conversions from `aws_smithy_types::DateTime` to `OffsetDateTime` from the `time` crate are now available from the `aws-smithy-types-convert` crate. (smithy-rs#849)
+- Fixed links to Usage Examples (smithy-rs#862, @floric)
+- Added missing features to user agent formatting, and made it possible to configure an app name for the user agent via service config. (smithy-rs#865)
+
+**Contributions**
+
+Thank you for your contributions! :heart:
+
+- @floric (smithy-rs#862)
+
 
 v0.0.25-alpha (November 11th, 2021)
 ===================================

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -6,50 +6,52 @@ vNext (Month Day, Year)
 
 **Breaking Changes**
 
-Several breaking changes around `aws_smithy_types::Instant` were introduced by smithy-rs#849:
-- `aws_smithy_types::Instant` from was renamed to `DateTime` to avoid confusion with the standard library's monotonically nondecreasing `Instant` type.
-- `DateParseError` in `aws_smithy_types` has been renamed to `DateTimeParseError` to match the type that's being parsed.
-- The `chrono-conversions` feature and associated functions have been moved to the `aws-smithy-types-convert` crate.
-  - Calls to `Instant::from_chrono` should be changed to:
-    ```rust
-    use aws_smithy_types::DateTime;
-    use aws_smithy_types_convert::date_time::DateTimeExt;
+- The `add_metadata` function was removed from `AwsUserAgent` in `aws-http`.
+  Use `with_feature_metadata`, `with_config_metadata`, or `with_framework_metadata` now instead. (smithy-rs#865)
+- Several breaking changes around `aws_smithy_types::Instant` were introduced by smithy-rs#849:
+  - `aws_smithy_types::Instant` from was renamed to `DateTime` to avoid confusion with the standard library's monotonically nondecreasing `Instant` type.
+  - `DateParseError` in `aws_smithy_types` has been renamed to `DateTimeParseError` to match the type that's being parsed.
+  - The `chrono-conversions` feature and associated functions have been moved to the `aws-smithy-types-convert` crate.
+    - Calls to `Instant::from_chrono` should be changed to:
+      ```rust
+      use aws_smithy_types::DateTime;
+      use aws_smithy_types_convert::date_time::DateTimeExt;
 
-    // For chrono::DateTime<Utc>
-    let date_time = DateTime::from_chrono_utc(chrono_date_time);
-    // For chrono::DateTime<FixedOffset>
-    let date_time = DateTime::from_chrono_offset(chrono_date_time);
-    ```
-  - Calls to `instant.to_chrono()` should be changed to:
-    ```rust
-    use aws_smithy_types_convert::date_time::DateTimeExt;
+      // For chrono::DateTime<Utc>
+      let date_time = DateTime::from_chrono_utc(chrono_date_time);
+      // For chrono::DateTime<FixedOffset>
+      let date_time = DateTime::from_chrono_offset(chrono_date_time);
+      ```
+    - Calls to `instant.to_chrono()` should be changed to:
+      ```rust
+      use aws_smithy_types_convert::date_time::DateTimeExt;
 
-    date_time.to_chrono_utc();
-    ```
-- `Instant::from_system_time` and `Instant::to_system_time` have been changed to `From` trait implementations.
-  - Calls to `from_system_time` should be changed to:
-    ```rust
-    DateTime::from(system_time);
-    // or
-    let date_time: DateTime = system_time.into();
-    ```
-  - Calls to `to_system_time` should be changed to:
-    ```rust
-    SystemTime::from(date_time);
-    // or
-    let system_time: SystemTime = date_time.into();
-    ```
-- Several functions in `Instant`/`DateTime` were renamed:
-  - `Instant::from_f64` -> `DateTime::from_secs_f64`
-  - `Instant::from_fractional_seconds` -> `DateTime::from_fractional_secs`
-  - `Instant::from_epoch_seconds` -> `DateTime::from_secs`
-  - `Instant::from_epoch_millis` -> `DateTime::from_millis`
-  - `Instant::epoch_fractional_seconds` -> `DateTime::as_secs_f64`
-  - `Instant::has_nanos` -> `DateTime::has_subsec_nanos`
-  - `Instant::epoch_seconds` -> `DateTime::secs`
-  - `Instant::epoch_subsecond_nanos` -> `DateTime::subsec_nanos`
-  - `Instant::to_epoch_millis` -> `DateTime::to_millis`
-- The `DateTime::fmt` method is now fallible and fails when a `DateTime`'s value is outside what can be represented by the desired date format.
+      date_time.to_chrono_utc();
+      ```
+  - `Instant::from_system_time` and `Instant::to_system_time` have been changed to `From` trait implementations.
+    - Calls to `from_system_time` should be changed to:
+      ```rust
+      DateTime::from(system_time);
+      // or
+      let date_time: DateTime = system_time.into();
+      ```
+    - Calls to `to_system_time` should be changed to:
+      ```rust
+      SystemTime::from(date_time);
+      // or
+      let system_time: SystemTime = date_time.into();
+      ```
+  - Several functions in `Instant`/`DateTime` were renamed:
+    - `Instant::from_f64` -> `DateTime::from_secs_f64`
+    - `Instant::from_fractional_seconds` -> `DateTime::from_fractional_secs`
+    - `Instant::from_epoch_seconds` -> `DateTime::from_secs`
+    - `Instant::from_epoch_millis` -> `DateTime::from_millis`
+    - `Instant::epoch_fractional_seconds` -> `DateTime::as_secs_f64`
+    - `Instant::has_nanos` -> `DateTime::has_subsec_nanos`
+    - `Instant::epoch_seconds` -> `DateTime::secs`
+    - `Instant::epoch_subsecond_nanos` -> `DateTime::subsec_nanos`
+    - `Instant::to_epoch_millis` -> `DateTime::to_millis`
+  - The `DateTime::fmt` method is now fallible and fails when a `DateTime`'s value is outside what can be represented by the desired date format.
 
 **New this week**
 

--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -194,7 +194,7 @@ pub mod app_name {
         Builder::default()
     }
 
-    /// Builder for [DefaultRegionChain]
+    /// Default provider builder for [`AppName`]
     #[derive(Default)]
     pub struct Builder {
         env_provider: EnvironmentVariableAppNameProvider,
@@ -219,7 +219,7 @@ pub mod app_name {
             self
         }
 
-        /// Build a [DefaultRegionChain]
+        /// Build an [`AppName`] from the default chain
         pub async fn app_name(self) -> Option<AppName> {
             self.env_provider
                 .app_name()
@@ -243,7 +243,7 @@ pub mod app_name {
             ]);
             let app_name = Builder::default()
                 .configure(
-                    &ProviderConfig::empty()
+                    &ProviderConfig::no_configuration()
                         .with_fs(fs)
                         .with_env(env)
                         .with_http_connector(no_traffic_connector()),

--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -178,6 +178,101 @@ pub mod retry_config {
     }
 }
 
+/// Default app name provider chain
+pub mod app_name {
+    use crate::environment::app_name::EnvironmentVariableAppNameProvider;
+    use crate::profile::app_name;
+    use crate::provider_config::ProviderConfig;
+    use aws_types::app_name::AppName;
+
+    /// Default App Name Provider chain
+    ///
+    /// This provider will check the following sources in order:
+    /// 1. [Environment variables](EnvironmentVariableAppNameProvider)
+    /// 2. [Profile file](crate::profile::app_name::ProfileFileAppNameProvider)
+    pub fn default_provider() -> Builder {
+        Builder::default()
+    }
+
+    /// Builder for [DefaultRegionChain]
+    #[derive(Default)]
+    pub struct Builder {
+        env_provider: EnvironmentVariableAppNameProvider,
+        profile_file: app_name::Builder,
+    }
+
+    impl Builder {
+        #[doc(hidden)]
+        /// Configure the default chain
+        ///
+        /// Exposed for overriding the environment when unit-testing providers
+        pub fn configure(mut self, configuration: &ProviderConfig) -> Self {
+            self.env_provider =
+                EnvironmentVariableAppNameProvider::new_with_env(configuration.env());
+            self.profile_file = self.profile_file.configure(configuration);
+            self
+        }
+
+        /// Override the profile name used by this provider
+        pub fn profile_name(mut self, name: &str) -> Self {
+            self.profile_file = self.profile_file.profile_name(name);
+            self
+        }
+
+        /// Build a [DefaultRegionChain]
+        pub async fn app_name(self) -> Option<AppName> {
+            self.env_provider
+                .app_name()
+                .or(self.profile_file.build().app_name().await)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::provider_config::ProviderConfig;
+        use crate::test_case::no_traffic_connector;
+        use aws_types::os_shim_internal::{Env, Fs};
+
+        #[tokio::test]
+        async fn prefer_env_to_profile() {
+            let fs = Fs::from_slice(&[("test_config", "[default]\nsdk-ua-app-id = wrong")]);
+            let env = Env::from_slice(&[
+                ("AWS_CONFIG_FILE", "test_config"),
+                ("AWS_SDK_UA_APP_ID", "correct"),
+            ]);
+            let app_name = Builder::default()
+                .configure(
+                    &ProviderConfig::empty()
+                        .with_fs(fs)
+                        .with_env(env)
+                        .with_http_connector(no_traffic_connector()),
+                )
+                .app_name()
+                .await;
+
+            assert_eq!(Some(AppName::new("correct").unwrap()), app_name);
+        }
+
+        #[tokio::test]
+        async fn load_from_profile() {
+            let fs = Fs::from_slice(&[("test_config", "[default]\nsdk-ua-app-id = correct")]);
+            let env = Env::from_slice(&[("AWS_CONFIG_FILE", "test_config")]);
+            let app_name = Builder::default()
+                .configure(
+                    &ProviderConfig::empty()
+                        .with_fs(fs)
+                        .with_env(env)
+                        .with_http_connector(no_traffic_connector()),
+                )
+                .app_name()
+                .await;
+
+            assert_eq!(Some(AppName::new("correct").unwrap()), app_name);
+        }
+    }
+}
+
 /// Default credentials provider chain
 pub mod credentials {
     use std::borrow::Cow;

--- a/aws/rust-runtime/aws-config/src/environment/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/environment/app_name.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_types::app_name::AppName;
+use aws_types::os_shim_internal::Env;
+
+/// Load an app name from the `AWS_SDK_UA_APP_ID` environment variable.
+#[derive(Debug, Default)]
+pub struct EnvironmentVariableAppNameProvider {
+    env: Env,
+}
+
+impl EnvironmentVariableAppNameProvider {
+    /// Create a new `EnvironmentVariableAppNameProvider`
+    pub fn new() -> Self {
+        Self { env: Env::real() }
+    }
+
+    #[doc(hidden)]
+    /// Create an region provider from a given `Env`
+    ///
+    /// This method is used for tests that need to override environment variables.
+    pub fn new_with_env(env: Env) -> Self {
+        Self { env }
+    }
+
+    /// Attempts to create an `AppName` from the `AWS_SDK_UA_APP_ID` environment variable.
+    pub fn app_name(&self) -> Option<AppName> {
+        if let Ok(name) = self.env.get("AWS_SDK_UA_APP_ID") {
+            match AppName::new(name) {
+                Ok(name) => Some(name),
+                Err(err) => {
+                    tracing::warn!(err = %err, "`AWS_SDK_UA_APP_ID` environment variable value was invalid");
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::environment::EnvironmentVariableAppNameProvider;
+    use aws_types::app_name::AppName;
+    use aws_types::os_shim_internal::Env;
+    use std::collections::HashMap;
+
+    #[test]
+    fn env_var_not_set() {
+        let provider = EnvironmentVariableAppNameProvider::new_with_env(Env::from(HashMap::new()));
+        assert_eq!(None, provider.app_name());
+    }
+
+    #[test]
+    fn env_var_set() {
+        let provider = EnvironmentVariableAppNameProvider::new_with_env(Env::from(
+            vec![("AWS_SDK_UA_APP_ID".to_string(), "something".to_string())]
+                .into_iter()
+                .collect::<HashMap<String, String>>(),
+        ));
+        assert_eq!(
+            Some(AppName::new("something").unwrap()),
+            provider.app_name()
+        );
+    }
+}

--- a/aws/rust-runtime/aws-config/src/environment/mod.rs
+++ b/aws/rust-runtime/aws-config/src/environment/mod.rs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+/// Load app name from the environment
+pub mod app_name;
+pub use app_name::EnvironmentVariableAppNameProvider;
 /// Load credentials from the environment
 pub mod credentials;
 pub use credentials::EnvironmentVariableCredentialsProvider;

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -48,14 +48,7 @@ const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn user_agent() -> AwsUserAgent {
-    AwsUserAgent::new_from_environment(
-        Env::real(),
-        ApiMetadata::new("imds", PKG_VERSION),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        None,
-    )
+    AwsUserAgent::new_from_environment(Env::real(), ApiMetadata::new("imds", PKG_VERSION))
 }
 
 /// IMDSv2 Client

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -39,9 +39,6 @@ use crate::provider_config::{HttpSettings, ProviderConfig};
 use crate::{profile, PKG_VERSION};
 use tokio::sync::OnceCell;
 
-const USER_AGENT: AwsUserAgent =
-    AwsUserAgent::new_from_environment(ApiMetadata::new("imds", PKG_VERSION));
-
 mod token;
 
 // 6 hours
@@ -49,6 +46,17 @@ const DEFAULT_TOKEN_TTL: Duration = Duration::from_secs(21_600);
 const DEFAULT_ATTEMPTS: u32 = 4;
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(1);
+
+fn user_agent() -> AwsUserAgent {
+    AwsUserAgent::new_from_environment(
+        Env::real(),
+        ApiMetadata::new("imds", PKG_VERSION),
+        Vec::new(),
+        Vec::new(),
+        Vec::new(),
+        None,
+    )
+}
 
 /// IMDSv2 Client
 ///
@@ -215,7 +223,7 @@ impl Client {
             .body(SdkBody::empty())
             .expect("valid request");
         let mut request = operation::Request::new(request);
-        request.properties_mut().insert(USER_AGENT);
+        request.properties_mut().insert(user_agent());
         Ok(Operation::new(request, ImdsGetResponseHandler)
             .with_metadata(Metadata::new("get", "imds"))
             .with_retry_policy(ImdsErrorPolicy))

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -131,7 +131,7 @@ impl TokenMiddleware {
             .body(SdkBody::empty())
             .expect("valid HTTP request");
         let mut request = operation::Request::new(request);
-        request.properties_mut().insert(super::USER_AGENT);
+        request.properties_mut().insert(super::user_agent());
 
         let operation = Operation::new(request, self.token_parser.clone())
             .with_retry_policy(ImdsErrorPolicy)

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -89,6 +89,10 @@ mod json_credentials;
 #[cfg(feature = "http-provider")]
 mod http_provider;
 
+// Re-export types from aws-types
+pub use aws_types::app_name::{AppName, InvalidAppName};
+pub use aws_types::config::Config;
+
 /// Create an environment loader for AWS Configuration
 ///
 /// # Examples

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -117,9 +117,10 @@ pub use loader::ConfigLoader;
 
 #[cfg(feature = "default-provider")]
 mod loader {
-    use crate::default_provider::{credentials, region, retry_config};
+    use crate::default_provider::{app_name, credentials, region, retry_config};
     use crate::meta::region::ProvideRegion;
     use aws_smithy_types::retry::RetryConfig;
+    use aws_types::app_name::AppName;
     use aws_types::config::Config;
     use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
 
@@ -133,6 +134,7 @@ mod loader {
     pub struct ConfigLoader {
         region: Option<Box<dyn ProvideRegion>>,
         retry_config: Option<RetryConfig>,
+        app_name: Option<AppName>,
         credentials_provider: Option<SharedCredentialsProvider>,
     }
 
@@ -210,6 +212,12 @@ mod loader {
                 retry_config::default_provider().retry_config().await
             };
 
+            let app_name = if self.app_name.is_some() {
+                self.app_name
+            } else {
+                app_name::default_provider().app_name().await
+            };
+
             let credentials_provider = if let Some(provider) = self.credentials_provider {
                 provider
             } else {
@@ -218,11 +226,12 @@ mod loader {
                 SharedCredentialsProvider::new(builder.build().await)
             };
 
-            Config::builder()
+            let mut builder = Config::builder()
                 .region(region)
                 .retry_config(retry_config)
-                .credentials_provider(credentials_provider)
-                .build()
+                .credentials_provider(credentials_provider);
+            builder.set_app_name(app_name);
+            builder.build()
         }
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/profile/app_name.rs
@@ -1,0 +1,184 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! Load an app name from an AWS profile
+
+use crate::provider_config::ProviderConfig;
+use aws_sdk_sts::AppName;
+use aws_types::os_shim_internal::{Env, Fs};
+
+/// Loads an app name from a profile file
+///
+/// This provider will attempt to shared AWS shared configuration and then read the
+/// `sdk-ua-app-id` property from the active profile.
+///
+/// # Examples
+///
+/// **Loads "my-app" as the app name**
+/// ```ini
+/// [default]
+/// sdk-ua-app-id = my-app
+/// ```
+///
+/// **Loads "my-app" as the app name _if and only if_ the `AWS_PROFILE` environment variable
+/// is set to `other`.**
+/// ```ini
+/// [profile other]
+/// sdk-ua-app-id = my-app
+/// ```
+///
+/// This provider is part of the [default app name provider chain](crate::default_provider::app_name).
+#[derive(Debug, Default)]
+pub struct ProfileFileAppNameProvider {
+    fs: Fs,
+    env: Env,
+    profile_override: Option<String>,
+}
+
+impl ProfileFileAppNameProvider {
+    /// Create a new [ProfileFileAppNameProvider}
+    ///
+    /// To override the selected profile, set the `AWS_PROFILE` environment variable or use the [`Builder`].
+    pub fn new() -> Self {
+        Self {
+            fs: Fs::real(),
+            env: Env::real(),
+            profile_override: None,
+        }
+    }
+
+    /// [`Builder`] to construct a [`ProfileFileRegionProvider`]
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    /// Parses the profile config and attempts to find an app name.
+    pub async fn app_name(&self) -> Option<AppName> {
+        let profile = super::parser::load(&self.fs, &self.env)
+            .await
+            .map_err(|err| tracing::warn!(err = %err, "failed to parse profile"))
+            .ok()?;
+        let selected_profile_name = self
+            .profile_override
+            .as_deref()
+            .unwrap_or_else(|| profile.selected_profile());
+        let selected_profile = profile.get_profile(selected_profile_name)?;
+        selected_profile
+            .get("sdk-ua-app-id")
+            .map(|name| match AppName::new(name.to_owned()) {
+                Ok(app_name) => Some(app_name),
+                Err(err) => {
+                    tracing::warn!(err = %err, "`sdk-ua-app-id` property in profile {} was invalid", selected_profile_name);
+                    None
+                }
+            })
+            .flatten()
+    }
+}
+
+/// Builder for [ProfileFileAppNameProvider]
+#[derive(Default)]
+pub struct Builder {
+    config: Option<ProviderConfig>,
+    profile_override: Option<String>,
+}
+
+impl Builder {
+    /// Override the configuration for this provider
+    pub fn configure(mut self, config: &ProviderConfig) -> Self {
+        self.config = Some(config.clone());
+        self
+    }
+
+    /// Override the profile name used by the [ProfileFileAppNameProvider]
+    pub fn profile_name(mut self, profile_name: impl Into<String>) -> Self {
+        self.profile_override = Some(profile_name.into());
+        self
+    }
+
+    /// Build a [ProfileFileAppNameProvider] from this builder
+    pub fn build(self) -> ProfileFileAppNameProvider {
+        let conf = self.config.unwrap_or_default();
+        ProfileFileAppNameProvider {
+            env: conf.env(),
+            fs: conf.fs(),
+            profile_override: self.profile_override,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProfileFileAppNameProvider;
+    use crate::provider_config::ProviderConfig;
+    use crate::test_case::no_traffic_connector;
+    use aws_sdk_sts::AppName;
+    use aws_types::os_shim_internal::{Env, Fs};
+    use tracing_test::traced_test;
+
+    fn provider_config(config_contents: &str) -> ProviderConfig {
+        let fs = Fs::from_slice(&[("test_config", config_contents)]);
+        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "test_config")]);
+        ProviderConfig::empty()
+            .with_fs(fs)
+            .with_env(env)
+            .with_http_connector(no_traffic_connector())
+    }
+
+    fn default_provider(config_contents: &str) -> ProfileFileAppNameProvider {
+        ProfileFileAppNameProvider::builder()
+            .configure(&provider_config(config_contents))
+            .build()
+    }
+
+    #[tokio::test]
+    async fn no_app_name() {
+        assert_eq!(None, default_provider("[default]\n").app_name().await);
+    }
+
+    #[tokio::test]
+    async fn app_name_default_profile() {
+        assert_eq!(
+            Some(AppName::new("test").unwrap()),
+            default_provider("[default]\nsdk-ua-app-id = test")
+                .app_name()
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn app_name_other_profiles() {
+        let config = "\
+            [default]\n\
+            sdk-ua-app-id = test\n\
+            \n\
+            [profile other]\n\
+            sdk-ua-app-id = bar\n
+        ";
+        assert_eq!(
+            Some(AppName::new("bar").unwrap()),
+            ProfileFileAppNameProvider::builder()
+                .profile_name("other")
+                .configure(&provider_config(config))
+                .build()
+                .app_name()
+                .await
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn invalid_app_name() {
+        assert_eq!(
+            None,
+            default_provider("[default]\nsdk-ua-app-id = definitely invalid")
+                .app_name()
+                .await
+        );
+        assert!(logs_contain(
+            "`sdk-ua-app-id` property in profile default was invalid"
+        ));
+    }
+}

--- a/aws/rust-runtime/aws-config/src/profile/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/profile/app_name.rs
@@ -6,7 +6,7 @@
 //! Load an app name from an AWS profile
 
 use crate::provider_config::ProviderConfig;
-use aws_sdk_sts::AppName;
+use aws_types::app_name::AppName;
 use aws_types::os_shim_internal::{Env, Fs};
 
 /// Loads an app name from a profile file
@@ -49,7 +49,7 @@ impl ProfileFileAppNameProvider {
         }
     }
 
-    /// [`Builder`] to construct a [`ProfileFileRegionProvider`]
+    /// [`Builder`] to construct a [`ProfileFileAppNameProvider`]
     pub fn builder() -> Builder {
         Builder::default()
     }
@@ -70,7 +70,7 @@ impl ProfileFileAppNameProvider {
             .map(|name| match AppName::new(name.to_owned()) {
                 Ok(app_name) => Some(app_name),
                 Err(err) => {
-                    tracing::warn!(err = %err, "`sdk-ua-app-id` property in profile {} was invalid", selected_profile_name);
+                    tracing::warn!(err = %err, "`sdk-ua-app-id` property in profile `{}` was invalid", selected_profile_name);
                     None
                 }
             })
@@ -178,7 +178,7 @@ mod tests {
                 .await
         );
         assert!(logs_contain(
-            "`sdk-ua-app-id` property in profile default was invalid"
+            "`sdk-ua-app-id` property in profile `default` was invalid"
         ));
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -12,6 +12,7 @@ mod parser;
 #[doc(inline)]
 pub use parser::{load, Profile, ProfileParseError, ProfileSet, Property};
 
+pub mod app_name;
 pub mod credentials;
 pub mod region;
 pub mod retry_config;

--- a/aws/rust-runtime/aws-config/src/profile/region.rs
+++ b/aws/rust-runtime/aws-config/src/profile/region.rs
@@ -17,14 +17,14 @@ use aws_types::region::Region;
 ///
 /// # Examples
 ///
-/// **Loads "us-west-2" as the region
+/// **Loads "us-west-2" as the region**
 /// ```ini
 /// [default]
 /// region = us-west-2
 /// ```
 ///
 /// **Loads `us-east-1` as the region _if and only if_ the `AWS_PROFILE` environment variable is set
-/// to `other`.
+/// to `other`.**
 ///
 /// ```ini
 /// [profile other]
@@ -73,7 +73,7 @@ impl Builder {
 impl ProfileFileRegionProvider {
     /// Create a new [ProfileFileRegionProvider]
     ///
-    /// To override the selected profile, set the `AWS_PROFILE` environment variable or use the [Builder].
+    /// To override the selected profile, set the `AWS_PROFILE` environment variable or use the [`Builder`].
     pub fn new() -> Self {
         Self {
             fs: Fs::real(),
@@ -82,7 +82,7 @@ impl ProfileFileRegionProvider {
         }
     }
 
-    /// [Builder] to construct a [ProfileFileRegionProvider]
+    /// [`Builder`] to construct a [`ProfileFileRegionProvider`]
     pub fn builder() -> Builder {
         Builder::default()
     }

--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -13,7 +13,6 @@ aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-types = { path = "../aws-types" }
 http = "0.2.3"
 lazy_static = "1"
-thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/aws/rust-runtime/aws-http/src/auth.rs
+++ b/aws/rust-runtime/aws-http/src/auth.rs
@@ -10,6 +10,7 @@ use aws_types::credentials::{CredentialsError, ProvideCredentials, SharedCredent
 use std::future::Future;
 use std::pin::Pin;
 
+/// Sets the credentials provider in the given property bag.
 pub fn set_provider(bag: &mut PropertyBag, provider: SharedCredentialsProvider) {
     bag.insert(provider);
 }
@@ -21,11 +22,12 @@ pub fn set_provider(bag: &mut PropertyBag, provider: SharedCredentialsProvider) 
 /// 1. Retrieves a `CredentialsProvider` from the property bag.
 /// 2. Calls the credential provider's `provide_credentials` and awaits its result.
 /// 3. Places returned `Credentials` into the property bad to drive downstream signing middleware.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct CredentialsStage;
 
 impl CredentialsStage {
+    /// Creates a new credentials stage.
     pub fn new() -> Self {
         CredentialsStage
     }
@@ -63,9 +65,12 @@ mod error {
     use std::error::Error as StdError;
     use std::fmt;
 
+    /// Failures that can occur in the credentials middleware.
     #[derive(Debug)]
     pub enum CredentialsStageError {
+        /// No credentials provider was found in the property bag for the operation.
         MissingCredentialsProvider,
+        /// Failed to load credentials with the credential provider in the property bag.
         CredentialsLoadingError(CredentialsError),
     }
 

--- a/aws/rust-runtime/aws-http/src/lib.rs
+++ b/aws/rust-runtime/aws-http/src/lib.rs
@@ -3,7 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+//! Provides user agent and credentials middleware for the AWS SDK.
+
+#![warn(
+    missing_docs,
+    missing_crate_level_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
+/// Credentials middleware
 pub mod auth;
+
+/// User agent middleware
 pub mod user_agent;
 
 use aws_smithy_http::result::SdkError;
@@ -19,7 +32,7 @@ use std::time::Duration;
 /// 3. The code is checked against a predetermined list of throttling errors & transient error codes
 /// 4. The status code is checked against a predetermined list of status codes
 #[non_exhaustive]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AwsErrorRetryPolicy;
 
 const TRANSIENT_ERROR_STATUS_CODES: &[u16] = &[500, 502, 503, 504];

--- a/aws/rust-runtime/aws-http/src/user_agent.rs
+++ b/aws/rust-runtime/aws-http/src/user_agent.rs
@@ -20,7 +20,7 @@ use std::fmt;
 /// Ths struct should be inserted into the [`PropertyBag`](aws_smithy_http::operation::Request::properties)
 /// during operation construction. [`UserAgentStage`](UserAgentStage) reads `AwsUserAgent`
 /// from the property bag and sets the `User-Agent` and `x-amz-user-agent` headers.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct AwsUserAgent {
     sdk_metadata: SdkMetadata,
     api_metadata: ApiMetadata,
@@ -100,18 +100,21 @@ impl AwsUserAgent {
         }
     }
 
+    #[doc(hidden)]
     /// Adds feature metadata to the user agent.
     pub fn with_feature_metadata(mut self, metadata: FeatureMetadata) -> Self {
         self.feature_metadata.push(metadata);
         self
     }
 
+    #[doc(hidden)]
     /// Adds config metadata to the user agent.
     pub fn with_config_metadata(mut self, metadata: ConfigMetadata) -> Self {
         self.config_metadata.push(metadata);
         self
     }
 
+    #[doc(hidden)]
     /// Adds framework metadata to the user agent.
     pub fn with_framework_metadata(mut self, metadata: FrameworkMetadata) -> Self {
         self.framework_metadata.push(metadata);
@@ -181,8 +184,8 @@ impl AwsUserAgent {
     }
 }
 
-#[derive(Clone, Copy)]
-pub struct SdkMetadata {
+#[derive(Clone, Copy, Debug)]
+struct SdkMetadata {
     name: &'static str,
     version: &'static str,
 }
@@ -193,13 +196,15 @@ impl fmt::Display for SdkMetadata {
     }
 }
 
-#[derive(Clone)]
+/// Metadata about the client that's making the call.
+#[derive(Clone, Debug)]
 pub struct ApiMetadata {
     service_id: Cow<'static, str>,
     version: &'static str,
 }
 
 impl ApiMetadata {
+    /// Creates new `ApiMetadata`.
     pub const fn new(service_id: &'static str, version: &'static str) -> Self {
         Self {
             service_id: Cow::Borrowed(service_id),
@@ -253,6 +258,8 @@ fn validate_metadata(value: Cow<'static, str>) -> Result<Cow<'static, str>, Inva
     Ok(value)
 }
 
+#[doc(hidden)]
+/// Additional metadata that can be bundled with framework or feature metadata.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct AdditionalMetadata {
@@ -260,6 +267,13 @@ pub struct AdditionalMetadata {
 }
 
 impl AdditionalMetadata {
+    /// Creates `AdditionalMetadata`.
+    ///
+    /// This will result in `InvalidMetadataValue` if the given value isn't alphanumeric or
+    /// has characters other than the following:
+    /// ```text
+    /// !#$%&'*+-.^_`|~
+    /// ```
     pub fn new(value: impl Into<Cow<'static, str>>) -> Result<Self, InvalidMetadataValue> {
         Ok(Self {
             value: validate_metadata(value.into())?,
@@ -292,6 +306,8 @@ impl fmt::Display for AdditionalMetadataList {
     }
 }
 
+#[doc(hidden)]
+/// Metadata about a feature that is being used in the SDK.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct FeatureMetadata {
@@ -301,6 +317,13 @@ pub struct FeatureMetadata {
 }
 
 impl FeatureMetadata {
+    /// Creates `FeatureMetadata`.
+    ///
+    /// This will result in `InvalidMetadataValue` if the given value isn't alphanumeric or
+    /// has characters other than the following:
+    /// ```text
+    /// !#$%&'*+-.^_`|~
+    /// ```
     pub fn new(
         name: impl Into<Cow<'static, str>>,
         version: Option<Cow<'static, str>>,
@@ -312,6 +335,7 @@ impl FeatureMetadata {
         })
     }
 
+    /// Bundles additional arbitrary metadata with this feature metadata.
     pub fn with_additional(mut self, metadata: AdditionalMetadata) -> Self {
         self.additional.push(metadata);
         self
@@ -329,6 +353,8 @@ impl fmt::Display for FeatureMetadata {
     }
 }
 
+#[doc(hidden)]
+/// Metadata about a config value that is being used in the SDK.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ConfigMetadata {
@@ -337,6 +363,13 @@ pub struct ConfigMetadata {
 }
 
 impl ConfigMetadata {
+    /// Creates `ConfigMetadata`.
+    ///
+    /// This will result in `InvalidMetadataValue` if the given value isn't alphanumeric or
+    /// has characters other than the following:
+    /// ```text
+    /// !#$%&'*+-.^_`|~
+    /// ```
     pub fn new(
         config: impl Into<Cow<'static, str>>,
         value: Option<Cow<'static, str>>,
@@ -359,6 +392,8 @@ impl fmt::Display for ConfigMetadata {
     }
 }
 
+#[doc(hidden)]
+/// Metadata about a software framework that is being used with the SDK.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct FrameworkMetadata {
@@ -368,6 +403,13 @@ pub struct FrameworkMetadata {
 }
 
 impl FrameworkMetadata {
+    /// Creates `FrameworkMetadata`.
+    ///
+    /// This will result in `InvalidMetadataValue` if the given value isn't alphanumeric or
+    /// has characters other than the following:
+    /// ```text
+    /// !#$%&'*+-.^_`|~
+    /// ```
     pub fn new(
         name: impl Into<Cow<'static, str>>,
         version: Option<Cow<'static, str>>,
@@ -379,6 +421,7 @@ impl FrameworkMetadata {
         })
     }
 
+    /// Bundles additional arbitrary metadata with this framework metadata.
     pub fn with_additional(mut self, metadata: AdditionalMetadata) -> Self {
         self.additional.push(metadata);
         self
@@ -396,7 +439,7 @@ impl fmt::Display for FrameworkMetadata {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct OsMetadata {
     os_family: &'static OsFamily,
     version: Option<String>,
@@ -420,7 +463,7 @@ impl fmt::Display for OsMetadata {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct LanguageMetadata {
     lang: &'static str,
     version: &'static str,
@@ -433,7 +476,7 @@ impl fmt::Display for LanguageMetadata {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct ExecEnvMetadata {
     name: String,
 }
@@ -443,19 +486,24 @@ impl fmt::Display for ExecEnvMetadata {
     }
 }
 
+/// User agent middleware
 #[non_exhaustive]
 #[derive(Default, Clone, Debug)]
 pub struct UserAgentStage;
 
 impl UserAgentStage {
+    /// Creates a new `UserAgentStage`
     pub fn new() -> Self {
         Self
     }
 }
 
+/// Failures that can arise from the user agent middleware
 #[derive(Debug)]
 pub enum UserAgentStageError {
+    /// There was no [`AwsUserAgent`] in the property bag.
     UserAgentMissing,
+    /// The formatted user agent string is not a valid HTTP header value. This indicates a bug.
     InvalidHeader(InvalidHeaderValue),
 }
 
@@ -465,7 +513,9 @@ impl fmt::Display for UserAgentStageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::UserAgentMissing => write!(f, "User agent missing from property bag"),
-            Self::InvalidHeader(_) => write!(f, "Provided user agent header was invalid"),
+            Self::InvalidHeader(_) => {
+                write!(f, "Provided user agent header was invalid. This is a bug.")
+            }
         }
     }
 }

--- a/aws/rust-runtime/aws-http/src/user_agent.rs
+++ b/aws/rust-runtime/aws-http/src/user_agent.rs
@@ -108,8 +108,22 @@ impl AwsUserAgent {
     }
 
     #[doc(hidden)]
+    /// Adds feature metadata to the user agent.
+    pub fn add_feature_metadata(&mut self, metadata: FeatureMetadata) -> &mut Self {
+        self.feature_metadata.push(metadata);
+        self
+    }
+
+    #[doc(hidden)]
     /// Adds config metadata to the user agent.
     pub fn with_config_metadata(mut self, metadata: ConfigMetadata) -> Self {
+        self.config_metadata.push(metadata);
+        self
+    }
+
+    #[doc(hidden)]
+    /// Adds config metadata to the user agent.
+    pub fn add_config_metadata(&mut self, metadata: ConfigMetadata) -> &mut Self {
         self.config_metadata.push(metadata);
         self
     }
@@ -121,8 +135,21 @@ impl AwsUserAgent {
         self
     }
 
+    #[doc(hidden)]
+    /// Adds framework metadata to the user agent.
+    pub fn add_framework_metadata(&mut self, metadata: FrameworkMetadata) -> &mut Self {
+        self.framework_metadata.push(metadata);
+        self
+    }
+
     /// Sets the app name for the user agent.
     pub fn with_app_name(mut self, app_name: AppName) -> Self {
+        self.app_name = Some(app_name);
+        self
+    }
+
+    /// Sets the app name for the user agent.
+    pub fn set_app_name(&mut self, app_name: AppName) -> &mut Self {
         self.app_name = Some(app_name);
         self
     }
@@ -330,7 +357,7 @@ impl FeatureMetadata {
     ) -> Result<Self, InvalidMetadataValue> {
         Ok(Self {
             name: validate_metadata(name.into())?,
-            version,
+            version: version.map(validate_metadata).transpose()?,
             additional: Default::default(),
         })
     }
@@ -376,14 +403,14 @@ impl ConfigMetadata {
     ) -> Result<Self, InvalidMetadataValue> {
         Ok(Self {
             config: validate_metadata(config.into())?,
-            value,
+            value: value.map(validate_metadata).transpose()?,
         })
     }
 }
 
 impl fmt::Display for ConfigMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // config-metadata = "cfg/" config ["/" name]
+        // config-metadata = "cfg/" config ["/" value]
         if let Some(value) = &self.value {
             write!(f, "cfg/{}/{}", self.config, value)
         } else {
@@ -416,7 +443,7 @@ impl FrameworkMetadata {
     ) -> Result<Self, InvalidMetadataValue> {
         Ok(Self {
             name: validate_metadata(name.into())?,
-            version,
+            version: version.map(validate_metadata).transpose()?,
             additional: Default::default(),
         })
     }
@@ -750,7 +777,7 @@ os-metadata          = "os/" os-family ["/" version]
 language-metadata    = "lang/" language "/" version *(RWS additional-metadata)
 env-metadata         = "exec-env/" name
 feat-metadata        = "ft/" name ["/" version] *(RWS additional-metadata)
-config-metadata      = "cfg/" config ["/" name]
+config-metadata      = "cfg/" config ["/" value]
 framework-metadata   = "lib/" name ["/" version] *(RWS additional-metadata)
 appId                = "app/" name
 ua-string            = sdk-metadata RWS

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -15,6 +15,7 @@ zeroize = "1.4.1"
 
 [dev-dependencies]
 futures-util = "0.3.16"
+tracing-test = "0.1"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 [dependencies]
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
+tracing = "0.1"
 zeroize = "1.4.1"
 
 [dev-dependencies]

--- a/aws/rust-runtime/aws-types/src/app_name.rs
+++ b/aws/rust-runtime/aws-types/src/app_name.rs
@@ -17,7 +17,7 @@ use std::fmt;
 /// ```text
 /// !#$%&'*+-.^_`|~
 /// ```
-/// Spaces are not allowed. If unsupported characters are given, this will lead to a panic.
+/// Spaces are not allowed.
 ///
 /// App names are recommended to be no more than 50 characters.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/aws/rust-runtime/aws-types/src/app_name.rs
+++ b/aws/rust-runtime/aws-types/src/app_name.rs
@@ -1,0 +1,97 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+//! New-type for a configurable app name.
+
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt;
+
+/// App name that can be configured with an AWS SDK client to become part of the user agent string.
+///
+/// This name is used to identify the application in the user agent that gets sent along with requests.
+///
+/// The name may only have alphanumeric characters and any of these characters:
+/// ```text
+/// !#$%&'*+-.^_`|~
+/// ```
+/// Spaces are not allowed. If unsupported characters are given, this will lead to a panic.
+///
+/// App names are recommended to be no more than 50 characters.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AppName(Cow<'static, str>);
+
+impl AsRef<str> for AppName {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AppName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AppName {
+    /// Creates a new app name.
+    ///
+    /// This will return an `InvalidAppName` error if the given name doesn't meet the
+    /// character requirements. See [`AppName`] for details on these requirements.
+    pub fn new(app_name: impl Into<Cow<'static, str>>) -> Result<Self, InvalidAppName> {
+        let app_name = app_name.into();
+
+        fn valid_character(c: char) -> bool {
+            match c {
+                _ if c.is_ascii_alphanumeric() => true,
+                '!' | '#' | '$' | '%' | '&' | '\'' | '*' | '+' | '-' | '.' | '^' | '_' | '`'
+                | '|' | '~' => true,
+                _ => false,
+            }
+        }
+        if !app_name.chars().all(valid_character) {
+            return Err(InvalidAppName);
+        }
+        if app_name.len() > 50 {
+            tracing::warn!(
+                "The `app_name` set when configuring the SDK client is recommended \
+                 to have no more than 50 characters."
+            )
+        }
+        Ok(Self(app_name))
+    }
+}
+
+/// Error for when an app name doesn't meet character requirements.
+///
+/// See [`AppName`] for details on these requirements.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct InvalidAppName;
+
+impl Error for InvalidAppName {}
+
+impl fmt::Display for InvalidAppName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "The app name can only have alphanumeric characters, or any of \
+             '!' |  '#' |  '$' |  '%' |  '&' |  '\\'' |  '*' |  '+' |  '-' | \
+             '.' |  '^' |  '_' |  '`' |  '|' |  '~'"
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AppName;
+
+    #[test]
+    fn validation() {
+        assert!(AppName::new("asdf1234ASDF!#$%&'*+-.^_`|~").is_ok());
+        assert!(AppName::new("foo bar").is_err());
+        assert!(AppName::new("🚀").is_err());
+    }
+}

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -9,16 +9,17 @@
 //!
 //! This module contains an shared configuration representation that is agnostic from a specific service.
 
-use aws_smithy_types::retry::RetryConfig;
-
+use crate::app_name::AppName;
 use crate::credentials::SharedCredentialsProvider;
 use crate::region::Region;
+use aws_smithy_types::retry::RetryConfig;
 
 /// AWS Shared Configuration
 pub struct Config {
     region: Option<Region>,
     retry_config: Option<RetryConfig>,
     credentials_provider: Option<SharedCredentialsProvider>,
+    app_name: Option<AppName>,
 }
 
 /// Builder for AWS Shared Configuration
@@ -27,6 +28,7 @@ pub struct Builder {
     region: Option<Region>,
     retry_config: Option<RetryConfig>,
     credentials_provider: Option<SharedCredentialsProvider>,
+    app_name: Option<AppName>,
 }
 
 impl Builder {
@@ -152,12 +154,31 @@ impl Builder {
         self
     }
 
+    /// Sets the name of the app that is using the client.
+    ///
+    /// This _optional_ name is used to identify the application in the user agent that
+    /// gets sent along with requests.
+    pub fn app_name(mut self, app_name: AppName) -> Self {
+        self.set_app_name(Some(app_name));
+        self
+    }
+
+    /// Sets the name of the app that is using the client.
+    ///
+    /// This _optional_ name is used to identify the application in the user agent that
+    /// gets sent along with requests.
+    pub fn set_app_name(&mut self, app_name: Option<AppName>) -> &mut Self {
+        self.app_name = app_name;
+        self
+    }
+
     /// Build a [`Config`](Config) from this builder
     pub fn build(self) -> Config {
         Config {
             region: self.region,
             retry_config: self.retry_config,
             credentials_provider: self.credentials_provider,
+            app_name: self.app_name,
         }
     }
 }
@@ -176,6 +197,11 @@ impl Config {
     /// Configured credentials provider
     pub fn credentials_provider(&self) -> Option<&SharedCredentialsProvider> {
         self.credentials_provider.as_ref()
+    }
+
+    /// Configured app name
+    pub fn app_name(&self) -> Option<&AppName> {
+        self.app_name.as_ref()
     }
 
     /// Config builder

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+pub mod app_name;
 pub mod build_metadata;
-// internal APIs, may be unstable
 pub mod config;
 pub mod credentials;
 #[doc(hidden)]

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeDependency.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeDependency.kt
@@ -49,3 +49,6 @@ object AwsRuntimeType {
 
 fun RuntimeConfig.awsRuntimeDependency(name: String, features: Set<String> = setOf()): CargoDependency =
     CargoDependency(name, awsRoot().crateLocation(), features = features)
+
+fun RuntimeConfig.awsHttp(): CargoDependency = awsRuntimeDependency("aws-http")
+fun RuntimeConfig.awsTypes(): CargoDependency = awsRuntimeDependency("aws-types")

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SharedConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SharedConfigDecorator.kt
@@ -48,6 +48,7 @@ class SharedConfigDecorator : RustCodegenDecorator {
                         builder = builder.region(input.region().cloned());
                         builder.set_retry_config(input.retry_config().cloned());
                         builder.set_credentials_provider(input.credentials_provider().cloned());
+                        builder.set_app_name(input.app_name().cloned());
                         builder
                     }
                 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -87,16 +87,14 @@ private class UserAgentFeature(private val runtimeConfig: RuntimeConfig) : Opera
         is OperationSection.MutateRequest -> writable {
             rustTemplate(
                 """
-                ${section.request}.properties_mut().insert(
-                    #{ua_module}::AwsUserAgent::new_from_environment(
-                        #{Env}::real(),
-                        crate::API_METADATA.clone(),
-                        Vec::new(),
-                        Vec::new(),
-                        Vec::new(),
-                        _config.app_name().cloned(),
-                    )
+                let mut user_agent = #{ua_module}::AwsUserAgent::new_from_environment(
+                    #{Env}::real(),
+                    crate::API_METADATA.clone(),
                 );
+                if let Some(app_name) = _config.app_name() {
+                    user_agent = user_agent.with_app_name(app_name.clone());
+                }
+                ${section.request}.properties_mut().insert(user_agent);
                 """,
                 "ua_module" to runtimeConfig.userAgentModule(),
                 "Env" to runtimeConfig.env(),

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -78,7 +78,7 @@ private class ApiVersionAndPubUse(private val runtimeConfig: RuntimeConfig, serv
     }
 }
 
-private fun RuntimeConfig.userAgentModule() = awsHttp().asType().copy(name = "user_agent")
+private fun RuntimeConfig.userAgentModule() = awsHttp().asType().member("user_agent")
 private fun RuntimeConfig.env(): RuntimeType = RuntimeType("Env", awsTypes(), "aws_types::os_shim_internal")
 private fun RuntimeConfig.appName(): RuntimeType = RuntimeType("AppName", awsTypes(this), "aws_types::app_name")
 

--- a/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
+++ b/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_http::user_agent::AwsUserAgent;
+use aws_sdk_s3::operation::ListObjectsV2;
+use aws_sdk_s3::{Credentials, Region};
+
+#[tokio::test]
+async fn user_agent_app_name() -> Result<(), aws_sdk_s3::Error> {
+    let creds = Credentials::from_keys(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+    );
+    let conf = aws_sdk_s3::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .app_name("test-app-name") // set app name in config
+        .build();
+
+    let op = ListObjectsV2::builder()
+        .bucket("test-bucket")
+        .build()
+        .unwrap()
+        .make_operation(&conf)
+        .await
+        .unwrap();
+    let properties = op.properties();
+    let user_agent = properties.get::<AwsUserAgent>().unwrap();
+    let formatted = user_agent.aws_ua_header();
+
+    // verify app name made it to the user agent
+    assert!(
+        formatted.ends_with(" app/test-app-name"),
+        "'{}' didn't end with the app name",
+        formatted
+    );
+
+    Ok(())
+}

--- a/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
+++ b/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use aws_http::user_agent::AwsUserAgent;
-use aws_sdk_s3::operation::ListObjectsV2;
 use aws_sdk_s3::{AppName, Credentials, Region};
+use aws_smithy_client::test_connection::capture_request;
 
 #[tokio::test]
 async fn user_agent_app_name() -> Result<(), aws_sdk_s3::Error> {
+    let (conn, handler) = capture_request(None);
     let creds = Credentials::from_keys(
         "ANOTREAL",
         "notrealrnrELgWzOk3IfjzDKtFBhDby",
@@ -19,19 +19,19 @@ async fn user_agent_app_name() -> Result<(), aws_sdk_s3::Error> {
         .region(Region::new("us-east-1"))
         .app_name(AppName::new("test-app-name").expect("valid app name")) // set app name in config
         .build();
-
-    let op = ListObjectsV2::builder()
-        .bucket("test-bucket")
-        .build()
-        .unwrap()
-        .make_operation(&conf)
-        .await
-        .unwrap();
-    let properties = op.properties();
-    let user_agent = properties.get::<AwsUserAgent>().unwrap();
-    let formatted = user_agent.aws_ua_header();
+    let client = aws_sdk_s3::Client::from_conf_conn(conf, conn);
+    let _response = client.list_objects_v2().bucket("test-bucket").send().await;
 
     // verify app name made it to the user agent
+    let request = handler.expect_request();
+    let formatted = std::str::from_utf8(
+        request
+            .headers()
+            .get("x-amz-user-agent")
+            .unwrap()
+            .as_bytes(),
+    )
+    .unwrap();
     assert!(
         formatted.ends_with(" app/test-app-name"),
         "'{}' didn't end with the app name",

--- a/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
+++ b/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
@@ -5,7 +5,7 @@
 
 use aws_http::user_agent::AwsUserAgent;
 use aws_sdk_s3::operation::ListObjectsV2;
-use aws_sdk_s3::{Credentials, Region};
+use aws_sdk_s3::{AppName, Credentials, Region};
 
 #[tokio::test]
 async fn user_agent_app_name() -> Result<(), aws_sdk_s3::Error> {
@@ -17,7 +17,7 @@ async fn user_agent_app_name() -> Result<(), aws_sdk_s3::Error> {
     let conf = aws_sdk_s3::Config::builder()
         .credentials_provider(creds)
         .region(Region::new("us-east-1"))
-        .app_name("test-app-name") // set app name in config
+        .app_name(AppName::new("test-app-name").expect("valid app name")) // set app name in config
         .build();
 
     let op = ListObjectsV2::builder()


### PR DESCRIPTION
## Description
This PR adds feature, config, framework, and app name formatting to user agents, and also adds the ability to set the app name from service config, shared config, profile config, and environment variables.

## Testing
- Added integration test
- Ran an example to manually verify it works end to end

## Checklist
- [ ] I have updated `CHANGELOG.md`
- [x] I have updated `aws/SDK_CHANGELOG.md` if applicable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
