### PR TITLE
fix cli version

### DIFF
--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -13,6 +13,13 @@ plugins { id("software.amazon.smithy").version("0.5.3") }
 
 val smithyVersion: String by project
 
+buildscript {
+    val smithyVersion: String by project
+    dependencies {
+        classpath("software.amazon.smithy:smithy-cli:$smithyVersion")
+    }
+}
+
 dependencies {
     implementation(project(":codegen-server"))
     implementation("software.amazon.smithy:smithy-aws-protocol-tests:$smithyVersion")

--- a/codegen-test/build.gradle.kts
+++ b/codegen-test/build.gradle.kts
@@ -14,6 +14,12 @@ plugins {
 
 val smithyVersion: String by project
 
+buildscript {
+    val smithyVersion: String by project
+    dependencies {
+        classpath("software.amazon.smithy:smithy-cli:$smithyVersion")
+    }
+}
 
 dependencies {
     implementation(project(":codegen"))
@@ -62,13 +68,15 @@ val CodegenTests = listOf(
     ),
     CodegenTest(
         "crate#Config",
-        "naming_test_ops", """
+        "naming_test_ops",
+        """
             , "codegen": { "renameErrors": false }
         """.trimIndent()
     ),
     CodegenTest(
         "naming_obs_structs#NamingObstacleCourseStructs",
-        "naming_test_structs", """
+        "naming_test_structs",
+        """
             , "codegen": { "renameErrors": false }
         """.trimIndent()
     )
@@ -126,7 +134,6 @@ task("generateCargoWorkspace") {
 
 tasks["smithyBuildJar"].dependsOn("generateSmithyBuild")
 tasks["assemble"].finalizedBy("generateCargoWorkspace")
-
 
 tasks.register<Exec>("cargoCheck") {
     workingDir("build/smithyprojections/codegen-test/")


### PR DESCRIPTION
## Motivation and Context
Smithy CLI version wasn't pinned which caused us to accidentally pull in Smithy 1.16 which apparently has a breaking change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
