### PR TITLE
Fix errors discovered with RestJson protocol tests

### DIFF
--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -24,10 +24,7 @@ data class CodegenTest(val service: String, val module: String, val extraConfig:
 
 val CodegenTests = listOf(
     CodegenTest("com.amazonaws.simple#SimpleService", "simple"),
-    // TODO: this is kept here commented to allow to add the RestJson protocol test
-    // quickly when continuting the test development. As of now the tests do not generate
-    // valid tests and will fail the build.
-    // CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
+    CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
     CodegenTest("com.amazonaws.ebs#Ebs", "ebs")
 )
 

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -24,8 +24,11 @@ data class CodegenTest(val service: String, val module: String, val extraConfig:
 
 val CodegenTests = listOf(
     CodegenTest("com.amazonaws.simple#SimpleService", "simple"),
-    CodegenTest("com.amazonaws.ebs#Ebs", "ebs"),
-    CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json")
+    // TODO: this is kept here commented to allow to add the RestJson protocol test
+    // quickly when continuting the test development. As of now the tests do not generate
+    // valid tests and will fail the build.
+    // CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
+    CodegenTest("com.amazonaws.ebs#Ebs", "ebs")
 )
 
 /**

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -24,7 +24,8 @@ data class CodegenTest(val service: String, val module: String, val extraConfig:
 
 val CodegenTests = listOf(
     CodegenTest("com.amazonaws.simple#SimpleService", "simple"),
-    CodegenTest("com.amazonaws.ebs#Ebs", "ebs")
+    CodegenTest("com.amazonaws.ebs#Ebs", "ebs"),
+    CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json")
 )
 
 /**

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
@@ -17,5 +17,4 @@ object ServerCargoDependency {
     val FuturesUtil: CargoDependency = CargoDependency("futures-util", CratesIo("0.3"))
     val PinProject: CargoDependency = CargoDependency("pin-project", CratesIo("1"))
     val Tower: CargoDependency = CargoDependency("tower", CratesIo("0.4"))
-    val Nom: CargoDependency = CargoDependency("nom", CratesIo("7"))
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
@@ -17,4 +17,5 @@ object ServerCargoDependency {
     val FuturesUtil: CargoDependency = CargoDependency("futures-util", CratesIo("0.3"))
     val PinProject: CargoDependency = CargoDependency("pin-project", CratesIo("1"))
     val Tower: CargoDependency = CargoDependency("tower", CratesIo("0.4"))
+    val PrettyAssertions: CargoDependency = CargoDependency("pretty_assertions", CratesIo("1"))
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
@@ -17,5 +17,5 @@ object ServerCargoDependency {
     val FuturesUtil: CargoDependency = CargoDependency("futures-util", CratesIo("0.3"))
     val PinProject: CargoDependency = CargoDependency("pin-project", CratesIo("1"))
     val Tower: CargoDependency = CargoDependency("tower", CratesIo("0.4"))
-    val PrettyAssertions: CargoDependency = CargoDependency("pretty_assertions", CratesIo("1"))
+    val Nom: CargoDependency = CargoDependency("nom", CratesIo("7"))
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -184,7 +184,7 @@ class ServerProtocolTestGenerator(
         httpRequestTestCase.body.orNull()?.also { body ->
             rustTemplate(
                 """
-                let http_request = http::Request::builder()
+                ##[allow(unused_mut)] let mut http_request = http::Request::builder()
                     .uri(${httpRequestTestCase.uri.dq()})
                     .body(#{SmithyHttpServer}::Body::from(#{Bytes}::from_static(b${body.dq()}))).unwrap();
                 """,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -209,7 +209,7 @@ class ServerProtocolTestGenerator(
             rust("""*http_request.uri_mut() = "${httpRequestTestCase.uri}?$queryParams".parse().unwrap();""")
         }
         httpRequestTestCase.host.orNull()?.also {
-            rust("// TODO: support endpoint trait")
+            rust("""todo!("endpoint trait not supported yet");""")
         }
         checkQueryParams(this, httpRequestTestCase.queryParams)
         checkForbidQueryParams(this, httpRequestTestCase.forbidQueryParams)
@@ -316,7 +316,7 @@ class ServerProtocolTestGenerator(
             *codegenScope,
         )
         if (operationShape.outputShape(model).hasStreamingMember(model)) {
-            rustWriter.rust("""panic!("streaming types aren't supported")""")
+            rustWriter.rust("""todo!("streaming types aren't supported yet");""")
         } else {
             rustWriter.rust("assert_eq!(input, expected);")
         }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -462,9 +462,9 @@ private class ServerHttpProtocolImplGenerator(
                 rustTemplate(
                     """
                     let status = output.$memberName
-                        .ok_or(#{Error}::generic(${(memberName + " missing or empty").dq()}))?;
-                    let http_status: u16 = #{Convert}::TryFrom::<i32>::try_from(status)
-                        .map_err(|_| #{Error}::generic(${("invalid status code").dq()}))?;
+                        .ok_or(#{SmithyHttpServer}::rejection::Serialize::from(${(memberName + " missing or empty").dq()}))?;
+                    let http_status: u16 = std::convert::TryFrom::<i32>::try_from(status)
+                        .map_err(|_| #{SmithyHttpServer}::rejection::Serialize::from(${("invalid status code").dq()}))?;
                     """.trimIndent(),
                     *codegenScope,
                 )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -104,7 +104,6 @@ class JsonParserGenerator(
             ) {
                 rustTemplate(
                     """
-                    // CMON $unusedMut
                     let mut tokens_owned = #{json_token_iter}(#{or_empty}(value)).peekable();
                     let tokens = &mut tokens_owned;
                     #{expect_start_object}(tokens.next())?;
@@ -202,7 +201,7 @@ class JsonParserGenerator(
     override fun serverInputParser(operationShape: OperationShape): RuntimeType {
         val inputShape = operationShape.inputShape(model)
         val includedMembers = httpBindingResolver.requestMembers(operationShape, HttpLocation.DOCUMENT)
-        val fnName = symbolProvider.deserializeFunctionName(inputShape)
+        val fnName = symbolProvider.deserializeFunctionName(operationShape)
         return structureParser(fnName, inputShape, includedMembers)
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -52,13 +52,11 @@ import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.outputShape
 import software.amazon.smithy.utils.StringUtils
-import java.util.logging.Logger
 
 class JsonParserGenerator(
     codegenContext: CodegenContext,
     private val httpBindingResolver: HttpBindingResolver,
 ) : StructuredDataParserGenerator {
-    private val logger = Logger.getLogger(javaClass.name)
     private val model = codegenContext.model
     private val symbolProvider = codegenContext.symbolProvider
     private val runtimeConfig = codegenContext.runtimeConfig

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -93,8 +93,8 @@ class JsonParserGenerator(
         structureShape: StructureShape,
         includedMembers: List<MemberShape>
     ): RuntimeType {
-        val unusedMut = if (includedMembers.isEmpty()) "##[allow(unused_mut)] " else ""
         return RuntimeType.forInlineFun(fnName, jsonDeserModule) {
+            val unusedMut = if (includedMembers.isEmpty()) "##[allow(unused_mut)] " else ""
             it.rustBlockTemplate(
                 "pub fn $fnName(value: &[u8], ${unusedMut}mut builder: #{Builder}) -> Result<#{Builder}, #{Error}>",
                 "Builder" to structureShape.builderSymbol(symbolProvider),
@@ -196,9 +196,12 @@ class JsonParserGenerator(
         )
     }
 
-    override fun serverInputParser(operationShape: OperationShape): RuntimeType {
-        val inputShape = operationShape.inputShape(model)
+    override fun serverInputParser(operationShape: OperationShape): RuntimeType? {
         val includedMembers = httpBindingResolver.requestMembers(operationShape, HttpLocation.DOCUMENT)
+        if (includedMembers.isEmpty()) {
+            return null
+        }
+        val inputShape = operationShape.inputShape(model)
         val fnName = symbolProvider.deserializeFunctionName(operationShape)
         return structureParser(fnName, inputShape, includedMembers)
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -52,11 +52,13 @@ import software.amazon.smithy.rust.codegen.util.hasTrait
 import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.outputShape
 import software.amazon.smithy.utils.StringUtils
+import java.util.logging.Logger
 
 class JsonParserGenerator(
     codegenContext: CodegenContext,
     private val httpBindingResolver: HttpBindingResolver,
 ) : StructuredDataParserGenerator {
+    private val logger = Logger.getLogger(javaClass.name)
     private val model = codegenContext.model
     private val symbolProvider = codegenContext.symbolProvider
     private val runtimeConfig = codegenContext.runtimeConfig
@@ -102,6 +104,7 @@ class JsonParserGenerator(
             ) {
                 rustTemplate(
                     """
+                    // CMON $unusedMut
                     let mut tokens_owned = #{json_token_iter}(#{or_empty}(value)).peekable();
                     let tokens = &mut tokens_owned;
                     #{expect_start_object}(tokens.next())?;

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/StructuredDataParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/StructuredDataParserGenerator.kt
@@ -66,5 +66,5 @@ interface StructuredDataParserGenerator {
      * }
      * ```
      */
-    fun serverInputParser(operationShape: OperationShape): RuntimeType
+    fun serverInputParser(operationShape: OperationShape): RuntimeType?
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -243,7 +243,7 @@ class XmlBindingTraitParserGenerator(
         TODO("Document shapes are not supported by rest XML")
     }
 
-    override fun serverInputParser(operationShape: OperationShape): RuntimeType {
+    override fun serverInputParser(operationShape: OperationShape): RuntimeType? {
         TODO("Not yet implemented")
     }
 

--- a/rust-runtime/aws-smithy-http-server/src/macros.rs
+++ b/rust-runtime/aws-smithy-http-server/src/macros.rs
@@ -109,6 +109,12 @@ macro_rules! define_rejection {
                 Some(&self.0)
             }
         }
+
+        impl From<&str> for $name {
+            fn from(src: &str) -> Self {
+                Self(Err(src).expect("Unable to convert string into error"))
+            }
+        }
     };
 }
 

--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -147,6 +147,24 @@ impl From<std::num::ParseIntError> for SmithyRejection {
     }
 }
 
+impl From<std::num::ParseFloatError> for SmithyRejection {
+    fn from(err: std::num::ParseFloatError) -> Self {
+        SmithyRejection::Deserialize(Deserialize::from_err(err))
+    }
+}
+
+impl From<std::str::ParseBoolError> for SmithyRejection {
+    fn from(err: std::str::ParseBoolError) -> Self {
+        SmithyRejection::Deserialize(Deserialize::from_err(err))
+    }
+}
+
+impl From<aws_smithy_types::date_time::DateTimeParseError> for SmithyRejection {
+    fn from(err: aws_smithy_types::date_time::DateTimeParseError) -> Self {
+        SmithyRejection::Deserialize(Deserialize::from_err(err))
+    }
+}
+
 impl From<aws_smithy_http::operation::SerializationError> for SmithyRejection {
     fn from(err: aws_smithy_http::operation::SerializationError) -> Self {
         SmithyRejection::Serialize(Serialize::from_err(err))


### PR DESCRIPTION
## Motivation and Context
This PR fixes some errors discovered running the protocol tests for RestJson. It allows to fully build the RestJson protocol tests model, but it doesn't still generate proper tests (IE `cargo test` will fail) since we still haven't implemented parts for the protocol, like httpQuery trait.

The main problem discovered and fixed is that we were generating JSON deserializers for input structures without a JSON body (for traits like httpQuery that we still do not support). This was causing the in memory deduplication to get confused and the only visible effect was some clippy warning around mutable builders that shouldn't have been mutable. Without the protocol tests this would not surface since the `ebs` and `simple` model do not exercise that specific code path in the codegen.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
