### PR TITLE
Changelog Automation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Checklist
 <!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
-- [ ] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
-- [ ] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates
+- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
+- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,4 @@
-vNext (Month Day, Year)
-=======================
-**New this week**
-- Fix typos in module documentation for generated crates (smithy-rs#920)
-
-**Breaking changes**
+<!-- Do not manually edit this file, use `update-changelogs` -->
 
 v0.32.0 (December 2nd, 2021)
 =======================

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,3 +22,9 @@ message = "Fix typos in module documentation for generated crates"
 references = ["smithy-rs#920"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[smithy-rs]]
+message = "Add changelog automation to sdk-lints"
+references = ["smithy-rs#todo"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "rcoh"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -1,0 +1,24 @@
+# Example changelog entries
+# [[aws-sdk-rust]]
+# message = "Fix typos in module documentation for generated crates"
+# references = ["smithy-rs#920"]
+# meta = { "breaking" = false, "tada" = false, "bug" = false }
+# author = "rcoh"
+#
+# [[smithy-rs]]
+# message = "Fix typos in module documentation for generated crates"
+# references = ["smithy-rs#920"]
+# meta = { "breaking" = false, "tada" = false, "bug" = false }
+# author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Fix typos in module documentation for generated crates"
+references = ["smithy-rs#920"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"
+
+[[smithy-rs]]
+message = "Fix typos in module documentation for generated crates"
+references = ["smithy-rs#920"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -37,6 +37,6 @@ author = "rcoh"
 
 [[smithy-rs]]
 message = "Add changelog automation to sdk-lints"
-references = ["smithy-rs#todo"]
+references = ["smithy-rs#922", "smithy-rs#914"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "rcoh"

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,7 +1,4 @@
-vNext (Month Day, Year)
-=======================
-**New this release**
-- Fix typos in module documentation for generated crates (smithy-rs#920)
+<!-- Do not manually edit this file, use `update-changelogs` -->
 
 v0.2.0 (December 2nd, 2021)
 ===========================

--- a/tools/sdk-lints/Cargo.lock
+++ b/tools/sdk-lints/Cargo.lock
@@ -61,6 +61,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,30 @@ name = "libc"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -105,9 +138,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "clap",
  "lazy_static",
  "serde",
+ "structopt",
+ "toml",
 ]
 
 [[package]]
@@ -135,6 +169,30 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "structopt"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -166,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +246,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "winapi"

--- a/tools/sdk-lints/Cargo.toml
+++ b/tools/sdk-lints/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "2"
 anyhow = "1"
 cargo_toml = "0.10.1"
+toml = "0.5.8"
+structopt = "0.3.25"
 serde = { version = "1", features = ["derive"]}
 lazy_static = "1.4.0"

--- a/tools/sdk-lints/smithy-rs-maintainers.txt
+++ b/tools/sdk-lints/smithy-rs-maintainers.txt
@@ -1,0 +1,5 @@
+rcoh
+velfi
+jdisanti
+crisidev
+david-perez

--- a/tools/sdk-lints/src/changelog.rs
+++ b/tools/sdk-lints/src/changelog.rs
@@ -237,7 +237,7 @@ fn validate(entry: &ChangelogEntry) -> Result<()> {
             ),
             Some(("aws-sdk-rust" | "smithy-rs", number)) if number.parse::<u32>().is_ok() => {}
             _other => bail!(
-                "unexpected reference format: {} (expected aws-sdk-rust/smithy-rs#number",
+                "unexpected reference format: {} (expected aws-sdk-rust/smithy-rs#number)",
                 reference
             ),
         }

--- a/tools/sdk-lints/src/changelog.rs
+++ b/tools/sdk-lints/src/changelog.rs
@@ -1,0 +1,324 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::fmt::Write;
+use std::path::Path;
+use std::process::Command;
+
+const EXAMPLE_ENTRY: &str = r#"
+# Example changelog entries
+# [[aws-sdk-rust]]
+# message = "Fix typos in module documentation for generated crates"
+# references = ["smithy-rs#920"]
+# meta = { "breaking" = false, "tada" = false, "bug" = false }
+# author = "rcoh"
+#
+# [[smithy-rs]]
+# message = "Fix typos in module documentation for generated crates"
+# references = ["smithy-rs#920"]
+# meta = { "breaking" = false, "tada" = false, "bug" = false }
+# author = "rcoh"
+"#;
+
+const USE_UPDATE_CHANGELOGS: &str =
+    "<!-- Do not manually edit this file, use `update-changelogs` -->";
+
+fn maintainers() -> Vec<&'static str> {
+    include_str!("../smithy-rs-maintainers.txt")
+        .lines()
+        .collect()
+}
+
+#[derive(Deserialize)]
+struct ChangelogEntry {
+    message: String,
+    meta: Meta,
+    author: String,
+    #[serde(default)]
+    references: Vec<String>,
+}
+
+impl ChangelogEntry {
+    fn render(&self, mut out: &mut String) {
+        let mut meta = String::new();
+        if self.meta.bug {
+            meta.push('🐛');
+        }
+        if self.meta.breaking {
+            meta.push('⚠');
+        }
+        if self.meta.tada {
+            meta.push('🎉');
+        }
+        if !meta.is_empty() {
+            meta.push(' ');
+        }
+        let mut references = self.references.clone();
+        if !maintainers().contains(&self.author.to_ascii_lowercase().as_str()) {
+            references.push(format!("@{}", self.author.to_ascii_lowercase()));
+        };
+        write!(
+            &mut out,
+            "- {meta}{message}",
+            meta = meta,
+            message = self.message,
+        )
+        .unwrap();
+        if !references.is_empty() {
+            write!(out, " ({})", references.join(", ")).unwrap();
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct Meta {
+    bug: bool,
+    breaking: bool,
+    tada: bool,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Changelog {
+    #[serde(rename = "smithy-rs")]
+    #[serde(default)]
+    smithy_rs: Vec<ChangelogEntry>,
+    #[serde(rename = "aws-sdk-rust")]
+    #[serde(default)]
+    aws_sdk_rust: Vec<ChangelogEntry>,
+}
+
+impl Changelog {
+    pub(crate) fn num_entries(&self) -> usize {
+        self.smithy_rs.len() + self.aws_sdk_rust.len()
+    }
+}
+
+fn no_uncommited_changes(path: &Path) -> Result<()> {
+    let unstaged = !Command::new("git")
+        .arg("diff")
+        .arg("--exit-code")
+        .arg(path)
+        .status()?
+        .success();
+    let staged = !Command::new("git")
+        .arg("diff")
+        .arg("--exit-code")
+        .arg("--staged")
+        .arg(path)
+        .status()?
+        .success();
+    if unstaged || staged {
+        bail!("Unstaged changes to {}", path.display())
+    }
+    Ok(())
+}
+
+pub(crate) fn update_changelogs(
+    changelog_next: impl AsRef<Path>,
+    smithy_rs: impl AsRef<Path>,
+    aws_sdk_rust: impl AsRef<Path>,
+    smithy_rs_version: &str,
+    aws_sdk_rust_version: &str,
+    date: &str,
+) -> Result<()> {
+    no_uncommited_changes(changelog_next.as_ref())
+        .context("CHANGELOG.next.toml had unstaged changes")?;
+    let changelog = check_changelog_next(changelog_next.as_ref())?;
+    for (entries, path, version) in [
+        (changelog.smithy_rs, smithy_rs.as_ref(), smithy_rs_version),
+        (
+            changelog.aws_sdk_rust,
+            aws_sdk_rust.as_ref(),
+            aws_sdk_rust_version,
+        ),
+    ] {
+        no_uncommited_changes(path)
+            .with_context(|| format!("{} had unstaged changes", path.display()))?;
+        let mut update = USE_UPDATE_CHANGELOGS.to_string();
+        update.push('\n');
+        update.push_str(&render(entries, version, date));
+        let current = std::fs::read_to_string(path)?.replace(USE_UPDATE_CHANGELOGS, "");
+        update.push('\n');
+        update.push_str(&current);
+        std::fs::write(path, update)?;
+    }
+    std::fs::write(changelog_next.as_ref(), EXAMPLE_ENTRY.trim())?;
+    Ok(())
+}
+
+/// Convert a list of changelog entries into markdown
+fn render(entries: Vec<ChangelogEntry>, version: &str, date: &str) -> String {
+    let mut out = String::new();
+    let header = format!("{version} ({date})", version = version, date = date);
+    out.push_str(&header);
+    out.push('\n');
+    for _ in 0..header.len() {
+        out.push('=');
+    }
+    out.push('\n');
+    let (breaking, non_breaking) = entries
+        .iter()
+        .partition::<Vec<_>, _>(|entry| entry.meta.breaking);
+
+    if !breaking.is_empty() {
+        out.push_str("**Breaking Changes:**\n");
+        for change in breaking {
+            change.render(&mut out);
+            out.push_str("\n");
+        }
+        out.push('\n')
+    }
+
+    if !non_breaking.is_empty() {
+        out.push_str("**New this release:**\n");
+        for change in non_breaking {
+            change.render(&mut out);
+            out.push_str("\n");
+        }
+        out.push('\n');
+    }
+
+    let external_contribs = entries
+        .iter()
+        .map(|entry| entry.author.to_ascii_lowercase())
+        .filter(|author| !maintainers().contains(&author.as_str()))
+        .collect::<HashSet<_>>();
+    if !external_contribs.is_empty() {
+        out.push_str("**Contributors**\nThank you for your contributions! ❤️\n");
+        for contributor_handle in external_contribs {
+            // retrieve all contributions this author made
+            let contribution_references = entries
+                .iter()
+                .filter(|entry| {
+                    entry
+                        .author
+                        .eq_ignore_ascii_case(contributor_handle.as_str())
+                })
+                .flat_map(|entry| entry.references.iter().map(|it| it.as_str()))
+                .collect::<Vec<_>>();
+            let contribution_references = contribution_references.as_slice().join(", ");
+            out.push_str("- @");
+            out.push_str(&contributor_handle);
+            if !contribution_references.is_empty() {
+                out.push_str(&format!(" ({})", contribution_references));
+            }
+            out.push('\n');
+        }
+    }
+
+    out
+}
+
+fn validate(entry: &ChangelogEntry) -> Result<()> {
+    if entry.author.is_empty() {
+        bail!("Author must be set (was empty)");
+    }
+    if !entry
+        .author
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '-')
+    {
+        bail!("Author must be valid GitHub username: [a-zA-Z0-9\\-]")
+    }
+    if entry.references.is_empty() {
+        bail!("Changelog entry must refer to at least one pull request or issue");
+    }
+
+    for reference in &entry.references {
+        match reference.split_once('#') {
+            None => bail!(
+                "Reference must of the form `repo#number` but found {}",
+                reference
+            ),
+            Some(("aws-sdk-rust" | "smithy-rs", number)) if number.parse::<u32>().is_ok() => {}
+            _other => bail!(
+                "unexpected reference format: {} (expected aws-sdk-rust/smithy-rs#number",
+                reference
+            ),
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn check_changelog_next(path: impl AsRef<Path>) -> Result<Changelog> {
+    let contents = std::fs::read_to_string(path).context("failed to read CHANGELOG.next")?;
+    let parsed: Changelog = toml::from_str(&contents).context("Invalid changelog format")?;
+    let mut errors = 0;
+    for entry in parsed.aws_sdk_rust.iter().chain(parsed.smithy_rs.iter()) {
+        if let Err(e) = validate(entry) {
+            eprintln!("{:?}", e);
+            errors += 1;
+        }
+    }
+    if errors == 0 {
+        eprintln!("Validated {} changelog entries", parsed.num_entries());
+        Ok(parsed)
+    } else {
+        bail!("Invalid changelog entries")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::changelog::{render, Changelog};
+
+    #[test]
+    fn end_to_end_changelog() {
+        let changelog_toml = r#"
+        [[smithy-rs]]
+        author = "rcoh"
+        message = "I made a major change to update the code generator"
+        meta = { breaking = true, tada = false, bug = false }
+        references = ["smithy-rs#445"]
+
+        [[smithy-rs]]
+        author = "external-contrib"
+        message = "I made a change to update the code generator"
+        meta = { breaking = false, tada = true, bug = false }
+        references = ["smithy-rs#446"]
+
+        [[smithy-rs]]
+        author = "another-contrib"
+        message = "I made a minor change"
+        meta = { breaking = false, tada = false, bug = false }
+
+        [[aws-sdk-rust]]
+        author = "rcoh"
+        message = "I made a major change to update the AWS SDK"
+        meta = { breaking = true, tada = false, bug = false }
+        references = ["smithy-rs#445"]
+
+        [[aws-sdk-rust]]
+        author = "external-contrib"
+        message = "I made a change to update the code generator"
+        meta = { breaking = false, tada = true, bug = false }
+        references = ["smithy-rs#446"]
+        "#;
+        let changelog: Changelog = toml::from_str(changelog_toml).expect("valid changelog");
+        let rendered = render(changelog.smithy_rs, "v0.3.0", "January 4th, 2022");
+
+        let expected = r#"
+v0.3.0 (January 4th, 2022)
+==========================
+**Breaking Changes:**
+- ⚠ I made a major change to update the code generator (smithy-rs#445)
+
+**New this release:**
+- 🎉 I made a change to update the code generator (smithy-rs#446, @external-contrib)
+- I made a minor change (@another-contrib)
+
+**Contributors**
+Thank you for your contributions! ❤️
+- @external-contrib (smithy-rs#446)
+- @another-contrib
+"#
+        .trim_start();
+        assert_eq!(expected, rendered);
+    }
+}


### PR DESCRIPTION
## Motivation and Context
- manually updating the changelog introduces difficult to resolve merge conflicts & inconsistencies
- We need to eventually support fully automated releases

Fixes #914 

## Description
This adds two features to `sdk-lints`:
1. Validating `CHANGELOG.next.toml`
2. Updating the actual changelogs automatically via `update-changelogs`
3. Switch the sdk-lints to use structopt

This adds a new changelog TOML format: 
```toml
[[aws-sdk-rust]]
message = "Fix typos in module documentation for generated crates"
references = ["smithy-rs#920"]
meta = { "breaking" = false, "tada" = false, "bug" = false }
author = "rcoh"

[[smithy-rs]]
message = "Add changelog automation to sdk-lints"
references = ["smithy-rs#123"]
meta = { "breaking" = false, "tada" = true, "bug" = false }
author = "rcoh"
```

The changelog format can then be rendered into markdown while the release is being cut.

## Testing
- [x] ran a dry run of updating the changelogs with the auto-updater
- [x] UT of changelog format / parsing 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.md` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `aws/SDK_CHANGELOG.md` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
