### PR TITLE
fix: typo for _X_AMZN_TRACE_ID

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,8 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+[[aws-sdk-rust]]
+message = "Fix typos for X-Ray trace ID environment variable in aws_http::recursion_detection"
+references = ["smithy-rs#1050"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "nmoutschen"

--- a/aws/rust-runtime/aws-http/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-http/src/recursion_detection.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 
 /// Recursion Detection Middleware
 ///
-/// This middleware inspects the value of the `AWS_LAMBDA_FUNCTION_NAME` and `_X_AMZ_TRACE_ID` environment
+/// This middleware inspects the value of the `AWS_LAMBDA_FUNCTION_NAME` and `_X_AMZN_TRACE_ID` environment
 /// variables to detect if the request is being invoked in a lambda function. If it is, the `X-Amzn-Trace-Id` header
 /// will be set. This enables downstream services to prevent accidentally infinitely recursive invocations spawned
 /// from lambda.
@@ -45,7 +45,7 @@ const TRACE_ID_HEADER: &str = "x-amzn-trace-id";
 
 mod env {
     pub(super) const LAMBDA_FUNCTION_NAME: &str = "AWS_LAMBDA_FUNCTION_NAME";
-    pub(super) const TRACE_ID: &str = "_X_AMZ_TRACE_ID";
+    pub(super) const TRACE_ID: &str = "_X_AMZN_TRACE_ID";
 }
 
 /// Set the trace id header from the request

--- a/aws/rust-runtime/aws-http/test-data/recursion-detection.json
+++ b/aws/rust-runtime/aws-http/test-data/recursion-detection.json
@@ -4,14 +4,14 @@
     "requestHeadersBefore": [],
     "requestHeadersAfter": [],
     "description": [
-      "The AWS_LAMBDA_FUNCTION_NAME and _X_AMZ_TRACE_ID environment variables are not set.",
+      "The AWS_LAMBDA_FUNCTION_NAME and _X_AMZN_TRACE_ID environment variables are not set.",
       "There should be no X-Amzn-Trace-Id header sent."
     ]
   },
   {
     "env": {
       "AWS_LAMBDA_FUNCTION_NAME": "some-function",
-      "_X_AMZ_TRACE_ID": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2"
+      "_X_AMZN_TRACE_ID": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2"
     },
     "requestHeadersBefore": [],
     "requestHeadersAfter": [
@@ -19,26 +19,26 @@
     ],
     "description": [
       "AWS_LAMBDA_FUNCTION_NAME is set, and",
-      "_X_AMZ_TRACE_ID is set to \"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2\".",
+      "_X_AMZN_TRACE_ID is set to \"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2\".",
       "The X-Amzn-Trace-Id header should be sent with that value."
     ]
   },
   {
     "env": {
-      "_X_AMZ_TRACE_ID": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2"
+      "_X_AMZN_TRACE_ID": "Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2"
     },
     "requestHeadersBefore": [],
     "requestHeadersAfter": [],
     "description": [
       "AWS_LAMBDA_FUNCTION_NAME is NOT set, and",
-      "_X_AMZ_TRACE_ID is set to \"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2\".",
+      "_X_AMZN_TRACE_ID is set to \"Root=1-5759e988-bd862e3fe1be46a994272793;Parent=53995c3f42cd8ad8;Sampled=1;lineage=a87bd80c:0,68fd508a:5,c512fbe3:2\".",
       "The X-Amzn-Trace-Id header should NOT be sent with that value."
     ]
   },
   {
     "env": {
       "AWS_LAMBDA_FUNCTION_NAME": "some-function",
-      "_X_AMZ_TRACE_ID": "EnvValue"
+      "_X_AMZN_TRACE_ID": "EnvValue"
     },
     "requestHeadersBefore": [
       "X-Amzn-Trace-Id: OriginalValue"
@@ -48,7 +48,7 @@
     ],
     "desciption": [
       "AWS_LAMBDA_FUNCTION_NAME is set, and",
-      "_X_AMZ_TRACE_ID is set to \"EnvValue\",",
+      "_X_AMZN_TRACE_ID is set to \"EnvValue\",",
       "but the X-Amzn-Trace-Id header is already set on the request.",
       "The X-Amzn-Trace-Id header should keep its original value."
     ]
@@ -56,7 +56,7 @@
   {
     "env": {
       "AWS_LAMBDA_FUNCTION_NAME": "some-function",
-      "_X_AMZ_TRACE_ID": "first\nsecond¼\t"
+      "_X_AMZN_TRACE_ID": "first\nsecond¼\t"
     },
     "requestHeadersBefore": [],
     "requestHeadersAfter": [
@@ -64,7 +64,7 @@
     ],
     "description": [
       "AWS_LAMBDA_FUNCTION_NAME is set, and",
-      "_X_AMZ_TRACE_ID has ASCII control characters in it.",
+      "_X_AMZN_TRACE_ID has ASCII control characters in it.",
       "The X-Amzn-Trace-Id header is added with the control characters percent encoded."
     ]
   }

--- a/aws/sdk/integration-tests/s3/tests/recursion-detection.rs
+++ b/aws/sdk/integration-tests/s3/tests/recursion-detection.rs
@@ -10,7 +10,7 @@ use http::HeaderValue;
 #[tokio::test]
 async fn recursion_detection_applied() {
     std::env::set_var("AWS_LAMBDA_FUNCTION_NAME", "some-function");
-    std::env::set_var("_X_AMZ_TRACE_ID", "traceid");
+    std::env::set_var("_X_AMZN_TRACE_ID", "traceid");
     let (conn, captured_request) = capture_request(None);
 
     let creds = Credentials::new(


### PR DESCRIPTION
## Motivation and Context

This changes fixes a typo in the name of the X-Ray trace environment variable on Lambda functions. It should be `_X_AMZN_TRACE_ID`, but is `_X_AMZ_TRACE_ID`.

See [the documentation on custom runtimes](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html) for more information.

## Description

Replace all occurrences of `_X_AMZ_TRACE_ID` by `_X_AMZN_TRACE_ID`. 

## Testing

Searched for all occurrences of `_X_AMZ_TRACE_ID` with grep and confirmed none were left.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
