### PR TITLE
`aws-smithy-http-server`: remove S3-like URI pattern conflict avoidance test

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -362,14 +362,6 @@ mod tests {
                 ),
                 "B2",
             ),
-            (
-                RequestSpec::from_parts(Method::GET, Vec::new(), Vec::new()),
-                "ListBuckets",
-            ),
-            (
-                RequestSpec::from_parts(Method::GET, vec![PathSegment::Label], Vec::new()),
-                "ListObjects",
-            ),
         ];
 
         let mut router = Router::from_box_clone_service_iter(request_specs.into_iter().map(|(spec, svc_name)| {
@@ -384,8 +376,6 @@ mod tests {
             ("A2", Method::GET, "/a/foo/a"),
             ("B1", Method::GET, "/b/foo/bar/baz"),
             ("B2", Method::GET, "/b/foo?q=baz"),
-            ("ListBuckets", Method::GET, "/"),
-            ("ListObjects", Method::GET, "/bucket"),
         ];
         for (svc_name, method, uri) in &hits {
             let mut res = router.call(req(method, uri)).await.unwrap();


### PR DESCRIPTION
The previous commit introduced a failing test because CI doesn't have
Rust tests as a blocking step and auto-merge was enabled.

With the two operations:

1. `ListBuckets` with URI pattern `/`; and
2. `ListObjects` with URI pattern `/{bucket}`,

the test wants to route the request `/` to the first operation. However,
in #1029 we started allowing empty path segments. Since `ListBuckets`
has more weight than `ListObjects`, the request matches against it,
binding `""` to the `bucket` label.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
