### PR TITLE
Update sync script to copy folder contents instead of folder

### DIFF
--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -35,6 +35,7 @@ struct Opt {
 const BOT_NAME: &str = "AWS SDK Rust Bot";
 const BOT_EMAIL: &str = "aws-sdk-rust-primary@amazon.com";
 const COMMIT_HASH_FILENAME: &str = ".smithyrs-githash";
+const BOT_COMMIT_PREFIX: &str = "[autosync]";
 
 /// A macro for attaching info to error messages pointing to the line of code responsible for the error.
 /// [Thanks to dtolnay for this macro](https://github.com/dtolnay/anyhow/issues/22#issuecomment-542309452)
@@ -280,6 +281,8 @@ fn copy_sdk(from_path: &Path, to_path: &Path) -> Result<()> {
         bail!("expected absolute to_path but got: {}", from_path.display());
     }
 
+    // The '.' tells cp to copy the folder contents, not the folder
+    let from_path = from_path.join(".");
     let from_path = from_path
         .to_str()
         .expect("for our use case, this will always be UTF-8");
@@ -336,7 +339,11 @@ fn create_mirror_commit(aws_sdk_repo: &Repository, based_on_commit: &Commit) -> 
             Some("HEAD"),
             &based_on_commit.author(),
             &bot_signature,
-            based_on_commit.message().unwrap_or_default(),
+            &format!(
+                "{} {}",
+                BOT_COMMIT_PREFIX,
+                based_on_commit.message().unwrap_or_default()
+            ),
             &tree,
             &[&parent_commit],
         )


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
The script is currently copying the folder instead of the folder's contents

## Description
<!--- Describe your changes in detail -->
fix: sync script to copy folder contents instead of folder
add: bot prefix to sync commits

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran locally

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
