### PR TITLE
update: insecure deps

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1" }
-hyper = { version = "0.14.13", default-features = false }
+hyper = { version = "0.14.16", default-features = false }
 
 aws-http = { path = "../../sdk/build/aws-sdk/sdk/aws-http" }
 aws-smithy-http = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1" }
-hyper = { version = "0.14.16", default-features = false }
+hyper = { version = "0.14", default-features = false }
 
 aws-http = { path = "../../sdk/build/aws-sdk/sdk/aws-http" }
 aws-smithy-http = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["sync"] }
 tracing = { version = "0.1" }
-hyper = { version = "0.14.16", default-features = false }
+hyper = { version = "0.14.13", default-features = false }
 
 aws-http = { path = "../../sdk/build/aws-sdk/sdk/aws-http" }
 aws-smithy-http = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http" }
@@ -35,7 +35,7 @@ tower = { version = "0.4.8" }
 
 [dev-dependencies]
 futures-util = "0.3.16"
-tracing-test = "0.1.0"
+tracing-test = "0.2.1"
 
 tokio = { version = "1", features = ["full", "test-util"] }
 # used to test compatibility

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -1028,8 +1028,17 @@ pub(crate) mod test {
             .get("/latest/metadata")
             .await
             .expect_err("240.0.0.0 will never resolve");
-        assert!(now.elapsed().unwrap() > Duration::from_secs(1));
-        assert!(now.elapsed().unwrap() < Duration::from_secs(2));
+        let time_elapsed = now.elapsed().unwrap();
+        assert!(
+            time_elapsed > Duration::from_secs(1),
+            "time_elapsed should be greater than 1s but was {:?}",
+            time_elapsed
+        );
+        assert!(
+            time_elapsed < Duration::from_secs(2),
+            "time_elapsed should be less than 2s but was {:?}",
+            time_elapsed
+        );
         match resp {
             ImdsError::FailedToLoadToken(err) if format!("{}", err).contains("timeout") => {} // ok,
             other => panic!(

--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -23,7 +23,7 @@ aws-smithy-protocol-test = { path = "../../../rust-runtime/aws-smithy-protocol-t
 env_logger = "0.9"
 http = "0.2.3"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "test-util"] }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 proptest = "1"
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"

--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -23,7 +23,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 aws-endpoint = { path = "../aws-endpoint" }
-tracing-test = "0.1"
+tracing-test = "0.2.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -24,7 +24,7 @@ once_cell = "1.8"
 percent-encoding = { version = "2.1", optional = true }
 regex = "1.5"
 ring = "0.16"
-time = "0.3.4"
+time = "0.3.5"
 tracing = "0.1"
 
 [dev-dependencies]

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -18,7 +18,7 @@ zeroize = "1.4.1"
 
 [dev-dependencies]
 futures-util = "0.3.16"
-tracing-test = "0.1"
+tracing-test = "0.2.1"
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/aws/sdk/examples/apigateway/Cargo.toml
+++ b/aws/sdk/examples/apigateway/Cargo.toml
@@ -11,4 +11,4 @@ aws-smithy-types-convert = { path = "../../build/aws-sdk/sdk/aws-smithy-types-co
 aws-sdk-apigateway = { path = "../../build/aws-sdk/sdk/apigateway" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/apigateway/Cargo.toml
+++ b/aws/sdk/examples/apigateway/Cargo.toml
@@ -11,4 +11,4 @@ aws-smithy-types-convert = { path = "../../build/aws-sdk/sdk/aws-smithy-types-co
 aws-sdk-apigateway = { path = "../../build/aws-sdk/sdk/apigateway" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/apigatewaymanagement/Cargo.toml
+++ b/aws/sdk/examples/apigatewaymanagement/Cargo.toml
@@ -11,4 +11,4 @@ aws-sdk-apigatewaymanagement = { path = "../../build/aws-sdk/sdk/apigatewaymanag
 http = "0.2.5"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/apigatewaymanagement/Cargo.toml
+++ b/aws/sdk/examples/apigatewaymanagement/Cargo.toml
@@ -11,4 +11,4 @@ aws-sdk-apigatewaymanagement = { path = "../../build/aws-sdk/sdk/apigatewaymanag
 http = "0.2.5"
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/applicationautoscaling/Cargo.toml
+++ b/aws/sdk/examples/applicationautoscaling/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-applicationautoscaling = { path = "../../build/aws-sdk/sdk/applicationau
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/autoscaling/Cargo.toml
+++ b/aws/sdk/examples/autoscaling/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-autoscaling = { path = "../../build/aws-sdk/sdk/autoscaling" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/autoscaling/Cargo.toml
+++ b/aws/sdk/examples/autoscaling/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-autoscaling = { path = "../../build/aws-sdk/sdk/autoscaling" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/autoscalingplans/Cargo.toml
+++ b/aws/sdk/examples/autoscalingplans/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-autoscalingplans = { path = "../../build/aws-sdk/sdk/autoscalingplans" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/autoscalingplans/Cargo.toml
+++ b/aws/sdk/examples/autoscalingplans/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-autoscalingplans = { path = "../../build/aws-sdk/sdk/autoscalingplans" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/batch/Cargo.toml
+++ b/aws/sdk/examples/batch/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-batch = { path = "../../build/aws-sdk/sdk/batch" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/batch/Cargo.toml
+++ b/aws/sdk/examples/batch/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-batch = { path = "../../build/aws-sdk/sdk/batch" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/cloudformation/Cargo.toml
+++ b/aws/sdk/examples/cloudformation/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-cloudformation = { package = "aws-sdk-cloudformation", path = "../../bui
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/cloudformation/Cargo.toml
+++ b/aws/sdk/examples/cloudformation/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-cloudformation = { package = "aws-sdk-cloudformation", path = "../../bui
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/cloudwatch/Cargo.toml
+++ b/aws/sdk/examples/cloudwatch/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-cloudwatch = { path = "../../build/aws-sdk/sdk/cloudwatch" }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = { version = "0.2", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/cloudwatchlogs/Cargo.toml
+++ b/aws/sdk/examples/cloudwatchlogs/Cargo.toml
@@ -11,5 +11,5 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-cloudwatchlogs = { path = "../../build/aws-sdk/sdk/cloudwatchlogs" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }

--- a/aws/sdk/examples/cognitoidentity/Cargo.toml
+++ b/aws/sdk/examples/cognitoidentity/Cargo.toml
@@ -14,4 +14,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/cognitoidentity/Cargo.toml
+++ b/aws/sdk/examples/cognitoidentity/Cargo.toml
@@ -14,4 +14,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 chrono = "0.4"
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/cognitoidentityprovider/Cargo.toml
+++ b/aws/sdk/examples/cognitoidentityprovider/Cargo.toml
@@ -13,4 +13,4 @@ aws-sdk-cognitoidentityprovider = { package = "aws-sdk-cognitoidentityprovider",
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/cognitoidentityprovider/Cargo.toml
+++ b/aws/sdk/examples/cognitoidentityprovider/Cargo.toml
@@ -13,4 +13,4 @@ aws-sdk-cognitoidentityprovider = { package = "aws-sdk-cognitoidentityprovider",
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/cognitosync/Cargo.toml
+++ b/aws/sdk/examples/cognitosync/Cargo.toml
@@ -13,4 +13,4 @@ aws-sdk-cognitosync = { package = "aws-sdk-cognitosync", path = "../../build/aws
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/cognitosync/Cargo.toml
+++ b/aws/sdk/examples/cognitosync/Cargo.toml
@@ -13,4 +13,4 @@ aws-sdk-cognitosync = { package = "aws-sdk-cognitosync", path = "../../build/aws
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/config/Cargo.toml
+++ b/aws/sdk/examples/config/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-config = { package = "aws-sdk-config", path = "../../build/aws-sdk/sdk/config" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/config/Cargo.toml
+++ b/aws/sdk/examples/config/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-config = { package = "aws-sdk-config", path = "../../build/aws-sdk/sdk/config" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/dynamodb/Cargo.toml
+++ b/aws/sdk/examples/dynamodb/Cargo.toml
@@ -18,4 +18,4 @@ rand = "0.8.3"
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["fmt"] }

--- a/aws/sdk/examples/dynamodb/Cargo.toml
+++ b/aws/sdk/examples/dynamodb/Cargo.toml
@@ -18,5 +18,5 @@ rand = "0.8.3"
 serde_json = "1"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = { version = "0.3.5", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 tokio-stream = "0.1.8"

--- a/aws/sdk/examples/ebs/Cargo.toml
+++ b/aws/sdk/examples/ebs/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1", features = ["full"]}
 base64 = "0.13.0"
 sha2 = "0.9.5"
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.19"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/ebs/Cargo.toml
+++ b/aws/sdk/examples/ebs/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1", features = ["full"]}
 base64 = "0.13.0"
 sha2 = "0.9.5"
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/ec2/Cargo.toml
+++ b/aws/sdk/examples/ec2/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/sdk/ec2" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/ec2/Cargo.toml
+++ b/aws/sdk/examples/ec2/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-ec2 = { package = "aws-sdk-ec2", path = "../../build/aws-sdk/sdk/ec2" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/ecr/Cargo.toml
+++ b/aws/sdk/examples/ecr/Cargo.toml
@@ -9,5 +9,5 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-ecr = { path = "../../build/aws-sdk/sdk/ecr" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }

--- a/aws/sdk/examples/iam/Cargo.toml
+++ b/aws/sdk/examples/iam/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-iam = { path = "../../build/aws-sdk/sdk/iam" }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/iam/Cargo.toml
+++ b/aws/sdk/examples/iam/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-iam = { path = "../../build/aws-sdk/sdk/iam" }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/kinesis/Cargo.toml
+++ b/aws/sdk/examples/kinesis/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-kinesis = { path = "../../build/aws-sdk/sdk/kinesis" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/kms/Cargo.toml
+++ b/aws/sdk/examples/kms/Cargo.toml
@@ -12,4 +12,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
 base64 = "0.13.0"
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/lambda/Cargo.toml
+++ b/aws/sdk/examples/lambda/Cargo.toml
@@ -13,4 +13,4 @@ aws-sdk-lambda = { package = "aws-sdk-lambda", path = "../../build/aws-sdk/sdk/l
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/medialive/Cargo.toml
+++ b/aws/sdk/examples/medialive/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-medialive = { path = "../../build/aws-sdk/sdk/medialive" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/mediapackage/Cargo.toml
+++ b/aws/sdk/examples/mediapackage/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-mediapackage = { path = "../../build/aws-sdk/sdk/mediapackage" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/polly/Cargo.toml
+++ b/aws/sdk/examples/polly/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-polly = { path = "../../build/aws-sdk/sdk/polly" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/qldb/Cargo.toml
+++ b/aws/sdk/examples/qldb/Cargo.toml
@@ -13,4 +13,4 @@ aws-sdk-qldbsession = { path = "../../build/aws-sdk/sdk/qldbsession" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/rds/Cargo.toml
+++ b/aws/sdk/examples/rds/Cargo.toml
@@ -12,4 +12,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 aws-sdk-rds = { path = "../../build/aws-sdk/sdk/rds" }
 structopt = { version = "0.3", default-features = false }
 tokio = {version = "1", features = ["full"]}
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/rdsdata/Cargo.toml
+++ b/aws/sdk/examples/rdsdata/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-rdsdata = { path = "../../build/aws-sdk/sdk/rdsdata"}
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = {version = "1", features = ["full"]}
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/route53/Cargo.toml
+++ b/aws/sdk/examples/route53/Cargo.toml
@@ -13,4 +13,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["fmt", "env-filter"] }

--- a/aws/sdk/examples/route53/Cargo.toml
+++ b/aws/sdk/examples/route53/Cargo.toml
@@ -13,4 +13,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.3.5", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/s3/Cargo.toml
+++ b/aws/sdk/examples/s3/Cargo.toml
@@ -14,4 +14,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/s3/Cargo.toml
+++ b/aws/sdk/examples/s3/Cargo.toml
@@ -14,4 +14,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/sagemaker/Cargo.toml
+++ b/aws/sdk/examples/sagemaker/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1", features = ["full"] }
 env_logger = "0.8.2"
 chrono = "0.4.19"
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/sagemaker/Cargo.toml
+++ b/aws/sdk/examples/sagemaker/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1", features = ["full"] }
 env_logger = "0.8.2"
 chrono = "0.4.19"
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/secretsmanager/Cargo.toml
+++ b/aws/sdk/examples/secretsmanager/Cargo.toml
@@ -13,4 +13,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.3.5", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/secretsmanager/Cargo.toml
+++ b/aws/sdk/examples/secretsmanager/Cargo.toml
@@ -13,4 +13,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"]}
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["fmt", "env-filter"] }

--- a/aws/sdk/examples/ses/Cargo.toml
+++ b/aws/sdk/examples/ses/Cargo.toml
@@ -12,4 +12,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/ses/Cargo.toml
+++ b/aws/sdk/examples/ses/Cargo.toml
@@ -12,4 +12,4 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/setting_timeouts/Cargo.toml
+++ b/aws/sdk/examples/setting_timeouts/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["rustls"] }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/setting_timeouts/Cargo.toml
+++ b/aws/sdk/examples/setting_timeouts/Cargo.toml
@@ -11,4 +11,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["rustls"] }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/snowball/Cargo.toml
+++ b/aws/sdk/examples/snowball/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-snowball = { path = "../../build/aws-sdk/sdk/snowball" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/snowball/Cargo.toml
+++ b/aws/sdk/examples/snowball/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-snowball = { path = "../../build/aws-sdk/sdk/snowball" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/sns/Cargo.toml
+++ b/aws/sdk/examples/sns/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-sns = { package = "aws-sdk-sns", path = "../../build/aws-sdk/sdk/sns" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/sns/Cargo.toml
+++ b/aws/sdk/examples/sns/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-sns = { package = "aws-sdk-sns", path = "../../build/aws-sdk/sdk/sns" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 tokio = { version = "1", features = ["full"] }
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/sqs/Cargo.toml
+++ b/aws/sdk/examples/sqs/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-sqs = { path = "../../build/aws-sdk/sdk/sqs" }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/sqs/Cargo.toml
+++ b/aws/sdk/examples/sqs/Cargo.toml
@@ -10,4 +10,4 @@ edition = "2018"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-sdk-sqs = { path = "../../build/aws-sdk/sdk/sqs" }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/ssm/Cargo.toml
+++ b/aws/sdk/examples/ssm/Cargo.toml
@@ -13,4 +13,4 @@ tokio = { version = "1", features = ["full"] }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 
 structopt = { version = "0.3", default-features = false }
-tracing-subscriber = { version = "0.2.16", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/telephone-game/Cargo.toml
+++ b/aws/sdk/examples/telephone-game/Cargo.toml
@@ -13,10 +13,10 @@ aws-sdk-polly = { package = "aws-sdk-polly", path = "../../build/aws-sdk/sdk/pol
 aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3" }
 aws-sdk-transcribe = { package = "aws-sdk-transcribe", path = "../../build/aws-sdk/sdk/transcribe" }
 anyhow = "1.0.44"
-clap = "2.33.3"
+clap = "2.34.0"
 rodio = "0.14.0"
 serde_json = "1.0.68"
-tempdir = "0.3.7"
+tempfile = "3.2.0"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.28"
-tracing-subscriber = { version = "0.2.24", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.5", features = ["fmt", "env-filter"] }

--- a/aws/sdk/examples/telephone-game/Cargo.toml
+++ b/aws/sdk/examples/telephone-game/Cargo.toml
@@ -19,4 +19,4 @@ serde_json = "1.0.68"
 tempfile = "3.2.0"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.28"
-tracing-subscriber = { version = "0.3.5", features = ["fmt", "env-filter"] }
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/transcribestreaming/Cargo.toml
+++ b/aws/sdk/examples/transcribestreaming/Cargo.toml
@@ -14,4 +14,4 @@ bytes = "1"
 hound = "3.4"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/transcribestreaming/Cargo.toml
+++ b/aws/sdk/examples/transcribestreaming/Cargo.toml
@@ -14,4 +14,4 @@ bytes = "1"
 hound = "3.4"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/examples/using_native_tls_instead_of_rustls/Cargo.toml
+++ b/aws/sdk/examples/using_native_tls_instead_of_rustls/Cargo.toml
@@ -15,4 +15,4 @@ aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3", defa
 # aws-sdk-sts is the same as aws-sdk-s3
 aws-sdk-sts = { package = "aws-sdk-sts", path = "../../build/aws-sdk/sdk/sts", default-features = false, features = ["native-tls"] }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/examples/using_native_tls_instead_of_rustls/Cargo.toml
+++ b/aws/sdk/examples/using_native_tls_instead_of_rustls/Cargo.toml
@@ -15,4 +15,4 @@ aws-sdk-s3 = { package = "aws-sdk-s3", path = "../../build/aws-sdk/sdk/s3", defa
 # aws-sdk-sts is the same as aws-sdk-s3
 aws-sdk-sts = { package = "aws-sdk-sts", path = "../../build/aws-sdk/sdk/sts", default-features = false, features = ["native-tls"] }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = "0.3"
 http = "0.2.4"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 tokio-stream = "0.1.8"
 
 [[bench]]

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -15,12 +15,12 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 bytes = "1"
-criterion = { version = "0.3.4" }
+criterion = { version = "0.3.5" }
 futures-util = "0.3"
 http = "0.2.4"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.2.16"
+tracing-subscriber = "0.3.5"
 
 [[bench]]
 name = "deserialization_bench"

--- a/aws/sdk/integration-tests/glacier/Cargo.toml
+++ b/aws/sdk/integration-tests/glacier/Cargo.toml
@@ -15,4 +15,4 @@ aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/glacier/Cargo.toml
+++ b/aws/sdk/integration-tests/glacier/Cargo.toml
@@ -15,4 +15,4 @@ aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -16,4 +16,4 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -16,4 +16,4 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -16,4 +16,4 @@ aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.2.16"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -16,4 +16,4 @@ aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full", "test-util"]}
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/lambda/Cargo.toml
+++ b/aws/sdk/integration-tests/lambda/Cargo.toml
@@ -17,4 +17,4 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-eventstream = { path = "../../build/aws-sdk/sdk/aws-smithy-eventstream" }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/lambda/Cargo.toml
+++ b/aws/sdk/integration-tests/lambda/Cargo.toml
@@ -17,4 +17,4 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-eventstream = { path = "../../build/aws-sdk/sdk/aws-smithy-eventstream" }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/polly/Cargo.toml
+++ b/aws/sdk/integration-tests/polly/Cargo.toml
@@ -15,4 +15,4 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full"]}
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/polly/Cargo.toml
+++ b/aws/sdk/integration-tests/polly/Cargo.toml
@@ -15,4 +15,4 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 bytes = "1"
 http = "0.2.3"
 tokio = { version = "1", features = ["full"]}
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/qldbsession/Cargo.toml
+++ b/aws/sdk/integration-tests/qldbsession/Cargo.toml
@@ -15,4 +15,4 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 http = "0.2.3"
 tokio = { version = "1", features = ["full"]}
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/qldbsession/Cargo.toml
+++ b/aws/sdk/integration-tests/qldbsession/Cargo.toml
@@ -15,4 +15,4 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 http = "0.2.3"
 tokio = { version = "1", features = ["full"]}
-tracing-subscriber = "0.2.16"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -21,6 +21,6 @@ bytes = "1"
 http = "0.2.3"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 tracing = "0.1"
 tracing-test = "0.2.1"

--- a/aws/sdk/integration-tests/s3control/Cargo.toml
+++ b/aws/sdk/integration-tests/s3control/Cargo.toml
@@ -16,4 +16,4 @@ bytes = "1"
 http = "0.2.3"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/s3control/Cargo.toml
+++ b/aws/sdk/integration-tests/s3control/Cargo.toml
@@ -16,4 +16,4 @@ bytes = "1"
 http = "0.2.3"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -12,4 +12,4 @@ aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.2"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
+++ b/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
@@ -17,4 +17,4 @@ hound = "3.4"
 http = "0.2.3"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.2.18"
+tracing-subscriber = "0.3.5"

--- a/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
+++ b/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
@@ -17,4 +17,4 @@ hound = "3.4"
 http = "0.2.3"
 serde_json = "1"
 tokio = { version = "1", features = ["full", "test-util"] }
-tracing-subscriber = "0.3.5"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "1"
 fastrand = "1.4.0"
 http = "0.2.3"
 http-body = "0.4.4"
-hyper = { version = "0.14.13", features = ["client", "http2", "http1"], optional = true }
+hyper = { version = "0.14", features = ["client", "http2", "http1"], optional = true }
 hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1", optional = true }

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "1"
 fastrand = "1.4.0"
 http = "0.2.3"
 http-body = "0.4.4"
-hyper = { version = "0.14.2", features = ["client", "http2", "http1"], optional = true }
+hyper = { version = "0.14.13", features = ["client", "http2", "http1"], optional = true }
 hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1", optional = true }

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -33,7 +33,7 @@ tokio-util = { version = "0.6", optional = true}
 [dev-dependencies]
 async-stream = "0.3"
 futures-util = "0.3"
-hyper = { version = "0.14.5", features = ["stream"] }
+hyper = { version = "0.14.13", features = ["stream"] }
 proptest = "1"
 tokio = {version = "1.6", features = ["macros", "rt", "rt-multi-thread", "fs", "io-util"]}
 tokio-stream = "0.1.5"

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -23,7 +23,7 @@ pin-project = "1"
 tracing = "0.1"
 
 # We are using hyper for our streaming body implementation, but this is an internal detail.
-hyper = "0.14.5"
+hyper = "0.14"
 
 # ByteStream internals
 futures-core = "0.3.14"
@@ -33,7 +33,7 @@ tokio-util = { version = "0.6", optional = true}
 [dev-dependencies]
 async-stream = "0.3"
 futures-util = "0.3"
-hyper = { version = "0.14.13", features = ["stream"] }
+hyper = { version = "0.14", features = ["stream"] }
 proptest = "1"
 tokio = {version = "1.6", features = ["macros", "rt", "rt-multi-thread", "fs", "io-util"]}
 tokio-stream = "0.1.5"

--- a/tools/publisher/Cargo.lock
+++ b/tools/publisher/Cargo.lock
@@ -127,11 +127,9 @@ version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits",
  "serde",
- "winapi",
 ]
 
 [[package]]
@@ -548,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -1256,35 +1254,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "5d81bfa81424cc98cb034b837c985b7a290f592e5b4322f353f94a0ab0f9f594"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
  "lazy_static",
  "matchers",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/tools/publisher/Cargo.toml
+++ b/tools/publisher/Cargo.toml
@@ -25,4 +25,4 @@ thiserror = "1.0"
 tokio = { version = "1.12", features = ["full"] }
 toml = { version = "0.5.8", features = ["preserve_order"] }
 tracing = "0.1.29"
-tracing-subscriber = "0.2.25"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-rust-sdk CI is failing on a cargo audit. This updates dependencies to avoid that.

## Description
<!--- Describe your changes in detail -->
update: insecure deps
add: extra context to timeout test failure
This doesn't fix all audit issues but the remaining ones are for examples so I think the path forward is to ignore them for now.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran existing tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
