### PR TITLE
Fix paginator bug where `None` was returned immediately

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -52,3 +52,15 @@ message = "Silence profile credential warnings in Lambda environment"
 references = ["smithy-rs#1065", "aws-sdk-rust#398"]
 meta = { "breaking" = false, "tada" = true, "bug" = true }
 author = "nmoutschen"
+
+[[aws-sdk-rust]]
+message = "Fixed paginator bug impacting EC2 describe VPCs (and others)"
+references = ["aws-sdk-rust#405", "smithy-rs#1083"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"
+
+[[smithy-rs]]
+message = "Fixed paginator bug impacting EC2 describe VPCs (and others)"
+references = ["aws-sdk-rust#405", "smithy-rs#1083"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"

--- a/aws/sdk/integration-tests/ec2/tests/paginators.rs
+++ b/aws/sdk/integration-tests/ec2/tests/paginators.rs
@@ -50,3 +50,39 @@ async fn paginators_handle_empty_tokens() {
     assert_eq!(first_item, None);
     conn.assert_requests_match(&[]);
 }
+
+/// See https://github.com/awslabs/aws-sdk-rust/issues/405
+///
+/// EC2 can also reply with the token truly unset which will be interpreted as `None`
+#[tokio::test]
+async fn paginators_handle_unset_tokens() {
+    let request= "Action=DescribeSpotPriceHistory&Version=2016-11-15&AvailabilityZone=eu-north-1a&InstanceType.1=g5.48xlarge&ProductDescription.1=Linux%2FUNIX";
+    let response = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <DescribeSpotPriceHistoryResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
+            <requestId>edf3e86c-4baf-47c1-9228-9a5ea09542e8</requestId>
+            <spotPriceHistorySet/>
+        </DescribeSpotPriceHistoryResponse>"#;
+    let conn = TestConnection::<&str>::new(vec![(
+        http::Request::builder()
+            .uri("https://ec2.us-east-1.amazonaws.com/")
+            .body(request.into())
+            .unwrap(),
+        http::Response::builder()
+            .status(200)
+            .body(response)
+            .unwrap(),
+    )]);
+    let client = Client::from_conf_conn(stub_config(), conn.clone());
+    let instance_type = InstanceType::from("g5.48xlarge");
+    let mut paginator = client
+        .describe_spot_price_history()
+        .instance_types(instance_type)
+        .product_descriptions("Linux/UNIX")
+        .availability_zone("eu-north-1a")
+        .into_paginator()
+        .items()
+        .send();
+    let first_item = paginator.try_next().await.expect("success");
+    assert_eq!(first_item, None);
+    conn.assert_requests_match(&[]);
+}

--- a/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
@@ -40,7 +40,10 @@ pub async fn paginator_canary(client: ec2::Client, page_size: usize) -> anyhow::
         num_pages += 1;
     }
     if dbg!(num_pages) < 2 {
-        bail!("expected 3+ pages containing ~60 results but got {} pages", num_pages)
+        bail!(
+            "expected 3+ pages containing ~60 results but got {} pages",
+            num_pages
+        )
     }
 
     // https://github.com/awslabs/aws-sdk-rust/issues/405

--- a/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
@@ -43,6 +43,15 @@ pub async fn paginator_canary(client: ec2::Client, page_size: usize) -> anyhow::
         bail!("should be ~60 of pages of results")
     }
 
+    // https://github.com/awslabs/aws-sdk-rust/issues/405
+    let _ = client
+        .describe_vpcs()
+        .into_paginator()
+        .items()
+        .send()
+        .collect::<Result<Vec<_>, _>>()
+        .await?;
+
     Ok(())
 }
 
@@ -54,6 +63,6 @@ mod test {
     async fn test_paginator() {
         let conf = aws_config::load_from_env().await;
         let client = aws_sdk_ec2::Client::new(&conf);
-        paginator_canary(client).await.unwrap()
+        paginator_canary(client, 20).await.unwrap()
     }
 }

--- a/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/paginator_canary.rs
@@ -40,7 +40,7 @@ pub async fn paginator_canary(client: ec2::Client, page_size: usize) -> anyhow::
         num_pages += 1;
     }
     if dbg!(num_pages) < 2 {
-        bail!("should be ~60 of pages of results")
+        bail!("expected 3+ pages containing ~60 results but got {} pages", num_pages)
     }
 
     // https://github.com/awslabs/aws-sdk-rust/issues/405


### PR DESCRIPTION


## Motivation and Context
- https://github.com/awslabs/aws-sdk-rust/issues/405

## Description
The escape hatch added by aws-sdk-rust#391 did not properly handle the case where the first response was `None` and _not_ the empty string. This diff:
- Checks for emptiness for both maps and strings
- Fixes the check so that an initial `None` input does not cause an incorrect paginator error

## Testing
- [x] added to canary
- [x] added mocked-traffic IT
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
