### PR TITLE
docs.rs metadata & license linter & fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ vNext (Month Day, Year)
 - Improve docs on `aws-smithy-client` (smithy-rs#855)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 - `SdkError` now includes a variant `TimeoutError` for when a request times out (smithy-rs#885)
+- Add docs.rs metadata section to all crates to document all features
 
 **Breaking Changes**
 - (aws-smithy-client): Extraneous `pub use SdkSuccess` removed from `aws_smithy_client::hyper_ext`. (smithy-rs#855)

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -12,6 +12,7 @@ vNext (Month Day, Year)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 - [Added a new example showing how to set all currently supported timeouts](./sdk/examples/setting_timeouts/src/main.rs)
 - Add a new check so that the SDK doesn't emit an irrelevant `$HOME` dir warning when running in a Lambda (aws-sdk-rust#307)
+- Add docs.rs metadata section to all crates to document all features
 
 **Breaking changes**
 

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -69,3 +69,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 aws-smithy-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0.
  */
-
 #![warn(missing_docs)]
 
 //! `aws-config` provides implementations of region, credential resolution.

--- a/aws/rust-runtime/aws-endpoint/Cargo.toml
+++ b/aws/rust-runtime/aws-endpoint/Cargo.toml
@@ -13,3 +13,9 @@ aws-types = { path = "../aws-types" }
 http = "0.2.3"
 regex = { version = "1", default-features = false, features = ["std"]}
 tracing = "0.1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -22,3 +22,9 @@ env_logger = "0.9"
 http = "0.2.3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util"] }
 tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-hyper/Cargo.toml
+++ b/aws/rust-runtime/aws-hyper/Cargo.toml
@@ -41,3 +41,9 @@ aws-smithy-client = { path = "../../../rust-runtime/aws-smithy-client", features
 
 [[test]]
 name = "e2e_test"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -29,3 +29,9 @@ hex = "0.4.3"
 
 [dev-dependencies]
 temp-file = "0.1.6"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -25,3 +25,9 @@ tracing = "0.1"
 [dev-dependencies]
 aws-endpoint = { path = "../aws-endpoint" }
 tracing-test = "0.1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -32,3 +32,9 @@ httparse = "1.5"
 pretty_assertions = "1.0"
 proptest = "1"
 time = { version = "0.3.4", features = ["parsing"] }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -23,3 +23,9 @@ tracing-test = "0.1"
 
 [build-dependencies]
 rustc_version = "0.4.0"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -18,3 +18,9 @@ tokio = { version = "1.6", features = ["time"], optional = true }
 [dev-dependencies]
 tokio = { version = "1.6", features = ["rt", "macros"] }
 futures-util = "0.3.16"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -42,3 +42,9 @@ tokio = { version = "1", features = ["full", "test-util"] }
 tower-test = "0.4.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -19,3 +19,9 @@ crc32fast = "1"
 
 [dev-dependencies]
 bytes-utils = "0.1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -37,3 +37,9 @@ tower-http = { version = "0.1", features = ["add-extension", "map-response-body"
 
 [dev-dependencies]
 pretty_assertions = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-http-tower/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-tower/Cargo.toml
@@ -19,3 +19,9 @@ tracing = "0.1"
 [dev-dependencies]
 tower = { version = "0.4.4", features = ["util"] }
 tokio = { version = "1", features = ["full"]}
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -42,4 +42,6 @@ tempfile = "3.2.0"
 
 [package.metadata.docs.rs]
 all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-json/Cargo.toml
+++ b/rust-runtime/aws-smithy-json/Cargo.toml
@@ -13,3 +13,9 @@ aws-smithy-types = { path = "../aws-smithy-types" }
 [dev-dependencies]
 proptest = "1"
 serde_json = "1.0"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-protocol-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-protocol-test/Cargo.toml
@@ -17,3 +17,9 @@ assert-json-diff = "1"
 
 pretty_assertions = "1.0"
 roxmltree = "0.14.1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -10,3 +10,9 @@ repository = "https://github.com/awslabs/smithy-rs"
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types" }
 urlencoding = "1.3"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -16,3 +16,9 @@ default = []
 aws-smithy-types = { path = "../aws-smithy-types" }
 chrono = { version = "0.4.19", optional = true }
 time = { version = "0.3.4", optional = true }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -19,3 +19,9 @@ lazy_static = "1.4"
 proptest = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-xml/Cargo.toml
+++ b/rust-runtime/aws-smithy-xml/Cargo.toml
@@ -15,3 +15,9 @@ thiserror = "1"
 aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test" }
 base64 = "0.13.0"
 proptest = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/aws-smithy-xml/LICENSE
+++ b/rust-runtime/aws-smithy-xml/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -22,3 +22,9 @@ repository = "https://github.com/awslabs/smithy-rs"
 [dev-dependencies]
 proptest = "1"
 regex = "1"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+# End of doc.rs metadata

--- a/rust-runtime/inlineable/LICENSE
+++ b/rust-runtime/inlineable/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/tools/sdk-lints/Cargo.lock
+++ b/tools/sdk-lints/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +106,7 @@ dependencies = [
  "anyhow",
  "cargo_toml",
  "clap",
+ "lazy_static",
  "serde",
 ]
 

--- a/tools/sdk-lints/Cargo.lock
+++ b/tools/sdk-lints/Cargo.lock
@@ -35,6 +35,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cargo_toml"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d613611c914a7db07f28526941ce1e956d2f977b0c5e2014fbfa42230d420f"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "toml",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -65,11 +76,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
 name = "sdk-lints"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo_toml",
  "clap",
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -77,6 +128,17 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "syn"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "textwrap"
@@ -88,10 +150,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "vec_map"

--- a/tools/sdk-lints/Cargo.toml
+++ b/tools/sdk-lints/Cargo.toml
@@ -10,3 +10,4 @@ clap = "2"
 anyhow = "1"
 cargo_toml = "0.10.1"
 serde = { version = "1", features = ["derive"]}
+lazy_static = "1.4.0"

--- a/tools/sdk-lints/Cargo.toml
+++ b/tools/sdk-lints/Cargo.toml
@@ -8,3 +8,5 @@ edition = "2018"
 [dependencies]
 clap = "2"
 anyhow = "1"
+cargo_toml = "0.10.1"
+serde = { version = "1", features = ["derive"]}

--- a/tools/sdk-lints/src/anchor.rs
+++ b/tools/sdk-lints/src/anchor.rs
@@ -17,11 +17,11 @@ const ANCHOR_END: &str = "<!-- anchor_end:";
 
 pub fn replace_anchor(
     haystack: &mut String,
-    anchors: &(String, String),
+    anchors: &(impl AsRef<str>, impl AsRef<str>),
     new_content: &str,
 ) -> anyhow::Result<bool> {
-    let anchor_start = anchors.0.as_str();
-    let anchor_end = anchors.1.as_str();
+    let anchor_start = anchors.0.as_ref();
+    let anchor_end = anchors.1.as_ref();
     let start = haystack.find(&anchor_start);
     if start.is_none() {
         if haystack.contains(anchor_end) {

--- a/tools/sdk-lints/src/lint_cargo_toml.rs
+++ b/tools/sdk-lints/src/lint_cargo_toml.rs
@@ -108,7 +108,7 @@ pub(crate) fn check_docs_rs(path: impl AsRef<Path>) -> Result<()> {
         Some(metadata) => metadata,
         None => bail!("mising `[docs.rs.metadata]` section"),
     };
-    if metadata.all_features {
+    if !metadata.all_features {
         bail!("all-features must be set to true")
     }
     if metadata.targets != ["x86_64-unknown-linux-gnu"] {

--- a/tools/sdk-lints/src/lint_cargo_toml.rs
+++ b/tools/sdk-lints/src/lint_cargo_toml.rs
@@ -7,7 +7,7 @@ use crate::anchor::replace_anchor;
 use anyhow::{bail, Context, Result};
 use cargo_toml::Manifest;
 use serde::Deserialize;
-use std::fs::{read, read_to_string, Metadata};
+use std::fs::read_to_string;
 use std::ops::Deref;
 use std::path::Path;
 
@@ -16,27 +16,22 @@ struct DocsRsMetadata {
     docs: Docs,
 }
 
+/// Convenience wrapper to expose fields of the inner struct on the outer struct
 impl Deref for DocsRsMetadata {
-    type Target = Rs;
+    type Target = Metadata;
 
     fn deref(&self) -> &Self::Target {
         &self.docs.rs
     }
 }
 
-impl DocsRsMetadata {
-    fn all_features(&self) -> bool {
-        self.docs.rs.all_features
-    }
-}
-
 #[derive(Deserialize)]
 struct Docs {
-    rs: Rs,
+    rs: Metadata,
 }
 
 #[derive(Deserialize)]
-struct Rs {
+struct Metadata {
     #[serde(rename = "all-features")]
     all_features: bool,
     targets: Vec<String>,
@@ -47,6 +42,11 @@ struct Rs {
 const RUST_TEAM: &str = "AWS Rust SDK Team <aws-sdk-rust@amazon.com>";
 const SERVER_CRATES: &[&str] = &["aws-smithy-http-server"];
 
+/// Check crate licensing
+///
+/// Validates that:
+/// - `[package.license]` is set to `Apache-2.0`
+/// - A `LICENSE` file is present in the same directory as the `Cargo.toml` file
 pub(crate) fn check_crate_license(path: impl AsRef<Path>) -> Result<()> {
     let parsed = Manifest::from_path(path.as_ref()).context("failed to parse Cargo.toml")?;
     let package = match parsed.package {
@@ -91,6 +91,12 @@ pub(crate) fn check_crate_author(path: impl AsRef<Path>) -> Result<()> {
     Ok(())
 }
 
+/// Check docsrs for a Cargo.toml
+///
+/// This function validates:
+/// - it is valid TOMl
+/// - it contains a package.metadata.docs.rs section
+/// - All of the standard docs.rs settings are respected
 pub(crate) fn check_docs_rs(path: impl AsRef<Path>) -> Result<()> {
     let parsed = Manifest::<DocsRsMetadata>::from_path_with_metadata(path)
         .context("failed to parse Cargo.toml")?;
@@ -102,13 +108,13 @@ pub(crate) fn check_docs_rs(path: impl AsRef<Path>) -> Result<()> {
         Some(metadata) => metadata,
         None => bail!("mising `[docs.rs.metadata]` section"),
     };
-    if metadata.all_features != true {
+    if metadata.all_features {
         bail!("all-features must be set to true")
     }
-    if metadata.targets != &["x86_64-unknown-linux-gnu"] {
+    if metadata.targets != ["x86_64-unknown-linux-gnu"] {
         bail!("targets must be pruned to linux only `x86_64-unknown-linux-gnu`")
     }
-    if metadata.rustdoc_args != &["--cfg", "docsrs"] {
+    if metadata.rustdoc_args != ["--cfg", "docsrs"] {
         bail!("rustdoc args must be [\"--cfg\", \"docsrs\"]");
     }
     Ok(())
@@ -120,6 +126,10 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustdoc-args = ["--cfg", "docsrs"]
 "#;
 
+/// Set the default docs.rs anchor block
+///
+/// `[package.metadata.docs.rs]` is used as the head anchor. A comment `# End of docs.rs metadata` is used
+/// as the tail anchor.
 pub(crate) fn fix_docs_rs(path: impl AsRef<Path>) -> Result<bool> {
     let mut cargo_toml = read_to_string(path.as_ref()).context("failed to read Cargo.toml")?;
     let updated = replace_anchor(

--- a/tools/sdk-lints/src/lint_cargo_toml.rs
+++ b/tools/sdk-lints/src/lint_cargo_toml.rs
@@ -1,0 +1,134 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use crate::anchor::replace_anchor;
+use anyhow::{bail, Context, Result};
+use cargo_toml::Manifest;
+use serde::Deserialize;
+use std::fs::{read, read_to_string, Metadata};
+use std::ops::Deref;
+use std::path::Path;
+
+#[derive(Deserialize)]
+struct DocsRsMetadata {
+    docs: Docs,
+}
+
+impl Deref for DocsRsMetadata {
+    type Target = Rs;
+
+    fn deref(&self) -> &Self::Target {
+        &self.docs.rs
+    }
+}
+
+impl DocsRsMetadata {
+    fn all_features(&self) -> bool {
+        self.docs.rs.all_features
+    }
+}
+
+#[derive(Deserialize)]
+struct Docs {
+    rs: Rs,
+}
+
+#[derive(Deserialize)]
+struct Rs {
+    #[serde(rename = "all-features")]
+    all_features: bool,
+    targets: Vec<String>,
+    #[serde(rename = "rustdoc-args")]
+    rustdoc_args: Vec<String>,
+}
+
+const RUST_TEAM: &str = "AWS Rust SDK Team <aws-sdk-rust@amazon.com>";
+const SERVER_CRATES: &[&str] = &["aws-smithy-http-server"];
+
+pub(crate) fn check_crate_license(path: impl AsRef<Path>) -> Result<()> {
+    let parsed = Manifest::from_path(path.as_ref()).context("failed to parse Cargo.toml")?;
+    let package = match parsed.package {
+        Some(package) => package,
+        None => bail!("missing `[package]` section"),
+    };
+    let license = match package.license {
+        Some(license) => license,
+        None => bail!("license must be specified"),
+    };
+    if license != "Apache-2.0" {
+        bail!("incorrect license: {}", license)
+    }
+    if !path
+        .as_ref()
+        .parent()
+        .expect("path must have parent")
+        .join("LICENSE")
+        .exists()
+    {
+        bail!("LICENSE file missing")
+    }
+    Ok(())
+}
+
+pub(crate) fn check_crate_author(path: impl AsRef<Path>) -> Result<()> {
+    let parsed = Manifest::from_path(path).context("failed to parse Cargo.toml")?;
+    let package = match parsed.package {
+        Some(package) => package,
+        None => bail!("missing `[package]` section"),
+    };
+    if SERVER_CRATES.contains(&package.name.as_str()) {
+        return Ok(());
+    }
+    if !package.authors.iter().any(|s| s == RUST_TEAM) {
+        bail!(
+            "missing `{}` in package author list ({:?})",
+            RUST_TEAM,
+            package.authors
+        )
+    }
+    Ok(())
+}
+
+pub(crate) fn check_docs_rs(path: impl AsRef<Path>) -> Result<()> {
+    let parsed = Manifest::<DocsRsMetadata>::from_path_with_metadata(path)
+        .context("failed to parse Cargo.toml")?;
+    let package = match parsed.package {
+        Some(package) => package,
+        None => bail!("missing `[package]` section"),
+    };
+    let metadata = match package.metadata {
+        Some(metadata) => metadata,
+        None => bail!("mising `[docs.rs.metadata]` section"),
+    };
+    if metadata.all_features != true {
+        bail!("all-features must be set to true")
+    }
+    if metadata.targets != &["x86_64-unknown-linux-gnu"] {
+        bail!("targets must be pruned to linux only `x86_64-unknown-linux-gnu`")
+    }
+    if metadata.rustdoc_args != &["--cfg", "docsrs"] {
+        bail!("rustdoc args must be [\"--cfg\", \"docsrs\"]");
+    }
+    Ok(())
+}
+
+const DEFAULT_DOCS_RS_SECTION: &str = r#"
+all-features = true
+targets = ["x86_64-unknown-linux-gnu"]
+rustdoc-args = ["--cfg", "docsrs"]
+"#;
+
+pub(crate) fn fix_docs_rs(path: impl AsRef<Path>) -> Result<bool> {
+    let mut cargo_toml = read_to_string(path.as_ref()).context("failed to read Cargo.toml")?;
+    let updated = replace_anchor(
+        &mut cargo_toml,
+        &("[package.metadata.docs.rs]", "# End of doc.rs metadata"),
+        DEFAULT_DOCS_RS_SECTION,
+    )?;
+    if updated {
+        std::fs::write(path.as_ref(), cargo_toml)?;
+    }
+    Ok(updated)
+}

--- a/tools/sdk-lints/src/main.rs
+++ b/tools/sdk-lints/src/main.rs
@@ -146,6 +146,7 @@ fn check_authors() -> Result<()> {
     }
 }
 
+/// Check that all crates have correct licensing
 fn check_license() -> Result<()> {
     let mut failed = 0;
     for toml in all_cargo_tomls()? {
@@ -165,6 +166,7 @@ fn check_license() -> Result<()> {
     }
 }
 
+/// Check that all crates have correct `[package.metadata.docs.rs]` settings
 fn check_docsrs_metadata() -> Result<()> {
     let mut failed = 0;
     for toml in all_cargo_tomls()? {
@@ -184,6 +186,7 @@ fn check_docsrs_metadata() -> Result<()> {
     }
 }
 
+/// Checks that all crates have README files
 fn check_readmes() -> Result<()> {
     let no_readme = all_runtime_crates()?.filter(|dir| !dir.join("README.md").exists());
 

--- a/tools/sdk-lints/src/main.rs
+++ b/tools/sdk-lints/src/main.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
 use crate::lint_cargo_toml::{check_crate_author, check_crate_license, check_docs_rs, fix_docs_rs};
 use anyhow::{bail, Context, Result};
 use clap::{App, Arg, SubCommand};


### PR DESCRIPTION
## Motivation and Context
- docsrs builds should include all features
- docsrs builds should be restricted to a single target to reduce the docsrs build load
- all crates needs licenses / consistent authorship

## Description
- Lint / fix step for doc.rs metadata
- Follow up change is required to add `#![cfg_attr(docsrs, feature(doc_cfg_auto))]` to all crates
- Add 2 missing license files

## Testing
- [x] UTs
- [x] Ran fix/check on the repo 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
