### PR TITLE
fix: silence home directory warning when running on lambda

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -10,6 +10,7 @@ vNext (Month Day, Year)
   - `SdkError` now includes a variant `TimeoutError` for when a request times out  (smithy-rs#885)
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
+- Add a new check so that the SDK doesn't emit an irrelevant `$HOME` dir warning when running in a Lambda (aws-sdk-rust#307)
 
 **Breaking changes**
 

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -178,16 +178,12 @@ fn expand_home(
     }
 }
 
-// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
-// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
-// that we can check.
+/// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
+/// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
+/// that we can check.
 fn check_is_likely_running_on_a_lambda(environment: &os_shim_internal::Env) -> bool {
-    // AWS_EXECUTION_ENV – The runtime identifier, prefixed by AWS_Lambda_—for example, AWS_Lambda_java8.
-    environment
-        .get("AWS_EXECUTION_ENV")
-        .ok()
-        .map(|value| value.starts_with("AWS_Lambda_"))
-        .unwrap_or_default()
+    // LAMBDA_TASK_ROOT – The path to your Lambda function code.
+    environment.get("LAMBDA_TASK_ROOT").is_ok()
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -305,7 +301,7 @@ mod tests {
     #[traced_test]
     #[test]
     fn load_config_file_should_not_emit_warning_on_lambda() {
-        let env = Env::from_slice(&[("AWS_EXECUTION_ENV", "AWS_Lambda_rust")]);
+        let env = Env::from_slice(&[("LAMBDA_TASK_ROOT", "/")]);
         let fs = Fs::from_slice(&[]);
 
         let _src = load_config_file(FileKind::Config, &None, &fs, &env).now_or_never();


### PR DESCRIPTION
update: SDK_CHANGELOG.md

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
[aws](https://github.com/awslabs/aws-sdk-rust/issues/307)

## Description
<!--- Describe your changes in detail -->
This adds a new function that determines whether or not an app is running in an AWS Lambda. If it is, it will silence a warning that gets emitted when no home directory can be found

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a test ensuring logs won't be emitted when a lambda-specific env var is set

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
