### PR TITLE
Fix bug in codegen diff that omitted new files

### DIFF
--- a/tools/codegen-diff-revisions.py
+++ b/tools/codegen-diff-revisions.py
@@ -87,6 +87,10 @@ def main():
 
 
 def generate_and_commit_generated_code(revision_sha):
+    # Clean the build artifacts before continuing
+    run("rm -rf aws/sdk/build")
+
+    # Generate code
     run("./gradlew --rerun-tasks :aws:sdk:assemble")
     run("./gradlew --rerun-tasks :codegen-server-test:assemble")
 


### PR DESCRIPTION
## Motivation and Context
The codegen diffs for https://github.com/awslabs/smithy-rs/pull/1006 weren't including the new paginators module, and it turns out this was happening because the generated `paginators.rs` was getting included in the `base` branch because `head` was generated first without any cleaning in between.

This PR cleans the build artifacts so that this can't happen anymore.

## Testing
- Checked out the paginators branch locally and ran the codegen diff to verify the new files are now present in the diff

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
