### PR TITLE
Specify origin in rebase operation in the sync tool

### DIFF
--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -184,7 +184,7 @@ fn resolve_git_repo(repo: &str, path: &Path) -> Result<PathBuf> {
 /// before syncing a commit into the target branch.
 fn rebase_on_main(aws_sdk_path: &Path, branch: &str) -> Result<()> {
     let _ = run(&["git", "fetch", "origin", "main"], aws_sdk_path).context(here!())?;
-    if let Err(err) = run(&["git", "rebase", "main"], aws_sdk_path) {
+    if let Err(err) = run(&["git", "rebase", "origin/main"], aws_sdk_path) {
         bail!(
             "Failed to rebase `{0}` on top of `main`. This means there are conflicts \
             between `{0}` and `main` that need to be manually resolved. This should only \


### PR DESCRIPTION
## Motivation and Context
The sync tool failed with ` fatal: invalid upstream 'main'`. This change specifies that it should rebase on `origin/main` in attempt to fix that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
