### PR TITLE
Disable incremental compilation for tier 1 tests and switch caching mechanism

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,13 +148,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    # Pinned to the commit hash of v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        working-directory: ${{ matrix.runtime }}/rust-runtime/
+        sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        target-dir: ../target
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
@@ -236,21 +235,17 @@ jobs:
         path: artifact
     - name: untar
       run: mkdir aws-sdk && cd aws-sdk && tar -xvf ../artifact/sdk.tar
-    - uses: actions/cache@v2
+    # Pinned to the commit hash of v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-
-          ${{ runner.os }}-${{ env.rust_version }}-
+        sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        target-dir: ../target
     - name: Cargo Test
       run: cargo test $(cat service-with-tests)
       working-directory: aws-sdk
       env:
-        RUSTC_FORCE_INCREMENTAL: 1
+        # Disable incremental compilation to reduce disk space use
+        CARGO_INCREMENTAL: 0
         RUSTFLAGS: -D warnings
         # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
         # so we have to manually restore the target directory override
@@ -261,16 +256,11 @@ jobs:
     needs: generate-sdk
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/cache@v2
+    # Pinned to the commit hash of v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-
-          ${{ runner.os }}-${{ env.rust_version }}-
+        sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        target-dir: ../target
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
@@ -300,16 +290,11 @@ jobs:
     needs: generate-sdk
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/cache@v2
+    # Pinned to the commit hash of v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
       with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-${{ hashFiles('**/Cargo.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}-
-          ${{ runner.os }}-${{ env.rust_version }}-
+        sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        target-dir: ../target
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}


### PR DESCRIPTION
## Motivation and Context
CI is running out of disk space for the tier 1 tests. This might fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
