### PR TITLE
Add Clone derive to aws_types::Config

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -32,3 +32,9 @@ message = "Fix bug where ECS credential provider could not perform retries."
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 references = ["smithy-rs#998", "aws-sdk-rust#359"]
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "aws_types::Config is now `Clone`"
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+references = ["smithy-rs#1002", "aws-sdk-rust#352"]
+author = "rcoh"

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -20,7 +20,7 @@ use crate::credentials::SharedCredentialsProvider;
 use crate::region::Region;
 
 /// AWS Shared Configuration
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Config {
     app_name: Option<AppName>,
     credentials_provider: Option<SharedCredentialsProvider>,


### PR DESCRIPTION
## Motivation and Context
- https://github.com/awslabs/aws-sdk-rust/issues/352

## Description
adds clone bound to `aws_config::Config`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
