### PR TITLE
fix: normalize generated cargo dependency paths

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -10,7 +10,6 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.util.dq
-import kotlin.io.path.Path
 
 sealed class DependencyScope {
     object Dev : DependencyScope()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.util.dq
+import java.nio.file.Path
 
 sealed class DependencyScope {
     object Dev : DependencyScope()
@@ -150,7 +151,7 @@ data class CargoDependency(
             when (this) {
                 is CratesIo -> attribs["version"] = version
                 is Local -> {
-                    val fullPath = java.nio.file.Path.of("$basePath/$name")
+                    val fullPath = Path.of("$basePath/$name")
                     attribs["path"] = fullPath.normalize().toString()
                     version?.also { attribs["version"] = version }
                 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.codegen.core.SymbolDependencyContainer
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.util.dq
+import kotlin.io.path.Path
 
 sealed class DependencyScope {
     object Dev : DependencyScope()
@@ -150,8 +151,8 @@ data class CargoDependency(
             when (this) {
                 is CratesIo -> attribs["version"] = version
                 is Local -> {
-                    val fullPath = "$basePath/$name"
-                    attribs["path"] = fullPath
+                    val fullPath = java.nio.file.Path.of("$basePath/$name")
+                    attribs["path"] = fullPath.normalize().toString()
                     version?.also { attribs["version"] = version }
                 }
             }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This fixes an issue where we were generating file paths but not normalizing them. This caused issues with IDEs.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I visually inspected the new paths generated after the fix

Before the fix:
```
[dependencies.aws-endpoint]
path = "..//aws-endpoint"
version = "0.0.26-alpha"
```
After the fix
```
[dependencies.aws-endpoint]
path = "../aws-endpoint"
version = "0.0.26-alpha"
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
