### PR TITLE
Setup server default RustSettings

### DIFF
--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -42,9 +42,6 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
             "${it.module}": {
                 "plugins": {
                     "rust-server-codegen": {
-                      "codegen": {
-                        "includeFluentClient": false
-                      },
                       "runtimeConfig": {
                         "relativePath": "${rootProject.projectDir.absolutePath}/rust-runtime"
                       },

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -53,7 +53,7 @@ class ServerCodegenVisitor(context: PluginContext, private val codegenDecorator:
     ShapeVisitor.Default<Unit>() {
 
     private val logger = Logger.getLogger(javaClass.name)
-    private val settings = RustSettings.from(context.model, context.settings)
+    private val settings = ServerRustSettings.from(context.model, context.settings)
 
     private val symbolProvider: RustSymbolProvider
     private val rustCrate: RustCrate

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -25,9 +25,9 @@ import java.util.Optional
  * [formatTimeoutSeconds]: Timeout for running cargo fmt at the end of code generation
  */
 data class ServerCodegenConfig(
-    val renameExceptions: Boolean = true,
+    val renameExceptions: Boolean = false,
     val includeFluentClient: Boolean = false,
-    val addMessageToErrors: Boolean = true,
+    val addMessageToErrors: Boolean = false,
     val formatTimeoutSeconds: Int = 20,
     // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
     val eventStreamAllowList: Set<String> = emptySet(),
@@ -38,9 +38,9 @@ data class ServerCodegenConfig(
                 CodegenConfig.fromNode(node)
             } else {
                 CodegenConfig(
-                    true,
                     false,
-                    true,
+                    false,
+                    false,
                     20,
                     emptySet()
                 )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -5,17 +5,14 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy
 
-import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.node.ObjectNode
-import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.smithy.CODEGEN_SETTINGS
 import software.amazon.smithy.rust.codegen.smithy.CodegenConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RustSettings
 import java.util.Optional
-import java.util.logging.Logger
 
 /**
  * Configuration of codegen settings
@@ -68,23 +65,7 @@ class ServerRustSettings(
     val examplesUri: String? = null,
     private val model: Model
 ) {
-
-    /**
-     * Get the corresponding [ServiceShape] from a model.
-     * @return Returns the found `Service`
-     * @throws CodegenException if the service is invalid or not found
-     */
-    fun getService(model: Model): ServiceShape {
-        return model
-            .getShape(service)
-            .orElseThrow { CodegenException("Service shape not found: $service") }
-            .asServiceShape()
-            .orElseThrow { CodegenException("Shape is not a service: $service") }
-    }
-
     companion object {
-        private val LOGGER: Logger = Logger.getLogger(ServerRustSettings::class.java.name)
-
         /**
          * Create settings from a configuration object node.
          *

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy
+
+import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.smithy.CODEGEN_SETTINGS
+import software.amazon.smithy.rust.codegen.smithy.CodegenConfig
+import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.smithy.RustSettings
+import java.util.Optional
+import java.util.logging.Logger
+
+/**
+ * Configuration of codegen settings
+ *
+ * [renameExceptions]: Rename `Exception` to `Error` in the generated SDK
+ * [includeFluentClient]: Generate a `client` module in the generated SDK (currently the AWS SDK sets this to false
+ *   and generates its own client)
+ *
+ * [addMessageToErrors]: Adds a `message` field automatically to all error shapes
+ * [formatTimeoutSeconds]: Timeout for running cargo fmt at the end of code generation
+ */
+data class ServerCodegenConfig(
+    val renameExceptions: Boolean = true,
+    val includeFluentClient: Boolean = false,
+    val addMessageToErrors: Boolean = true,
+    val formatTimeoutSeconds: Int = 20,
+    // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
+    val eventStreamAllowList: Set<String> = emptySet(),
+) {
+    companion object {
+        fun fromNode(node: Optional<ObjectNode>): CodegenConfig {
+            return if (node.isPresent) {
+                CodegenConfig.fromNode(node)
+            } else {
+                CodegenConfig(
+                    true,
+                    false,
+                    true,
+                    20,
+                    emptySet()
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Settings used by [RustCodegenPlugin]
+ */
+class ServerRustSettings(
+    val service: ShapeId,
+    val moduleName: String,
+    val moduleVersion: String,
+    val moduleAuthors: List<String>,
+    val moduleDescription: String?,
+    val moduleRepository: String?,
+    val runtimeConfig: RuntimeConfig,
+    val codegenConfig: CodegenConfig,
+    val license: String?,
+    val examplesUri: String? = null,
+    private val model: Model
+) {
+
+    /**
+     * Get the corresponding [ServiceShape] from a model.
+     * @return Returns the found `Service`
+     * @throws CodegenException if the service is invalid or not found
+     */
+    fun getService(model: Model): ServiceShape {
+        return model
+            .getShape(service)
+            .orElseThrow { CodegenException("Service shape not found: $service") }
+            .asServiceShape()
+            .orElseThrow { CodegenException("Shape is not a service: $service") }
+    }
+
+    companion object {
+        private val LOGGER: Logger = Logger.getLogger(ServerRustSettings::class.java.name)
+
+        /**
+         * Create settings from a configuration object node.
+         *
+         * @param model Model to infer the service from (if not explicitly set in config)
+         * @param config Config object to load
+         * @throws software.amazon.smithy.model.node.ExpectationNotMetException
+         * @return Returns the extracted settings
+         */
+        fun from(model: Model, config: ObjectNode): RustSettings {
+            val codegenSettings = config.getObjectMember(CODEGEN_SETTINGS)
+            val codegenConfig = ServerCodegenConfig.fromNode(codegenSettings)
+            return RustSettings.fromCodegenConfig(model, config, codegenConfig)
+        }
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -328,7 +328,7 @@ class ServerProtocolTestGenerator(
     private fun checkHttpExtensions(rustWriter: RustWriter) {
         rustWriter.rust(
             """
-            let request_extensions = http_response.extensions().get::<aws_smithy_http_server::RequestExtensions>().expect("extension RequestExtensions not found");
+            let request_extensions = http_response.extensions().get::<aws_smithy_http_server::RequestExtensions>().expect("extension `RequestExtensions` not found");
             assert_eq!(request_extensions.namespace, ${operationShape.id.getNamespace().dq()});
             assert_eq!(request_extensions.operation_name, ${operationSymbol.name.dq()});
             """.trimIndent()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -225,7 +225,6 @@ class ServerProtocolTestGenerator(
                 checkBody(this, body, httpRequestTestCase)
             }
         }
-        checkHttpExtensions(this)
 
         // Explicitly warn if the test case defined parameters that we aren't doing anything with
         with(httpRequestTestCase) {
@@ -288,6 +287,7 @@ class ServerProtocolTestGenerator(
             );
             """
         )
+        checkHttpExtensions(this)
         if (!testCase.body.isEmpty()) {
             rustTemplate(
                 """
@@ -328,8 +328,7 @@ class ServerProtocolTestGenerator(
     private fun checkHttpExtensions(rustWriter: RustWriter) {
         rustWriter.rust(
             """
-            let extensions = http_request.extensions().expect("unable to extract http request extensions");
-            let request_extensions = extensions.get::<aws_smithy_http_server::RequestExtensions>().expect("extension RequestExtensions not found");
+            let request_extensions = http_response.extensions().get::<aws_smithy_http_server::RequestExtensions>().expect("extension RequestExtensions not found");
             assert_eq!(request_extensions.namespace, ${operationShape.id.getNamespace().dq()});
             assert_eq!(request_extensions.operation_name, ${operationSymbol.name.dq()});
             """.trimIndent()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -146,7 +146,7 @@ private class ServerHttpProtocolImplGenerator(
             // It will first offer the streaming input to the parser and potentially read the body into memory
             // if an error occurred or if the streaming parser indicates that it needs the full data to proceed.
             """
-            async fn from_request(req: &mut #{AxumCore}::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
+            async fn from_request(_req: &mut #{AxumCore}::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
                 todo!("Streaming support for input shapes is not yet supported in `smithy-rs`")
             }
             """.trimIndent()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -140,7 +140,6 @@ private class ServerHttpProtocolImplGenerator(
         val operationName = symbolProvider.toSymbol(operationShape).name
         // Implement Axum `FromRequest` trait for input types.
         val inputName = "${operationName}${ServerHttpProtocolGenerator.OPERATION_INPUT_WRAPPER_SUFFIX}"
-        val httpExtensions = setHttpExtensions(operationShape)
 
         val fromRequest = if (operationShape.inputShape(model).hasStreamingMember(model)) {
             // For streaming request bodies, we need to generate a different implementation of the `FromRequest` trait.
@@ -148,14 +147,12 @@ private class ServerHttpProtocolImplGenerator(
             // if an error occurred or if the streaming parser indicates that it needs the full data to proceed.
             """
             async fn from_request(req: &mut #{AxumCore}::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
-                $httpExtensions
                 todo!("Streaming support for input shapes is not yet supported in `smithy-rs`")
             }
             """.trimIndent()
         } else {
             """
             async fn from_request(req: &mut #{AxumCore}::extract::RequestParts<B>) -> Result<Self, Self::Rejection> {
-                $httpExtensions
                 Ok($inputName(#{parse_request}(req).await?))
             }
             """.trimIndent()
@@ -184,6 +181,7 @@ private class ServerHttpProtocolImplGenerator(
         val outputName = "${operationName}${ServerHttpProtocolGenerator.OPERATION_OUTPUT_WRAPPER_SUFFIX}"
         val errorSymbol = operationShape.errorSymbol(symbolProvider)
 
+        val httpExtensions = setHttpExtensions(operationShape)
         // For streaming response bodies, we need to generate a different implementation of the `IntoResponse` trait.
         // The body type will have to be a `StreamBody`. The service implementer will return a `Stream` from their handler.
         val intoResponseStreaming = "todo!(\"Streaming support for output shapes is not yet supported in `smithy-rs`\")"
@@ -192,7 +190,7 @@ private class ServerHttpProtocolImplGenerator(
                 intoResponseStreaming
             } else {
                 """
-                match self {
+                let mut response = match self {
                     Self::Output(o) => {
                         match #{serialize_response}(&o) {
                             Ok(response) => response,
@@ -212,7 +210,9 @@ private class ServerHttpProtocolImplGenerator(
                             }
                         }
                     }
-                }
+                };
+                $httpExtensions
+                response
                 """.trimIndent()
             }
             // The output of fallible operations is a `Result` which we convert into an isomorphic `enum` type we control
@@ -241,10 +241,10 @@ private class ServerHttpProtocolImplGenerator(
                 intoResponseStreaming
             } else {
                 """
-                match #{serialize_response}(&self.0) {
+                let mut response = match #{serialize_response}(&self.0) {
                     Ok(response) => response,
                     Err(e) => e.into_response()
-                }
+                };
                 """.trimIndent()
             }
             // The output of non-fallible operations is a model type which we convert into a "wrapper" unit `struct` type
@@ -314,8 +314,7 @@ private class ServerHttpProtocolImplGenerator(
         val namespace = operationShape.id.getNamespace()
         val operationName = symbolProvider.toSymbol(operationShape).name
         return """
-            let extensions = req.extensions_mut().ok_or(#{SmithyHttpServer}::rejection::ExtensionsAlreadyExtracted)?;
-            extensions.insert(#{SmithyHttpServer}::RequestExtensions::new(${namespace.dq()}, ${operationName.dq()}));
+            response.extensions_mut().insert(#{SmithyHttpServer}::RequestExtensions::new(${namespace.dq()}, ${operationName.dq()}));
         """.trimIndent()
     }
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -241,10 +241,10 @@ private class ServerHttpProtocolImplGenerator(
                 intoResponseStreaming
             } else {
                 """
-                let mut response = match #{serialize_response}(&self.0) {
+                match #{serialize_response}(&self.0) {
                     Ok(response) => response,
                     Err(e) => e.into_response()
-                };
+                }
                 """.trimIndent()
             }
             // The output of non-fallible operations is a model type which we convert into a "wrapper" unit `struct` type

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
@@ -24,9 +24,9 @@ private const val MODULE_VERSION = "moduleVersion"
 private const val MODULE_AUTHORS = "moduleAuthors"
 private const val MODULE_REPOSITORY = "moduleRepository"
 private const val RUNTIME_CONFIG = "runtimeConfig"
-private const val CODEGEN_SETTINGS = "codegen"
 private const val LICENSE = "license"
 private const val EXAMPLES = "examples"
+const val CODEGEN_SETTINGS = "codegen"
 
 /**
  * Configuration of codegen settings
@@ -107,6 +107,21 @@ class RustSettings(
          * @return Returns the extracted settings
          */
         fun from(model: Model, config: ObjectNode): RustSettings {
+            val codegenSettings = config.getObjectMember(CODEGEN_SETTINGS)
+            val codegenConfig = CodegenConfig.fromNode(codegenSettings)
+            return fromCodegenConfig(model, config, codegenConfig)
+        }
+
+        /**
+         * Create settings from a configuration object node and CodegenConfig.
+         *
+         * @param model Model to infer the service from (if not explicitly set in config)
+         * @param config Config object to load
+         * @param codegenConfig CodegenConfig object to use
+         * @throws software.amazon.smithy.model.node.ExpectationNotMetException
+         * @return Returns the extracted settings
+         */
+        fun fromCodegenConfig(model: Model, config: ObjectNode, codegenConfig: CodegenConfig): RustSettings {
             config.warnIfAdditionalProperties(
                 arrayListOf(
                     SERVICE,
@@ -127,7 +142,6 @@ class RustSettings(
                 .orElseGet { inferService(model) }
 
             val runtimeConfig = config.getObjectMember(RUNTIME_CONFIG)
-            val codegenSettings = config.getObjectMember(CODEGEN_SETTINGS)
             return RustSettings(
                 service = service,
                 moduleName = config.expectStringMember(MODULE_NAME).value,
@@ -136,7 +150,7 @@ class RustSettings(
                 moduleDescription = config.getStringMember(MODULE_DESCRIPTION).orNull()?.value,
                 moduleRepository = config.getStringMember(MODULE_REPOSITORY).orNull()?.value,
                 runtimeConfig = RuntimeConfig.fromNode(runtimeConfig),
-                codegenConfig = CodegenConfig.fromNode(codegenSettings),
+                codegenConfig,
                 license = config.getStringMember(LICENSE).orNull()?.value,
                 examplesUri = config.getStringMember(EXAMPLES).orNull()?.value,
                 model = model


### PR DESCRIPTION
## Motivation and Context
This PR involves 2 changes:
1) We depend on client codegen `RustSettings` to configure things like `includeFluentClient`. This PR gives the server its own configurable `ServerRustSettings`, with good defaults. For example `includeFluentClient = true` will generate a server SDK that doesn't build properly.
2) Move store of operation and namespace inside the response extensions or it will be unusable inside other layers. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Bigo <1781140+crisidev@users.noreply.github.com>

