### PR TITLE
Version bump to fix crates.io conflict with aws-sigv4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ vNext (Month Day, Year)
 
 **Breaking changes**
 
+v0.32.0 (December 2nd, 2021)
+=======================
+
+- This release was a version bump to fix a version number conflict in crates.io
+
 v0.31.0 (December 2nd, 2021)
 =======================
 **New this week**

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -2,6 +2,11 @@ vNext (Month Day, Year)
 =======================
 **New this release**
 
+v0.2.0 (December 2nd, 2021)
+===========================
+
+- This release was a version bump to fix a version number conflict in crates.io
+
 v0.1.0 (December 2nd, 2021)
 ===========================
 **New this release**

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,10 @@
 
 # Version number to use for the generated SDK
 # Note: these must always be full 3-segment semver versions
-aws.sdk.version=0.1.0
+aws.sdk.version=0.2.0
 
 # Version number to use for the generated runtime crates
-smithy.rs.runtime.crate.version=0.31.0
+smithy.rs.runtime.crate.version=0.32.0
 
 kotlin.code.style=official
 


### PR DESCRIPTION
## Motivation and Context
Version 0.1.0 can't be published to crates.io since aws-sigv4 already has that version from before it was moved into smithy-rs. This bumps to 0.2.0 to side-step the issue.

## Checklist
- [x] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
