### PR TITLE
fix instances of write_all without flush

### DIFF
--- a/aws/rust-runtime/aws-types/build.rs
+++ b/aws/rust-runtime/aws-types/build.rs
@@ -15,6 +15,7 @@ fn generate_build_vars(output_path: &Path) {
         .expect("Could not create build environment");
     f.write_all(format!("const RUST_VERSION: &str = \"{}\";", rust_version).as_bytes())
         .expect("Unable to write rust version");
+    f.flush().expect("failed to flush");
 }
 
 fn main() {

--- a/aws/sdk/examples/kms/src/bin/encrypt.rs
+++ b/aws/sdk/examples/kms/src/bin/encrypt.rs
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Error> {
 
     let mut ofile = File::create(&out_file).expect("unable to create file");
     ofile.write_all(s.as_bytes()).expect("unable to write");
-    ofile.flush().await?;
+    ofile.flush().expect("failed to flush");
 
     if verbose {
         println!("Wrote the following to {:?}", out_file);

--- a/aws/sdk/examples/kms/src/bin/encrypt.rs
+++ b/aws/sdk/examples/kms/src/bin/encrypt.rs
@@ -83,6 +83,7 @@ async fn main() -> Result<(), Error> {
 
     let mut ofile = File::create(&out_file).expect("unable to create file");
     ofile.write_all(s.as_bytes()).expect("unable to write");
+    ofile.flush().await?;
 
     if verbose {
         println!("Wrote the following to {:?}", out_file);

--- a/aws/sdk/examples/kms/src/bin/reencrypt-data.rs
+++ b/aws/sdk/examples/kms/src/bin/reencrypt-data.rs
@@ -103,6 +103,7 @@ async fn main() -> Result<(), Error> {
 
     let mut ofile = File::create(o).expect("unable to create file");
     ofile.write_all(s.as_bytes()).expect("unable to write");
+    ofile.flush()?;
 
     if verbose {
         println!("Wrote the following to {}:", output_file);

--- a/aws/sdk/examples/kms/src/bin/reencrypt-data.rs
+++ b/aws/sdk/examples/kms/src/bin/reencrypt-data.rs
@@ -103,7 +103,7 @@ async fn main() -> Result<(), Error> {
 
     let mut ofile = File::create(o).expect("unable to create file");
     ofile.write_all(s.as_bytes()).expect("unable to write");
-    ofile.flush()?;
+    ofile.flush().expect("failed to flush");
 
     if verbose {
         println!("Wrote the following to {}:", output_file);

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -68,7 +68,6 @@
 //!     while let Some(bytes) = stream.next().await {
 //!         let bytes: Bytes = bytes?;
 //!         file.write_all(&bytes).await?;
-//!         file.flush().await?;
 //!     }
 //!     file.flush().await?;
 //!     Ok(())

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -67,6 +67,7 @@
 //!     while let Some(bytes) = stream.next().await {
 //!         let bytes: Bytes = bytes?;
 //!         file.write_all(&bytes).await?;
+//!         file.flush().await?;
 //!     }
 //!     Ok(())
 //! }


### PR DESCRIPTION
`write_all` does not flush—`flush()` must be called to ensure changes are written to disk.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
