### PR TITLE
add: function that exposes profile names

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -98,3 +98,9 @@ message = "Simplify features in aws-config. All features have been removed from 
 references = ["smithy-rs#1017", "smithy-rs#930"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Add function to `aws_config::profile::ProfileSet`` that allows listing of loaded profiles by name."
+references = ["smithy-rs#1021"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "kiiadi"

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -134,7 +134,7 @@ impl ProfileSet {
 
     /// Returns the names of the profiles in this profile set
     pub fn profiles(&self) -> impl Iterator<Item=&str> {
-        self.profiles.keys().into_iter().map(|k| k.as_ref())
+        self.profiles.keys().map(String::as_ref)
     }
 
     fn parse(source: Source) -> Result<Self, ProfileParseError> {
@@ -258,7 +258,7 @@ mod test {
 
         let profile_set = ProfileSet::parse(source).expect("profiles loaded");
 
-        let mut profile_names: Vec<&str> = profile_set.profiles().collect();
+        let mut profile_names: Vec<_> = profile_set.profiles().collect();
         profile_names.sort();
         assert_eq!(profile_names, vec!["bar", "foo"]);
     }

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -133,7 +133,7 @@ impl ProfileSet {
     }
 
     /// Returns the names of the profiles in this profile set
-    pub fn profiles(&self) -> impl Iterator<Item=&str> {
+    pub fn profiles(&self) -> impl Iterator<Item = &str> {
         self.profiles.keys().map(String::as_ref)
     }
 
@@ -242,7 +242,7 @@ mod test {
     fn empty_source_empty_profile() {
         let source = make_source(ParserInput {
             config_file: Some("".to_string()),
-            credentials_file: Some("".to_string())
+            credentials_file: Some("".to_string()),
         });
 
         let profile_set = ProfileSet::parse(source).expect("empty profiles are valid");
@@ -253,7 +253,7 @@ mod test {
     fn profile_names_are_exposed() {
         let source = make_source(ParserInput {
             config_file: Some("[profile foo]\n[profile bar]".to_string()),
-            credentials_file: Some("".to_string())
+            credentials_file: Some("".to_string()),
         });
 
         let profile_set = ProfileSet::parse(source).expect("profiles loaded");

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -132,6 +132,11 @@ impl ProfileSet {
         self.profiles.is_empty()
     }
 
+    /// Returns the names of the profiles in this profile set
+    pub fn profiles(&self) -> impl Iterator<Item=&str> {
+        self.profiles.keys().into_iter().map(|k| k.as_ref())
+    }
+
     fn parse(source: Source) -> Result<Self, ProfileParseError> {
         let mut base = ProfileSet::empty();
         base.selected_profile = source.profile;
@@ -235,19 +240,27 @@ mod test {
 
     #[test]
     fn empty_source_empty_profile() {
-        let source = Source {
-            config_file: File {
-                path: "~/.aws/config".to_string(),
-                contents: "".into(),
-            },
-            credentials_file: File {
-                path: "~/.aws/credentials".to_string(),
-                contents: "".into(),
-            },
-            profile: "default".into(),
-        };
+        let source = make_source(ParserInput {
+            config_file: Some("".to_string()),
+            credentials_file: Some("".to_string())
+        });
+
         let profile_set = ProfileSet::parse(source).expect("empty profiles are valid");
         assert!(profile_set.is_empty());
+    }
+
+    #[test]
+    fn profile_names_are_exposed() {
+        let source = make_source(ParserInput {
+            config_file: Some("[profile foo]\n[profile bar]".to_string()),
+            credentials_file: Some("".to_string())
+        });
+
+        let profile_set = ProfileSet::parse(source).expect("profiles loaded");
+
+        let mut profile_names: Vec<&str> = profile_set.profiles().collect();
+        profile_names.sort();
+        assert_eq!(profile_names, vec!["bar", "foo"]);
     }
 
     /// Run all tests from the fuzzing corpus to validate coverage


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Tooling will often want the ability to list available profiles for someone to select from. Currently the `ProfileSet` does not expose this.

## Description
<!--- Describe your changes in detail -->
Added `fn profiles()` function to `ProfileSet`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New unit test added

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
