### PR TITLE
Fix URL encoding signing bug & add ApiGatewayManagement example

### DIFF
--- a/aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/double-encode-path/double-encode-path.creq
+++ b/aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/double-encode-path/double-encode-path.creq
@@ -1,0 +1,8 @@
+POST
+/test/%40connections/JBDvjfGEIAMCERw%253D
+
+host:tj9n5r0m12.execute-api.us-east-1.amazonaws.com
+x-amz-date:20210511T154045Z
+
+host;x-amz-date
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

--- a/aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/double-encode-path/double-encode-path.req
+++ b/aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/double-encode-path/double-encode-path.req
@@ -1,0 +1,3 @@
+POST /test/@connections/JBDvjfGEIAMCERw%3D HTTP/1.1
+Host:tj9n5r0m12.execute-api.us-east-1.amazonaws.com
+X-amz-date:20150830T123600Z

--- a/aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/double-encode-path/double-encode-path.sreq
+++ b/aws/rust-runtime/aws-sigv4/aws-sig-v4-test-suite/double-encode-path/double-encode-path.sreq
@@ -1,0 +1,4 @@
+POST /test/@connections/JBDvjfGEIAMCERw%3D HTTP/1.1
+X-amz-date:20150830T123600Z
+Authorization:AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/service/aws4_request, SignedHeaders=host;x-amz-date, Signature=6f871eb157f326fa5f7439eb88ca200048635950ce7d6037deda56f0c95d4364
+Host:tj9n5r0m12.execute-api.us-east-1.amazonaws.com

--- a/aws/rust-runtime/aws-sigv4/src/http_request/query_writer.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/query_writer.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use crate::http_request::url_escape::percent_encode;
+use crate::http_request::url_escape::percent_encode_query;
 use http::Uri;
 
 /// Utility for updating the query string in a [`Uri`].
@@ -49,10 +49,10 @@ impl QueryWriter {
             self.new_path_and_query.push(prefix);
         }
         self.prefix = Some('&');
-        self.new_path_and_query.push_str(&percent_encode(k));
+        self.new_path_and_query.push_str(&percent_encode_query(k));
         self.new_path_and_query.push('=');
 
-        self.new_path_and_query.push_str(&percent_encode(v));
+        self.new_path_and_query.push_str(&percent_encode_query(v));
     }
 
     /// Returns just the built query string.

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -348,6 +348,35 @@ mod tests {
     }
 
     #[test]
+    fn test_sign_url_escape() {
+        let test = "double-encode-path";
+        let settings = SigningSettings::default();
+        let params = SigningParams {
+            access_key: "AKIDEXAMPLE",
+            secret_key: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+            security_token: None,
+            region: "us-east-1",
+            service_name: "service",
+            time: parse_date_time("20150830T123600Z").unwrap(),
+            settings,
+        };
+
+        let original = test_request(test);
+        let signable = SignableRequest::from(&original);
+        let out = sign(signable, &params).unwrap();
+        assert_eq!(
+            "6f871eb157f326fa5f7439eb88ca200048635950ce7d6037deda56f0c95d4364",
+            out.signature
+        );
+
+        let mut signed = original;
+        out.output.apply_to_request(&mut signed);
+
+        let mut expected = test_signed_request(test);
+        assert_req_eq!(expected, signed);
+    }
+
+    #[test]
     fn test_sign_vanilla_with_query_params() {
         let mut settings = SigningSettings::default();
         settings.signature_location = SignatureLocation::QueryParams;

--- a/aws/rust-runtime/aws-sigv4/src/http_request/url_escape.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/url_escape.rs
@@ -8,7 +8,6 @@ use percent_encoding::{AsciiSet, CONTROLS};
 /// base set of characters that must be URL encoded
 const BASE_SET: &AsciiSet = &CONTROLS
     .add(b' ')
-    .add(b'/')
     // RFC-3986 §3.3 allows sub-delims (defined in section2.2) to be in the path component.
     // This includes both colon ':' and comma ',' characters.
     // Smithy protocol tests & AWS services percent encode these expected values. Signing
@@ -32,6 +31,13 @@ const BASE_SET: &AsciiSet = &CONTROLS
     .add(b'=')
     .add(b'%');
 
-pub(super) fn percent_encode(value: &str) -> String {
-    percent_encoding::percent_encode(value.as_bytes(), BASE_SET).to_string()
+const QUERY_SET: &AsciiSet = &BASE_SET.add(b'/');
+const PATH_SET: &AsciiSet = BASE_SET;
+
+pub(super) fn percent_encode_query(value: &str) -> String {
+    percent_encoding::percent_encode(value.as_bytes(), QUERY_SET).to_string()
+}
+
+pub(super) fn percent_encode_path(value: &str) -> String {
+    percent_encoding::percent_encode(value.as_bytes(), PATH_SET).to_string()
 }

--- a/aws/sdk/examples/apigatewaymanagement/Cargo.toml
+++ b/aws/sdk/examples/apigatewaymanagement/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "apigatewaymanagement-code-examples"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-sdk-apigatewaymanagement = { path = "../../build/aws-sdk/sdk/apigatewaymanagement" }
+http = "0.2.5"
+tokio = { version = "1", features = ["full"] }
+structopt = { version = "0.3", default-features = false }
+tracing-subscriber = "0.2.18"

--- a/aws/sdk/examples/apigatewaymanagement/README.md
+++ b/aws/sdk/examples/apigatewaymanagement/README.md
@@ -1,0 +1,17 @@
+# AWS SDK for Rust code examples for API Gateway
+
+The Amazon API Gateway Management API allows you to directly manage runtime aspects of your deployed APIs. To use it, you must explicitly set the SDK's endpoint to point to the endpoint of your deployed API. The endpoint will be of the form https://`[api-id].execute-api.[region].amazonaws.com/[stage]`, or will be the endpoint corresponding to your API's custom domain and base path, if applicable.
+
+### Notes
+
+- We recommend that you grant this code least privilege,
+  or at most the minimum permissions required to perform the task.
+  For more information, see
+  [Grant Least Privilege](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#grant-least-privilege)
+  in the AWS Identity and Access Management User Guide.
+- This code has not been tested in all AWS Regions.
+  Some AWS services are available only in specific
+  [Regions](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services).
+- Running this code might result in charges to your AWS account.
+
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved. SPDX-License-Identifier: Apache-2.0

--- a/aws/sdk/examples/apigatewaymanagement/src/bin/post_to_connection.rs
+++ b/aws/sdk/examples/apigatewaymanagement/src/bin/post_to_connection.rs
@@ -1,0 +1,104 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use aws_config::meta::region::RegionProviderChain;
+use aws_sdk_apigatewaymanagement::{
+    config, Blob, Client, Config, Endpoint, Error, Region, PKG_VERSION,
+};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+/// AWS apigatewaymanagenent must be used with a custom endpoint, which this example demonstrates how to set.
+///
+/// Usage:
+/// 1. Setup a Websocket API Gateway endpoint with a route configured.
+/// 2. Connect to the route with `wscat`: wscat -c wss://<api-id>.execute-api.<region>.amazonaws.com/<stage>/
+/// 2. Determine the connection id (eg. by configuring your route to echo the connection id into the websocket)
+/// 3. Invoke this example. The `data` sent should appear in `wscat`
+struct Opt {
+    /// The AWS Region.
+    #[structopt(short, long)]
+    region: Option<String>,
+
+    /// Whether to display additional information.
+    #[structopt(short, long)]
+    verbose: bool,
+
+    /// API ID for your API
+    #[structopt(short, long)]
+    api_id: String,
+
+    /// Deployment stage for your API
+    #[structopt(short, long)]
+    stage: String,
+
+    /// Connection Id to send data to
+    #[structopt(short, long)]
+    connection_id: String,
+
+    /// Data to send to the connection
+    #[structopt(short, long)]
+    data: String,
+}
+
+/// Displays information about the Amazon API Gateway REST APIs in the Region.
+///
+/// # Arguments
+///
+/// * `--api-id` - API ID for your API
+/// * `--stage` - Stage for your API
+/// * `[-r REGION]` - The Region in which the client is created.
+///   If not supplied, uses the value of the **AWS_REGION** environment variable.
+///   If the environment variable is not set, defaults to **us-west-2**.
+/// * `[-v]` - Whether to display information.
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    tracing_subscriber::fmt::init();
+    let Opt {
+        region,
+        verbose,
+        api_id,
+        stage,
+        connection_id,
+        data,
+    } = Opt::from_args();
+
+    let region_provider = RegionProviderChain::first_try(region.map(Region::new))
+        .or_default_provider()
+        .or_else(Region::new("us-west-2"));
+    println!();
+
+    let region = region_provider.region().await.unwrap();
+    if verbose {
+        println!("APIGatewayManagement client version: {}", PKG_VERSION);
+        println!("Region:                    {}", region.as_ref());
+
+        println!();
+    }
+
+    let uri = format!(
+        "https://{api_id}.execute-api.{region}.amazonaws.com/{stage}",
+        api_id = api_id,
+        region = region,
+        stage = stage
+    )
+    .parse()
+    .expect("could not construct valid URI for endpoint");
+    let endpoint = Endpoint::immutable(uri);
+
+    let shared_config = aws_config::from_env().region(region_provider).load().await;
+    let api_management_config = config::Builder::from(&shared_config)
+        .endpoint_resolver(endpoint)
+        .build();
+    let client = Client::from_conf(api_management_config);
+
+    client
+        .post_to_connection()
+        .connection_id(connection_id)
+        .data(Blob::new(data))
+        .send()
+        .await;
+    Ok(())
+}


### PR DESCRIPTION
## Motivation and Context
- aws-sdk-rust#300
- Parameters in `path` that must be URI encoded were not being encoded.

## Description
- Fix bug in aws-sigv4 that did not properly double-uri encode URI paths
- Add example for ApiGatewayManagement

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [ ] verify top level landing page includes a link to the examples
- [x] manually verified example works
- [x] CI
- [x] New unit tests in aws-sigv4  

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
