### PR TITLE
Server XML response use correct members and return null if nothing to serialize

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -451,12 +451,12 @@ private class ServerHttpProtocolImplGenerator(
         bindings: List<HttpBindingDescriptor>,
     ) {
         val structuredDataSerializer = protocol.structuredDataSerializer(operationShape)
-        structuredDataSerializer.serverOutputSerializer(operationShape).also { serializer ->
+        structuredDataSerializer.serverOutputSerializer(operationShape)?.let { serializer ->
             rust(
                 "let payload = #T(output)?;",
                 serializer
             )
-        }
+        } ?: rust("""let payload = "";""")
         // avoid non-usage warnings for response
         Attribute.AllowUnusedMut.render(this)
         rustTemplate("let mut response = #{http}::Response::builder();", *codegenScope)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlNameIndex.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/XmlNameIndex.kt
@@ -63,5 +63,6 @@ data class XmlMemberIndex(val dataMembers: List<MemberShape>, val attributeMembe
         }
     }
 
-    fun isNotEmpty() = dataMembers.isNotEmpty() || attributeMembers.isNotEmpty()
+    fun isEmpty() = dataMembers.isEmpty() && attributeMembers.isEmpty()
+    fun isNotEmpty() = !isEmpty()
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/AwsQuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/AwsQuerySerializerGenerator.kt
@@ -22,7 +22,7 @@ class AwsQuerySerializerGenerator(codegenContext: CodegenContext) : QuerySeriali
 
     override fun MemberShape.isFlattened(): Boolean = getTrait<XmlFlattenedTrait>() != null
 
-    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
+    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType? {
         TODO("Not yet implemented")
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/Ec2QuerySerializerGenerator.kt
@@ -25,7 +25,7 @@ class Ec2QuerySerializerGenerator(codegenContext: CodegenContext) : QuerySeriali
 
     override fun MemberShape.isFlattened(): Boolean = true
 
-    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
+    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType? {
         TODO("Not yet implemented")
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -242,7 +242,7 @@ class JsonSerializerGenerator(
         }
     }
 
-    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType {
+    override fun serverOutputSerializer(operationShape: OperationShape): RuntimeType? {
         val outputShape = operationShape.outputShape(model)
         val includedMembers = httpBindingResolver.responseMembers(operationShape, HttpLocation.DOCUMENT)
         val fnName = symbolProvider.serializeFunctionName(outputShape)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/StructuredDataSerializerGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/serialize/StructuredDataSerializerGenerator.kt
@@ -55,7 +55,7 @@ interface StructuredDataSerializerGenerator {
      * }
      * ```
      */
-    fun serverOutputSerializer(operationShape: OperationShape): RuntimeType
+    fun serverOutputSerializer(operationShape: OperationShape): RuntimeType?
 
     /**
      * Generate a serializer for a server operation error structure


### PR DESCRIPTION
## Motivation and Context
- Fix #1101

## Description
- fix to use response members for server output
- return null if no members

## Testing
- Tested with S3 API server codegen.

## Checklist

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
