### PR TITLE
Add file.flush to ByteStream code example in docs

### DIFF
--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -25,6 +25,7 @@
 //!     let mut buf = output.audio_stream.collect().await?;
 //!     let mut file = File::open("audio.mp3").await?;
 //!     file.write_all_buf(&mut buf).await?;
+//!     file.flush().await?;
 //!     Ok(())
 //! }
 //! ```
@@ -68,6 +69,7 @@
 //!         let bytes: Bytes = bytes?;
 //!         file.write_all(&bytes).await?;
 //!     }
+//!     file.flush().await?;
 //!     Ok(())
 //! }
 //! ```


### PR DESCRIPTION
## Motivation and Context

In the examples on how to copy a ByteStream to a file, flush
is not called explicitly in the `tokio::fs::File`. A user copying this code can hit
a race condition as the flush will happen asynchronously in a separate thread.
This deviates from the std file implementation that flushes on drop
and may be confusing if not explicitly stated in the example.

Personally, after copy-pasting the example from the docs, I spent almost a day trying to figure out why my file contents sometimes were missing after downloading a file from s3, and I believe some other user may also fall from it.

## Description
Just added the explicit flushes in the examples where the ByteStream is copied into a `tokio::fs::File`.

## Testing
I tried to build locally, but it fails to build cargoTests, cargoDoc and cargoClippy, it may be my rust version, as the errors are mostly warnings, that may well be a product of having a different version. I would appreciate any guidance for building this properly.

Nevertheless the change is two lines in the documentation, shouldn't be affecting anything else. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
