### PR TITLE
Assorted canary Improvements

### DIFF
--- a/tools/ci-cdk/canary-lambda/src/canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/canary.rs
@@ -66,6 +66,8 @@ impl Clients {
 pub struct CanaryEnv {
     pub(crate) s3_bucket_name: String,
     pub(crate) expected_transcribe_result: String,
+    #[allow(dead_code)]
+    pub(crate) page_size: usize,
 }
 
 impl fmt::Debug for CanaryEnv {
@@ -95,9 +97,15 @@ impl CanaryEnv {
                     .to_string()
             });
 
+        let page_size = env::var("PAGE_SIZE")
+            .map(|ps| ps.parse::<usize>())
+            .unwrap_or_else(|_| Ok(16))
+            .expect("invalid page size");
+
         Self {
             s3_bucket_name,
             expected_transcribe_result,
+            page_size,
         }
     }
 }

--- a/tools/ci-cdk/canary-lambda/src/main.rs
+++ b/tools/ci-cdk/canary-lambda/src/main.rs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use anyhow::bail;
 use canary::{get_canaries_to_run, CanaryEnv};
 use lambda_runtime::{Context as LambdaContext, Error};
 use serde_json::{json, Value};

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -3,12 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use crate::canary::CanaryError;
+use crate::canary::{CanaryError, Clients};
+use crate::{mk_canary, CanaryEnv};
 use anyhow::Context;
 use aws_sdk_s3 as s3;
 use uuid::Uuid;
 
 const METADATA_TEST_VALUE: &str = "some   value";
+
+mk_canary!("s3", |clients: &Clients, env: &CanaryEnv| s3_canary(
+    clients.s3.clone(),
+    env.s3_bucket_name.clone()
+));
 
 pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Result<()> {
     use s3::{error::GetObjectError, error::GetObjectErrorKind, SdkError};

--- a/tools/ci-cdk/canary-lambda/src/transcribe_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/transcribe_canary.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::canary::CanaryError;
+use crate::mk_canary;
 use async_stream::stream;
 use aws_sdk_transcribestreaming as transcribe;
 use bytes::BufMut;
@@ -13,6 +14,14 @@ use transcribe::model::{
 use transcribe::Blob;
 
 const CHUNK_SIZE: usize = 8192;
+use crate::canary::{CanaryEnv, Clients};
+
+mk_canary!("transcribe_canary", |client: &Clients, env: &CanaryEnv| {
+    transcribe_canary(
+        client.transcribe.clone(),
+        env.expected_transcribe_result.clone(),
+    )
+});
 
 pub async fn transcribe_canary(
     client: transcribe::Client,

--- a/tools/ci-cdk/canary-lambda/write-cargo-toml.py
+++ b/tools/ci-cdk/canary-lambda/write-cargo-toml.py
@@ -32,6 +32,7 @@ anyhow = "1"
 async-stream = "0.3"
 bytes = "1"
 hound = "3.4"
+async-trait = "0.1"
 lambda_runtime = "0.4"
 serde_json = "1"
 thiserror = "1"
@@ -39,8 +40,13 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 uuid = { version = "0.8", features = ["v4"] }
+tokio-stream = "0"
 """
 
+notable_versions = [
+    # first version to add support for paginators
+    "0.4.1"
+]
 
 def main():
     args = Args()
@@ -51,9 +57,18 @@ def main():
               args.path, args.sdk_version), file=file)
         print(format_dependency("aws-sdk-s3",
               args.path, args.sdk_version), file=file)
+        print(format_dependency("aws-sdk-ec2",
+                                args.path, args.sdk_version), file=file)
         print(format_dependency("aws-sdk-transcribestreaming",
               args.path, args.sdk_version), file=file)
+        print("[features]", file=file)
+        for version in notable_versions:
+            print(f'"v{version}" = []', file=file)
+        enabled = ', '.join(enabled_versions(args.sdk_version))
+        print(f'default = [{enabled}]', file=file)
 
+def enabled_versions(sdk_version):
+    return [f'"v{version}"' for version in notable_versions if version.split('.') <= sdk_version.split('.')]
 
 def format_dependency(crate, path, version):
     if path is None:


### PR DESCRIPTION
## Motivation and Context
- canaries that run forever should timeout
- add a canary for EC2 paginators
- make it possible to run canaries locally with `--local`

## Description
1. Add a timeout for individual canaries
2. Add an Ec2 canary.
3. Add functionality to enable/disable canaries based on SDK version
4. Add `--local` flag to support running canaries locally
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
