### PR TITLE
Use a single struct to represent the RequestExtension

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -327,10 +327,9 @@ class ServerProtocolTestGenerator(
         rustWriter.rust(
             """
             let extensions = http_request.extensions().expect("unable to extract http request extensions");
-            let namespace = extensions.get::<aws_smithy_http_server::ExtensionNamespace>().expect("extension ExtensionNamespace not found");
-            assert_eq!(**namespace, ${operationShape.id.getNamespace().dq()});
-            let operation_name = extensions.get::<aws_smithy_http_server::ExtensionOperationName>().expect("extension ExtensionOperationName not found");
-            assert_eq!(**operation_name, ${operationSymbol.name.dq()});
+            let request_extensions = extensions.get::<aws_smithy_http_server::RequestExtensions>().expect("extension RequestExtensions not found");
+            assert_eq!(request_extensions.namespace, ${operationShape.id.getNamespace().dq()});
+            assert_eq!(request_extensions.operation_name, ${operationSymbol.name.dq()});
             """.trimIndent()
         )
     }

--- a/rust-runtime/aws-smithy-http-server/rustfmt.toml
+++ b/rust-runtime/aws-smithy-http-server/rustfmt.toml
@@ -1,10 +1,4 @@
 edition = "2018"
 max_width = 120
-# The "Default" setting has a heuristic which splits lines too aggresively.
-# We are willing to revisit this setting in future versions of rustfmt.
-# Bugs:
-#   * https://github.com/rust-lang/rustfmt/issues/3119
-#   * https://github.com/rust-lang/rustfmt/issues/3120
-use_small_heuristics = "Max"
 # Prevent carriage returns
 newline_style = "Unix"

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -56,6 +56,11 @@ impl RequestExtensions {
             operation_name,
         }
     }
+
+    /// Returns the current operation formatted as <namespace>#<operation_name>.
+    pub fn operation(&self) -> String {
+        format!("{}#{}", self.namespace, self.operation_name)
+    }
 }
 
 /// Extension type used to store the type of user defined error returned by an operation.

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -39,15 +39,24 @@ use async_trait::async_trait;
 use axum_core::extract::{FromRequest, RequestParts};
 use std::ops::Deref;
 
-/// Extension type used to store the Smithy model namespace.
-#[derive(Debug, Clone)]
-pub struct ExtensionNamespace(&'static str);
-impl_extension_new_and_deref!(ExtensionNamespace);
+/// Extension type used to store Smithy request information.
+#[derive(Debug, Clone, Default, Copy)]
+pub struct RequestExtensions {
+    /// Smithy model namespace.
+    pub namespace: &'static str,
+    /// Smithy operation name.
+    pub operation_name: &'static str,
+}
 
-/// Extension type used to store the Smithy operation name.
-#[derive(Debug, Clone)]
-pub struct ExtensionOperationName(&'static str);
-impl_extension_new_and_deref!(ExtensionOperationName);
+impl RequestExtensions {
+    /// Generates a new `RequestExtensions`.
+    pub fn new(namespace: &'static str, operation_name: &'static str) -> Self {
+        Self {
+            namespace,
+            operation_name,
+        }
+    }
+}
 
 /// Extension type used to store the type of user defined error returned by an operation.
 /// These are modeled errors, defined in the Smithy model.

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -24,9 +24,7 @@ pub use self::body::{boxed, to_boxed, Body, BoxBody, HttpBody};
 #[doc(inline)]
 pub use self::error::Error;
 #[doc(inline)]
-pub use self::extension::{
-    Extension, ExtensionModeledError, ExtensionNamespace, ExtensionOperationName, ExtensionRejection,
-};
+pub use self::extension::{Extension, ExtensionModeledError, ExtensionRejection, RequestExtensions};
 #[doc(inline)]
 pub use self::routing::Router;
 #[doc(inline)]

--- a/rust-runtime/aws-smithy-http-server/src/macros.rs
+++ b/rust-runtime/aws-smithy-http-server/src/macros.rs
@@ -232,6 +232,19 @@ macro_rules! opaque_future {
 
 pub use opaque_future;
 
+/// Implements `Deref` for all `Extension` holding a `&'static, str`.
+macro_rules! impl_deref {
+    ($name:ident) => {
+        impl Deref for $name {
+            type Target = &'static str;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    };
+}
+
 /// Implements `new` for all `Extension` holding a `&'static, str`.
 macro_rules! impl_extension_new_and_deref {
     ($name:ident) => {
@@ -242,12 +255,6 @@ macro_rules! impl_extension_new_and_deref {
             }
         }
 
-        impl Deref for $name {
-            type Target = &'static str;
-
-            fn deref(&self) -> &Self::Target {
-                &self.0
-            }
-        }
+        impl_deref!($name);
     };
 }

--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -43,7 +43,9 @@ pub struct Router<B = Body> {
 
 impl<B> Clone for Router<B> {
     fn clone(&self) -> Self {
-        Self { routes: self.routes.clone() }
+        Self {
+            routes: self.routes.clone(),
+        }
     }
 }
 
@@ -66,7 +68,9 @@ where
     /// all requests.
     #[doc(hidden)]
     pub fn new() -> Self {
-        Self { routes: Default::default() }
+        Self {
+            routes: Default::default(),
+        }
     }
 
     /// Add a route to the router.
@@ -107,9 +111,15 @@ where
         NewResBody: HttpBody<Data = bytes::Bytes> + Send + 'static,
         NewResBody::Error: Into<BoxError>,
     {
-        let layer = ServiceBuilder::new().layer_fn(Route::new).layer(MapResponseBodyLayer::new(boxed)).layer(layer);
-        let routes =
-            self.routes.into_iter().map(|(route, request_spec)| (Layer::layer(&layer, route), request_spec)).collect();
+        let layer = ServiceBuilder::new()
+            .layer_fn(Route::new)
+            .layer(MapResponseBodyLayer::new(boxed))
+            .layer(layer);
+        let routes = self
+            .routes
+            .into_iter()
+            .map(|(route, request_spec)| (Layer::layer(&layer, route), request_spec))
+            .collect();
         Router { routes }
     }
 }
@@ -142,8 +152,17 @@ where
             }
         }
 
-        let status_code = if method_not_allowed { StatusCode::METHOD_NOT_ALLOWED } else { StatusCode::NOT_FOUND };
-        RouterFuture::from_response(Response::builder().status(status_code).body(crate::body::empty()).unwrap())
+        let status_code = if method_not_allowed {
+            StatusCode::METHOD_NOT_ALLOWED
+        } else {
+            StatusCode::NOT_FOUND
+        };
+        RouterFuture::from_response(
+            Response::builder()
+                .status(status_code)
+                .body(crate::body::empty())
+                .unwrap(),
+        )
     }
 }
 
@@ -201,7 +220,11 @@ mod tests {
             (
                 RequestSpec::from_parts(
                     Method::GET,
-                    vec![PathSegment::Literal(String::from("a")), PathSegment::Label, PathSegment::Label],
+                    vec![
+                        PathSegment::Literal(String::from("a")),
+                        PathSegment::Label,
+                        PathSegment::Label,
+                    ],
                     vec![],
                 ),
                 "A",

--- a/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
@@ -96,7 +96,11 @@ impl From<&PathSpec> for Regex {
 impl RequestSpec {
     pub fn new(method: http::Method, uri_spec: UriSpec) -> Self {
         let uri_path_regex = (&uri_spec.path_and_query.path_segments).into();
-        RequestSpec { method, uri_spec, uri_path_regex }
+        RequestSpec {
+            method,
+            uri_spec,
+            uri_path_regex,
+        }
     }
 
     pub(super) fn matches<B>(&self, req: &Request<B>) -> Match {
@@ -233,25 +237,38 @@ mod tests {
 
     #[test]
     fn repeated_query_keys_same_values_match() {
-        assert_eq!(Match::Yes, key_value_spec().matches(&req(&Method::DELETE, "/?foo=bar&foo=bar")));
+        assert_eq!(
+            Match::Yes,
+            key_value_spec().matches(&req(&Method::DELETE, "/?foo=bar&foo=bar"))
+        );
     }
 
     #[test]
     fn repeated_query_keys_distinct_values_does_not_match() {
-        assert_eq!(Match::No, key_value_spec().matches(&req(&Method::DELETE, "/?foo=bar&foo=baz")));
+        assert_eq!(
+            Match::No,
+            key_value_spec().matches(&req(&Method::DELETE, "/?foo=bar&foo=baz"))
+        );
     }
 
     fn ab_spec() -> RequestSpec {
         RequestSpec::from_parts(
             Method::GET,
-            vec![PathSegment::Literal(String::from("a")), PathSegment::Literal(String::from("b"))],
+            vec![
+                PathSegment::Literal(String::from("a")),
+                PathSegment::Literal(String::from("b")),
+            ],
             vec![],
         )
     }
 
     #[test]
     fn empty_segments_in_the_middle_dont_matter() {
-        let hits = vec![(Method::GET, "/a/b"), (Method::GET, "/a//b"), (Method::GET, "//////a//b")];
+        let hits = vec![
+            (Method::GET, "/a/b"),
+            (Method::GET, "/a//b"),
+            (Method::GET, "//////a//b"),
+        ];
         for (method, uri) in &hits {
             assert_eq!(Match::Yes, ab_spec().matches(&req(method, uri)));
         }
@@ -262,7 +279,11 @@ mod tests {
     // end of URIs _do_ matter.
     #[test]
     fn empty_segments_at_the_end_do_matter() {
-        let misses = vec![(Method::GET, "/a/b/"), (Method::GET, "/a/b//"), (Method::GET, "//a//b////")];
+        let misses = vec![
+            (Method::GET, "/a/b/"),
+            (Method::GET, "/a/b//"),
+            (Method::GET, "//a//b////"),
+        ];
         for (method, uri) in &misses {
             assert_eq!(Match::No, ab_spec().matches(&req(method, uri)));
         }

--- a/rust-runtime/aws-smithy-http-server/src/routing/route.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/route.rs
@@ -57,13 +57,17 @@ impl<B> Route<B> {
         T: Service<Request<B>, Response = Response<BoxBody>, Error = Infallible> + Clone + Send + 'static,
         T::Future: Send + 'static,
     {
-        Self { service: BoxCloneService::new(svc) }
+        Self {
+            service: BoxCloneService::new(svc),
+        }
     }
 }
 
 impl<ReqBody> Clone for Route<ReqBody> {
     fn clone(&self) -> Self {
-        Self { service: self.service.clone() }
+        Self {
+            service: self.service.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
Instead of using multiple wrappers around static strings, it's better to get() a reference to a single structure from the `http::Extensions`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
