### PR TITLE
Fix canary target path

### DIFF
--- a/tools/ci-cdk/canary-lambda/build-bundle.sh
+++ b/tools/ci-cdk/canary-lambda/build-bundle.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0.
 #
 
-set -e
+set -ex
 
 if [[ $# -ne 1 ]]; then
     echo "Usage: $0 <sdk version>"
@@ -16,7 +16,7 @@ cd `dirname $0`
 ./write-cargo-toml.py --sdk-version ${SDK_VERSION}
 cargo build --release --target=x86_64-unknown-linux-musl
 
-TARGET_PATH="$(git rev-parse --show-toplevel)/target/x86_64-unknown-linux-musl/release"
+TARGET_PATH="$(git rev-parse --show-toplevel)/tools/target/x86_64-unknown-linux-musl/release"
 pushd "${TARGET_PATH}" &>/dev/null
 
 BIN_NAME="bootstrap"


### PR DESCRIPTION
## Motivation and Context
Moving the tool target directory in #1069 broke the `build-bundle.sh` script for the canary.

## Testing
Ran the script locally with the corrected path and verified its exit status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
