### PR TITLE
Fix indentation issue with block quote pre-commit script

### DIFF
--- a/.pre-commit-hooks/kotlin-block-quotes.py
+++ b/.pre-commit-hooks/kotlin-block-quotes.py
@@ -110,6 +110,9 @@ def fix_lines(lines):
 
         # Format block quotes
         elif state == State.InsideBlockQuote:
+            if first_inner_indent == None and len(line.strip()) == 0:
+                continue
+
             current_indent = line_indent(line)
             # Track the first line's indentation inside of the block quote
             # so that relative indentation can be preserved.
@@ -252,6 +255,11 @@ class SelfTest(unittest.TestCase):
             expected = ['    """', '    asdf {', '        asdf', '    }', '    """'], \
             input = ['    """', '  asdf {', '      asdf', '  }', '"""'], \
             lines_changed = [2, 3, 4, 5] \
+        )
+        self.fix_lines_test_case( \
+            expected = ['    """', '', '    foo', '    bar', '    """'], \
+            input = ['    """', '', '    foo', '    bar', '    """'], \
+            lines_changed = [] \
         )
 
 def main():


### PR DESCRIPTION
## Motivation and Context
If the first line in a block quote was empty, the correct indentation level was determined incorrectly which would lead to pre-commit infinitely indenting the block quote (as in, each successive run would indent it more). This PR fixes that issue.

## Testing
- Added unit test
- Manually tested against input that caused it

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
