### PR TITLE
Make it possible to turn off the Tokio runtime feature

### DIFF
--- a/aws/rust-runtime/aws-hyper/Cargo.toml
+++ b/aws/rust-runtime/aws-hyper/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
 default = []
+rt-tokio = ["hyper/runtime", "hyper/tcp"]
 native-tls = ["hyper-tls", "aws-smithy-client/native-tls"]
 rustls = ["hyper-rustls", "aws-smithy-client/rustls"]
 
@@ -24,10 +25,9 @@ bytes = "1"
 fastrand = "1.4.0"
 http = "0.2.3"
 http-body = "0.4.0"
-hyper = { version = "0.14.2", features = ["client", "http1", "http2", "tcp", "runtime"] }
-hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
+hyper = { version = "0.14.2", features = ["client", "http1", "http2"] }
+hyper-rustls = { version = "0.22.1", optional = true, features = ["native-tokio"] }
 hyper-tls = { version ="0.5.0", optional = true }
-tokio = { version = "1", features = ["time"] }
 tower = { version = "0.4.6", features = ["util", "retry"] }
 
 pin-project = "1"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -75,6 +75,7 @@ class AwsFluentClientDecorator : RustCodegenDecorator {
         rustCrate.mergeFeature(Feature("client", default = true, listOf(awsHyper, "aws-smithy-client")))
         rustCrate.mergeFeature(Feature("rustls", default = true, listOf("$awsHyper/rustls")))
         rustCrate.mergeFeature(Feature("native-tls", default = false, listOf("$awsHyper/native-tls")))
+        rustCrate.mergeFeature(Feature("rt-tokio", default = true, listOf("$awsHyper/rt-tokio", "aws-smithy-async/rt-tokio")))
     }
 
     override fun libRsCustomizations(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
@@ -93,5 +93,5 @@ private val Criterion = CargoDependency("criterion", CratesIo("0.3"), scope = De
 private val FuturesCore = CargoDependency("futures-core", CratesIo("0.3"), DependencyScope.Dev)
 private val Hound = CargoDependency("hound", CratesIo("3.4"), DependencyScope.Dev)
 private val SerdeJson = CargoDependency("serde_json", CratesIo("1"), features = emptySet(), scope = DependencyScope.Dev)
-private val Tokio = CargoDependency("tokio", CratesIo("1"), features = setOf("macros", "test-util"), scope = DependencyScope.Dev)
+private val Tokio = CargoDependency("tokio", CratesIo("1"), features = setOf("macros", "time", "test-util"), scope = DependencyScope.Dev)
 private val FuturesUtil = CargoDependency("futures-util", CratesIo("0.3"), scope = DependencyScope.Dev)

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -14,7 +14,6 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 tracing-subscriber = "0.2.18"
-tokio  = { version = "1", features = ["full"]}
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
@@ -22,3 +21,4 @@ aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
 bytes = "1"
 http = "0.2.3"
 serde_json = "1"
+tokio  = { version = "1", features = ["full", "test-util"]}

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
 rt-tokio = ["tokio"]
-default = ["rt-tokio"]
+default = []
 
 [dependencies]
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -9,10 +9,10 @@ repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
 rt-tokio = ["aws-smithy-async/rt-tokio"]
-test-util = ["aws-smithy-protocol-test", "serde/derive"]
-default = ["hyper", "rustls", "rt-tokio"]
-native-tls = ["hyper", "hyper-tls", "rt-tokio"]
-rustls = ["hyper", "hyper-rustls", "rt-tokio", "lazy_static"]
+test-util = ["aws-smithy-protocol-test", "serde/derive", "hyper/tcp"]
+default = ["hyper"]
+native-tls = ["hyper", "hyper-tls"]
+rustls = ["hyper", "hyper-rustls", "lazy_static"]
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
@@ -24,7 +24,7 @@ fastrand = "1.4.0"
 http = "0.2.3"
 http-body = "0.4.0"
 hyper = { version = "0.14.2", features = ["client", "http2"], optional = true }
-hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
+hyper-rustls = { version = "0.22.1", features = ["native-tokio"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project-lite = "0.2.7"
@@ -38,6 +38,7 @@ aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test", optional = tr
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
+aws-smithy-async = { path = "../aws-smithy-async", features = ["rt-tokio"] }
 tokio = { version = "1", features = ["full", "test-util"] }
 tower-test = "0.4.0"
 serde = { version = "1", features = ["derive"] }

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -33,7 +33,7 @@ pub mod hyper_ext;
 #[doc(hidden)]
 pub mod static_tests;
 
-#[cfg(feature = "hyper")]
+#[cfg(feature = "test-util")]
 pub mod never;
 pub mod timeout;
 pub use timeout::TimeoutLayer;


### PR DESCRIPTION
## Motivation and Context
This is an incremental step towards supporting multiple async runtimes.

## Description
These changes make it possible to disable the Tokio `runtime` feature by doing the following, for example:
```
[dependencies]
aws-sdk-s3 = { version = "VERSION", default-features = false, features = ["client"] }
```

The approach taken is to change all the runtime crates to no longer default to using Tokio `runtime`, and then have the generated service crates turn on the `rt-tokio` features by default. That way, the features only need to be tweaked on the crates customers will directly depend on.

These changes have not:
- Vetted whether this makes it possible to use async-std
- Done anything with the `aws-config` crate

More work is needed after this PR.

## Testing
- [x] Created a cargo project out of tree that references the generated `aws-sdk-s3`, and used `cargo tree -e features` to determine that nothing was enabling the Tokio `runtime` feature
- [x] Compiled and ran the S3 and DynamoDB examples
- [x] Compiled and ran the S3 integration tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
