### PR TITLE
fix: don't panic on missing key in manifest

### DIFF
--- a/tools/publisher/src/subcommand/fix_manifests.rs
+++ b/tools/publisher/src/subcommand/fix_manifests.rs
@@ -53,13 +53,19 @@ async fn read_manifests(fs: Fs, manifest_paths: Vec<PathBuf>) -> Result<Vec<Mani
 fn package_versions(manifests: &[Manifest]) -> Result<BTreeMap<String, Version>> {
     let mut versions = BTreeMap::new();
     for manifest in manifests {
-        let name = manifest.metadata["package"]["name"]
-            .as_str()
+        let name = manifest
+            .metadata
+            .get("package")
+            .and_then(|package| package.get("name"))
+            .and_then(|name| name.as_str())
             .ok_or_else(|| {
                 anyhow::Error::msg(format!("{:?} is missing a package name", manifest.path))
             })?;
-        let version = manifest.metadata["package"]["version"]
-            .as_str()
+        let version = manifest
+            .metadata
+            .get("package")
+            .and_then(|package| package.get("version"))
+            .and_then(|name| name.as_str())
             .ok_or_else(|| {
                 anyhow::Error::msg(format!("{:?} is missing a package version", manifest.path))
             })?;


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Without this change, the fix_manifests command can fail in a way that produces a much less helpful error

## Description
<!--- Describe your changes in detail -->
avoid panicking on a bad manifest by avoiding use of indexing

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the command locally and verified the error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
