### PR TITLE
`rust-server-codegen`: make operation input / output wrappers public

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -145,7 +145,7 @@ private class ServerHttpProtocolImplGenerator(
         }
         rustTemplate(
             """
-            pub(crate) struct $inputName(#{I});
+            pub struct $inputName(pub #{I});
             ##[#{Axum}::async_trait]
             impl<B> #{Axum}::extract::FromRequest<B> for $inputName
             where
@@ -194,7 +194,7 @@ private class ServerHttpProtocolImplGenerator(
             // that can in turn be converted into a response.
             rustTemplate(
                 """
-                pub(crate) enum $outputName {
+                pub enum $outputName {
                     Output(#{O}),
                     Error(#{E})
                 }
@@ -228,7 +228,7 @@ private class ServerHttpProtocolImplGenerator(
             // we control that can in turn be converted into a response.
             rustTemplate(
                 """
-                pub(crate) struct $outputName(#{O});
+                pub struct $outputName(pub #{O});
                 ##[#{Axum}::async_trait]
                 impl #{Axum}::response::IntoResponse for $outputName {
                     type Body = #{SmithyHttpServer}::Body;


### PR DESCRIPTION
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
