### PR TITLE
Add SSO to the list of circular dep supressions

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Fix dev-dependency cycle between aws-sdk-sso and aws-config"
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+references = ["smithy-rs#1088"]
+author = "rcoh"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -14,5 +14,5 @@
 [[aws-sdk-rust]]
 message = "Fix dev-dependency cycle between aws-sdk-sso and aws-config"
 meta = { "breaking" = false, "tada" = false, "bug" = true }
-references = ["smithy-rs#1088"]
+references = ["smithy-rs#1089"]
 author = "rcoh"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -172,7 +172,7 @@ private class AwsFluentClientDocs(codegenContext: CodegenContext) : FluentClient
     // Usage docs on STS must be suppressed—aws-config cannot be added as a dev-dependency because it would create
     // a circular dependency
     private fun suppressUsageDocs(): Boolean =
-        serviceShape.id == ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615")
+        setOf(ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"), ShapeId.from("com.amazonaws.sso#SWBPortalService")).contains(serviceShape.id)
 
     override fun section(section: FluentClientSection): Writable {
         return when (section) {

--- a/tools/publisher/src/sort.rs
+++ b/tools/publisher/src/sort.rs
@@ -59,6 +59,7 @@ fn dependency_order_visit(
         return Ok(());
     }
     if stack.contains(package_handle) {
+        tracing::error!(stack = ?stack, handle = ?package_handle, "dependency cycle!");
         return Err(Error::DependencyCycle);
     }
     stack.insert(package_handle.clone());


### PR DESCRIPTION
## Motivation and Context
fix dependency cycle

## Description
When SSO was added we failed to suppress if from the list of services that got docs that autolinked back to aws-config

## Testing
- [ ] review generated code diff
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
