### PR TITLE
remove: step that sets git hash incorrectly

### DIFF
--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -160,21 +160,6 @@ fn sync_aws_sdk_with_smithy_rs(
         create_mirror_commit(&aws_sdk_repo, &commit)
             .context("couldn't commit SDK changes to aws-sdk-rust")?;
     }
-    eprintln!("Successfully synced {} commit(s)", commit_revs.len());
-
-    // Get the last commit we synced so that we can set that for the next time this tool gets run
-    let last_synced_commit = commit_revs
-        .last()
-        .expect("can't be empty because we'd have early returned");
-    eprintln!("Updating 'commit at last sync' to {}", last_synced_commit);
-
-    // Update the file containing the commit hash
-    set_last_synced_commit(&aws_sdk_repo, last_synced_commit).with_context(|| {
-        format!(
-            "couldn't write last synced commit hash ({}) to aws-sdk-rust/{}",
-            last_synced_commit, COMMIT_HASH_FILENAME,
-        )
-    })?;
 
     eprintln!(
         "Successfully synced {} mirror commit(s) to aws-sdk-rust/{}. Don't forget to push them",


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
found another issue where I was setting last synced commit twice. The second time it was getting set, it was getting set to the latest smithy-rs commit instead of the actual last-synced commit

## Description
<!--- Describe your changes in detail -->
remove: step that sets git hash incorrectly

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran it locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
