### PR TITLE
Fix several bugs associated with retry/sleep

### DIFF
--- a/.github/workflows/codegen-preview.yml
+++ b/.github/workflows/codegen-preview.yml
@@ -8,6 +8,8 @@ on:
     - synchronize
 env:
   java_version: 11
+  rust_version: 1.54.0
+
 jobs:
   generate-diff:
     runs-on: ubuntu-latest
@@ -64,11 +66,81 @@ jobs:
       if: ${{ github.head_ref != null }}
       with:
         script: |
-          const { DIFF_FILE_NAME } = process.env;
-
           await github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: '${{ steps.generate-diff.outputs.bot-message }}'
+          })
+
+  generate-doc-preview:
+    runs-on: ubuntu-latest
+    name: Generate rustdoc preview and upload to S3
+    env:
+      AWS_REGION: us-west-2
+      S3_BUCKET_NAME: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Gradle Cache
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+      # JDK is needed to generate code
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ env.java_version }}
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.rust_version }}
+        default: true
+    - name: Generate doc preview
+      # Only generate two of the smallest services since these get huge. One of these must be
+      # STS since aws-config depends on it. STS and Transcribe Streaming were chosen below to stay
+      # small while still representing most features. Combined, they are about 11 MB at time of writing.
+      run: |
+        ./gradlew -Paws.services=+sts,+transcribestreaming :aws:sdk:assemble
+
+        # Copy the Server runtime crate(s) in
+        cp -r rust-runtime/aws-smithy-http-server aws/sdk/build/aws-sdk/sdk
+
+        pushd aws/sdk/build/aws-sdk
+
+        # Remove example crates from workspace
+        sed -i '/examples/d' Cargo.toml
+
+        # Add server runtime crates to the workspace
+        sed -i 's/"sdk\/sts",/"sdk\/sts","sdk\/aws-smithy-http-server",/' Cargo.toml
+
+        cargo doc --no-deps --all-features
+        popd
+        ./tools/generate-doc-preview-index.sh ${{ github.event.pull_request.base.sha }}
+    - uses: aws-actions/configure-aws-credentials@v1
+      name: Acquire credentials for uploading to S3
+      with:
+        role-to-assume: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}
+        role-session-name: GitHubActions
+        aws-region: us-west-2
+    - name: Upload doc preview to S3
+      run: |
+        aws s3 cp target/doc "s3://${S3_BUCKET_NAME}/docs/${{ github.event.pull_request.head.sha }}" --recursive
+    - uses: actions/github-script@v5
+      # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"
+      if: ${{ github.head_ref != null }}
+      with:
+        script: |
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: 'A [new doc preview](https://d2luzm2xt3nokh.cloudfront.net/docs/${{ github.event.pull_request.head.sha }}/index.html) is ready to view.'
           })

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -62,10 +62,11 @@ usage examples can be found on the [aws_hyper docs](https://docs.rs/aws-hyper).
 """
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
-references = ["smithy-rs#todo"]
+references = ["smithy-rs#940"]
 
 [[smithy-rs]]
-message = "`aws_smithy_client::Client::https()` has been renamed to `dyn_https()`. This is to clearly distinguish it from `rustls` and `native_tls` which do not use a boxed connector.
+message = """`aws_smithy_client::Client::https()` has been renamed to `dyn_https()`.
+This is to clearly distinguish it from `rustls` and `native_tls` which do not use a boxed connector."""
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
-references = ["smithy-rs#todo"]
+references = ["smithy-rs#940"]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -51,3 +51,21 @@ message = "Add changelog automation to sdk-lints"
 references = ["smithy-rs#922", "smithy-rs#914"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = """
+`aws_hyper::Client` which was just a re-export of `aws_smithy_types::Client` with generics set has been removed. If you used
+`aws_hyper::Client` or `aws_hyper::Client::https()` you can update your code to use `aws_smithy_client::Builder::https()`. Other
+usage examples can be found on the [aws_hyper docs](https://docs.rs/aws-hyper).
+
+**Note**: `aws-hyper` will be removed in a coming release and `AwsMiddleware` will be migrated elsewhere.
+"""
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"
+references = ["smithy-rs#todo"]
+
+[[smithy-rs]]
+message = "`aws_smithy_client::Client::https()` has been renamed to `dyn_https()`. This is to clearly distinguish it from `rustls` and `native_tls` which do not use a boxed connector.
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"
+references = ["smithy-rs#todo"]

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -444,11 +444,11 @@ mod test {
     use crate::provider_config::ProviderConfig;
     use crate::test_case::GenericTestResult;
 
-    use aws_hyper::DynConnector;
     use aws_types::credentials::ProvideCredentials;
     use aws_types::os_shim_internal::Env;
     use aws_types::Credentials;
 
+    use aws_smithy_client::erase::DynConnector;
     use aws_smithy_client::test_connection::TestConnection;
     use aws_smithy_http::body::SdkBody;
     use http::header::AUTHORIZATION;

--- a/aws/rust-runtime/aws-config/src/http_provider.rs
+++ b/aws/rust-runtime/aws-config/src/http_provider.rs
@@ -8,11 +8,10 @@
 //!
 //! Future work will stabilize this interface and enable it to be used directly.
 
-use aws_hyper::{DynConnector, SdkSuccess};
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::operation::{Operation, Request};
 use aws_smithy_http::response::ParseStrictResponse;
-use aws_smithy_http::result::SdkError;
+use aws_smithy_http::result::{SdkError, SdkSuccess};
 use aws_smithy_http::retry::ClassifyResponse;
 use aws_smithy_types::retry::{ErrorKind, RetryKind};
 use aws_types::credentials::CredentialsError;
@@ -22,6 +21,7 @@ use crate::connector::expect_connector;
 use crate::json_credentials::{parse_json_credentials, JsonCredentials};
 use crate::provider_config::{HttpSettings, ProviderConfig};
 
+use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::timeout;
 use bytes::Bytes;
 use http::header::{ACCEPT, AUTHORIZATION};
@@ -195,11 +195,10 @@ impl ClassifyResponse<SdkSuccess<Credentials>, SdkError<CredentialsError>>
 #[cfg(test)]
 mod test {
     use crate::http_provider::{CredentialsResponseParser, HttpCredentialRetryPolicy};
-    use aws_hyper::SdkSuccess;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_http::operation;
     use aws_smithy_http::response::ParseStrictResponse;
-    use aws_smithy_http::result::SdkError;
+    use aws_smithy_http::result::{SdkError, SdkSuccess};
     use aws_smithy_http::retry::ClassifyResponse;
     use aws_smithy_types::retry::{ErrorKind, RetryKind};
     use aws_types::credentials::CredentialsError;

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -941,11 +941,8 @@ pub(crate) mod test {
 
     /// 500 error during token acquisition should be retried
     #[tokio::test]
-    //#[traced_test]
+    #[traced_test]
     async fn retry_token_failure() {
-        env_logger::builder()
-            .filter_level(LevelFilter::Debug)
-            .init();
         let connection = TestConnection::new(vec![
             (
                 token_request("http://169.254.169.254", 21600),

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -1026,8 +1026,7 @@ pub(crate) mod test {
         assert!(now.elapsed().unwrap() > Duration::from_secs(1));
         assert!(now.elapsed().unwrap() < Duration::from_secs(2));
         match resp {
-            ImdsError::FailedToLoadToken(err)
-                if format!("{}", err).contains("HTTP connect timeout") => {} // ok,
+            ImdsError::FailedToLoadToken(err) if format!("{}", err).contains("timeout") => {} // ok,
             other => panic!(
                 "wrong error, expected construction failure with TimedOutError inside: {}",
                 other

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -735,7 +735,6 @@ pub(crate) mod test {
     use crate::imds::client::{Client, EndpointMode, ImdsError};
     use crate::provider_config::ProviderConfig;
     use http::header::USER_AGENT;
-    use tracing::log::LevelFilter;
 
     const TOKEN_A: &str = "AQAEAFTNrA4eEGx0AQgJ1arIq_Cc-t4tWt3fB0Hd8RKhXlKc5ccvhg==";
     const TOKEN_B: &str = "alternatetoken==";

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -34,6 +34,7 @@ use http::{HeaderValue, Uri};
 
 use crate::cache::ExpiringCache;
 use crate::imds::client::{ImdsError, ImdsErrorPolicy, TokenError};
+use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_client::retry;
 use aws_smithy_types::timeout::TimeoutConfig;
 use std::fmt::{Debug, Formatter};
@@ -84,8 +85,12 @@ impl TokenMiddleware {
         token_ttl: Duration,
         retry_config: retry::Config,
         timeout_config: TimeoutConfig,
+        sleep_impl: Option<Arc<dyn AsyncSleep>>,
     ) -> Self {
-        let inner_client = aws_smithy_client::Client::new(connector)
+        let inner_client = aws_smithy_client::Builder::new()
+            .connector(connector)
+            .sleep_impl(sleep_impl)
+            .build()
             .with_retry_config(retry_config)
             .with_timeout_config(timeout_config);
         let client = Arc::new(inner_client);

--- a/aws/rust-runtime/aws-config/src/imds/region.rs
+++ b/aws/rust-runtime/aws-config/src/imds/region.rs
@@ -118,9 +118,9 @@ mod test {
     use crate::imds::client::test::{imds_request, imds_response, token_request, token_response};
     use crate::imds::region::ImdsRegionProvider;
     use crate::provider_config::ProviderConfig;
-    use aws_hyper::DynConnector;
     use aws_sdk_sts::Region;
     use aws_smithy_async::rt::sleep::TokioSleep;
+    use aws_smithy_client::erase::DynConnector;
     use aws_smithy_client::test_connection::TestConnection;
     use aws_smithy_http::body::SdkBody;
     use tracing_test::traced_test;

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -21,6 +21,7 @@
 //! build it from `~/.aws/credentials` and `~/.aws/config`.
 //! - `exec` which contains a chain representation of providers to implement passing bootstrapped credentials
 //! through a series of providers.
+
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::error::Error;
@@ -427,7 +428,7 @@ impl Builder {
             });
         let factory = exec::named::NamedProviderFactory::new(named_providers);
         let connector = expect_connector(conf.default_connector());
-        let core_client = aws_hyper::Client::new(connector.clone());
+        let core_client = conf.sdk_client();
 
         ProfileFileCredentialsProvider {
             factory,

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -15,6 +15,7 @@ use crate::profile::credentials::ProfileFileError;
 use crate::provider_config::ProviderConfig;
 use crate::sts;
 use crate::web_identity_token::{StaticConfiguration, WebIdentityTokenCredentialsProvider};
+use aws_hyper::AwsMiddleware;
 use aws_smithy_client::erase::DynConnector;
 use aws_types::credentials::{self, CredentialsError, ProvideCredentials};
 use aws_types::os_shim_internal::Fs;
@@ -29,7 +30,7 @@ pub struct AssumeRoleProvider {
 
 #[derive(Debug)]
 pub struct ClientConfiguration {
-    pub(crate) core_client: aws_hyper::StandardClient,
+    pub(crate) core_client: aws_smithy_client::Client<DynConnector, AwsMiddleware>,
     pub(crate) region: Option<Region>,
 }
 

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -6,6 +6,7 @@
 //! Configuration Options for Credential Providers
 
 use crate::connector::default_connector;
+
 use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep};
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::timeout;

--- a/aws/rust-runtime/aws-config/src/sts.rs
+++ b/aws/rust-runtime/aws-config/src/sts.rs
@@ -6,7 +6,23 @@
 //! Credential provider augmentation through the AWS Security Token Service (STS).
 
 mod assume_role;
+
+use crate::connector::expect_connector;
+use crate::provider_config::{HttpSettings, ProviderConfig};
 pub use assume_role::{AssumeRoleProvider, AssumeRoleProviderBuilder};
+use aws_hyper::AwsMiddleware;
+use aws_smithy_client::erase::DynConnector;
+
+impl ProviderConfig {
+    pub(crate) fn sdk_client(&self) -> aws_smithy_client::Client<DynConnector, AwsMiddleware> {
+        aws_smithy_client::Builder::<(), AwsMiddleware>::new()
+            .connector(expect_connector(
+                self.connector(&HttpSettings::default()).clone(),
+            ))
+            .sleep_impl(self.sleep())
+            .build()
+    }
+}
 
 pub(crate) mod util {
     use aws_sdk_sts::model::Credentials as StsCredentials;

--- a/aws/rust-runtime/aws-config/src/sts.rs
+++ b/aws/rust-runtime/aws-config/src/sts.rs
@@ -16,9 +16,7 @@ use aws_smithy_client::erase::DynConnector;
 impl ProviderConfig {
     pub(crate) fn sdk_client(&self) -> aws_smithy_client::Client<DynConnector, AwsMiddleware> {
         aws_smithy_client::Builder::<(), AwsMiddleware>::new()
-            .connector(expect_connector(
-                self.connector(&HttpSettings::default()).clone(),
-            ))
+            .connector(expect_connector(self.connector(&HttpSettings::default())))
             .sleep_impl(self.sleep())
             .build()
     }

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -5,6 +5,7 @@
 
 //! Assume credentials for a role through the AWS Security Token Service (STS).
 
+use aws_hyper::AwsMiddleware;
 use aws_sdk_sts::error::AssumeRoleErrorKind;
 use aws_sdk_sts::operation::AssumeRole;
 use aws_types::credentials::{
@@ -14,6 +15,8 @@ use aws_types::region::Region;
 
 use crate::provider_config::HttpSettings;
 use aws_smithy_async::rt::sleep::default_async_sleep;
+use aws_smithy_client::erase::DynConnector;
+use aws_smithy_http::result::SdkError;
 use tracing::Instrument;
 
 /// Credentials provider that uses credentials provided by another provider to assume a role
@@ -38,7 +41,7 @@ use tracing::Instrument;
 /// ```
 #[derive(Debug)]
 pub struct AssumeRoleProvider {
-    sts: aws_hyper::StandardClient,
+    sts: aws_smithy_client::Client<DynConnector, AwsMiddleware>,
     conf: aws_sdk_sts::Config,
     op: aws_sdk_sts::input::AssumeRoleInput,
 }
@@ -136,7 +139,11 @@ impl AssumeRoleProviderBuilder {
                 default_async_sleep(),
             ))
         });
-        let client = aws_hyper::Client::new(conn);
+        let client = aws_smithy_client::Builder::new()
+            .connector(conn)
+            .middleware(AwsMiddleware::new())
+            .sleep_impl(default_async_sleep())
+            .build();
 
         let session_name = self
             .session_name
@@ -184,20 +191,21 @@ impl AssumeRoleProvider {
                 );
                 super::util::into_credentials(assumed.credentials, "AssumeRoleProvider")
             }
-            Err(aws_hyper::SdkError::ServiceError { err, raw }) => {
+            Err(SdkError::ServiceError { err, raw }) => {
                 match err.kind {
                     AssumeRoleErrorKind::RegionDisabledException(_)
                     | AssumeRoleErrorKind::MalformedPolicyDocumentException(_) => {
                         return Err(CredentialsError::invalid_configuration(
-                            aws_hyper::SdkError::ServiceError { err, raw },
+                            SdkError::ServiceError { err, raw },
                         ))
                     }
                     _ => {}
                 }
                 tracing::warn!(error = ?err.message(), "sts refused to grant assume role");
-                Err(CredentialsError::provider_error(
-                    aws_hyper::SdkError::ServiceError { err, raw },
-                ))
+                Err(CredentialsError::provider_error(SdkError::ServiceError {
+                    err,
+                    raw,
+                }))
             }
             Err(err) => Err(CredentialsError::provider_error(err)),
         }

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -63,7 +63,6 @@
 use aws_sdk_sts::Region;
 use aws_types::os_shim_internal::{Env, Fs};
 
-use crate::connector::expect_connector;
 use crate::provider_config::ProviderConfig;
 use crate::sts;
 use aws_hyper::AwsMiddleware;

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -211,7 +211,6 @@ impl Builder {
     /// builder, this function will panic.
     pub fn build(self) -> WebIdentityTokenCredentialsProvider {
         let conf = self.config.unwrap_or_default();
-        let _connector = expect_connector(conf.default_connector());
         let client = conf.sdk_client();
         let source = self.source.unwrap_or_else(|| Source::Env(conf.env()));
         WebIdentityTokenCredentialsProvider {

--- a/aws/rust-runtime/aws-hyper/tests/e2e_test.rs
+++ b/aws/rust-runtime/aws-hyper/tests/e2e_test.rs
@@ -18,7 +18,7 @@ use aws_endpoint::partition::endpoint::{Protocol, SignatureVersion};
 use aws_endpoint::set_endpoint_resolver;
 use aws_http::user_agent::AwsUserAgent;
 use aws_http::AwsErrorRetryPolicy;
-use aws_hyper::Client;
+use aws_hyper::AwsMiddleware;
 use aws_sig_auth::signer::OperationSigningConfig;
 
 use aws_smithy_client::test_connection::TestConnection;
@@ -32,6 +32,8 @@ use aws_types::credentials::SharedCredentialsProvider;
 use aws_types::region::Region;
 use aws_types::Credentials;
 use aws_types::SigningService;
+
+type Client<C> = aws_smithy_client::Client<C, AwsMiddleware>;
 
 #[derive(Clone)]
 struct TestOperationParser;
@@ -114,7 +116,7 @@ fn test_operation() -> Operation<TestOperationParser, AwsErrorRetryPolicy> {
 #[cfg(any(feature = "native-tls", feature = "rustls"))]
 #[test]
 fn test_default_client() {
-    let client = Client::https();
+    let client = Client::dyn_https();
     let _ = client.call(test_operation());
 }
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -149,6 +149,8 @@ private class AwsFluentClientExtensions(private val types: Types) {
                         .middleware(#{aws_hyper}::AwsMiddleware::default());
                     builder.set_retry_config(retry_config.into());
                     builder.set_timeout_config(timeout_config);
+                    // the builder maintains a try-state. To avoid suppressing the warning when sleep is unset,
+                    // only set it if we actually have a sleep impl.
                     if let Some(sleep_impl) = sleep_impl {
                         builder.set_sleep_impl(Some(sleep_impl));
                     }

--- a/aws/sdk/examples/dynamodb/Cargo.toml
+++ b/aws/sdk/examples/dynamodb/Cargo.toml
@@ -8,10 +8,11 @@ edition = "2018"
 
 [dependencies]
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
-aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper"}
+aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 rand = "0.8.3"

--- a/aws/sdk/examples/dynamodb/src/bin/crud.rs
+++ b/aws/sdk/examples/dynamodb/src/bin/crud.rs
@@ -5,7 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_http::AwsErrorRetryPolicy;
-use aws_hyper::{SdkError, SdkSuccess};
+use aws_hyper::AwsMiddleware;
 use aws_sdk_dynamodb::error::DescribeTableError;
 use aws_sdk_dynamodb::input::DescribeTableInput;
 use aws_sdk_dynamodb::model::{
@@ -15,6 +15,8 @@ use aws_sdk_dynamodb::model::{
 use aws_sdk_dynamodb::operation::DescribeTable;
 use aws_sdk_dynamodb::output::DescribeTableOutput;
 use aws_sdk_dynamodb::{Client, Config, Error, Region, PKG_VERSION};
+use aws_smithy_client::erase::DynConnector;
+use aws_smithy_http::result::{SdkError, SdkSuccess};
 
 use aws_smithy_http::operation::Operation;
 use aws_smithy_http::retry::ClassifyResponse;
@@ -56,7 +58,7 @@ async fn make_table(
     client: &Client,
     table: &str,
     key: &str,
-) -> Result<(), aws_hyper::SdkError<aws_sdk_dynamodb::error::CreateTableError>> {
+) -> Result<(), SdkError<aws_sdk_dynamodb::error::CreateTableError>> {
     let ad = AttributeDefinition::builder()
         .attribute_name(key)
         .attribute_type(ScalarAttributeType::S)
@@ -282,7 +284,7 @@ async fn main() -> Result<(), Error> {
 
     println!("Waiting for table to be ready.");
 
-    let raw_client = aws_hyper::Client::https();
+    let raw_client = aws_smithy_client::Client::<DynConnector, AwsMiddleware>::dyn_https();
 
     raw_client
         .call(wait_for_ready_table(&table, client.conf()).await)

--- a/aws/sdk/examples/dynamodb/src/bin/movies.rs
+++ b/aws/sdk/examples/dynamodb/src/bin/movies.rs
@@ -5,7 +5,7 @@
 
 use aws_config::meta::region::RegionProviderChain;
 use aws_http::AwsErrorRetryPolicy;
-use aws_hyper::{SdkError, SdkSuccess};
+use aws_hyper::AwsMiddleware;
 use aws_sdk_dynamodb::client::fluent_builders::Query;
 use aws_sdk_dynamodb::error::DescribeTableError;
 use aws_sdk_dynamodb::input::DescribeTableInput;
@@ -16,6 +16,7 @@ use aws_sdk_dynamodb::model::{
 use aws_sdk_dynamodb::operation::DescribeTable;
 use aws_sdk_dynamodb::output::DescribeTableOutput;
 use aws_sdk_dynamodb::{Client, Config, Error, Region, PKG_VERSION};
+use aws_smithy_http::{SdkError, SdkSuccess};
 
 use aws_smithy_http::operation::Operation;
 use aws_smithy_http::retry::ClassifyResponse;
@@ -77,7 +78,7 @@ async fn main() -> Result<(), Error> {
 
     let client = Client::new(&shared_config);
 
-    let raw_client = aws_hyper::Client::https();
+    let raw_client = aws_smithy_client::Client::<DynConnector, AwsMiddleware>::dyn_https();
 
     let table_exists = client
         .list_tables()

--- a/aws/sdk/examples/dynamodb/src/bin/movies.rs
+++ b/aws/sdk/examples/dynamodb/src/bin/movies.rs
@@ -3,6 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
+use std::collections::HashMap;
+use std::time::Duration;
+
 use aws_config::meta::region::RegionProviderChain;
 use aws_http::AwsErrorRetryPolicy;
 use aws_hyper::AwsMiddleware;
@@ -16,14 +19,12 @@ use aws_sdk_dynamodb::model::{
 use aws_sdk_dynamodb::operation::DescribeTable;
 use aws_sdk_dynamodb::output::DescribeTableOutput;
 use aws_sdk_dynamodb::{Client, Config, Error, Region, PKG_VERSION};
-use aws_smithy_http::{SdkError, SdkSuccess};
-
+use aws_smithy_client::erase::DynConnector;
 use aws_smithy_http::operation::Operation;
+use aws_smithy_http::result::{SdkError, SdkSuccess};
 use aws_smithy_http::retry::ClassifyResponse;
 use aws_smithy_types::retry::RetryKind;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/aws/sdk/integration-tests/dynamodb/tests/movies.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/movies.rs
@@ -6,11 +6,11 @@
 use aws_sdk_dynamodb as dynamodb;
 
 use aws_http::AwsErrorRetryPolicy;
-use aws_hyper::{SdkError, SdkSuccess};
 use aws_sdk_dynamodb::input::CreateTableInput;
 use aws_smithy_client::test_connection::TestConnection;
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::operation::Operation;
+use aws_smithy_http::result::{SdkError, SdkSuccess};
 use aws_smithy_http::retry::ClassifyResponse;
 use aws_smithy_types::retry::RetryKind;
 use dynamodb::error::DescribeTableError;
@@ -28,6 +28,10 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::time::Duration;
 use tokio::time::Instant;
+
+use aws_hyper::AwsMiddleware;
+use aws_smithy_client::Client as CoreClient;
+pub type Client<C> = CoreClient<C, AwsMiddleware>;
 
 fn create_table(table_name: &str) -> CreateTableInput {
     CreateTable::builder()
@@ -189,7 +193,7 @@ async fn movies_it() {
     // The waiter will retry 5 times
     tokio::time::pause();
     let conn = movies_it_test_connection(); // RecordingConnection::https();
-    let client = aws_hyper::Client::new(conn.clone());
+    let client = Client::new(conn.clone());
     let conf = dynamodb::Config::builder()
         .region(Region::new("us-east-1"))
         .credentials_provider(Credentials::new(

--- a/aws/sdk/integration-tests/kms/tests/integration.rs
+++ b/aws/sdk/integration-tests/kms/tests/integration.rs
@@ -4,9 +4,10 @@
  */
 
 use aws_http::user_agent::AwsUserAgent;
-use aws_hyper::{Client, SdkError};
+use aws_hyper::AwsMiddleware;
 use aws_sdk_kms as kms;
 use aws_smithy_client::test_connection::TestConnection;
+use aws_smithy_client::{Client as CoreClient, SdkError};
 use aws_smithy_http::body::SdkBody;
 use http::header::AUTHORIZATION;
 use http::Uri;
@@ -14,6 +15,8 @@ use kms::operation::GenerateRandom;
 use kms::Credentials;
 use kms::{Config, Region};
 use std::time::{Duration, UNIX_EPOCH};
+
+type Client<C> = CoreClient<C, AwsMiddleware>;
 
 // TODO: having the full HTTP requests right in the code is a bit gross, consider something
 // like https://github.com/davidbarsky/sigv4/blob/master/aws-sigv4/src/lib.rs#L283-L315 to store

--- a/aws/sdk/integration-tests/qldbsession/tests/integration.rs
+++ b/aws/sdk/integration-tests/qldbsession/tests/integration.rs
@@ -4,9 +4,10 @@
  */
 
 use aws_http::user_agent::AwsUserAgent;
+use aws_hyper::AwsMiddleware;
 use aws_sdk_qldbsession as qldbsession;
 use aws_smithy_client::test_connection::TestConnection;
-use aws_smithy_client::Client;
+use aws_smithy_client::Client as CoreClient;
 use aws_smithy_http::body::SdkBody;
 use http::Uri;
 use qldbsession::model::StartSessionRequest;
@@ -14,6 +15,7 @@ use qldbsession::operation::SendCommand;
 use qldbsession::Credentials;
 use qldbsession::{Config, Region};
 use std::time::{Duration, UNIX_EPOCH};
+pub type Client<C> = CoreClient<C, AwsMiddleware>;
 
 // TODO: having the full HTTP requests right in the code is a bit gross, consider something
 // like https://github.com/davidbarsky/sigv4/blob/master/aws-sigv4/src/lib.rs#L283-L315 to store

--- a/aws/sdk/integration-tests/qldbsession/tests/integration.rs
+++ b/aws/sdk/integration-tests/qldbsession/tests/integration.rs
@@ -4,9 +4,9 @@
  */
 
 use aws_http::user_agent::AwsUserAgent;
-use aws_hyper::Client;
 use aws_sdk_qldbsession as qldbsession;
 use aws_smithy_client::test_connection::TestConnection;
+use aws_smithy_client::Client;
 use aws_smithy_http::body::SdkBody;
 use http::Uri;
 use qldbsession::model::StartSessionRequest;

--- a/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
+++ b/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
@@ -4,11 +4,14 @@
  */
 
 use aws_http::user_agent::AwsUserAgent;
+use aws_hyper::AwsMiddleware;
 use aws_sdk_s3::{operation::PutObject, Credentials, Region};
 use aws_smithy_client::test_connection::capture_request;
+use aws_smithy_client::Client as CoreClient;
 use http::HeaderValue;
 use std::time::UNIX_EPOCH;
 use tokio::time::Duration;
+pub type Client<C> = CoreClient<C, AwsMiddleware>;
 
 const NAUGHTY_STRINGS: &str = include_str!("blns/blns.txt");
 
@@ -61,7 +64,7 @@ async fn test_s3_signer_with_naughty_string_metadata() -> Result<(), aws_sdk_s3:
         .build();
     let (conn, rcvr) = capture_request(None);
 
-    let client = aws_hyper::Client::new(conn.clone());
+    let client = Client::new(conn.clone());
     let mut builder = PutObject::builder()
         .bucket("test-bucket")
         .key("text.txt")

--- a/aws/sdk/integration-tests/s3/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3/tests/signing-it.rs
@@ -4,11 +4,14 @@
  */
 
 use aws_http::user_agent::AwsUserAgent;
+use aws_hyper::AwsMiddleware;
 use aws_sdk_s3::operation::ListObjectsV2;
 use aws_sdk_s3::{Credentials, Region};
 use aws_smithy_client::test_connection::TestConnection;
+use aws_smithy_client::Client as CoreClient;
 use aws_smithy_http::body::SdkBody;
 use std::time::{Duration, UNIX_EPOCH};
+pub type Client<C> = CoreClient<C, AwsMiddleware>;
 
 #[tokio::test]
 async fn test_signer() -> Result<(), aws_sdk_s3::Error> {
@@ -31,7 +34,7 @@ async fn test_signer() -> Result<(), aws_sdk_s3::Error> {
             .unwrap(),
         http::Response::builder().status(200).body("").unwrap(),
     )]);
-    let client = aws_hyper::Client::new(conn.clone());
+    let client = Client::new(conn.clone());
     let mut op = ListObjectsV2::builder()
         .bucket("test-bucket")
         .prefix("prefix~")

--- a/aws/sdk/integration-tests/s3control/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3control/tests/signing-it.rs
@@ -10,6 +10,10 @@ use aws_smithy_client::test_connection::TestConnection;
 use aws_smithy_http::body::SdkBody;
 use std::time::{Duration, UNIX_EPOCH};
 
+use aws_hyper::AwsMiddleware;
+use aws_smithy_client::Client as CoreClient;
+pub type Client<C> = CoreClient<C, AwsMiddleware>;
+
 #[tokio::test]
 async fn test_signer() -> Result<(), aws_sdk_s3control::Error> {
     let creds = Credentials::new(
@@ -34,7 +38,7 @@ async fn test_signer() -> Result<(), aws_sdk_s3control::Error> {
             .unwrap(),
         http::Response::builder().status(200).body("").unwrap(),
     )]);
-    let client = aws_hyper::Client::new(conn.clone());
+    let client = Client::new(conn.clone());
     let mut op = ListAccessPoints::builder()
         .account_id("test-bucket")
         .build()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -193,8 +193,7 @@ class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomiz
                     /// ```
                     /// use $moduleUseName::{Builder, Client, Config};
                     /// let raw_client =
-                    ///     Builder::new()
-                    ///       .https()
+                    ///     Builder::dyn_https()
                     /// ##     /*
                     ///       .middleware(/* discussed below */)
                     /// ##     */

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
-rt-tokio = ["aws-smithy-async/rt-tokio"]
+rt-tokio = ["aws-smithy-async/rt-tokio", "tokio/net"]
 test-util = ["aws-smithy-protocol-test", "serde/derive", "rustls"]
 default = ["client-hyper", "rustls", "rt-tokio"]
 native-tls = ["client-hyper", "hyper-tls", "rt-tokio"]

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -44,6 +44,7 @@ tokio = { version = "1", features = ["full", "test-util"] }
 tower-test = "0.4.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing-test = "0.2.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -533,7 +533,7 @@ mod timeout_middleware {
         use aws_smithy_http::body::SdkBody;
 
         use crate::hyper_ext::Adapter;
-        use crate::never::{stream::NeverConnected, NeverReplies};
+        use crate::never::{NeverConnected, NeverReplies};
         use crate::timeout;
 
         #[allow(unused)]

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -259,6 +259,9 @@ where
     /// Create a Smithy client builder with an HTTPS connector and the [standard retry
     /// policy](crate::retry::Standard) over the default middleware implementation.
     ///
+    /// *Note:* This function **does not** set a sleep implementation to ensure that [`default_async_sleep`](crate::Builder::default_async_sleep)
+    /// or [`set_sleep_impl`](crate::Builder::set_sleep_impl) is called.
+    ///
     /// For convenience, this constructor type-erases the concrete TLS connector backend used using
     /// dynamic dispatch. This comes at a slight runtime performance cost. See
     /// [`DynConnector`](crate::erase::DynConnector) for details. To avoid that overhead, use

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -127,8 +127,9 @@ impl<C, M> Client<C, M>
 where
     M: Default,
 {
-    /// Create a Smithy client that the given connector, a middleware default, the [standard
-    /// retry policy](crate::retry::Standard), and the [`default_async_sleep`] sleep implementation.
+    /// Create a Smithy client from the given `connector`, a middleware default, the [standard
+    /// retry policy](crate::retry::Standard), and the [`default_async_sleep`](aws_smithy_async::rt::sleep::default_async_sleep)
+    /// sleep implementation.
     pub fn new(connector: C) -> Self {
         Builder::new()
             .connector(connector)
@@ -164,6 +165,8 @@ impl<C, M, R> Client<C, M, R> {
     }
 
     /// Set the [`AsyncSleep`] function that the client will use to create things like timeout futures.
+    ///
+    /// *Note: If `None` is passed, this will prevent the client from using retries or timeouts.*
     pub fn set_sleep_impl(&mut self, sleep_impl: Option<Arc<dyn AsyncSleep>>) {
         self.sleep_impl = sleep_impl.clone().into();
     }

--- a/rust-runtime/aws-smithy-client/src/never.rs
+++ b/rust-runtime/aws-smithy-client/src/never.rs
@@ -12,6 +12,7 @@ use aws_smithy_async::future::never::Never;
 use std::marker::PhantomData;
 
 use std::task::{Context, Poll};
+use tokio::net::TcpStream;
 
 use crate::erase::boxclone::BoxFuture;
 use aws_smithy_http::body::SdkBody;
@@ -54,17 +55,18 @@ impl<Req, Resp, Err> NeverService<Req, Resp, Err> {
 pub type NeverConnector =
     NeverService<http::Request<SdkBody>, http::Response<SdkBody>, ConnectorError>;
 
+#[cfg(feature = "rt-tokio")]
+#[allow(dead_code)]
+/// A service where the underlying TCP connection never connects
+pub type NeverConnected = NeverService<Uri, TcpStream, BoxError>;
+
 /// Streams that never return data
 pub(crate) mod stream {
     use std::io::Error;
     use std::pin::Pin;
 
-    use crate::never::NeverService;
-    use http::Uri;
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-    use tokio::net::TcpStream;
-    use tower::BoxError;
 
     /// A stream that will never return or accept any data
     #[non_exhaustive]
@@ -104,10 +106,6 @@ pub(crate) mod stream {
             Poll::Pending
         }
     }
-
-    #[allow(dead_code)]
-    /// A service where the underlying TCP connection never connects
-    pub type NeverConnected = NeverService<Uri, TcpStream, BoxError>;
 }
 
 /// A service that will connect but never send any data

--- a/rust-runtime/aws-smithy-client/src/never.rs
+++ b/rust-runtime/aws-smithy-client/src/never.rs
@@ -51,7 +51,7 @@ impl<Req, Resp, Err> NeverService<Req, Resp, Err> {
     }
 }
 
-/// A Connector that can be use with [`aws_smithy_client::Client`] that never returns a response.
+/// A Connector that can be use with [`Client`](crate::Client) that never returns a response.
 pub type NeverConnector =
     NeverService<http::Request<SdkBody>, http::Response<SdkBody>, ConnectorError>;
 

--- a/rust-runtime/aws-smithy-client/src/never.rs
+++ b/rust-runtime/aws-smithy-client/src/never.rs
@@ -15,6 +15,8 @@ use std::task::{Context, Poll};
 use tokio::net::TcpStream;
 
 use crate::erase::boxclone::BoxFuture;
+use aws_smithy_http::body::SdkBody;
+use aws_smithy_http::result::ConnectorError;
 use tower::BoxError;
 
 /// A service that will never return whatever it is you want
@@ -48,6 +50,10 @@ impl<Req, Resp, Err> NeverService<Req, Resp, Err> {
         }
     }
 }
+
+/// A Connector that can be use with [`aws_smithy_client::Client`] that never returns a response.
+pub type NeverConnector =
+    NeverService<http::Request<SdkBody>, http::Response<SdkBody>, ConnectorError>;
 
 /// Streams that never return data
 mod stream {

--- a/rust-runtime/aws-smithy-client/tests/e2e_test.rs
+++ b/rust-runtime/aws-smithy-client/tests/e2e_test.rs
@@ -5,6 +5,7 @@
 
 use crate::test_operation::TestPolicy;
 use aws_smithy_async::rt::sleep::TokioSleep;
+
 use aws_smithy_client::test_connection::TestConnection;
 use aws_smithy_client::Client;
 use aws_smithy_http::body::SdkBody;

--- a/tools/codegen-diff-revisions.py
+++ b/tools/codegen-diff-revisions.py
@@ -212,7 +212,7 @@ def run(command, shell=False):
 
 # Returns the output from a shell command. Bails if the command failed
 def get_cmd_output(command):
-    result = subprocess.run(command, capture_output=True, shell=True, check=True)
+    result = subprocess.run(shlex.split(command), capture_output=True, check=True)
     return result.stdout.decode("utf-8").strip()
 
 

--- a/tools/generate-doc-preview-index.sh
+++ b/tools/generate-doc-preview-index.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+#
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <base commit hash>"
+    exit 1
+fi
+
+BASE_COMMIT_SHA=$1
+HEAD_COMMIT_SHA=$(git rev-parse HEAD)
+DOC_TITLE_CONTEXT=$(git log -1 --oneline)
+cd $(git rev-parse --show-toplevel)/target/doc
+
+if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+    echo "Fetching base revision ${BASE_COMMIT_SHA} from GitHub..."
+    git fetch --no-tags --progress --no-recurse-submodules --depth=1 origin ${BASE_COMMIT_SHA}
+fi
+
+CHANGED_RUNTIME_CRATES_FILE=$(mktemp)
+git diff --name-only $BASE_COMMIT_SHA -- $(git rev-parse --show-toplevel)/rust-runtime | cut -d '/' -f2 | sed 's/-/_/g' | sort | uniq > "${CHANGED_RUNTIME_CRATES_FILE}"
+
+{
+    echo '<!doctype html>'
+    echo '<html>'
+    echo '<head>'
+    echo '  <metadata charset="utf-8">'
+    echo "  <title>Doc preview: ${DOC_TITLE_CONTEXT}</title>"
+    echo '</head>'
+    echo '<body>'
+    echo "  <h2>Doc preview: ${DOC_TITLE_CONTEXT}</h2>"
+} > index.html
+
+doc_link () {
+    local crate=$1
+    if [[ -d ${crate} ]]; then
+        grep -q -e "^${crate}$" "${CHANGED_RUNTIME_CRATES_FILE}"
+        CHANGED=$?
+        if [[ $CHANGED -eq 0 ]]; then
+          echo "  <li><strong><a href='${crate}/index.html'>${crate}</a></strong></li>" >> index.html
+        else
+          echo "  <li><a href='${crate}/index.html'>${crate}</a></li>" >> index.html
+        fi
+    fi
+}
+
+echo '  <h3>AWS Services</h3><ul>' >> index.html
+for crate in $(ls -d aws_sdk_*); do doc_link ${crate}; done
+echo '  </ul>' >> index.html
+
+echo '  <h3>AWS Runtime Crates</h3><ul>' >> index.html
+for crate in $(ls -d aws_* | grep -v '_smithy_\|_sdk_'); do doc_link ${crate}; done
+echo '  </ul>' >> index.html
+
+echo '  <h3>Smithy Runtime Crates</h3><ul>' >> index.html
+for crate in $(ls -d aws_smithy_*); do doc_link ${crate}; done
+echo '  </ul>' >> index.html
+
+{
+    echo "<p><strong>Bold</strong> indicates a runtime crate had changes since the base revision \
+         $(git log -1 --oneline ${BASE_COMMIT_SHA}). These may or may not be documentation changes.</p>"
+    echo '</body>'
+    echo '</html>'
+} >> index.html
+
+rm "${CHANGED_RUNTIME_CRATES_FILE}"


### PR DESCRIPTION
## Motivation and Context
- aws-hyper is confusingly named and contains re-exports of other types.
- the last change around retries caused some issues

## Description

The sleep implementation was late-bound but early loaded in retry which created a large surface area for bugs & meant that we emitted a lot of spurious warnings. This commit:
- Removes more kruft from aws-hyper and deals with the consequences
- Cleans up the way that HTTP clients are generated
- Passes in sleep to each incarnation of the retry controller to work around issues caused by late-binding vs. early binding sleep.

## Testing
- [x] draft PR, I need to add more tests to generated clients to ensure that in all cases a sleep impl is set and retries work
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
