### PR TITLE
Fix #1011 - Server allows empty query

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -73,13 +73,6 @@ define_rejection! {
 
 define_rejection! {
     #[status = BAD_REQUEST]
-    #[body = "Expected query string in URI but none found"]
-    /// Rejection type used if the URI has no query string and we need to deserialize data from it.
-    pub struct MissingQueryString;
-}
-
-define_rejection! {
-    #[status = BAD_REQUEST]
     #[body = "Failed to parse request MIME type"]
     /// Rejection type used if the MIME type parsing failed.
     pub struct MimeParsingFailed;
@@ -140,7 +133,6 @@ composite_rejection! {
         BodyAlreadyExtracted,
         HeadersAlreadyExtracted,
         ExtensionsAlreadyExtracted,
-        MissingQueryString,
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
- Fix #1011 

## Description
- Avoid failing server requests on empty query.
- Temporary fix as described in https://github.com/awslabs/smithy-rs/issues/1011#issuecomment-1017394740

## Testing

## Checklist

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
