### PR TITLE
fix: exit with error code on failure

### DIFF
--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -59,20 +59,15 @@ pub(crate) use here;
 /// --smithy-rs /Users/zhessler/Documents/smithy-rs-test/ \
 /// --aws-sdk /Users/zhessler/Documents/aws-sdk-rust-test/
 /// ```
-fn main() {
+fn main() -> Result<()> {
     let Opt {
         smithy_rs,
         aws_sdk,
         branch,
     } = Opt::from_args();
 
-    match sync_aws_sdk_with_smithy_rs(&smithy_rs, &aws_sdk, &branch) {
-        Ok(_) => std::process::exit(0),
-        Err(e) => {
-            eprintln!("Sync failed with error: {:?}", e);
-            std::process::exit(1);
-        }
-    }
+    sync_aws_sdk_with_smithy_rs(&smithy_rs, &aws_sdk, &branch)
+        .map_err(|e| e.context("The sync failed"))
 }
 
 /// Run through all commits made to `smithy-rs` since last sync and "replay" them onto `aws-sdk-rust`.

--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -66,13 +66,26 @@ fn main() {
         branch,
     } = Opt::from_args();
 
-    if let Err(e) = sync_aws_sdk_with_smithy_rs(&smithy_rs, &aws_sdk, &branch) {
-        eprintln!("Sync failed with error: {:?}", e);
-    };
+    match sync_aws_sdk_with_smithy_rs(&smithy_rs, &aws_sdk, &branch) {
+        Ok(_) => std::process::exit(0),
+        Err(e) => {
+            eprintln!("Sync failed with error: {:?}", e);
+            std::process::exit(1);
+        }
+    }
 }
 
 /// Run through all commits made to `smithy-rs` since last sync and "replay" them onto `aws-sdk-rust`.
 fn sync_aws_sdk_with_smithy_rs(smithy_rs: &Path, aws_sdk: &Path, branch: &str) -> Result<()> {
+    eprintln!(
+        "aws-sdk-rust path:\t{}",
+        aws_sdk.canonicalize().context(here!())?.display()
+    );
+    eprintln!(
+        "smithy-rs path:\t{}",
+        smithy_rs.canonicalize().context(here!())?.display()
+    );
+
     // Open the repositories we'll be working with
     let smithy_rs_repo = Repository::open(smithy_rs).context("couldn't open smithy-rs repo")?;
     let aws_sdk_repo = Repository::open(aws_sdk).context("couldn't open aws-sdk-rust repo")?;


### PR DESCRIPTION
add: print directories at start

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The tool was exiting with failure but wasn't communicating that failure to the OS

## Description
<!--- Describe your changes in detail -->
When app would close due to an error, `call std::process::exit(1)`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran it locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
