### PR TITLE
Rebase `next` off `main` before syncing

### DIFF
--- a/tools/smithy-rs-sync/src/fs.rs
+++ b/tools/smithy-rs-sync/src/fs.rs
@@ -218,7 +218,7 @@ mod tests {
         let dir = TempDir::new("smithy-rs-sync_test-fs").unwrap();
         let file_path = dir.path().join(HANDWRITTEN_DOTFILE);
         // two newlines to test
-        let mut handwritten_files = handwritten_files.join("\n\n");
+        let handwritten_files = handwritten_files.join("\n\n");
         std::fs::write(file_path, handwritten_files).expect("failed to write");
         dir
     }

--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -163,7 +163,7 @@ fn sync_aws_sdk_with_smithy_rs(
 }
 
 fn resolve_git_repo(repo: &str, path: &Path) -> Result<PathBuf> {
-    // In case these are relative paths, canonicalize them into absolute paths
+    // In case this is a relative path, canonicalize it into an absolute path
     let full_path = path.canonicalize().context(here!())?;
     eprintln!("{} path:\t{:?}", repo, path);
     if !is_a_git_repository(path) {


### PR DESCRIPTION
## Motivation and Context
This is intended to address the sync issues between `next`/`main` in https://github.com/awslabs/smithy-rs/issues/1102. I think this approach should have the desired end result without the complexity of detecting/running at the end of a release.

## Description

Basically, every time the sync workflow runs, the sync tool will rebase `next` on top of `main` before doing anything else. Below, I attempt to think of scenarios we could run into and explain why they work with this approach.

### Scenario 1: `next` was recently merged into `main` for a release, and the sync tool runs

In this scenario, the `next` branch was rebase-merged into `main` via GitHub PR. When the sync tool runs, `main` and `next` will have the same effective commits, but potentially with different commit hashes since `main` will have rebased commits.

When the sync tool rebases in this scenario, git is able to determine the commits are the same despite their different hashes and make `next` match `main` (verified locally).

### Scenario 2: `main` has a commit that updates a handwritten file that doesn't conflict with `next`, and the sync tool runs

The `next` branch will acquire the commit from `main` underneath the rest of its synced, unreleased, changes.

### Scenario 3: `main` has a commit that modifies a file, and `next` has another commit that modifies that same file differently since the last release.

The sync tool will run in this case, but immediately fail because of the conflict. A developer will need to manually fix the `next` branch. This should be rare since generated files should not be modified directly in `main`. It could happen if, for example, a GitHub workflow was modified both in `main` and `next`.

### How is this different from the rebase-merge that broke during the last release?

This is keeping the `next` branch up-to-date with `main` such that its changes can always be fast-forward merged into `main`, or if they can't, the sync job will fail until that is rectified. In the last release, the `next` branch was allowed to drift away from `main` since its commits were rebase-merged into `main`, but never synced back into `next` after that rebase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
