### PR TITLE
Sync script needs gradle clean

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "_Internal:_ Update sync script to run gradle clean. This fixes an issue where codegen was not triggered when only properties changed."
+author = "rcoh"
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+references = ["smithy-rs#1100"]

--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -228,6 +228,7 @@ fn build_sdk(smithy_rs_path: &Path) -> Result<PathBuf> {
 
     // The output of running these commands isn't logged anywhere unless they fail
     let _ = run(&["rm", "-rf", "aws/sdk/build"], smithy_rs_path).context(here!())?;
+    let _ = run(&[gradlew, ":aws:sdk:clean"], smithy_rs_path).context(here!())?;
     let _ = run(
         &[gradlew, "-Paws.fullsdk=true", ":aws:sdk:assemble"],
         smithy_rs_path,


### PR DESCRIPTION
## Testing
- [x] reproduced the bug and tested locally

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
