### PR TITLE
Fix the canary Lambda build and add it to CI

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -71,6 +71,8 @@ jobs:
           run: cargo +nightly udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/
+        - name: Canary check
+          run: ../tools/ci-cdk/canary-lambda/ci-check.sh
     env:
       # Disable incremental compilation to reduce disk space use
       CARGO_INCREMENTAL: 0

--- a/tools/ci-cdk/canary-lambda/ci-check.sh
+++ b/tools/ci-cdk/canary-lambda/ci-check.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0.
+#
+# Run by CI to check the canary-lambda
+set -e
+cd "$(dirname $0)"
+
+SDK_PATH="$(git rev-parse --show-toplevel)"/aws/sdk/build/aws-sdk/sdk
+if [[ "${GITHUB_ACTIONS}" == "true" ]]; then
+   SDK_PATH="$(git rev-parse --show-toplevel)"/aws-sdk/sdk
+fi
+
+./write-cargo-toml.py --path "${SDK_PATH}"
+cargo check
+cargo clippy

--- a/tools/ci-cdk/canary-lambda/src/main.rs
+++ b/tools/ci-cdk/canary-lambda/src/main.rs
@@ -126,7 +126,7 @@ async fn lambda_main(clients: canary::Clients) -> Result<Value, Error> {
 
 async fn canary_result(handle: JoinHandle<anyhow::Result<()>>) -> Result<(), String> {
     match timeout(Duration::from_secs(20), handle).await {
-        Err(_timeout) => Err(format!("canary timed out")),
+        Err(_timeout) => Err("canary timed out".into()),
         Ok(Ok(result)) => match result {
             Ok(_) => Ok(()),
             Err(err) => Err(format!("{:?}", err)),

--- a/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
@@ -6,11 +6,10 @@
 use crate::canary::Clients;
 
 use crate::mk_canary;
-use anyhow::{bail, Context};
+use anyhow::bail;
 
 use aws_sdk_ec2 as ec2;
 use aws_sdk_ec2::model::InstanceType;
-use std::env;
 
 use crate::CanaryEnv;
 use tokio_stream::StreamExt;

--- a/tools/ci-cdk/canary-lambda/write-cargo-toml.py
+++ b/tools/ci-cdk/canary-lambda/write-cargo-toml.py
@@ -68,13 +68,22 @@ def main():
         print(f'default = [{enabled}]', file=file)
 
 def enabled_versions(sdk_version):
-    return [f'"v{version}"' for version in notable_versions if version.split('.') <= sdk_version.split('.')]
+    if sdk_version is None:
+        return [f'"v{version}"' for version in notable_versions]
+    else:
+        return [f'"v{version}"' for version in notable_versions if version.split('.') <= sdk_version.split('.')]
 
 def format_dependency(crate, path, version):
     if path is None:
         return f'{crate} = "{version}"'
     else:
-        return f'{crate} = {{ path = "{path}/{crate}", version = "{version}" }}'
+        crate_path = crate
+        if crate_path.startswith("aws-sdk-"):
+            crate_path = crate_path[(len("aws-sdk-")):]
+        if version is None:
+            return f'{crate} = {{ path = "{path}/{crate_path}" }}'
+        else:
+            return f'{crate} = {{ path = "{path}/{crate_path}", version = "{version}" }}'
 
 
 class Args:
@@ -83,11 +92,14 @@ class Args:
         parser.add_argument("--path", dest="path", type=str,
                             help="Path to the generated AWS Rust SDK")
         parser.add_argument("--sdk-version", dest="sdk_version",
-                            type=str, help="AWS Rust SDK version", required=True)
+                            type=str, help="AWS Rust SDK version")
 
         args = parser.parse_args()
         self.path = args.path
         self.sdk_version = args.sdk_version
+        if self.path == None and self.sdk_version == None:
+            print("Either of path or sdk-version are required")
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The canary is failing at build time in `aws-sdk-rust/next` due to some missing imports: https://github.com/awslabs/aws-sdk-rust/runs/4822595979?check_suite_focus=true

This PR fixes those failures, and also adds the canary to smithy-rs CI so that we detect these problems sooner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
