### PR TITLE
Make psuedo jobs fail if dependency jobs failed in CI

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -71,6 +71,8 @@ jobs:
           run: cargo +nightly udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/
+        - name: Failure test
+          run: exit 1
     env:
       # Disable incremental compilation to reduce disk space use
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -71,8 +71,6 @@ jobs:
           run: cargo +nightly udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/
-        - name: Failure test
-          run: exit 1
     env:
       # Disable incremental compilation to reduce disk space use
       CARGO_INCREMENTAL: 0

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -126,11 +126,15 @@ jobs:
   # the myriad of test matrix combinations into GitHub's protected branch rules
   require-smoke-tests:
     needs: smoke-test
+    # Run this job even if its dependency jobs fail
+    if: always()
     runs-on: ubuntu-latest
     name: Smoke Test Matrix Success
     steps:
-    - name: Run
-      run: echo "We should only get this far if the smoke-test matrix succeeded."
+    - name: Verify jobs succeeded
+      uses: re-actors/alls-green@3a2de129f0713010a71314c74e33c0e3ef90e696
+      with:
+        jobs: ${{ toJSON(needs) }}
 
   standalone-integration-tests-check:
     name: Standalone Integration Tests - cargo check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,11 +130,15 @@ jobs:
   # the myriad of test matrix combinations into GitHub's protected branch rules
   require-rust-tests:
     needs: rust-tests
+    # Run this job even if its dependency jobs fail
+    if: always()
     runs-on: ubuntu-latest
     name: Rust Tests Matrix Success
     steps:
-    - name: Run
-      run: echo "We should only get this far if the rust-tests matrix succeeded."
+    - name: Verify jobs succeeded
+      uses: re-actors/alls-green@3a2de129f0713010a71314c74e33c0e3ef90e696
+      with:
+        jobs: ${{ toJSON(needs) }}
 
   runtime-bundle:
     name: Produce smithy-rs runtime bundle


### PR DESCRIPTION
## Motivation and Context
The psuedo jobs are getting skipped when the jobs they depend on fail, and that's allowing merge with failing tests. This makes the psuedo jobs always run and check the status of the jobs they depend on.

## Testing
Testing as part of this PR by intentionally breaking one of the jobs the psuedo jobs depend on. Will revert this test break once it's verified.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
