### PR TITLE
Generate examples for Config builder

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,12 +11,8 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
 
-[[aws-sdk-rust]]
-message = """
-The `meta`, `environment`, and `dns` Cargo feature flags were removed from `aws-config`.
-The code behind the `dns` flag is now enabled when `rt-tokio` is enabled. The code behind
-the `meta` and `environment` flags is always enabled now.
-"""
-references = ["smithy-rs#961"]
-meta = { "breaking" = true, "tada" = false, "bug" = false }
-author = "jdisanti"
+[[smithy-rs]]
+message = "Examples for Config builder added"
+references = ["smithy-rs#670"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "Jacco"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -77,7 +77,7 @@ class RegionDecorator : RustCodegenDecorator {
         codegenContext: CodegenContext,
         baseCustomizations: List<ConfigCustomization>
     ): List<ConfigCustomization> {
-        return baseCustomizations + RegionProviderConfig(codegenContext.runtimeConfig)
+        return baseCustomizations + RegionProviderConfig(codegenContext)
     }
 
     override fun operationCustomizations(
@@ -96,8 +96,9 @@ class RegionDecorator : RustCodegenDecorator {
     }
 }
 
-class RegionProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomization() {
-    private val region = region(runtimeConfig)
+class RegionProviderConfig(codegenContext: CodegenContext) : ConfigCustomization() {
+    private val region = region(codegenContext.runtimeConfig)
+    private val moduleUseName = codegenContext.moduleUseName()
     private val codegenScope = arrayOf("Region" to region.member("Region"))
     override fun section(section: ServiceConfig) = writable {
         when (section) {
@@ -109,6 +110,15 @@ class RegionProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomization()
                 rustTemplate(
                     """
                     /// Sets the AWS region to use when making requests.
+                    ///
+                    /// ## Examples
+                    /// ```no_run
+                    /// use $moduleUseName::config::{Builder, Config};
+                    ///
+                    /// let config = $moduleUseName::Config::builder()
+                    ///     .region(Region::new("us-east-1"))
+                    ///     .build();
+                    /// ```
                     pub fn region(mut self, region: impl Into<Option<#{Region}>>) -> Self {
                         self.region = region.into();
                         self


### PR DESCRIPTION
## Motivation and Context
#670 

## Description
Added documentation to the region function in `RegionDecorator.kt`.
Also had to swap a few parameters around.

## Testing

`./gradlew :aws:sdk:assemble`
`cd aws/sdk/build/aws-sdk/sdk/dynamodb`
`cargo doc --open`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
