### PR TITLE
Cleanup AWS Hyper Features

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -123,3 +123,9 @@ This is to clearly distinguish it from `rustls` and `native_tls` which do not us
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
 references = ["smithy-rs#940"]
+
+[[aws-sdk-rust]]
+message = "The features `aws-hyper/rustls` and `aws-hyper/nativetls` have been removed. If you were using these, use the identical features on `aws-smithy-client`."
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+references = ["smithy-rs#947"]
+author = "rcoh"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -125,7 +125,7 @@ author = "rcoh"
 references = ["smithy-rs#940"]
 
 [[aws-sdk-rust]]
-message = "The features `aws-hyper/rustls` and `aws-hyper/nativetls` have been removed. If you were using these, use the identical features on `aws-smithy-client`."
+message = "The features `aws-hyper/rustls` and `aws-hyper/native-tls` have been removed. If you were using these, use the identical features on `aws-smithy-client`."
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 references = ["smithy-rs#947"]
 author = "rcoh"

--- a/aws/rust-runtime/aws-hyper/Cargo.toml
+++ b/aws/rust-runtime/aws-hyper/Cargo.toml
@@ -7,10 +7,6 @@ edition = "2018"
 license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
-[features]
-native-tls = ["hyper-tls", "aws-smithy-client/native-tls"]
-rustls = ["hyper-rustls", "aws-smithy-client/rustls"]
-
 [dependencies]
 aws-endpoint = { path = "../aws-endpoint" }
 aws-http = { path = "../aws-http" }
@@ -18,25 +14,16 @@ aws-sig-auth = { path = "../aws-sig-auth" }
 aws-smithy-client = { path = "../../../rust-runtime/aws-smithy-client" }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
 aws-smithy-http-tower = { path = "../../../rust-runtime/aws-smithy-http-tower" }
-aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
-bytes = "1"
-fastrand = "1.4.0"
-http = "0.2.3"
-http-body = "0.4.4"
-hyper = { version = "0.14.2", features = ["client", "http1", "http2", "tcp", "runtime"] }
-hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
-hyper-tls = { version ="0.5.0", optional = true }
-tokio = { version = "1", features = ["time"] }
-tower = { version = "0.4.6", features = ["util", "retry"] }
-
-pin-project = "1"
-tracing = "0.1"
+tower = { version = "0.4.6" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
 tower-test = "0.4.0"
 aws-types = { path = "../aws-types" }
 aws-smithy-client = { path = "../../../rust-runtime/aws-smithy-client", features = ["test-util"] }
+http = "0.2.5"
+bytes = "1.1.0"
+aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 
 [[test]]
 name = "e2e_test"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -34,7 +34,7 @@ import software.amazon.smithy.rust.codegen.util.expectTrait
 
 private class Types(runtimeConfig: RuntimeConfig) {
     private val smithyClientDep = CargoDependency.SmithyClient(runtimeConfig).copy(optional = true)
-    private val awsHyperDep = runtimeConfig.awsRuntimeDependency("aws-hyper").copy(optional = true)
+    private val awsHyperDep = runtimeConfig.awsRuntimeDependency("aws-hyper")
 
     val awsTypes = awsTypes(runtimeConfig).asType()
     val awsHyper = awsHyperDep.asType()
@@ -81,10 +81,9 @@ class AwsFluentClientDecorator : RustCodegenDecorator {
             ).render(writer)
             AwsFluentClientExtensions(types).render(writer)
         }
-        val awsHyper = "aws-hyper"
         val awsSmithyClient = "aws-smithy-client"
-        rustCrate.mergeFeature(Feature("rustls", default = true, listOf("$awsHyper/rustls", "$awsSmithyClient/rustls")))
-        rustCrate.mergeFeature(Feature("native-tls", default = false, listOf("$awsHyper/native-tls", "$awsSmithyClient/native-tls")))
+        rustCrate.mergeFeature(Feature("rustls", default = true, listOf("$awsSmithyClient/rustls")))
+        rustCrate.mergeFeature(Feature("native-tls", default = false, listOf("$awsSmithyClient/native-tls")))
     }
 
     override fun libRsCustomizations(

--- a/aws/sdk/examples/dynamodb/Cargo.toml
+++ b/aws/sdk/examples/dynamodb/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client" }

--- a/aws/sdk/examples/kms/Cargo.toml
+++ b/aws/sdk/examples/kms/Cargo.toml
@@ -8,7 +8,7 @@ description = "Example usage of the KMS service"
 [dependencies]
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 kms = { package = "aws-sdk-kms", path = "../../build/aws-sdk/sdk/kms" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }

--- a/aws/sdk/examples/secretsmanager/Cargo.toml
+++ b/aws/sdk/examples/secretsmanager/Cargo.toml
@@ -8,7 +8,8 @@ description = "Example usage of the SecretManager service"
 [dependencies]
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 secretsmanager = { package = "aws-sdk-secretsmanager", path = "../../build/aws-sdk/sdk/secretsmanager" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
+
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"]}

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/glacier/Cargo.toml
+++ b/aws/sdk/integration-tests/glacier/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"]}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-glacier = { path = "../../build/aws-sdk/sdk/glacier" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol-test"}

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dev-dependencies]
 aws-endpoint = { path = "../../build/aws-sdk/sdk/aws-endpoint" }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"]}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-iam = { path = "../../build/aws-sdk/sdk/iam" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-kms = { path = "../../build/aws-sdk/sdk/kms" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/lambda/Cargo.toml
+++ b/aws/sdk/integration-tests/lambda/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 async-stream = "0.3"
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-lambda = { path = "../../build/aws-sdk/sdk/lambda" }
 base64 = "0.13"
 bytes = "1"

--- a/aws/sdk/integration-tests/polly/Cargo.toml
+++ b/aws/sdk/integration-tests/polly/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"]}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-polly = { path = "../../build/aws-sdk/sdk/polly" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/qldbsession/Cargo.toml
+++ b/aws/sdk/integration-tests/qldbsession/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"]}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-qldbsession = { path = "../../build/aws-sdk/sdk/qldbsession" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["rt-tokio"] }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/s3control/Cargo.toml
+++ b/aws/sdk/integration-tests/s3control/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dev-dependencies]
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-s3control = { path = "../../build/aws-sdk/sdk/s3control" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"] }
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
+++ b/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dev-dependencies]
 async-stream = "0.3"
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper", features = ["rustls"]}
+aws-hyper = { path = "../../build/aws-sdk/sdk/aws-hyper" }
 aws-sdk-transcribestreaming = { path = "../../build/aws-sdk/sdk/transcribestreaming" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-eventstream = { path = "../../build/aws-sdk/sdk/aws-smithy-eventstream" }


### PR DESCRIPTION
## Motivation and Context
`aws-hyper` contained features that were unused

## Description
- remove unused features and deps from aws-hyper
- Update codegen to unconditionally depend on aws-hyper and avoid referencing aws-hyper features
## Testing
- [x] CI
- [x] review generated code diff

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
