### PR TITLE
Upgrade to itoa v1.0

### DIFF
--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [dependencies]
-itoa = "0.4.0"
+itoa = "1.0.0"
 num-integer = "0.1"
 ryu = "1.0.5"
 time = { version = "0.3.4", features = ["parsing"] }


### PR DESCRIPTION
## Motivation and Context

Removes a duplicate dependency on itoa v0.4 for downstream projects that have their own dependency on itoa.


## Testing

Did not test. Relying on CI.

## Checklist

Is this change CHANGELOG worthy?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
