### PR TITLE
update: client input links to point to fluent builder

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -133,10 +133,12 @@ fun RustType.qualifiedName(): String {
     return "$namespace$name"
 }
 
+/** Format this Rust type as an `impl Into<T>` */
 fun RustType.implInto(fullyQualified: Boolean = true): String {
     return "impl Into<${this.render(fullyQualified)}>"
 }
 
+/** Format this Rust type so that it may be used as an argument type in a function definition */
 fun RustType.asArgumentType(fullyQualified: Boolean = true): String {
     return when (this) {
         is RustType.String,
@@ -145,6 +147,10 @@ fun RustType.asArgumentType(fullyQualified: Boolean = true): String {
     }
 }
 
+/**
+ * For a given name, generate an `Argument` data class containing pre-formatted strings for using this type when
+ * writing a Rust function
+ */
 fun RustType.asArgument(name: String): Argument {
     return Argument(
         "$name: ${this.asArgumentType()}",

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -137,18 +137,20 @@ fun RustType.implInto(fullyQualified: Boolean = true): String {
     return "impl Into<${this.render(fullyQualified)}>"
 }
 
-fun RustType.asArgument(name: String): Argument {
+fun RustType.asArgumentType(fullyQualified: Boolean = true): String {
     return when (this) {
         is RustType.String,
-        is RustType.Box -> Argument(
-            "$name: ${this.implInto()}",
-            "$name.into()",
-        )
-        else -> Argument(
-            "$name: ${this.render()}",
-            name,
-        )
+        is RustType.Box -> this.implInto(fullyQualified)
+        else -> this.render(fullyQualified)
     }
+}
+
+fun RustType.asArgument(name: String): Argument {
+    return Argument(
+        "$name: ${this.asArgumentType()}",
+        name,
+        this.render(),
+    )
 }
 
 /**
@@ -364,4 +366,4 @@ sealed class Attribute {
     }
 }
 
-data class Argument(val argument: String, val value: String)
+data class Argument(val argument: String, val value: String, val type: String)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -147,6 +147,15 @@ fun RustType.asArgumentType(fullyQualified: Boolean = true): String {
     }
 }
 
+/** Format this Rust type so that it may be used as an argument type in a function definition */
+fun RustType.asArgumentValue(name: String): String {
+    return when (this) {
+        is RustType.String,
+        is RustType.Box -> "$name.into()"
+        else -> name
+    }
+}
+
 /**
  * For a given name, generate an `Argument` data class containing pre-formatted strings for using this type when
  * writing a Rust function
@@ -154,7 +163,7 @@ fun RustType.asArgumentType(fullyQualified: Boolean = true): String {
 fun RustType.asArgument(name: String): Argument {
     return Argument(
         "$name: ${this.asArgumentType()}",
-        name,
+        this.asArgumentValue(name),
         this.render(),
     )
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientCore.kt
@@ -16,40 +16,50 @@ import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 
 class FluentClientCore(private val model: Model) {
+    /** Generate and write Rust code for a builder method that sets a Vec<T> */
     fun RustWriter.renderVecHelper(member: MemberShape, memberName: String, coreType: RustType.Vec) {
         docs("Appends an item to `${member.memberName}`.")
         rust("///")
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
-        documentShape(member, model)
         val input = coreType.member.asArgument("input")
 
+        documentShape(member, model)
         rustBlock("pub fn $memberName(mut self, ${input.argument}) -> Self") {
-            rust(
-                """
-                self.inner = self.inner.$memberName(${input.value});
-                self
-                """
-            )
+            write("self.inner = self.inner.$memberName(${input.value});")
+            write("self")
         }
     }
 
+    /** Generate and write Rust code for a builder method that sets a HashMap<K,V> */
     fun RustWriter.renderMapHelper(member: MemberShape, memberName: String, coreType: RustType.HashMap) {
         docs("Adds a key-value pair to `${member.memberName}`.")
         rust("///")
         docs("To override the contents of this collection use [`${member.setterName()}`](Self::${member.setterName()}).")
         rust("///")
-        documentShape(member, model)
         val k = coreType.key.asArgument("k")
         val v = coreType.member.asArgument("v")
 
+        documentShape(member, model)
         rustBlock("pub fn $memberName(mut self, ${k.argument}, ${v.argument}) -> Self") {
-            rust(
-                """
-                self.inner = self.inner.$memberName(${k.value}, ${v.value});
-                self
-                """
-            )
+            write("self.inner = self.inner.$memberName(${k.value}, ${v.value});")
+            write("self")
+        }
+    }
+
+    /**
+     * Generate and write Rust code for a builder method that sets an input. Can be used for setter methods as well e.g.
+     *
+     * `renderInputHelper(memberShape, "foo", RustType.String)` -> `pub fn foo(mut self, input: impl Into<String>) -> Self { ... }`
+     * `renderInputHelper(memberShape, "set_bar", RustType.Option)` -> `pub fn set_bar(mut self, input: Option<String>) -> Self { ... }`
+     */
+    fun RustWriter.renderInputHelper(member: MemberShape, memberName: String, coreType: RustType) {
+        val functionInput = coreType.asArgument("input")
+
+        documentShape(member, model)
+        rustBlock("pub fn $memberName(mut self, ${functionInput.argument}) -> Self") {
+            write("self.inner = self.inner.$memberName(${functionInput.value});")
+            write("self")
         }
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/FluentClientDecorator.kt
@@ -22,6 +22,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asArgumentType
+import software.amazon.smithy.rust.codegen.rustlang.asOptional
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
@@ -537,7 +538,8 @@ class FluentClientGenerator(
                         }
                         // pure setter
                         val setterName = member.setterName()
-                        with(core) { renderInputHelper(member, setterName, outerType) }
+                        val optionalInputType = outerType.asOptional()
+                        with(core) { renderInputHelper(member, setterName, optionalInputType) }
                     }
                 }
             }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
This is more helpful than pointing to an operation's Input struct

## Description
<!--- Describe your changes in detail -->
update operation input doc links generated for `client::Client` to point to the fluent builder and related methods

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the docs locally and read them

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
