### PR TITLE
Feature: add TimeoutError variant to SdkError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ vNext (Month Day, Year)
 **New this release**
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
+- `SdkError` now includes a variant `TimeoutError` for when a request times out (smithy-rs#885)
 
 **Breaking Changes**
 - (aws-smithy-client): Extraneous `pub use SdkSuccess` removed from `aws_smithy_client::hyper_ext`. (smithy-rs#855)

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -7,7 +7,7 @@ vNext (Month Day, Year)
 **New this release**
 
 - :tada: Timeouts for requests are now configurable. You can set a timeout for each individual request attempt or for all attempts made for a request. (smithy-rs#831)
-  - both `SdkError` and `ImdsError` now include a variant `TimeoutError` for when a request times out  (smithy-rs#885)
+  - `SdkError` now includes a variant `TimeoutError` for when a request times out  (smithy-rs#885)
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -7,6 +7,7 @@ vNext (Month Day, Year)
 **New this release**
 
 - :tada: Timeouts for requests are now configurable. You can set a timeout for each individual request attempt or for all attempts made for a request. (smithy-rs#831)
+  - both `SdkError` and `ImdsError` now include a variant `TimeoutError` for when a request times out  (smithy-rs#885)
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -187,6 +187,7 @@ impl Client {
                 Ok(token_failure) => *token_failure,
                 Err(other) => ImdsError::Unexpected(other),
             },
+            SdkError::TimeoutError(err) => ImdsError::TimeoutError(err),
             SdkError::DispatchFailure(err) => ImdsError::IoError(err.into()),
             SdkError::ResponseError { err, .. } => ImdsError::IoError(err),
             SdkError::ServiceError {
@@ -251,6 +252,9 @@ pub enum ImdsError {
     /// An error occurred communication with IMDS
     IoError(Box<dyn Error + Send + Sync + 'static>),
 
+    /// A request to IMDS failed due to a timeout
+    TimeoutError(Box<dyn Error + Send + Sync + 'static>),
+
     /// An unexpected error occurred communicating with IMDS
     Unexpected(Box<dyn Error + Send + Sync + 'static>),
 }
@@ -259,7 +263,7 @@ impl Display for ImdsError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             ImdsError::FailedToLoadToken(inner) => {
-                write!(f, "failed to load session token: {}", inner)
+                write!(f, "Failed to load session token: {}", inner)
             }
             ImdsError::InvalidPath => write!(
                 f,
@@ -273,6 +277,9 @@ impl Display for ImdsError {
             ),
             ImdsError::IoError(err) => {
                 write!(f, "An IO error occurred communicating with IMDS: {}", err)
+            }
+            ImdsError::TimeoutError(err) => {
+                write!(f, "An IMDS request timed out: {}", err)
             }
             ImdsError::Unexpected(err) => write!(
                 f,

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -187,7 +187,7 @@ impl Client {
                 Ok(token_failure) => *token_failure,
                 Err(other) => ImdsError::Unexpected(other),
             },
-            SdkError::TimeoutError(err) => ImdsError::TimeoutError(err),
+            SdkError::TimeoutError(err) => ImdsError::IoError(err),
             SdkError::DispatchFailure(err) => ImdsError::IoError(err.into()),
             SdkError::ResponseError { err, .. } => ImdsError::IoError(err),
             SdkError::ServiceError {
@@ -252,9 +252,6 @@ pub enum ImdsError {
     /// An error occurred communication with IMDS
     IoError(Box<dyn Error + Send + Sync + 'static>),
 
-    /// A request to IMDS failed due to a timeout
-    TimeoutError(Box<dyn Error + Send + Sync + 'static>),
-
     /// An unexpected error occurred communicating with IMDS
     Unexpected(Box<dyn Error + Send + Sync + 'static>),
 }
@@ -277,9 +274,6 @@ impl Display for ImdsError {
             ),
             ImdsError::IoError(err) => {
                 write!(f, "An IO error occurred communicating with IMDS: {}", err)
-            }
-            ImdsError::TimeoutError(err) => {
-                write!(f, "An IMDS request timed out: {}", err)
             }
             ImdsError::Unexpected(err) => write!(
                 f,

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -14,7 +14,7 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 tracing-subscriber = "0.2.18"
-tokio  = { version = "1", features = ["full"]}
+tokio  = { version = "1", features = ["full", "test-util"]}
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}

--- a/aws/sdk/integration-tests/s3/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/s3/tests/timeouts.rs
@@ -62,6 +62,6 @@ async fn test_timeout_service_ends_request_that_never_completes() {
         .await
         .unwrap_err();
 
-    assert_eq!(format!("{:?}", err), "TimeoutError(TimedOutError)");
+    assert_eq!(format!("{:?}", err), "TimeoutError(RequestTimeoutError { kind: \"API call (all attempts including retries)\", duration: 500ms })");
     assert_elapsed!(now, std::time::Duration::from_secs_f32(0.5));
 }

--- a/aws/sdk/integration-tests/s3/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/s3/tests/timeouts.rs
@@ -62,6 +62,6 @@ async fn test_timeout_service_ends_request_that_never_completes() {
         .await
         .unwrap_err();
 
-    assert_eq!(format!("{:?}", err), "ConstructionFailure(TimedOutError)");
+    assert_eq!(format!("{:?}", err), "TimeoutError(TimedOutError)");
     assert_elapsed!(now, std::time::Duration::from_secs_f32(0.5));
 }

--- a/rust-runtime/aws-smithy-client/src/timeout.rs
+++ b/rust-runtime/aws-smithy-client/src/timeout.rs
@@ -252,7 +252,7 @@ where
         match future.poll(cx) {
             Poll::Ready(Ok(response)) => Poll::Ready(response),
             Poll::Ready(Err(_timeout)) => Poll::Ready(Err(SdkError::TimeoutError(
-                RequestTimeoutError::new_boxed(kind, duration.clone()),
+                RequestTimeoutError::new_boxed(kind, *duration),
             ))),
             Poll::Pending => Poll::Pending,
         }

--- a/rust-runtime/aws-smithy-client/src/timeout.rs
+++ b/rust-runtime/aws-smithy-client/src/timeout.rs
@@ -65,6 +65,30 @@ impl Settings {
     }
 }
 
+#[derive(Debug)]
+struct RequestTimeoutError {
+    kind: &'static str,
+    duration: Duration,
+}
+
+impl RequestTimeoutError {
+    pub fn new_boxed(kind: &'static str, duration: Duration) -> Box<Self> {
+        Box::new(Self { kind, duration })
+    }
+}
+
+impl std::fmt::Display for RequestTimeoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} timeout occurred after {:?}",
+            self.kind, self.duration
+        )
+    }
+}
+
+impl std::error::Error for RequestTimeoutError {}
+
 #[derive(Clone, Debug)]
 /// A struct containing everything needed to create a new [`TimeoutService`]
 pub struct TimeoutServiceParams {
@@ -217,7 +241,7 @@ where
     type Output = Result<T, SdkError<E>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let (future, _kind, _duration) = match self.project() {
+        let (future, kind, duration) = match self.project() {
             TimeoutServiceFutureProj::NoTimeout { future } => return future.poll(cx),
             TimeoutServiceFutureProj::Timeout {
                 future,
@@ -227,9 +251,9 @@ where
         };
         match future.poll(cx) {
             Poll::Ready(Ok(response)) => Poll::Ready(response),
-            Poll::Ready(Err(timeout)) => {
-                Poll::Ready(Err(SdkError::TimeoutError(Box::new(timeout))))
-            }
+            Poll::Ready(Err(_timeout)) => Poll::Ready(Err(SdkError::TimeoutError(
+                RequestTimeoutError::new_boxed(kind, duration.clone()),
+            ))),
             Poll::Pending => Poll::Pending,
         }
     }
@@ -293,7 +317,7 @@ mod test {
         let err: SdkError<Box<dyn std::error::Error + 'static>> =
             svc.ready().await.unwrap().call(op).await.unwrap_err();
 
-        assert_eq!(format!("{:?}", err), "TimeoutError(TimedOutError)");
+        assert_eq!(format!("{:?}", err), "TimeoutError(RequestTimeoutError { kind: \"API call (all attempts including retries)\", duration: 250ms })");
         assert_elapsed!(now, Duration::from_secs_f32(0.25));
     }
 }

--- a/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
+++ b/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
@@ -130,6 +130,9 @@ where
                 Err(SdkError::ConstructionFailure(err)) => inner_span
                     .record("status", &"construction_failure")
                     .record("message", &display(err)),
+                Err(SdkError::TimeoutError(err)) => inner_span
+                    .record("status", &"timeout_error")
+                    .record("message", &display(err)),
             };
             resp
         }

--- a/rust-runtime/aws-smithy-http/src/result.rs
+++ b/rust-runtime/aws-smithy-http/src/result.rs
@@ -33,11 +33,11 @@ pub struct SdkSuccess<O> {
 /// Failed SDK Result
 #[derive(Debug)]
 pub enum SdkError<E, R = operation::Response> {
-    // TODO Request failures due to a timeout currently report this error type even though
-    // they're not really a construction failure. Add a new variant for timeouts or update
-    // DispatchFailure to accept more than just ConnectorErrors
     /// The request failed during construction. It was not dispatched over the network.
     ConstructionFailure(BoxError),
+
+    /// The request failed due to a timeout. The request MAY have been sent and received.
+    TimeoutError(BoxError),
 
     /// The request failed during dispatch. An HTTP response was not received. The request MAY
     /// have been sent.
@@ -180,6 +180,7 @@ where
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             SdkError::ConstructionFailure(err) => write!(f, "failed to construct request: {}", err),
+            SdkError::TimeoutError(err) => write!(f, "request has timed out: {}", err),
             SdkError::DispatchFailure(err) => Display::fmt(&err, f),
             SdkError::ResponseError { err, .. } => Display::fmt(&err, f),
             SdkError::ServiceError { err, .. } => Display::fmt(&err, f),
@@ -193,12 +194,13 @@ where
     R: Debug,
 {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use SdkError::*;
         match self {
-            SdkError::ConstructionFailure(err) | SdkError::ResponseError { err, .. } => {
+            ConstructionFailure(err) | TimeoutError(err) | ResponseError { err, .. } => {
                 Some(err.as_ref())
             }
-            SdkError::DispatchFailure(err) => Some(err),
-            SdkError::ServiceError { err, .. } => Some(err),
+            DispatchFailure(err) => Some(err),
+            ServiceError { err, .. } => Some(err),
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Before this change, service timeouts returned an `SdkError::ConstructionFailure` which is not accurate. This adds a new variant `SdkError::TimeoutError` for them to return instead.

## Description
<!--- Describe your changes in detail -->
Add a new `TimeoutError` variant to `SdkError`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I updated and ran the extant timeout tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
