### PR TITLE
`aws-smithy-http-server`: upgrade to `tower-http` 0.2.1

### DIFF
--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -35,7 +35,7 @@ serde_urlencoded = "0.7"
 thiserror = "1"
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4.11", features = ["util", "make"], default-features = false }
-tower-http = { version = "0.1", features = ["add-extension", "map-response-body"] }
+tower-http = { version = "0.2.1", features = ["add-extension", "map-response-body"] }
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
`tower-http` versions 0.1.0 to 0.2.0 have been yanked, see
https://github.com/rustsec/advisory-db/pull/1159.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
