### PR TITLE
set appropriate minimum httpbody version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ vNext (Month Day, Year)
 
 **New this release**
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
+- Fix http-body dependency version (smithy-rs#TODO, aws-sdk-rust#305)
 
 **Breaking Changes**
 - (aws-smithy-client): Extraneous `pub use SdkSuccess` removed from `aws_smithy_client::hyper_ext`. (smithy-rs#855)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ vNext (Month Day, Year)
 
 **New this release**
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
-- Fix http-body dependency version (smithy-rs#TODO, aws-sdk-rust#305)
+- Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 
 **Breaking Changes**
 - (aws-smithy-client): Extraneous `pub use SdkSuccess` removed from `aws_smithy_client::hyper_ext`. (smithy-rs#855)

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -8,7 +8,7 @@ vNext (Month Day, Year)
 
 - :tada: Timeouts for requests are now configurable. You can set a timeout for each individual request attempt or for all attempts made for a request. (smithy-rs#831)
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
-- Fix http-body dependency version (smithy-rs#TODO, aws-sdk-rust#305)
+- Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 
 **Breaking changes**
 

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -8,6 +8,7 @@ vNext (Month Day, Year)
 
 - :tada: Timeouts for requests are now configurable. You can set a timeout for each individual request attempt or for all attempts made for a request. (smithy-rs#831)
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
+- Fix http-body dependency version (smithy-rs#TODO, aws-sdk-rust#305)
 
 **Breaking changes**
 

--- a/aws/rust-runtime/aws-hyper/Cargo.toml
+++ b/aws/rust-runtime/aws-hyper/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 bytes = "1"
 fastrand = "1.4.0"
 http = "0.2.3"
-http-body = "0.4.0"
+http-body = "0.4.4"
 hyper = { version = "0.14.2", features = ["client", "http1", "http2", "tcp", "runtime"] }
 hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
 hyper-tls = { version ="0.5.0", optional = true }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -194,7 +194,7 @@ data class CargoDependency(
         val BytesUtils: CargoDependency = CargoDependency("bytes-utils", CratesIo("0.1.1"))
         val FastRand: CargoDependency = CargoDependency("fastrand", CratesIo("1"))
         val Hex: CargoDependency = CargoDependency("hex", CratesIo("0.4.3"))
-        val HttpBody: CargoDependency = CargoDependency("http-body", CratesIo("0.4"))
+        val HttpBody: CargoDependency = CargoDependency("http-body", CratesIo("0.4.4"))
         val Http: CargoDependency = CargoDependency("http", CratesIo("0.2"))
         val Hyper: CargoDependency = CargoDependency("hyper", CratesIo("0.14"))
         val HyperWithStream: CargoDependency = Hyper.withFeature("stream")

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -22,7 +22,7 @@ aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 fastrand = "1.4.0"
 http = "0.2.3"
-http-body = "0.4.0"
+http-body = "0.4.4"
 hyper = { version = "0.14.2", features = ["client", "http2"], optional = true }
 hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
 hyper-tls = { version = "0.5.0", optional = true }

--- a/rust-runtime/aws-smithy-http-tower/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-tower/Cargo.toml
@@ -13,7 +13,7 @@ tower = { version = "0.4.4" }
 pin-project = "1"
 http = "0.2.3"
 bytes = "1"
-http-body = "0.4.0"
+http-body = "0.4.4"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -18,7 +18,7 @@ aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 bytes-utils = "0.1"
 http = "0.2.3"
-http-body = "0.4.0"
+http-body = "0.4.4"
 percent-encoding = "2.1.0"
 pin-project = "1"
 tracing = "0.1"


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/aws-sdk-rust/issues/305

## Description
http_body::combinators was added in 0.4.1 but we specify 0.4.0 in the dependencies.

## Testing
- CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
