### PR TITLE
Improve log messaging around missing sleep implementation

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -13,7 +13,7 @@
 
 [[aws-sdk-rust]]
 message = """
-Removed spamming log message when a client was used without a sleep implementation, and
+Removed inaccurate log message when a client was used without a sleep implementation, and
 improved context and call to action in logged messages around missing sleep implementations.
 """
 references = ["aws-sdk-rust#317", "smithy-rs#907"]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,6 +10,25 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = """
+Removed spamming log message when a client was used without a sleep implementation, and
+improved context and call to action in logged messages around missing sleep implementations.
+"""
+references = ["aws-sdk-rust#317", "smithy-rs#907"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = """
+Removed spamming log message when a client was used without a sleep implementation, and
+improved context and call to action in logged messages around missing sleep implementations.
+"""
+references = ["aws-sdk-rust#317", "smithy-rs#907"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"
+
 [[aws-sdk-rust]]
 message = "Use provided `sleep_impl` for retries instead of using Tokio directly."
 references = ["smithy-rs#923"]

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/SleepImplDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/SleepImplDecorator.kt
@@ -16,8 +16,10 @@ import software.amazon.smithy.rust.codegen.smithy.generators.config.ServiceConfi
 
 /* Example Generated Code */
 /*
+/// Service config.
+///
 pub struct Config {
-    pub(crate) sleep_impl: Option<Arc<dyn AsyncSleep>>,
+    pub(crate) sleep_impl: Option<std::sync::Arc<dyn aws_smithy_async::rt::sleep::AsyncSleep>>,
 }
 impl std::fmt::Debug for Config {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -26,39 +28,90 @@ impl std::fmt::Debug for Config {
     }
 }
 impl Config {
+    /// Constructs a config builder.
     pub fn builder() -> Builder {
         Builder::default()
     }
 }
+/// Builder for creating a `Config`.
 #[derive(Default)]
 pub struct Builder {
-    sleep_impl: Option<Arc<dyn AsyncSleep>>,
+    sleep_impl: Option<std::sync::Arc<dyn aws_smithy_async::rt::sleep::AsyncSleep>>,
 }
 impl Builder {
+    /// Constructs a config builder.
     pub fn new() -> Self {
         Self::default()
     }
-    pub fn sleep_impl(mut self, sleep_impl: Arc<dyn AsyncSleep>) -> Self {
+    /// Set the sleep_impl for the builder
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use test_smithy_test1832442648477221704::config::Config;
+    /// use aws_smithy_async::rt::sleep::AsyncSleep;
+    /// use aws_smithy_async::rt::sleep::Sleep;
+    ///
+    /// #[derive(Debug)]
+    /// pub struct ForeverSleep;
+    ///
+    /// impl AsyncSleep for ForeverSleep {
+    ///     fn sleep(&self, duration: std::time::Duration) -> Sleep {
+    ///         Sleep::new(std::future::pending())
+    ///     }
+    /// }
+    ///
+    /// let sleep_impl = std::sync::Arc::new(ForeverSleep);
+    /// let config = Config::builder().sleep_impl(sleep_impl).build();
+    /// ```
+    pub fn sleep_impl(
+        mut self,
+        sleep_impl: std::sync::Arc<dyn aws_smithy_async::rt::sleep::AsyncSleep>,
+    ) -> Self {
         self.set_sleep_impl(Some(sleep_impl));
         self
     }
+
+    /// Set the sleep_impl for the builder
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use test_smithy_test1832442648477221704::config::{Builder, Config};
+    /// use aws_smithy_async::rt::sleep::AsyncSleep;
+    /// use aws_smithy_async::rt::sleep::Sleep;
+    ///
+    /// #[derive(Debug)]
+    /// pub struct ForeverSleep;
+    ///
+    /// impl AsyncSleep for ForeverSleep {
+    ///     fn sleep(&self, duration: std::time::Duration) -> Sleep {
+    ///         Sleep::new(std::future::pending())
+    ///     }
+    /// }
+    ///
+    /// fn set_never_ending_sleep_impl(builder: &mut Builder) {
+    ///     let sleep_impl = std::sync::Arc::new(ForeverSleep);
+    ///     builder.set_sleep_impl(Some(sleep_impl));
+    /// }
+    ///
+    /// let mut builder = Config::builder();
+    /// set_never_ending_sleep_impl(&mut builder);
+    /// let config = builder.build();
+    /// ```
     pub fn set_sleep_impl(
         &mut self,
-        sleep_impl: Option<Arc<dyn AsyncSleep>>,
+        sleep_impl: Option<std::sync::Arc<dyn aws_smithy_async::rt::sleep::AsyncSleep>>,
     ) -> &mut Self {
         self.sleep_impl = sleep_impl;
         self
     }
+    /// Builds a [`Config`].
     pub fn build(self) -> Config {
         Config {
-            sleep_impl: self.sleep_impl,
+            sleep_impl: self.sleep_impl
         }
     }
-}
-#[test]
-fn test_1() {
-    fn assert_send_sync<T: Send + Sync>() {}
-    assert_send_sync::<Config>();
 }
  */
 
@@ -77,8 +130,10 @@ class SleepImplDecorator : RustCodegenDecorator {
 class SleepImplProviderConfig(codegenContext: CodegenContext) : ConfigCustomization() {
     private val sleepModule = smithyAsyncRtSleep(codegenContext.runtimeConfig)
     private val moduleUseName = codegenContext.moduleUseName()
-    private val codegenScope =
-        arrayOf("AsyncSleep" to sleepModule.member("AsyncSleep"), "Sleep" to sleepModule.member("Sleep"))
+    private val codegenScope = arrayOf(
+        "AsyncSleep" to sleepModule.member("AsyncSleep"),
+        "Sleep" to sleepModule.member("Sleep"),
+    )
 
     override fun section(section: ServiceConfig) = writable {
         when (section) {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/customizations/RetryConfigDecoratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/customizations/RetryConfigDecoratorTest.kt
@@ -6,7 +6,7 @@
 package software.amazon.smithy.rust.codegen.customizations
 
 import org.junit.jupiter.api.Test
-import software.amazon.smithy.rust.codegen.smithy.customizations.SleepImplProviderConfig
+import software.amazon.smithy.rust.codegen.smithy.customizations.RetryConfigProviderConfig
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.testutil.rustSettings
 import software.amazon.smithy.rust.codegen.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.testutil.validateConfigCustomizations
 
-internal class SleepImplProviderConfigTest {
+internal class RetryConfigDecoratorTest {
     private val baseModel = """
         namespace test
         use aws.protocols#awsQuery
@@ -38,6 +38,6 @@ internal class SleepImplProviderConfigTest {
         val project = TestWorkspace.testProject()
         val codegenContext = testCodegenContext(model, settings = project.rustSettings(model))
 
-        validateConfigCustomizations(SleepImplProviderConfig(codegenContext), project)
+        validateConfigCustomizations(RetryConfigProviderConfig(codegenContext), project)
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/customizations/SleepImplDecoratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/customizations/SleepImplDecoratorTest.kt
@@ -6,7 +6,7 @@
 package software.amazon.smithy.rust.codegen.customizations
 
 import org.junit.jupiter.api.Test
-import software.amazon.smithy.rust.codegen.smithy.customizations.TimeoutConfigProviderConfig
+import software.amazon.smithy.rust.codegen.smithy.customizations.SleepImplProviderConfig
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.testutil.rustSettings
 import software.amazon.smithy.rust.codegen.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.testutil.validateConfigCustomizations
 
-internal class TimeoutConfigProviderConfigTest {
+internal class SleepImplDecoratorTest {
     private val baseModel = """
         namespace test
         use aws.protocols#awsQuery
@@ -38,6 +38,6 @@ internal class TimeoutConfigProviderConfigTest {
         val project = TestWorkspace.testProject()
         val codegenContext = testCodegenContext(model, settings = project.rustSettings(model))
 
-        validateConfigCustomizations(TimeoutConfigProviderConfig(codegenContext), project)
+        validateConfigCustomizations(SleepImplProviderConfig(codegenContext), project)
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/customizations/TimeoutConfigDecoratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/customizations/TimeoutConfigDecoratorTest.kt
@@ -6,7 +6,7 @@
 package software.amazon.smithy.rust.codegen.customizations
 
 import org.junit.jupiter.api.Test
-import software.amazon.smithy.rust.codegen.smithy.customizations.RetryConfigProviderConfig
+import software.amazon.smithy.rust.codegen.smithy.customizations.TimeoutConfigProviderConfig
 import software.amazon.smithy.rust.codegen.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.testutil.rustSettings
 import software.amazon.smithy.rust.codegen.testutil.testCodegenContext
 import software.amazon.smithy.rust.codegen.testutil.validateConfigCustomizations
 
-internal class RetryConfigProviderConfigTest {
+internal class TimeoutConfigDecoratorTest {
     private val baseModel = """
         namespace test
         use aws.protocols#awsQuery
@@ -38,6 +38,6 @@ internal class RetryConfigProviderConfigTest {
         val project = TestWorkspace.testProject()
         val codegenContext = testCodegenContext(model, settings = project.rustSettings(model))
 
-        validateConfigCustomizations(RetryConfigProviderConfig(codegenContext), project)
+        validateConfigCustomizations(TimeoutConfigProviderConfig(codegenContext), project)
     }
 }

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -41,6 +41,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+tracing-test = "0.1.0"
 tower-test = "0.4.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -226,19 +226,23 @@ where
             Service<Operation<O, Retry>, Response = SdkSuccess<T>, Error = SdkError<E>> + Clone,
     {
         if matches!(&self.sleep_impl, TriState::Unset) {
-            tracing::debug!(NO_SLEEP_WARNING);
+            tracing::debug!(
+                "Client does not have a sleep implementation. Timeouts and retry \
+                will not work without this. {}",
+                MISSING_SLEEP_IMPL_RECOMMENDATION
+            );
         }
         let connector = self.connector.clone();
 
-        let timeout_servic_params = generate_timeout_service_params_from_timeout_config(
+        let timeout_service_params = generate_timeout_service_params_from_timeout_config(
             &self.timeout_config,
             self.sleep_impl.clone().into(),
         );
 
         let svc = ServiceBuilder::new()
-            .layer(TimeoutLayer::new(timeout_servic_params.api_call))
+            .layer(TimeoutLayer::new(timeout_service_params.api_call))
             .retry(self.retry_policy.new_request_policy())
-            .layer(TimeoutLayer::new(timeout_servic_params.api_call_attempt))
+            .layer(TimeoutLayer::new(timeout_service_params.api_call_attempt))
             .layer(ParseResponseLayer::<O, Retry>::new())
             // These layers can be considered as occurring in order. That is, first invoke the
             // customer-provided middleware, then dispatch dispatch over the wire.
@@ -269,10 +273,12 @@ where
     }
 }
 
-pub(crate) const NO_SLEEP_WARNING: &str = "No sleep implementation set. This will prevent retries \
-from occurring. If this is what you intended, you can suppress this error with `Client::set_sleep_impl(None)`. \
-If this is not what you intended, consider using `aws-config` to provide a default sleep implementation \
-or setting a sleep implementation manually.";
+pub(crate) const MISSING_SLEEP_IMPL_RECOMMENDATION: &str =
+    "If this was intentional, you can suppress this message with `Client::set_sleep_impl(None). \
+     Otherwise, unless you have a good reason to use the low-level service \
+     client API, consider using the `aws-config` crate to load a shared config from \
+     the environment, and construct a fluent client from that. If you need to use the low-level \
+     service client API, then pass in a sleep implementation to make timeouts and retry work.";
 
 /// Utility for tracking set vs. unset vs explicitly disabled
 ///

--- a/rust-runtime/aws-smithy-client/src/timeout.rs
+++ b/rust-runtime/aws-smithy-client/src/timeout.rs
@@ -133,11 +133,6 @@ pub fn generate_timeout_service_params_from_timeout_config(
             }),
         }
     } else {
-        tracing::warn!(
-            "One or more timeouts were set but no async_sleep fn was passed. No timeouts will occur.\n{:?}",
-            timeout_config
-        );
-
         Default::default()
     }
 }

--- a/rust-runtime/aws-smithy-types/src/timeout.rs
+++ b/rust-runtime/aws-smithy-types/src/timeout.rs
@@ -42,6 +42,17 @@ pub struct TimeoutConfig {
     api_call_timeout: Option<Duration>,
 }
 
+impl TimeoutConfig {
+    /// Returns true if any of the possible timeouts are set
+    pub fn has_timeouts(&self) -> bool {
+        self.connect_timeout.is_some()
+            || self.tls_negotiation_timeout.is_some()
+            || self.read_timeout.is_some()
+            || self.api_call_attempt_timeout.is_some()
+            || self.api_call_timeout.is_some()
+    }
+}
+
 impl Debug for TimeoutConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(


### PR DESCRIPTION
## Motivation and Context
This is the fix for https://github.com/awslabs/aws-sdk-rust/issues/317

When constructing a Smithy client manually, or when constructing a fluent client with a service config, the default sleep implementation wasn't being used, which was unintentionally disabling timeouts.

## Testing
- Added unit tests to ensure the builders fall back to the default sleep implementation
- Manually tested it in an local project where I had reproduced the issue

## Checklist
- [x] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
