### PR TITLE
fix: silence warnings in Lambda environment

### DIFF
--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -22,3 +22,11 @@ pub mod timeout_config;
 pub use credentials::ProfileFileCredentialsProvider;
 #[doc(inline)]
 pub use region::ProfileFileRegionProvider;
+
+/// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
+/// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
+/// that we can check.
+fn check_is_likely_running_on_a_lambda(environment: &os_shim_internal::Env) -> bool {
+    // LAMBDA_TASK_ROOT – The path to your Lambda function code.
+    environment.get("LAMBDA_TASK_ROOT").is_ok()
+}

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -26,7 +26,7 @@ pub use region::ProfileFileRegionProvider;
 /// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
 /// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
 /// that we can check.
-fn check_is_likely_running_on_a_lambda(environment: &os_shim_internal::Env) -> bool {
+fn check_is_likely_running_on_a_lambda(environment: &aws_types::os_shim_internal::Env) -> bool {
     // LAMBDA_TASK_ROOT – The path to your Lambda function code.
     environment.get("LAMBDA_TASK_ROOT").is_ok()
 }

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -22,11 +22,3 @@ pub mod timeout_config;
 pub use credentials::ProfileFileCredentialsProvider;
 #[doc(inline)]
 pub use region::ProfileFileRegionProvider;
-
-/// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
-/// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
-/// that we can check.
-fn check_is_likely_running_on_a_lambda(environment: &aws_types::os_shim_internal::Env) -> bool {
-    // LAMBDA_TASK_ROOT – The path to your Lambda function code.
-    environment.get("LAMBDA_TASK_ROOT").is_ok()
-}

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -57,10 +57,10 @@ impl FileKind {
 pub async fn load(proc_env: &os_shim_internal::Env, fs: &os_shim_internal::Fs) -> Source {
     let home = home_dir(proc_env, Os::real());
     let config = load_config_file(FileKind::Config, &home, fs, proc_env)
-        .instrument(tracing::info_span!("load_config_file"))
+        .instrument(tracing::debug_span!("load_config_file"))
         .await;
     let credentials = load_config_file(FileKind::Credentials, &home, fs, proc_env)
-        .instrument(tracing::info_span!("load_credentials_file"))
+        .instrument(tracing::debug_span!("load_credentials_file"))
         .await;
 
     Source {
@@ -105,7 +105,7 @@ async fn load_config_file(
         Err(e) => {
             match e.kind() {
                 ErrorKind::NotFound if path == kind.default_path() => {
-                    tracing::info!(path = %path, "config file not found")
+                    tracing::debug!(path = %path, "config file not found")
                 }
                 ErrorKind::NotFound if path != kind.default_path() => {
                     // in the case where the user overrode the path with an environment variable,
@@ -125,7 +125,7 @@ async fn load_config_file(
             Default::default()
         }
     };
-    tracing::info!(path = %path, size = ?data.len(), "config file loaded");
+    tracing::debug!(path = %path, size = ?data.len(), "config file loaded");
     File {
         // lossy is OK here, the name of this file is just for debugging purposes
         path: expanded.to_string_lossy().into(),

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -4,6 +4,7 @@
  */
 
 use crate::fs_util::{home_dir, Os};
+use crate::profile::check_is_likely_running_on_a_lambda;
 use aws_types::os_shim_internal;
 use std::borrow::Cow;
 use std::io::ErrorKind;
@@ -177,14 +178,6 @@ fn expand_home(
         // platform, so in that case, the separators should already be correct.
         _other => path.into(),
     }
-}
-
-/// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
-/// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
-/// that we can check.
-fn check_is_likely_running_on_a_lambda(environment: &os_shim_internal::Env) -> bool {
-    // LAMBDA_TASK_ROOT – The path to your Lambda function code.
-    environment.get("LAMBDA_TASK_ROOT").is_ok()
 }
 
 #[cfg(test)]

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -4,7 +4,6 @@
  */
 
 use crate::fs_util::{home_dir, Os};
-use crate::profile::check_is_likely_running_on_a_lambda;
 use aws_types::os_shim_internal;
 use std::borrow::Cow;
 use std::io::ErrorKind;
@@ -178,6 +177,14 @@ fn expand_home(
         // platform, so in that case, the separators should already be correct.
         _other => path.into(),
     }
+}
+
+/// Returns true or false based on whether or not this code is likely running inside an AWS Lambda.
+/// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
+/// that we can check.
+fn check_is_likely_running_on_a_lambda(environment: &aws_types::os_shim_internal::Env) -> bool {
+    // LAMBDA_TASK_ROOT – The path to your Lambda function code.
+    environment.get("LAMBDA_TASK_ROOT").is_ok()
 }
 
 #[cfg(test)]

--- a/aws/rust-runtime/aws-config/src/profile/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/retry_config.rs
@@ -107,11 +107,8 @@ impl ProfileFileRetryConfigProvider {
         let selected_profile = match profile.get_profile(selected_profile) {
             Some(profile) => profile,
             None => {
-                // Lambdas don't have home directories and emitting this warning is not helpful
-                // to users running the SDK from within a Lambda. This warning will be silenced
-                // if we determine that that is the case.
-                let is_likely_running_on_a_lambda = check_is_likely_running_on_a_lambda(self);
-                if !is_likely_running_on_a_lambda {
+                // Only warn if the user specified a profile name to use.
+                if self.profile_override.is_some() {
                     tracing::warn!("failed to get selected '{}' profile", selected_profile);
                 }
                 // return an empty builder

--- a/aws/rust-runtime/aws-config/src/profile/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/retry_config.rs
@@ -10,7 +10,6 @@ use std::str::FromStr;
 use aws_smithy_types::retry::{RetryConfigBuilder, RetryConfigErr, RetryMode};
 use aws_types::os_shim_internal::{Env, Fs};
 
-use crate::profile::check_is_likely_running_on_a_lambda;
 use crate::provider_config::ProviderConfig;
 
 /// Load retry configuration properties from a profile file

--- a/aws/rust-runtime/aws-config/src/profile/timeout_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/timeout_config.rs
@@ -5,7 +5,7 @@
 
 //! Load timeout configuration properties from an AWS profile
 
-use crate::profile::{check_is_likely_running_on_a_lambda, Profile};
+use crate::profile::Profile;
 use crate::provider_config::ProviderConfig;
 use aws_smithy_types::timeout::{parse_str_as_timeout, TimeoutConfig, TimeoutConfigError};
 use aws_types::os_shim_internal::{Env, Fs};
@@ -117,11 +117,8 @@ impl ProfileFileTimeoutConfigProvider {
         let selected_profile = match profile.get_profile(selected_profile) {
             Some(profile) => profile,
             None => {
-                // Lambdas don't have home directories and emitting this warning is not helpful
-                // to users running the SDK from within a Lambda. This warning will be silenced
-                // if we determine that that is the case.
-                let is_likely_running_on_a_lambda = check_is_likely_running_on_a_lambda(&self.env);
-                if !is_likely_running_on_a_lambda {
+                // Only warn if the user specified a profile name to use.
+                if self.profile_override.is_some() {
                     tracing::warn!(
                         "failed to get selected '{}' profile, skipping it",
                         selected_profile

--- a/aws/rust-runtime/aws-config/src/profile/timeout_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/timeout_config.rs
@@ -120,7 +120,7 @@ impl ProfileFileTimeoutConfigProvider {
                 // Lambdas don't have home directories and emitting this warning is not helpful
                 // to users running the SDK from within a Lambda. This warning will be silenced
                 // if we determine that that is the case.
-                let is_likely_running_on_a_lambda = check_is_likely_running_on_a_lambda(self.env);
+                let is_likely_running_on_a_lambda = check_is_likely_running_on_a_lambda(&self.env);
                 if !is_likely_running_on_a_lambda {
                     tracing::warn!(
                         "failed to get selected '{}' profile, skipping it",


### PR DESCRIPTION
## Motivation and Context

This silence some unnecessary warnings in a Lambda environment (ref: https://github.com/awslabs/aws-sdk-rust/issues/398).

## Description

* Silence warnings in `aws_config::profile::parser::timeout_config` and `aws_config::profile::parser::retry_config` when running in a Lambda function.
* Move `is_likely_running_on_a_lambda` function from `aws_config::profile::parser::source` to `aws_config::profile::parser`.

## Testing

I have a temporary issue setting the test environment, so I couldn't test this right now. See the error message below when running `./gradlew`:

```
A problem occurred configuring project ':buildSrc'.
> Could not resolve all artifacts for configuration ':buildSrc:classpath'.
   > Could not resolve org.gradle.kotlin:plugins:1.3.6.
     Required by:
         project :buildSrc > org.gradle.kotlin.kotlin-dsl:org.gradle.kotlin.kotlin-dsl.gradle.plugin:1.3.6
      > Could not resolve org.gradle.kotlin:plugins:1.3.6.
         > Could not get resource 'https://plugins.gradle.org/m2/org/gradle/kotlin/plugins/1.3.6/plugins-1.3.6.module'.
            > Could not GET 'https://jcenter.bintray.com/org/gradle/kotlin/plugins/1.3.6/plugins-1.3.6.module'. Received status code 502 from server: Bad Gatewa
```


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
