### PR TITLE
Collect canary tasks so that they are run in parallel

### DIFF
--- a/tools/ci-cdk/canary-lambda/src/main.rs
+++ b/tools/ci-cdk/canary-lambda/src/main.rs
@@ -104,7 +104,8 @@ async fn lambda_main(clients: canary::Clients) -> Result<Value, Error> {
     let canaries = get_canaries_to_run(clients, env);
     let join_handles = canaries
         .into_iter()
-        .map(|(name, future)| (name, tokio::spawn(future)));
+        .map(|(name, future)| (name, tokio::spawn(future)))
+        .collect::<Vec<_>>();
 
     // Wait for and aggregate results
     let mut failures = BTreeMap::new();


### PR DESCRIPTION
The canary tasks were running sequentially because the iterator wasn't being collected. As we get more tasks, running them in parallel should keep the canary run time sufficiently fast.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
