### PR TITLE
`rust-server-codegen`: fix deserialization of escaped query string data

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRuntimeType.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRuntimeType.kt
@@ -20,6 +20,7 @@ object ServerRuntimeType {
         RuntimeType(inlineDependency.name, inlineDependency, namespace = "crate")
 
     val Phantom = RuntimeType("PhantomData", dependency = null, namespace = "std::marker")
+    val Cow = RuntimeType("Cow", dependency = null, namespace = "std::borrow")
 
     fun Router(runtimeConfig: RuntimeConfig) =
         RuntimeType("Router", CargoDependency.SmithyHttpServer(runtimeConfig), "${runtimeConfig.crateSrcPrefix}_http_server::routing")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -441,7 +441,6 @@ class ServerProtocolTestGenerator(
             FailingTest(RestJson, "RestJsonOutputUnionWithUnitMember", Action.Response),
             FailingTest(RestJson, "RestJsonUnitInputAllowsAccept", Action.Request),
             FailingTest(RestJson, "RestJsonUnitInputAndOutputNoOutput", Action.Response),
-            FailingTest(RestJson, "RestJsonAllQueryStringTypes", Action.Request),
             FailingTest(RestJson, "RestJsonQueryStringEscaping", Action.Request),
             FailingTest(RestJson, "RestJsonSupportsNaNFloatQueryValues", Action.Request),
             FailingTest(RestJson, "DocumentOutput", Action.Response),
@@ -623,6 +622,49 @@ class ServerProtocolTestGenerator(
                     """.trimMargin()
                 ).asObjectNode().get()
             ).build()
+        private fun fixRestJsonAllQueryStringTypes(testCase: HttpRequestTestCase): HttpRequestTestCase =
+             testCase.toBuilder().params(
+                 Node.parse("""{
+                    "queryString": "Hello there",
+                    "queryStringList": ["a", "b", "c"],
+                    "queryStringSet": ["a", "b", "c"],
+                    "queryByte": 1,
+                    "queryShort": 2,
+                    "queryInteger": 3,
+                    "queryIntegerList": [1, 2, 3],
+                    "queryIntegerSet": [1, 2, 3],
+                    "queryLong": 4,
+                    "queryFloat": 1.1,
+                    "queryDouble": 1.1,
+                    "queryDoubleList": [1.1, 2.1, 3.1],
+                    "queryBoolean": true,
+                    "queryBooleanList": [true, false, true],
+                    "queryTimestamp": 1,
+                    "queryTimestampList": [1, 2, 3],
+                    "queryEnum": "Foo",
+                    "queryEnumList": ["Foo", "Baz", "Bar"],
+                    "queryParamsMapOfStringList": {
+                        "String": ["Hello there"],
+                        "StringList": ["a", "b", "c"],
+                        "StringSet": ["a", "b", "c"],
+                        "Byte": ["1"],
+                        "Short": ["2"],
+                        "Integer": ["3"],
+                        "IntegerList": ["1", "2", "3"],
+                        "IntegerSet": ["1", "2", "3"],
+                        "Long": ["4"],
+                        "Float": ["1.1"],
+                        "Double": ["1.1"],
+                        "DoubleList": ["1.1", "2.1", "3.1"],
+                        "Boolean": ["true"],
+                        "BooleanList": ["true", "false", "true"],
+                        "Timestamp": ["1970-01-01T00:00:01Z"],
+                        "TimestampList": ["1970-01-01T00:00:01Z", "1970-01-01T00:00:02Z", "1970-01-01T00:00:03Z"],
+                        "Enum": ["Foo"],
+                        "EnumList": ["Foo", "Baz", "Bar"]
+                    }
+                }""".trimMargin()).asObjectNode().get()
+             ).build()
 
         // These are tests whose definitions in the `awslabs/smithy` repository are wrong.
         // This is because they have not been written from a server perspective, and as such the expected `params` field is incomplete.
@@ -631,7 +673,8 @@ class ServerProtocolTestGenerator(
             // https://github.com/awslabs/smithy/pull/1040
             Pair(RestJson, "RestJsonSupportsNaNFloatQueryValues") to ::fixRestJsonSupportsNaNFloatQueryValues,
             Pair(RestJson, "RestJsonSupportsInfinityFloatQueryValues") to ::fixRestJsonSupportsInfinityFloatQueryValues,
-            Pair(RestJson, "RestJsonSupportsNegativeInfinityFloatQueryValues") to ::fixRestJsonSupportsNegativeInfinityFloatQueryValues
+            Pair(RestJson, "RestJsonSupportsNegativeInfinityFloatQueryValues") to ::fixRestJsonSupportsNegativeInfinityFloatQueryValues,
+            Pair(RestJson, "RestJsonAllQueryStringTypes") to ::fixRestJsonAllQueryStringTypes
         )
     }
 }


### PR DESCRIPTION
We are currently deserializing the query string into `Vec<(&str,
&str)>`. `serde_urlencoded` panics if the input string slice contains
escaped data, since in that case it needs to allocate a new `String` to
unescape the input string slice's contents.

Instead of deserializing to `Vec<(String, String)>`, we can instead use
`Cow<'a, str>` so that deserialization only allocates when strictly
required.

Reference: https://github.com/serde-rs/serde/issues/1413#issuecomment-494892266

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
