### PR TITLE
Don't capture empty session tokens from env

### DIFF
--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -12,6 +12,7 @@ vNext (Month Day, Year)
 - Fix http-body dependency version (smithy-rs#883, aws-sdk-rust#305)
 - [Added a new example showing how to set all currently supported timeouts](./sdk/examples/setting_timeouts/src/main.rs)
 - Add a new check so that the SDK doesn't emit an irrelevant `$HOME` dir warning when running in a Lambda (aws-sdk-rust#307)
+- :bug: Don't capture empty session tokens from the `AWS_SESSION_TOKEN` environment variable (aws-sdk-rust#316, smithy-rs#906)
 
 **Breaking changes**
 

--- a/aws/rust-runtime/aws-config/src/environment/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/environment/credentials.rs
@@ -33,8 +33,11 @@ impl EnvironmentVariableCredentialsProvider {
             .env
             .get("AWS_SESSION_TOKEN")
             .ok()
-            .map(|token| token.trim().to_string())
-            .filter(|token| !token.is_empty());
+            .map(|token| match token.trim() {
+                s if s.is_empty() => None,
+                s => Some(s.to_string()),
+            })
+            .flatten();
         Ok(Credentials::new(
             access_key,
             secret_key,


### PR DESCRIPTION
## Motivation and Context
This is the fix for https://github.com/awslabs/aws-sdk-rust/issues/316

The AWS CLI won't send session tokens if `AWS_SESSION_TOKEN` is empty or has nothing but whitespace.

## Testing
- Added a unit test
- Manually tested with S3 example

## Checklist
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
