### PR TITLE
update: don't generate useless Into<impl T>

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -12,6 +12,18 @@
 # author = "rcoh"
 
 [[aws-sdk-rust]]
+message = "Codegen will no longer produce builders and clients with methods that take `impl Into<T>` except for strings and boxed types."
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+references = ["smithy-rs#990"]
+author = "Velfi"
+
+[[smithy-rs]]
+message = "Codegen will no longer produce builders and clients with methods that take `impl Into<T>` except for strings and boxed types."
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+references = ["smithy-rs#990"]
+author = "Velfi"
+
+[[aws-sdk-rust]]
 message = """
 The `meta`, `environment`, and `dns` Cargo feature flags were removed from `aws-config`.
 The code behind the `dns` flag is now enabled when `rt-tokio` is enabled. The code behind
@@ -30,7 +42,7 @@ author = "rcoh"
 [[aws-sdk-rust]]
 message = "Add Route53 customization to trim `/hostedzone/` prefix prior to serialization. This fixes a bug where round-tripping a hosted zone id resulted in an error."
 meta = { "breaking" = false, "tada" = false, "bug" = true }
-references = ["smithy-rs#999", "smithy-rs#143", "aws-sdk-rust#344" ]
+references = ["smithy-rs#999", "smithy-rs#143", "aws-sdk-rust#344"]
 author = "rcoh"
 
 [[aws-sdk-rust]]

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -69,6 +69,30 @@ sealed class RustType {
         override val name: kotlin.String = "HashMap"
         override val namespace = "std::collections"
 
+        fun formattedKey() = when (key) {
+            is RustType.String,
+            is RustType.Box -> Pair(
+                "k: ${key.implInto()}",
+                "k.into()",
+            )
+            else -> Pair(
+                "k: ${key.render()}",
+                "k",
+            )
+        }
+
+        fun formattedMember() = when (member) {
+            is RustType.String,
+            is RustType.Box -> Pair(
+                "v: ${member.implInto()}",
+                "v.into()",
+            )
+            else -> Pair(
+                "v: ${member.render()}",
+                "v",
+            )
+        }
+
         companion object {
             val RuntimeType = RuntimeType("HashMap", dependency = null, namespace = "std::collections")
         }
@@ -112,6 +136,18 @@ sealed class RustType {
     data class Vec(override val member: RustType) : RustType(), Container {
         override val name: kotlin.String = "Vec"
         override val namespace = "std::vec"
+
+        fun formattedMember() = when (member) {
+            is RustType.String,
+            is RustType.Box -> Pair(
+                "input: ${member.implInto()}",
+                "input.into()",
+            )
+            else -> Pair(
+                "input: ${member.render()}",
+                "input",
+            )
+        }
     }
 
     data class Opaque(override val name: kotlin.String, override val namespace: kotlin.String? = null) : RustType()
@@ -126,6 +162,10 @@ sealed class RustType {
 fun RustType.qualifiedName(): String {
     val namespace = this.namespace?.let { "$it::" } ?: ""
     return "$namespace$name"
+}
+
+fun RustType.implInto(fullyQualified: Boolean = true): String {
+    return "impl Into<${this.render(fullyQualified)}>"
 }
 
 /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -69,30 +69,6 @@ sealed class RustType {
         override val name: kotlin.String = "HashMap"
         override val namespace = "std::collections"
 
-        fun formattedKey() = when (key) {
-            is RustType.String,
-            is RustType.Box -> Pair(
-                "k: ${key.implInto()}",
-                "k.into()",
-            )
-            else -> Pair(
-                "k: ${key.render()}",
-                "k",
-            )
-        }
-
-        fun formattedMember() = when (member) {
-            is RustType.String,
-            is RustType.Box -> Pair(
-                "v: ${member.implInto()}",
-                "v.into()",
-            )
-            else -> Pair(
-                "v: ${member.render()}",
-                "v",
-            )
-        }
-
         companion object {
             val RuntimeType = RuntimeType("HashMap", dependency = null, namespace = "std::collections")
         }
@@ -136,18 +112,6 @@ sealed class RustType {
     data class Vec(override val member: RustType) : RustType(), Container {
         override val name: kotlin.String = "Vec"
         override val namespace = "std::vec"
-
-        fun formattedMember() = when (member) {
-            is RustType.String,
-            is RustType.Box -> Pair(
-                "input: ${member.implInto()}",
-                "input.into()",
-            )
-            else -> Pair(
-                "input: ${member.render()}",
-                "input",
-            )
-        }
     }
 
     data class Opaque(override val name: kotlin.String, override val namespace: kotlin.String? = null) : RustType()
@@ -166,6 +130,20 @@ fun RustType.qualifiedName(): String {
 
 fun RustType.implInto(fullyQualified: Boolean = true): String {
     return "impl Into<${this.render(fullyQualified)}>"
+}
+
+fun RustType.asArgument(name: String): Argument {
+    return when (this) {
+        is RustType.String,
+        is RustType.Box -> Argument(
+            "$name: ${this.implInto()}",
+            "$name.into()",
+        )
+        else -> Argument(
+            "$name: ${this.render()}",
+            name,
+        )
+    }
 }
 
 /**
@@ -380,3 +358,5 @@ sealed class Attribute {
         }
     }
 }
+
+data class Argument(val argument: String, val value: String)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -199,17 +199,13 @@ class BuilderGenerator(
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
-        val input = when (coreType.member) {
-            is RustType.String,
-            is RustType.Box -> "impl Into<${coreType.member.render(true)}>"
-            else -> "${coreType.member.render(true)}"
-        }
+        val (input_param, input_usage) = coreType.formattedMember()
 
-        rustBlock("pub fn $memberName(mut self, input: $input) -> Self") {
+        rustBlock("pub fn $memberName(mut self, $input_param) -> Self") {
             rust(
                 """
                 let mut v = self.$memberName.unwrap_or_default();
-                v.push(input);
+                v.push($input_usage);
                 self.$memberName = Some(v);
                 self
                 """
@@ -223,24 +219,16 @@ class BuilderGenerator(
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
-        val k = when (coreType.key) {
-            is RustType.String,
-            is RustType.Box -> "impl Into<${coreType.key.render(true)}>"
-            else -> "${coreType.key.render(true)}"
-        }
-        val v = when (coreType.member) {
-            is RustType.String,
-            is RustType.Box -> "impl Into<${coreType.member.render(true)}>"
-            else -> "${coreType.member.render(true)}"
-        }
+        val (k_param, k_usage) = coreType.formattedKey()
+        val (v_param, v_usage) = coreType.formattedMember()
 
         rustBlock(
-            "pub fn $memberName(mut self, k: $k, v: $v) -> Self"
+            "pub fn $memberName(mut self, $k_param, $v_param) -> Self"
         ) {
             rust(
                 """
                 let mut hash_map = self.$memberName.unwrap_or_default();
-                hash_map.insert(k, v);
+                hash_map.insert($k_usage, $v_usage);
                 self.$memberName = Some(hash_map);
                 self
                 """

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -209,7 +209,7 @@ class BuilderGenerator(
             rust(
                 """
                 let mut v = self.$memberName.unwrap_or_default();
-                v.push(input.into());
+                v.push(input);
                 self.$memberName = Some(v);
                 self
                 """
@@ -240,7 +240,7 @@ class BuilderGenerator(
             rust(
                 """
                 let mut hash_map = self.$memberName.unwrap_or_default();
-                hash_map.insert(k.into(), v.into());
+                hash_map.insert(k, v);
                 self.$memberName = Some(hash_map);
                 self
                 """

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -199,7 +199,13 @@ class BuilderGenerator(
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
-        rustBlock("pub fn $memberName(mut self, input: impl Into<${coreType.member.render(true)}>) -> Self") {
+        val input = when (coreType.member) {
+            is RustType.String,
+            is RustType.Box -> "impl Into<${coreType.member.render(true)}>"
+            else -> "${coreType.member.render(true)}"
+        }
+
+        rustBlock("pub fn $memberName(mut self, input: $input) -> Self") {
             rust(
                 """
                 let mut v = self.$memberName.unwrap_or_default();
@@ -217,12 +223,19 @@ class BuilderGenerator(
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model, autoSuppressMissingDocs = false)
+        val k = when (coreType.key) {
+            is RustType.String,
+            is RustType.Box -> "impl Into<${coreType.key.render(true)}>"
+            else -> "${coreType.key.render(true)}"
+        }
+        val v = when (coreType.member) {
+            is RustType.String,
+            is RustType.Box -> "impl Into<${coreType.member.render(true)}>"
+            else -> "${coreType.member.render(true)}"
+        }
+
         rustBlock(
-            "pub fn $memberName(mut self, k: impl Into<${coreType.key.render(true)}>, v: impl Into<${
-            coreType.member.render(
-                true
-            )
-            }>) -> Self"
+            "pub fn $memberName(mut self, k: $k, v: $v) -> Self"
         ) {
             rust(
                 """

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asArgument
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -21,12 +22,12 @@ class FluentClientCore(private val model: Model) {
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model)
-        val (input_param, input_usage) = coreType.formattedMember()
+        val input = coreType.member.asArgument("input")
 
-        rustBlock("pub fn $memberName(mut self, $input_param) -> Self") {
+        rustBlock("pub fn $memberName(mut self, ${input.argument}) -> Self") {
             rust(
                 """
-                self.inner = self.inner.$memberName($input_usage);
+                self.inner = self.inner.$memberName(${input.value});
                 self
                 """
             )
@@ -39,13 +40,13 @@ class FluentClientCore(private val model: Model) {
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model)
-        val (k_param, k_usage) = coreType.formattedKey()
-        val (v_param, v_usage) = coreType.formattedMember()
+        val k = coreType.key.asArgument("k")
+        val v = coreType.member.asArgument("v")
 
-        rustBlock("pub fn $memberName(mut self, $k_param, $v_param) -> Self") {
+        rustBlock("pub fn $memberName(mut self, ${k.argument}, ${v.argument}) -> Self") {
             rust(
                 """
-                self.inner = self.inner.$memberName($k_usage, $v_usage);
+                self.inner = self.inner.$memberName(${k.value}, ${v.value});
                 self
                 """
             )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -22,10 +22,16 @@ class FluentClientCore(private val model: Model) {
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model)
-        rustBlock("pub fn $memberName(mut self, inp: impl Into<${coreType.member.render(true)}>) -> Self") {
+        val input = when (coreType.member) {
+            is RustType.String,
+            is RustType.Box -> "impl Into<${coreType.member.render(true)}>"
+            else -> "${coreType.member.render(true)}"
+        }
+
+        rustBlock("pub fn $memberName(mut self, input: $input) -> Self") {
             rust(
                 """
-                self.inner = self.inner.$memberName(inp);
+                self.inner = self.inner.$memberName(input);
                 self
                 """
             )
@@ -38,10 +44,18 @@ class FluentClientCore(private val model: Model) {
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model)
-        val k = coreType.key
-        val v = coreType.member
+        val k = when (coreType.key) {
+            is RustType.String,
+            is RustType.Box -> "impl Into<${coreType.key.render()}>"
+            else -> "${coreType.key.render()}"
+        }
+        val v = when (coreType.member) {
+            is RustType.String,
+            is RustType.Box -> "impl Into<${coreType.member.render()}>"
+            else -> "${coreType.member.render()}"
+        }
 
-        rustBlock("pub fn $memberName(mut self, k: impl Into<${k.render()}>, v: impl Into<${v.render()}>) -> Self") {
+        rustBlock("pub fn $memberName(mut self, k: $k, v: $v) -> Self") {
             rust(
                 """
                 self.inner = self.inner.$memberName(k, v);

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -11,7 +11,6 @@ import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
-import software.amazon.smithy.rust.codegen.rustlang.render
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 
@@ -22,16 +21,12 @@ class FluentClientCore(private val model: Model) {
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model)
-        val input = when (coreType.member) {
-            is RustType.String,
-            is RustType.Box -> "impl Into<${coreType.member.render(true)}>"
-            else -> "${coreType.member.render(true)}"
-        }
+        val (input_param, input_usage) = coreType.formattedMember()
 
-        rustBlock("pub fn $memberName(mut self, input: $input) -> Self") {
+        rustBlock("pub fn $memberName(mut self, $input_param) -> Self") {
             rust(
                 """
-                self.inner = self.inner.$memberName(input);
+                self.inner = self.inner.$memberName($input_usage);
                 self
                 """
             )
@@ -44,21 +39,13 @@ class FluentClientCore(private val model: Model) {
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
         documentShape(member, model)
-        val k = when (coreType.key) {
-            is RustType.String,
-            is RustType.Box -> "impl Into<${coreType.key.render()}>"
-            else -> "${coreType.key.render()}"
-        }
-        val v = when (coreType.member) {
-            is RustType.String,
-            is RustType.Box -> "impl Into<${coreType.member.render()}>"
-            else -> "${coreType.member.render()}"
-        }
+        val (k_param, k_usage) = coreType.formattedKey()
+        val (v_param, v_usage) = coreType.formattedMember()
 
-        rustBlock("pub fn $memberName(mut self, k: $k, v: $v) -> Self") {
+        rustBlock("pub fn $memberName(mut self, $k_param, $v_param) -> Self") {
             rust(
                 """
-                self.inner = self.inner.$memberName(k, v);
+                self.inner = self.inner.$memberName($k_usage, $v_usage);
                 self
                 """
             )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.asArgument
 import software.amazon.smithy.rust.codegen.rustlang.asOptional
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.docs
@@ -472,14 +473,11 @@ class FluentClientGenerator(
                             is RustType.Vec -> with(core) { renderVecHelper(member, memberName, coreType) }
                             is RustType.HashMap -> with(core) { renderMapHelper(member, memberName, coreType) }
                             else -> {
-                                val signature = when (coreType) {
-                                    is RustType.String,
-                                    is RustType.Box -> "(mut self, inp: impl Into<${coreType.render(true)}>) -> Self"
-                                    else -> "(mut self, inp: ${coreType.render(true)}) -> Self"
-                                }
+                                val signature = coreType.asArgument("signature")
+
                                 documentShape(member, model)
-                                rustBlock("pub fn $memberName$signature") {
-                                    write("self.inner = self.inner.$memberName(inp);")
+                                rustBlock("pub fn $memberName(mut self, ${signature.argument}) -> Self") {
+                                    write("self.inner = self.inner.$memberName(${signature.value});")
                                     write("self")
                                 }
                             }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
[smithy#990](https://github.com/awslabs/smithy-rs/issues/990)

## Description
<!--- Describe your changes in detail -->
Stop the code generator from inserting `impl Into` where it's not helpful

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running existing tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
