### PR TITLE
Fix: Sync script handwritten files working directory bug

### DIFF
--- a/tools/smithy-rs-sync/src/fs.rs
+++ b/tools/smithy-rs-sync/src/fs.rs
@@ -311,7 +311,6 @@ mod tests {
 
     #[test]
     fn test_find_handwritten_files_works() {
-        // The SDK dir _only_ contains the dotfile. The build artifacts dir contains the files
         let handwritten_files = &[HANDWRITTEN_DOTFILE, "foo.txt", "bar/"];
         let sdk_dir = create_test_dir_and_handwritten_files_dotfile(handwritten_files);
 

--- a/tools/smithy-rs-sync/src/fs.rs
+++ b/tools/smithy-rs-sync/src/fs.rs
@@ -330,7 +330,6 @@ mod tests {
         create_test_file(&build_artifacts_dir, "bar.txt");
         create_test_dir(&build_artifacts_dir, "qux");
 
-        // In practice, these would be two different folders but using the same folder is fine for the test
         let actual_files_and_folders =
             find_handwritten_files_and_folders(sdk_dir.path(), build_artifacts_dir.path()).unwrap();
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Fixes a bug where sync tool wouldn't correctly determine handwritten files

## Description
<!--- Describe your changes in detail -->
Update` `HandwrittenFiles` to use `gitignore` at a lower level, bypassing an issue with working directories

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the updated code against existing tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
