### PR TITLE
Improve generated docs for crates and clients

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -183,30 +183,27 @@ private class AwsFluentClientDocs(codegenContext: CodegenContext) : FluentClient
                         /// ## Examples
                         /// **Constructing a client and invoking an operation**
                         /// ```rust,no_run
-                        /// ##[tokio::main]
-                        /// async fn main() -> Result<(), $crateName::Error> {
-                        ///     let config = #{aws_config}::load_from_env().await;
+                        /// ## async fn docs() {
+                        ///     // create a shared configuration. This can be used & shared between multiple service clients.
+                        ///     let shared_config = #{aws_config}::load_from_env().await;
                         ///     let client = $crateName::Client::new(&shared_config);
                         ///     // invoke an operation
                         ///     /* let rsp = client
                         ///         .<operationname>().
                         ///         .<param>("some value")
                         ///         .send().await; */
-                        ///     Ok(())
-                        /// }
+                        /// ## }
                         /// ```
                         /// **Constructing a client with custom configuration**
                         /// ```rust,no_run
                         /// use #{aws_config}::RetryConfig;
-                        /// ##[tokio::main]
-                        /// async fn example() -> Result<(), $crateName::Error> {
+                        /// ## async fn docs() {
                         ///     let shared_config = #{aws_config}::load_from_env().await;
                         ///     let config = $crateName::config::Builder::from(&shared_config)
                         ///         .retry_config(RetryConfig::disabled())
                         ///         .build();
                         ///     let client = $crateName::Client::from_conf(config);
-                        ///     Ok(())
-                        /// }
+                        /// ## }
                         """,
                         *codegenScope
                     )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeDependency.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeDependency.kt
@@ -52,3 +52,4 @@ fun RuntimeConfig.awsRuntimeDependency(name: String, features: Set<String> = set
 
 fun RuntimeConfig.awsHttp(): CargoDependency = awsRuntimeDependency("aws-http")
 fun RuntimeConfig.awsTypes(): CargoDependency = awsRuntimeDependency("aws-types")
+fun RuntimeConfig.awsConfig(): CargoDependency = awsRuntimeDependency("aws-config")

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -130,6 +130,7 @@ fun generateSmithyBuild(services: List<AwsService>): String {
                         "moduleVersion": "${getProperty("aws.sdk.version")}",
                         "moduleAuthors": ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "Russell Cohen <rcoh@amazon.com>"],
                         "moduleDescription": "${service.moduleDescription}",
+                        ${service.examplesUri(project)?.let { """"examples": "$it",""" } ?: ""}
                         "moduleRepository": "https://github.com/awslabs/aws-sdk-rust",
                         "license": "Apache-2.0"
                         ${service.extraConfig ?: ""}

--- a/buildSrc/src/main/kotlin/DocsLandingPage.kt
+++ b/buildSrc/src/main/kotlin/DocsLandingPage.kt
@@ -29,7 +29,7 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
         writer.write("| Service | Package |")
         writer.write("| ------- | ------- |")
         awsServices.sortedBy { it.humanName }.forEach {
-            val items = listOfNotNull(cratesIo(it), docsRs(it), examples(it, project)).joinToString(" ")
+            val items = listOfNotNull(cratesIo(it), docsRs(it), examplesLink(it, project)).joinToString(" ")
             writer.write(
                 "| ${it.humanName} | $items |"
             )
@@ -41,11 +41,7 @@ fun Project.docsLandingPage(awsServices: List<AwsService>, outputDir: File) {
 /**
  * Generate a link to the examples for a given service
  */
-private fun examples(service: AwsService, project: Project) = if (with(service) { project.examples() }) {
-    "([examples](https://github.com/awslabs/aws-sdk-rust/tree/main/examples/${service.module}))"
-} else {
-    null
-}
+private fun examplesLink(service: AwsService, project: Project) = service.examplesUri(project)?.let { "([examples]($it))" }
 
 /**
  * Generate a link to the docs

--- a/buildSrc/src/main/kotlin/ServiceLoader.kt
+++ b/buildSrc/src/main/kotlin/ServiceLoader.kt
@@ -89,7 +89,15 @@ data class AwsService(
     val humanName: String
 ) {
     fun files(): List<File> = listOf(modelFile) + extraFiles
-    fun Project.examples(): Boolean = projectDir.resolve("examples").resolve(module).exists()
+    fun Project.examples(): File = projectDir.resolve("examples").resolve(module)
+    /**
+     * Generate a link to the examples for a given service
+     */
+    fun examplesUri(project: Project) = if (project.examples().exists()) {
+        "https://github.com/awslabs/aws-sdk-rust/tree/main/examples/$module"
+    } else {
+        null
+    }
 }
 
 fun AwsService.crate(): String = "aws-sdk-$module"

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -230,7 +230,10 @@ fun <T : CodeWriter> T.documentShape(shape: Shape, model: Model, autoSuppressMis
     return this
 }
 
-fun RustWriter.superDocs(text: String, vararg args: Any): RustWriter {
+/** Document the containing entity (eg. module, crate, etc.)
+ * Instead of prefixing lines with `///` lines are prefixed with `//!`
+ */
+fun RustWriter.containerDocs(text: String, vararg args: Any): RustWriter {
     return docs(text, newlinePrefix = "//! ", args = args)
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
@@ -26,6 +26,7 @@ private const val MODULE_REPOSITORY = "moduleRepository"
 private const val RUNTIME_CONFIG = "runtimeConfig"
 private const val CODEGEN_SETTINGS = "codegen"
 private const val LICENSE = "license"
+private const val EXAMPLES = "examples"
 
 /**
  * Configuration of codegen settings
@@ -77,6 +78,7 @@ class RustSettings(
     val runtimeConfig: RuntimeConfig,
     val codegenConfig: CodegenConfig,
     val license: String?,
+    val examplesUri: String? = null,
     private val model: Model
 ) {
 
@@ -115,6 +117,7 @@ class RustSettings(
                     MODULE_REPOSITORY,
                     RUNTIME_CONFIG,
                     CODEGEN_SETTINGS,
+                    EXAMPLES,
                     LICENSE
                 )
             )
@@ -135,6 +138,7 @@ class RustSettings(
                 runtimeConfig = RuntimeConfig.fromNode(runtimeConfig),
                 codegenConfig = CodegenConfig.fromNode(codegenSettings),
                 license = config.getStringMember(LICENSE).orNull()?.value,
+                examplesUri = config.getStringMember(EXAMPLES).orNull()?.value,
                 model = model
             )
         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.smithy.generators
 import software.amazon.smithy.model.knowledge.TopDownIndex
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.Feature
@@ -16,6 +17,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asOptional
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.docs
@@ -61,7 +63,11 @@ class FluentClientDecorator : RustCodegenDecorator {
                 documentation = "Client and fluent builders for calling the service."
             )
         ) { writer ->
-            FluentClientGenerator(codegenContext, includeSmithyGenericClientDocs = true).render(writer)
+            FluentClientGenerator(
+                codegenContext,
+                includeSmithyGenericClientDocs = true,
+                customizations = listOf(GenericFluentClient(codegenContext))
+            ).render(writer)
         }
         val smithyClient = CargoDependency.SmithyClient(codegenContext.runtimeConfig)
         rustCrate.mergeFeature(Feature("client", true, listOf(smithyClient.name)))
@@ -95,6 +101,9 @@ sealed class FluentClientSection(name: String) : Section(name) {
         val operationShape: OperationShape,
         val operationErrorType: RuntimeType
     ) : FluentClientSection("FluentBuilderImpl")
+
+    /** Write custom code into the docs */
+    data class FluentClientDocs(val serviceShape: ServiceShape) : FluentClientSection("FluentClientDocs")
 }
 
 abstract class FluentClientCustomization : NamedSectionGenerator<FluentClientSection>()
@@ -128,6 +137,135 @@ data class ClientGenerics(
     }
 }
 
+class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomization() {
+    val moduleUseName = codegenContext.moduleUseName()
+    override fun section(section: FluentClientSection): Writable {
+        return when (section) {
+            is FluentClientSection.FluentClientDocs -> writable {
+                val humanName = section.serviceShape.id.name
+                rust(
+                    """
+                    /// An ergonomic service client for `$humanName`.
+                    ///
+                    /// This client allows ergonomic access to a `$humanName`-shaped service.
+                    /// Each method corresponds to an endpoint defined in the service's Smithy model,
+                    /// and the request and response shapes are auto-generated from that same model.
+            ///"""
+                )
+                rust(
+                    """
+                    /// ## Constructing a Client
+                    ///
+                    /// To construct a client, you need a few different things:
+                    ///
+                    /// - A [`Config`](crate::Config) that specifies additional configuration
+                    ///   required by the service.
+                    /// - A connector (`C`) that specifies how HTTP requests are translated
+                    ///   into HTTP responses. This will typically be an HTTP client (like
+                    ///   `hyper`), though you can also substitute in your own, like a mock
+                    ///   mock connector for testing.
+                    /// - A "middleware" (`M`) that modifies requests prior to them being
+                    ///   sent to the request. Most commonly, middleware will decide what
+                    ///   endpoint the requests should be sent to, as well as perform
+                    ///   authentcation and authorization of requests (such as SigV4).
+                    ///   You can also have middleware that performs request/response
+                    ///   tracing, throttling, or other middleware-like tasks.
+                    /// - A retry policy (`R`) that dictates the behavior for requests that
+                    ///   fail and should (potentially) be retried. The default type is
+                    ///   generally what you want, as it implements a well-vetted retry
+                    ///   policy described in TODO.
+                    ///
+                    /// To construct a client, you will generally want to call
+                    /// [`Client::with_config`], which takes a [`#{client}::Client`] (a
+                    /// Smithy client that isn't specialized to a particular service),
+                    /// and a [`Config`](crate::Config). Both of these are constructed using
+                    /// the [builder pattern] where you first construct a `Builder` type,
+                    /// then configure it with the necessary parameters, and then call
+                    /// `build` to construct the finalized output type. The
+                    /// [`#{client}::Client`] builder is re-exported in this crate as
+                    /// [`Builder`] for convenience.
+                    ///
+                    /// In _most_ circumstances, you will want to use the following pattern
+                    /// to construct a client:
+                    ///
+                    /// ```
+                    /// use $moduleUseName::{Builder, Client, Config};
+                    /// let raw_client =
+                    ///     Builder::new()
+                    ///       .https()
+                    /// ##     /*
+                    ///       .middleware(/* discussed below */)
+                    /// ##     */
+                    /// ##     .middleware_fn(|r| r)
+                    ///       .build();
+                    /// let config = Config::builder().build();
+                    /// let client = Client::with_config(raw_client, config);
+                    /// ```
+                    ///
+                    /// For the middleware, you'll want to use whatever matches the
+                    /// routing, authentication and authorization required by the target
+                    /// service. For example, for the standard AWS SDK which uses
+                    /// [SigV4-signed requests], the middleware looks like this:
+                    ///
+                    // Ignored as otherwise we'd need to pull in all these dev-dependencies.
+                    /// ```rust,ignore
+                    /// use aws_endpoint::AwsEndpointStage;
+                    /// use aws_http::user_agent::UserAgentStage;
+                    /// use aws_sig_auth::middleware::SigV4SigningStage;
+                    /// use aws_sig_auth::signer::SigV4Signer;
+                    /// use aws_smithy_http_tower::map_request::MapRequestLayer;
+                    /// use tower::layer::util::Stack;
+                    /// use tower::ServiceBuilder;
+                    ///
+                    /// type AwsMiddlewareStack =
+                    ///     Stack<MapRequestLayer<SigV4SigningStage>,
+                    ///         Stack<MapRequestLayer<UserAgentStage>,
+                    ///             MapRequestLayer<AwsEndpointStage>>>,
+                    ///
+                    /// ##[derive(Debug, Default)]
+                    /// pub struct AwsMiddleware;
+                    /// impl<S> tower::Layer<S> for AwsMiddleware {
+                    ///     type Service = <AwsMiddlewareStack as tower::Layer<S>>::Service;
+                    ///
+                    ///     fn layer(&self, inner: S) -> Self::Service {
+                    ///         let signer = MapRequestLayer::for_mapper(SigV4SigningStage::new(SigV4Signer::new())); _signer: MapRequestLaye
+                    ///         let endpoint_resolver = MapRequestLayer::for_mapper(AwsEndpointStage); _endpoint_resolver: MapRequestLayer<Aw
+                    ///         let user_agent = MapRequestLayer::for_mapper(UserAgentStage::new()); _user_agent: MapRequestLayer<UserAgentSt
+                    ///         // These layers can be considered as occuring in order, that is:
+                    ///         // 1. Resolve an endpoint
+                    ///         // 2. Add a user agent
+                    ///         // 3. Sign
+                    ///         // (4. Dispatch over the wire)
+                    ///         ServiceBuilder::new() _ServiceBuilder<Identity>
+                    ///             .layer(endpoint_resolver) _ServiceBuilder<Stack<MapRequestLayer<_>, _>>
+                    ///             .layer(user_agent) _ServiceBuilder<Stack<MapRequestLayer<_>, _>>
+                    ///             .layer(signer) _ServiceBuilder<Stack<MapRequestLayer<_>, _>>
+                    ///             .service(inner)
+                    ///     }
+                    /// }
+                    /// ```
+                ///"""
+                )
+                rust(
+                    """
+                    /// ## Using a Client
+                    ///
+                    /// Once you have a client set up, you can access the service's endpoints
+                    /// by calling the appropriate method on [`Client`]. Each such method
+                    /// returns a request builder for that endpoint, with methods for setting
+                    /// the various fields of the request. Once your request is complete, use
+                    /// the `send` method to send the request. `send` returns a future, which
+                    /// you then have to `.await` to get the service's response.
+                    ///
+                    /// [builder pattern]: https://rust-lang.github.io/api-guidelines/type-safety.html##c-builder
+            /// [SigV4-signed requests]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html"""
+                )
+            }
+            else -> emptySection
+        }
+    }
+}
+
 class FluentClientGenerator(
     codegenContext: CodegenContext,
     // Whether to include Client construction details that are relevant to generic Smithy generated clients,
@@ -155,51 +293,61 @@ class FluentClientGenerator(
     fun render(writer: RustWriter) {
         writer.rustTemplate(
             """
+            // hello world
             ##[derive(Debug)]
             pub(crate) struct Handle${generics.decl} {
-                client: #{client}::Client${generics.inst},
-                conf: crate::Config,
+            client: #{client}::Client${generics.inst},
+            conf: crate::Config,
             }
 
-            ${clientDocComments()}
+            #{client_docs:W}
             ##[derive(std::fmt::Debug)]
             pub struct Client${generics.decl} {
-                handle: std::sync::Arc<Handle${generics.inst}>
+            handle: std::sync::Arc<Handle${generics.inst}>
             }
 
             impl${generics.inst} std::clone::Clone for Client${generics.inst} {
-                fn clone(&self) -> Self {
-                    Self { handle: self.handle.clone() }
-                }
+            fn clone(&self) -> Self {
+                Self { handle: self.handle.clone() }
+            }
             }
 
             ##[doc(inline)]
             pub use #{client}::Builder;
 
             impl${generics.inst} From<#{client}::Client${generics.inst}> for Client${generics.inst} {
-                fn from(client: #{client}::Client${generics.inst}) -> Self {
-                    Self::with_config(client, crate::Config::builder().build())
-                }
+            fn from(client: #{client}::Client${generics.inst}) -> Self {
+                Self::with_config(client, crate::Config::builder().build())
+            }
             }
 
             impl${generics.inst} Client${generics.inst} {
-                /// Creates a client with the given service configuration.
-                pub fn with_config(client: #{client}::Client${generics.inst}, conf: crate::Config) -> Self {
-                    Self {
-                        handle: std::sync::Arc::new(Handle {
-                            client,
-                            conf,
-                        })
-                    }
+            /// Creates a client with the given service configuration.
+            pub fn with_config(client: #{client}::Client${generics.inst}, conf: crate::Config) -> Self {
+                Self {
+                    handle: std::sync::Arc::new(Handle {
+                        client,
+                        conf,
+                    })
                 }
+            }
 
-                /// Returns the client's configuration.
-                pub fn conf(&self) -> &crate::Config {
-                    &self.handle.conf
-                }
+            /// Returns the client's configuration.
+            pub fn conf(&self) -> &crate::Config {
+                &self.handle.conf
+            }
             }
             """,
             "client" to clientDep.asType(),
+            "client_docs" to writable {
+                customizations.forEach {
+                    it.section(
+                        FluentClientSection.FluentClientDocs(
+                            serviceShape
+                        )
+                    )(this)
+                }
+            },
             *generics.codegenScope.toTypedArray()
         )
         writer.rustBlockTemplate(
@@ -214,7 +362,12 @@ class FluentClientGenerator(
                     ///
                     /// See [`$name`](crate::client::fluent_builders::$name) for more information about the
                     /// operation and its arguments.
-                    pub fn ${clientOperationFnName(operation, symbolProvider)}(&self) -> fluent_builders::$name${generics.inst} {
+                    pub fn ${
+                    clientOperationFnName(
+                        operation,
+                        symbolProvider
+                    )
+                    }(&self) -> fluent_builders::$name${generics.inst} {
                         fluent_builders::$name::new(self.handle.clone())
                     }
                     """
@@ -294,7 +447,8 @@ class FluentClientGenerator(
                         "input" to symbolProvider.toSymbol(operation.inputShape(model)),
                         "ok" to symbolProvider.toSymbol(operation.outputShape(model)),
                         "operation_err" to operation.errorSymbol(symbolProvider),
-                        "sdk_err" to CargoDependency.SmithyHttp(runtimeConfig).asType().copy(name = "result::SdkError"),
+                        "sdk_err" to CargoDependency.SmithyHttp(runtimeConfig).asType()
+                            .copy(name = "result::SdkError"),
                         "client" to clientDep.asType(),
                     )
                     writeCustomizations(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -139,6 +139,8 @@ data class ClientGenerics(
 
 class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomization() {
     val moduleUseName = codegenContext.moduleUseName()
+    private val clientDep = CargoDependency.SmithyClient(codegenContext.runtimeConfig).copy(optional = true)
+    private val codegenScope = arrayOf("client" to clientDep.asType())
     override fun section(section: FluentClientSection): Writable {
         return when (section) {
             is FluentClientSection.FluentClientDocs -> writable {
@@ -150,9 +152,9 @@ class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomiz
                     /// This client allows ergonomic access to a `$humanName`-shaped service.
                     /// Each method corresponds to an endpoint defined in the service's Smithy model,
                     /// and the request and response shapes are auto-generated from that same model.
-            ///"""
+                    /// """
                 )
-                rust(
+                rustTemplate(
                     """
                     /// ## Constructing a Client
                     ///
@@ -244,7 +246,8 @@ class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomiz
                     ///     }
                     /// }
                     /// ```
-                ///"""
+                    ///""",
+                    *codegenScope
                 )
                 rust(
                     """
@@ -258,7 +261,7 @@ class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomiz
                     /// you then have to `.await` to get the service's response.
                     ///
                     /// [builder pattern]: https://rust-lang.github.io/api-guidelines/type-safety.html##c-builder
-            /// [SigV4-signed requests]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html"""
+                    /// [SigV4-signed requests]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html"""
                 )
             }
             else -> emptySection
@@ -293,49 +296,48 @@ class FluentClientGenerator(
     fun render(writer: RustWriter) {
         writer.rustTemplate(
             """
-            // hello world
             ##[derive(Debug)]
             pub(crate) struct Handle${generics.decl} {
-            client: #{client}::Client${generics.inst},
-            conf: crate::Config,
+                client: #{client}::Client${generics.inst},
+                conf: crate::Config,
             }
 
             #{client_docs:W}
             ##[derive(std::fmt::Debug)]
             pub struct Client${generics.decl} {
-            handle: std::sync::Arc<Handle${generics.inst}>
+                handle: std::sync::Arc<Handle${generics.inst}>
             }
 
             impl${generics.inst} std::clone::Clone for Client${generics.inst} {
-            fn clone(&self) -> Self {
-                Self { handle: self.handle.clone() }
-            }
+                fn clone(&self) -> Self {
+                    Self { handle: self.handle.clone() }
+                }
             }
 
             ##[doc(inline)]
             pub use #{client}::Builder;
 
             impl${generics.inst} From<#{client}::Client${generics.inst}> for Client${generics.inst} {
-            fn from(client: #{client}::Client${generics.inst}) -> Self {
-                Self::with_config(client, crate::Config::builder().build())
-            }
-            }
-
-            impl${generics.inst} Client${generics.inst} {
-            /// Creates a client with the given service configuration.
-            pub fn with_config(client: #{client}::Client${generics.inst}, conf: crate::Config) -> Self {
-                Self {
-                    handle: std::sync::Arc::new(Handle {
-                        client,
-                        conf,
-                    })
+                fn from(client: #{client}::Client${generics.inst}) -> Self {
+                    Self::with_config(client, crate::Config::builder().build())
                 }
             }
 
-            /// Returns the client's configuration.
-            pub fn conf(&self) -> &crate::Config {
-                &self.handle.conf
-            }
+            impl${generics.inst} Client${generics.inst} {
+                /// Creates a client with the given service configuration.
+                pub fn with_config(client: #{client}::Client${generics.inst}, conf: crate::Config) -> Self {
+                    Self {
+                        handle: std::sync::Arc::new(Handle {
+                            client,
+                            conf,
+                        })
+                    }
+                }
+
+                /// Returns the client's configuration.
+                pub fn conf(&self) -> &crate::Config {
+                    &self.handle.conf
+                }
             }
             """,
             "client" to clientDep.asType(),
@@ -494,130 +496,5 @@ class FluentClientGenerator(
                 }
             }
         }
-    }
-
-    fun clientDocComments(): String {
-        val docs = StringBuilder()
-
-        docs.append(
-            """
-            /// An ergonomic service client for `$humanName`.
-            ///
-            /// This client allows ergonomic access to a `$humanName`-shaped service.
-            /// Each method corresponds to an endpoint defined in the service's Smithy model,
-            /// and the request and response shapes are auto-generated from that same model.
-            ///"""
-        )
-        if (includeSmithyGenericClientDocs) {
-            docs.append(
-                """
-                /// ## Constructing a Client
-                ///
-                /// To construct a client, you need a few different things:
-                ///
-                /// - A [`Config`](crate::Config) that specifies additional configuration
-                ///   required by the service.
-                /// - A connector (`C`) that specifies how HTTP requests are translated
-                ///   into HTTP responses. This will typically be an HTTP client (like
-                ///   `hyper`), though you can also substitute in your own, like a mock
-                ///   mock connector for testing.
-                /// - A "middleware" (`M`) that modifies requests prior to them being
-                ///   sent to the request. Most commonly, middleware will decide what
-                ///   endpoint the requests should be sent to, as well as perform
-                ///   authentcation and authorization of requests (such as SigV4).
-                ///   You can also have middleware that performs request/response
-                ///   tracing, throttling, or other middleware-like tasks.
-                /// - A retry policy (`R`) that dictates the behavior for requests that
-                ///   fail and should (potentially) be retried. The default type is
-                ///   generally what you want, as it implements a well-vetted retry
-                ///   policy described in TODO.
-                ///
-                /// To construct a client, you will generally want to call
-                /// [`Client::with_config`], which takes a [`#{client}::Client`] (a
-                /// Smithy client that isn't specialized to a particular service),
-                /// and a [`Config`](crate::Config). Both of these are constructed using
-                /// the [builder pattern] where you first construct a `Builder` type,
-                /// then configure it with the necessary parameters, and then call
-                /// `build` to construct the finalized output type. The
-                /// [`#{client}::Client`] builder is re-exported in this crate as
-                /// [`Builder`] for convenience.
-                ///
-                /// In _most_ circumstances, you will want to use the following pattern
-                /// to construct a client:
-                ///
-                /// ```
-                /// use $moduleUseName::{Builder, Client, Config};
-                /// let raw_client =
-                ///     Builder::new()
-                ///       .https()
-                /// ##     /*
-                ///       .middleware(/* discussed below */)
-                /// ##     */
-                /// ##     .middleware_fn(|r| r)
-                ///       .build();
-                /// let config = Config::builder().build();
-                /// let client = Client::with_config(raw_client, config);
-                /// ```
-                ///
-                /// For the middleware, you'll want to use whatever matches the
-                /// routing, authentication and authorization required by the target
-                /// service. For example, for the standard AWS SDK which uses
-                /// [SigV4-signed requests], the middleware looks like this:
-                ///
-                // Ignored as otherwise we'd need to pull in all these dev-dependencies.
-                /// ```ignore
-                /// use aws_endpoint::AwsEndpointStage;
-                /// use aws_http::user_agent::UserAgentStage;
-                /// use aws_sig_auth::middleware::SigV4SigningStage;
-                /// use aws_sig_auth::signer::SigV4Signer;
-                /// use aws_smithy_http_tower::map_request::MapRequestLayer;
-                /// use tower::layer::util::Stack;
-                /// use tower::ServiceBuilder;
-                ///
-                /// type AwsMiddlewareStack =
-                ///     Stack<MapRequestLayer<SigV4SigningStage>,
-                ///         Stack<MapRequestLayer<UserAgentStage>,
-                ///             MapRequestLayer<AwsEndpointStage>>>,
-                ///
-                /// ##[derive(Debug, Default)]
-                /// pub struct AwsMiddleware;
-                /// impl<S> tower::Layer<S> for AwsMiddleware {
-                ///     type Service = <AwsMiddlewareStack as tower::Layer<S>>::Service;
-                ///
-                ///     fn layer(&self, inner: S) -> Self::Service {
-                ///         let signer = MapRequestLayer::for_mapper(SigV4SigningStage::new(SigV4Signer::new())); _signer: MapRequestLaye
-                ///         let endpoint_resolver = MapRequestLayer::for_mapper(AwsEndpointStage); _endpoint_resolver: MapRequestLayer<Aw
-                ///         let user_agent = MapRequestLayer::for_mapper(UserAgentStage::new()); _user_agent: MapRequestLayer<UserAgentSt
-                ///         // These layers can be considered as occurring in order, that is:
-                ///         // 1. Resolve an endpoint
-                ///         // 2. Add a user agent
-                ///         // 3. Sign
-                ///         // (4. Dispatch over the wire)
-                ///         ServiceBuilder::new() _ServiceBuilder<Identity>
-                ///             .layer(endpoint_resolver) _ServiceBuilder<Stack<MapRequestLayer<_>, _>>
-                ///             .layer(user_agent) _ServiceBuilder<Stack<MapRequestLayer<_>, _>>
-                ///             .layer(signer) _ServiceBuilder<Stack<MapRequestLayer<_>, _>>
-                ///             .service(inner)
-                ///     }
-                /// }
-                /// ```
-                ///"""
-            )
-        }
-        docs.append(
-            """
-            /// ## Using a Client
-            ///
-            /// Once you have a client set up, you can access the service's endpoints
-            /// by calling the appropriate method on [`Client`]. Each such method
-            /// returns a request builder for that endpoint, with methods for setting
-            /// the various fields of the request. Once your request is complete, use
-            /// the `send` method to send the request. `send` returns a future, which
-            /// you then have to `.await` to get the service's response.
-            ///
-            /// [builder pattern]: https://rust-lang.github.io/api-guidelines/type-safety.html##c-builder
-            /// [SigV4-signed requests]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html"""
-        )
-        return docs.toString()
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/LibRsGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/LibRsGenerator.kt
@@ -50,7 +50,7 @@ class LibRsGenerator(
                 The entry point for must customers will be [`Client`]. [`Client`] exposes one method for each API offered
                 by the service.
 
-                Some APIs require complex arguments. These are available in [`model`].
+                Some APIs require complex or nested arguments. These exist in [`model`].
 
                 Lastly, errors that can be returned by the service are contained within [`error`]. [`Error`] defines a meta
                 error encompassing all possible errors that can be returned by the service.

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/LibRsGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/LibRsGenerator.kt
@@ -9,9 +9,9 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.containerDocs
 import software.amazon.smithy.rust.codegen.rustlang.escape
 import software.amazon.smithy.rust.codegen.rustlang.rust
-import software.amazon.smithy.rust.codegen.rustlang.superDocs
 import software.amazon.smithy.rust.codegen.rustlang.writable
 import software.amazon.smithy.rust.codegen.smithy.RustSettings
 import software.amazon.smithy.rust.codegen.smithy.customize.NamedSectionGenerator
@@ -41,9 +41,9 @@ class LibRsGenerator(
             }
 
             val libraryDocs = settings.getService(model).getTrait<DocumentationTrait>()?.value ?: settings.moduleName
-            superDocs(escape(libraryDocs))
+            containerDocs(escape(libraryDocs))
             // TODO: replace "service" below with the title trait
-            superDocs(
+            containerDocs(
                 """
                 ## Crate Organization
 
@@ -61,12 +61,12 @@ class LibRsGenerator(
             val examples = customizations.map { it.section(LibRsSection.ModuleDocumentation("Examples")) }
                 .filter { it != writable { } }
             if (examples.isNotEmpty() || settings.examplesUri != null) {
-                superDocs("## Examples")
+                containerDocs("## Examples")
                 examples.forEach { it(this) }
 
                 // TODO: Render a basic example for all crates (eg. select first operation and render an example of usage)
                 settings.examplesUri?.also { uri ->
-                    superDocs("Examples can be found [here]($uri).")
+                    containerDocs("Examples can be found [here]($uri).")
                 }
             }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/TestHelpers.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/TestHelpers.kt
@@ -50,7 +50,8 @@ fun testRustSettings(
     moduleRepository: String? = null,
     runtimeConfig: RuntimeConfig = RuntimeConfig(),
     codegenConfig: CodegenConfig = CodegenConfig(),
-    license: String? = null
+    license: String? = null,
+    examplesUri: String? = null,
 ) = RustSettings(
     service,
     moduleName,
@@ -61,6 +62,7 @@ fun testRustSettings(
     runtimeConfig,
     codegenConfig,
     license,
+    examplesUri,
     model
 )
 


### PR DESCRIPTION
## Motivation and Context
Currently, the generated documentation for crates and `Client` is quite poor, confusing, and not well targeted for AWS customers. This updates the code generators to make customizing generated documentation easier & makes a first cut at improving client and crate documentation.

fixes #691 

## Description
This commit makes a first pass at improving the documentation rendered for AWS crates for both generated crates as well as `Client` structs.

To facilitate examples `aws-config` is added as a dev-dependency—a customization doesn't generate these incline usage examples for STS to avoid a circular dependency.

## Testing
- [x] inspected generated docs
- [x] regular CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
