### PR TITLE
[Server] codegen-server support for restXml (S3)

### DIFF
--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -25,7 +25,8 @@ data class CodegenTest(val service: String, val module: String, val extraConfig:
 val CodegenTests = listOf(
     CodegenTest("com.amazonaws.simple#SimpleService", "simple"),
     CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
-    CodegenTest("com.amazonaws.ebs#Ebs", "ebs")
+    CodegenTest("com.amazonaws.ebs#Ebs", "ebs"),
+    CodegenTest("com.amazonaws.s3#AmazonS3", "s3")
 )
 
 /**

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -150,10 +150,12 @@ class ServerProtocolTestGenerator(
         testModuleWriter.write("Test ID: ${testCase.id}")
         testModuleWriter.setNewlinePrefix("")
         testModuleWriter.writeWithNoFormatting("#[tokio::test]")
-        // TODO: this allows to check-in RestJson protocol tests without
+        // TODO: this allows to check-in RestJson and RestXml protocol tests without
         // failures as the protocol is not fully implemented yet.
         // Remove it once the protocol is fully implemented.
-        if (operationShape.id.getNamespace() == "aws.protocoltests.restjson") {
+        if (operationShape.id.getNamespace() == "aws.protocoltests.restjson" ||
+            operationShape.id.getNamespace() == "com.amazonaws.s3"
+        ) {
             testModuleWriter.writeWithNoFormatting("#[ignore]")
         }
         val Tokio = CargoDependency(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerProtocolLoader.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerProtocolLoader.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rust.codegen.server.smithy.protocols
 
 import software.amazon.smithy.aws.traits.protocols.RestJson1Trait
+import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.ServiceIndex
@@ -39,6 +40,7 @@ class ServerProtocolLoader(private val supportedProtocols: ProtocolMap) {
         val DefaultProtocols = mapOf(
             // TODO: support other protocols.
             RestJson1Trait.ID to ServerRestJsonFactory(),
+            RestXmlTrait.ID to ServerRestXmlFactory(),
         )
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerRustXml.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerRustXml.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy.protocols
+
+import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.traits.TimestampFormatTrait
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
+import software.amazon.smithy.rust.codegen.smithy.protocols.HttpBindingResolver
+import software.amazon.smithy.rust.codegen.smithy.protocols.HttpTraitHttpBindingResolver
+import software.amazon.smithy.rust.codegen.smithy.protocols.Protocol
+import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolContentTypes
+import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolGeneratorFactory
+import software.amazon.smithy.rust.codegen.smithy.protocols.parse.RestXmlParserGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.parse.StructuredDataParserGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.serialize.StructuredDataSerializerGenerator
+import software.amazon.smithy.rust.codegen.smithy.protocols.serialize.XmlBindingTraitSerializerGenerator
+import software.amazon.smithy.rust.codegen.util.expectTrait
+
+class ServerRestXmlFactory(private val generator: (CodegenContext) -> Protocol = { ServerRestXml(it) }) :
+    ProtocolGeneratorFactory<ServerHttpProtocolGenerator> {
+    override fun protocol(codegenContext: CodegenContext): Protocol = generator(codegenContext)
+
+    override fun buildProtocolGenerator(codegenContext: CodegenContext): ServerHttpProtocolGenerator =
+        ServerHttpProtocolGenerator(codegenContext, ServerRestXml(codegenContext))
+
+    override fun transformModel(model: Model): Model = model
+
+    override fun support(): ProtocolSupport {
+        return ProtocolSupport(
+            /* Client support */
+            requestSerialization = false,
+            requestBodySerialization = false,
+            responseDeserialization = false,
+            errorDeserialization = false,
+            /* Server support */
+            requestDeserialization = true,
+            requestBodyDeserialization = true,
+            responseSerialization = true,
+            errorSerialization = true
+        )
+    }
+}
+
+open class ServerRestXml(private val codegenContext: CodegenContext) : Protocol {
+    private val restXml = codegenContext.serviceShape.expectTrait<RestXmlTrait>()
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val errorScope = arrayOf(
+        "Bytes" to RuntimeType.Bytes,
+        "Error" to RuntimeType.GenericError(runtimeConfig),
+        "HeaderMap" to RuntimeType.http.member("HeaderMap"),
+        "Response" to RuntimeType.http.member("Response"),
+        "XmlError" to CargoDependency.smithyXml(runtimeConfig).asType().member("decode::XmlError")
+    )
+    private val xmlDeserModule = RustModule.private("xml_deser")
+
+    protected val restXmlErrors: RuntimeType = when (restXml.isNoErrorWrapping) {
+        true -> RuntimeType.unwrappedXmlErrors(runtimeConfig)
+        false -> RuntimeType.wrappedXmlErrors(runtimeConfig)
+    }
+
+    override val httpBindingResolver: HttpBindingResolver =
+        HttpTraitHttpBindingResolver(codegenContext.model, ProtocolContentTypes.consistent("application/xml"))
+
+    override val defaultTimestampFormat: TimestampFormatTrait.Format =
+        TimestampFormatTrait.Format.DATE_TIME
+
+    override fun structuredDataParser(operationShape: OperationShape): StructuredDataParserGenerator {
+        return RestXmlParserGenerator(codegenContext, restXmlErrors)
+    }
+
+    override fun structuredDataSerializer(operationShape: OperationShape): StructuredDataSerializerGenerator {
+        return XmlBindingTraitSerializerGenerator(codegenContext, httpBindingResolver)
+    }
+
+    override fun parseHttpGenericError(operationShape: OperationShape): RuntimeType =
+        RuntimeType.forInlineFun("parse_http_generic_error", xmlDeserModule) { writer ->
+            writer.rustBlockTemplate(
+                "pub fn parse_http_generic_error(response: &#{Response}<#{Bytes}>) -> Result<#{Error}, #{XmlError}>",
+                *errorScope
+            ) {
+                rust("#T::parse_generic_error(response.body().as_ref())", restXmlErrors)
+            }
+        }
+
+    override fun parseEventStreamGenericError(operationShape: OperationShape): RuntimeType =
+        RuntimeType.forInlineFun("parse_event_stream_generic_error", xmlDeserModule) { writer ->
+            writer.rustBlockTemplate(
+                "pub fn parse_event_stream_generic_error(payload: &#{Bytes}) -> Result<#{Error}, #{XmlError}>",
+                *errorScope
+            ) {
+                rust("#T::parse_generic_error(payload.as_ref())", restXmlErrors)
+            }
+        }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -52,6 +52,7 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.deserializeFunctionN
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.expectMember
 import software.amazon.smithy.rust.codegen.util.hasTrait
+import software.amazon.smithy.rust.codegen.util.inputShape
 import software.amazon.smithy.rust.codegen.util.outputShape
 
 // The string argument is the name of the XML ScopedDecoder to continue parsing from
@@ -244,7 +245,38 @@ class XmlBindingTraitParserGenerator(
     }
 
     override fun serverInputParser(operationShape: OperationShape): RuntimeType? {
-        TODO("Not yet implemented")
+        val inputShape = operationShape.inputShape(model)
+        val fnName = symbolProvider.deserializeFunctionName(operationShape)
+        val shapeName = xmlIndex.operationInputShapeName(operationShape)
+        val members = operationShape.serverInputXmlMembers()
+        if (shapeName == null || !members.isNotEmpty()) {
+            return null
+        }
+        return RuntimeType.forInlineFun(fnName, xmlDeserModule) {
+            Attribute.AllowUnusedMut.render(it)
+            it.rustBlock(
+                "pub fn $fnName(inp: &[u8], mut builder: #1T) -> Result<#1T, #2T>",
+                inputShape.builderSymbol(symbolProvider),
+                xmlError
+            ) {
+                rustTemplate(
+                    """
+                    use std::convert::TryFrom;
+                    let mut doc = #{Document}::try_from(inp)?;
+
+                    ##[allow(unused_mut)]
+                    let mut decoder = doc.root_element()?;
+                    let start_el = decoder.start_el();
+                    """,
+                    *codegenScope
+                )
+                val context = OperationWrapperContext(operationShape, shapeName, xmlError)
+                writeOperationWrapper(context) { tagName ->
+                    parseStructureInner(members, builder = "builder", Ctx(tag = tagName, accum = null))
+                }
+                rust("Ok(builder)")
+            }
+        }
     }
 
     private fun RustWriter.unwrappedResponseParser(
@@ -662,6 +694,23 @@ class XmlBindingTraitParserGenerator(
                 val documentMembers =
                     responseBindings.filter { it.value.location == HttpBinding.Location.DOCUMENT }
                         .keys.map { outputShape.expectMember(it) }
+                return XmlMemberIndex.fromMembers(documentMembers)
+            }
+        }
+    }
+
+    private fun OperationShape.serverInputXmlMembers(): XmlMemberIndex {
+        val inputShape = this.inputShape(model)
+
+        // HTTP trait bound protocols, such as RestXml, need to restrict the members to DOCUMENT members,
+        // while protocols like AwsQuery do not support HTTP traits, and thus, all members are used.
+        val requestBindings = index.getRequestBindings(this)
+        return when (requestBindings.isEmpty()) {
+            true -> XmlMemberIndex.fromMembers(inputShape.members().toList())
+            else -> {
+                val documentMembers =
+                    requestBindings.filter { it.value.location == HttpBinding.Location.DOCUMENT }
+                        .keys.map { inputShape.expectMember(it) }
                 return XmlMemberIndex.fromMembers(documentMembers)
             }
         }

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -19,6 +19,7 @@ publish = false
 aws-smithy-http = { path = "../aws-smithy-http", features = ["rt-tokio"] }
 aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-json = { path = "../aws-smithy-json" }
+aws-smithy-xml = { path = "../aws-smithy-xml" }
 async-trait = "0.1"
 axum-core = "0.1"
 bytes = "1.1"

--- a/rust-runtime/aws-smithy-http-server/src/protocols.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocols.rs
@@ -4,7 +4,7 @@
  */
 
 //! Protocol helpers.
-use crate::rejection::{ContentTypeRejection, MimeParsingFailed, MissingJsonContentType};
+use crate::rejection::{ContentTypeRejection, MimeParsingFailed, MissingJsonContentType, MissingXmlContentType};
 use axum_core::extract::RequestParts;
 
 /// Validate that the request had the standard JSON content-type header.
@@ -25,5 +25,26 @@ pub fn check_json_content_type<B>(req: &RequestParts<B>) -> Result<(), ContentTy
         Ok(())
     } else {
         Err(ContentTypeRejection::MissingJsonContentType(MissingJsonContentType))
+    }
+}
+
+/// Validate that the request had the standard XML content-type header.
+pub fn check_xml_content_type<B>(req: &RequestParts<B>) -> Result<(), ContentTypeRejection> {
+    let mime = req
+        .headers()
+        .ok_or(MissingXmlContentType)?
+        .get(http::header::CONTENT_TYPE)
+        .ok_or(MissingXmlContentType)?
+        .to_str()
+        .map_err(|_| MissingXmlContentType)?
+        .parse::<mime::Mime>()
+        .map_err(|_| MimeParsingFailed)?;
+
+    if mime.type_() == "application"
+        && (mime.subtype() == "xml" || mime.suffix().filter(|name| *name == "xml").is_some())
+    {
+        Ok(())
+    } else {
+        Err(ContentTypeRejection::MissingXmlContentType(MissingXmlContentType))
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -66,6 +66,13 @@ define_rejection! {
 
 define_rejection! {
     #[status = BAD_REQUEST]
+    #[body = "Expected `Content-Type: application/xml`"]
+    /// Rejection type used if the XML `Content-Type` header is missing.
+    pub struct MissingXmlContentType;
+}
+
+define_rejection! {
+    #[status = BAD_REQUEST]
     #[body = "Expected query string in URI but none found"]
     /// Rejection type used if the URI has no query string and we need to deserialize data from it.
     pub struct MissingQueryString;
@@ -99,6 +106,7 @@ composite_rejection! {
     /// header, MIME parse issues, etc.
     pub enum ContentTypeRejection {
         MissingJsonContentType,
+        MissingXmlContentType,
         MimeParsingFailed,
     }
 }
@@ -138,6 +146,12 @@ composite_rejection! {
 
 impl From<aws_smithy_json::deserialize::Error> for SmithyRejection {
     fn from(err: aws_smithy_json::deserialize::Error) -> Self {
+        SmithyRejection::Deserialize(Deserialize::from_err(err))
+    }
+}
+
+impl From<aws_smithy_xml::decode::XmlError> for SmithyRejection {
+    fn from(err: aws_smithy_xml::decode::XmlError) -> Self {
         SmithyRejection::Deserialize(Deserialize::from_err(err))
     }
 }


### PR DESCRIPTION
Signed-off-by: Guy Margalit <guymguym@gmail.com>

## Motivation and Context

See #903

The motivation is to implement the server protocol code for the s3d-rs crate - still draft code in the project but the idea is to provide an S3 gateway for edge devices that handles disconnections and caching transparently. See: https://github.com/s3d-rs/s3d 

## Description

This PR adds generated server code for restXml protocol types as mentioned by @crisidev in the related issue.

Please keep in mind that I am quite new to this project and to kotlin, and I would be happy to get your review and fix anything that you may suggest.

## Testing

Added the S3 model namespace to the "blocklist" in ServerProtocolTestGenerator.kt because the server protocol is not fully implemented.

## Checklist

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
