### PR TITLE
update: don't run generated doc tests

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/RetryConfigDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/RetryConfigDecorator.kt
@@ -104,7 +104,7 @@ class RetryConfigProviderConfig(codegenContext: CodegenContext) : ConfigCustomiz
                     /// Set the retry_config for the builder
                     ///
                     /// ## Examples
-                    /// ```rust
+                    /// ```no_run
                     /// use $moduleUseName::config::Config;
                     /// use #{RetryConfig};
                     ///
@@ -119,7 +119,7 @@ class RetryConfigProviderConfig(codegenContext: CodegenContext) : ConfigCustomiz
                     /// Set the retry_config for the builder
                     ///
                     /// ## Examples
-                    /// ```rust
+                    /// ```no_run
                     /// use $moduleUseName::config::{Builder, Config};
                     /// use #{RetryConfig};
                     ///

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/SleepImplDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/SleepImplDecorator.kt
@@ -95,7 +95,8 @@ class SleepImplProviderConfig(codegenContext: CodegenContext) : ConfigCustomizat
                     /// Set the sleep_impl for the builder
                     ///
                     /// ## Examples
-                    /// ```rust
+                    ///
+                    /// ```no_run
                     /// use $moduleUseName::config::Config;
                     /// use #{AsyncSleep};
                     /// use #{Sleep};
@@ -120,7 +121,8 @@ class SleepImplProviderConfig(codegenContext: CodegenContext) : ConfigCustomizat
                     /// Set the sleep_impl for the builder
                     ///
                     /// ## Examples
-                    /// ```rust
+                    ///
+                    /// ```no_run
                     /// use $moduleUseName::config::{Builder, Config};
                     /// use #{AsyncSleep};
                     /// use #{Sleep};

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/TimeoutConfigDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/TimeoutConfigDecorator.kt
@@ -94,7 +94,8 @@ class TimeoutConfigProviderConfig(codegenContext: CodegenContext) : ConfigCustom
                     /// Set the timeout_config for the builder
                     ///
                     /// ## Examples
-                    /// ```rust
+                    ///
+                    /// ```no_run
                     /// ## use std::time::Duration;
                     /// use $moduleUseName::config::Config;
                     /// use #{TimeoutConfig};
@@ -111,7 +112,8 @@ class TimeoutConfigProviderConfig(codegenContext: CodegenContext) : ConfigCustom
                     /// Set the timeout_config for the builder
                     ///
                     /// ## Examples
-                    /// ```rust
+                    ///
+                    /// ```no_run
                     /// ## use std::time::Duration;
                     /// use $moduleUseName::config::{Builder, Config};
                     /// use #{TimeoutConfig};

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -411,7 +411,7 @@ class FluentClientGenerator(
                 /// [SigV4-signed requests], the middleware looks like this:
                 ///
                 // Ignored as otherwise we'd need to pull in all these dev-dependencies.
-                /// ```rust,ignore
+                /// ```ignore
                 /// use aws_endpoint::AwsEndpointStage;
                 /// use aws_http::user_agent::UserAgentStage;
                 /// use aws_sig_auth::middleware::SigV4SigningStage;
@@ -434,7 +434,7 @@ class FluentClientGenerator(
                 ///         let signer = MapRequestLayer::for_mapper(SigV4SigningStage::new(SigV4Signer::new())); _signer: MapRequestLaye
                 ///         let endpoint_resolver = MapRequestLayer::for_mapper(AwsEndpointStage); _endpoint_resolver: MapRequestLayer<Aw
                 ///         let user_agent = MapRequestLayer::for_mapper(UserAgentStage::new()); _user_agent: MapRequestLayer<UserAgentSt
-                ///         // These layers can be considered as occuring in order, that is:
+                ///         // These layers can be considered as occurring in order, that is:
                 ///         // 1. Resolve an endpoint
                 ///         // 2. Add a user agent
                 ///         // 3. Sign

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ServiceGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/ServiceGenerator.kt
@@ -21,7 +21,7 @@ import software.amazon.smithy.rust.codegen.util.inputShape
 /**
  * ServiceGenerator
  *
- * Service generator is the main codegeneration entry point for Smithy services. Individual structures and unions are
+ * Service generator is the main code generation entry point for Smithy services. Individual structures and unions are
  * generated in codegen visitor, but this class handles all protocol-specific code generation.
  */
 class ServiceGenerator(


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
generated doc tests closely mimic existing doc tests on `aws_smithy_client::Client` and `aws_types::Config` but take significant amounts of time to run in CI.

## Description
<!--- Describe your changes in detail -->
This change compiles generated doc tests but no longer runs them

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran `./gradlew :aws:sdk:cargoTest`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
