### PR TITLE
Misc fixes for aws-config documentation

### DIFF
--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -3,11 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-//! Default Provider chains for [`region`](default_provider::region) and [`credentials`](default_provider::credentials).
+//! Default Provider chains for [`region`](default_provider::region), [`credentials`](default_provider::credentials),
+//! [retries](default_provider::retry_config), [timeouts](default_provider::timeout_config) and [app name](default_provider::app_name).
 //!
-//! Unless specific configuration is required, these should be constructed via [`ConfigLoader`](crate::ConfigLoader).
+//! Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
+//! if you need to set custom configuration options to override the default resolution chain.
 
-/// Default region provider chain
+/// Default [region](aws_types::region::Region) provider chain
+///
+/// Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
+/// if you need to set custom configuration options to override the default resolution chain.
 pub mod region {
     use aws_types::region::Region;
 
@@ -21,6 +26,7 @@ pub mod region {
     /// This provider will check the following sources in order:
     /// 1. [Environment variables](EnvironmentVariableRegionProvider)
     /// 2. [Profile file](crate::profile::region::ProfileFileRegionProvider)
+    /// 3. [EC2 IMDSv2](crate::imds::region)
     pub fn default_provider() -> impl ProvideRegion {
         Builder::default().build()
     }
@@ -86,6 +92,9 @@ pub mod region {
 }
 
 /// Default retry behavior configuration provider chain
+///
+/// Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
+/// if you need to set custom configuration options to override the default resolution chain.
 pub mod retry_config {
     use aws_smithy_types::retry::RetryConfig;
 
@@ -190,6 +199,9 @@ pub mod retry_config {
 }
 
 /// Default app name provider chain
+///
+/// Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
+/// if you need to set custom configuration options to override the default resolution chain.
 pub mod app_name {
     use crate::environment::app_name::EnvironmentVariableAppNameProvider;
     use crate::profile::app_name;
@@ -285,6 +297,9 @@ pub mod app_name {
 }
 
 /// Default timeout configuration provider chain
+///
+/// Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
+/// if you need to set custom configuration options to override the default resolution chain.
 pub mod timeout_config {
     use aws_smithy_types::timeout::TimeoutConfig;
 
@@ -401,6 +416,9 @@ pub mod timeout_config {
 }
 
 /// Default credentials provider chain
+///
+/// Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
+/// if you need to set custom configuration options like [`region`](credentials::Builder::region) or [`profile_name`](credentials::Builder::profile_name).
 pub mod credentials {
     use std::borrow::Cow;
 
@@ -424,6 +442,9 @@ pub mod credentials {
     /// Resolution order:
     /// 1. Environment variables: [`EnvironmentVariableCredentialsProvider`](crate::environment::EnvironmentVariableCredentialsProvider)
     /// 2. Shared config (`~/.aws/config`, `~/.aws/credentials`): [`SharedConfigCredentialsProvider`](crate::profile::ProfileFileCredentialsProvider)
+    /// 3. [Web Identity Tokens](crate::web_identity_token)
+    /// 4. ECS (IAM Roles for Tasks) & General HTTP credentials: [`ecs`](crate::ecs)
+    /// 5. [EC2 IMDSv2](crate::imds)
     ///
     /// The outer provider is wrapped in a refreshing cache.
     ///

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -6,9 +6,11 @@
 //! Ecs Credentials Provider
 //!
 //! This credential provider is frequently used with an AWS-provided credentials service (e.g.
-//! [IAM Roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
+//! [IAM Roles for tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)).
 //! However, it's possible to use environment variables to configure this provider to use your own
 //! credentials sources.
+//!
+//! This provider is part of the [default credentials chain](crate::default_provider::credentials).
 //!
 //! ## Configuration
 //! **First**: It will check the value of `$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`. It will use this

--- a/aws/rust-runtime/aws-config/src/imds/mod.rs
+++ b/aws/rust-runtime/aws-config/src/imds/mod.rs
@@ -6,10 +6,6 @@
 //! IMDSv2 Client, credential, and region provider
 //!
 //! See [`client`] for more information.
-//!
-//! _Note: An IMDS credentials provider is not currently implemented. This module currently only
-//! contains an IMDS client._
-//!
 pub mod client;
 
 pub mod credentials;

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -58,7 +58,7 @@ impl ProvideCredentials for ProfileFileCredentialsProvider {
 /// AWS Profile based credentials provider
 ///
 /// This credentials provider will load credentials from `~/.aws/config` and `~/.aws/credentials`.
-/// The locations of these files are configurable, see [`profile::load`](crate::profile::load).
+/// The locations of these files are configurable via environment variables, see [below](#location-of-profile-files).
 ///
 /// Generally, this will be constructed via the default provider chain, however, it can be manually
 /// constructed with the builder:
@@ -123,6 +123,24 @@ impl ProvideCredentials for ProfileFileCredentialsProvider {
 /// ```
 ///
 /// Other more complex configurations are possible, consult `test-data/assume-role-tests.json`.
+///
+/// ## Location of Profile Files
+/// * The location of the config file will be loaded from the `AWS_CONFIG_FILE` environment variable
+/// with a fallback to `~/.aws/config`
+/// * The location of the credentials file will be loaded from the `AWS_SHARED_CREDENTIALS_FILE`
+/// environment variable with a fallback to `~/.aws/credentials`
+///
+/// ## Home directory resolution
+/// Home directory resolution is implemented to match the behavior of the CLI & Python. `~` is only
+/// used for home directory resolution when it:
+/// - Starts the path
+/// - Is followed immediately by `/` or a platform specific separator. (On windows, `~/` and `~\` both
+///   resolve to the home directory.
+///
+/// When determining the home directory, the following environment variables are checked:
+/// - `HOME` on all platforms
+/// - `USERPROFILE` on Windows
+/// - The concatenation of `HOMEDRIVE` and `HOMEPATH` on Windows (`$HOMEDRIVE$HOMEPATH`)
 #[derive(Debug)]
 pub struct ProfileFileCredentialsProvider {
     factory: NamedProviderFactory,


### PR DESCRIPTION
## Description
- fix out of date comments
- add notes about code that isn't generally needed
- clarify documentation about where to find profile files (fixes #733). 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
