### PR TITLE
Include examples in SDK auto-sync

### DIFF
--- a/tools/smithy-rs-sync/src/fs.rs
+++ b/tools/smithy-rs-sync/src/fs.rs
@@ -66,6 +66,18 @@ pub fn find_handwritten_files_and_folders(
     Ok(files)
 }
 
+/// Similar to [`std::fs::remove_dir_all`] except that it doesn't error out if
+/// the directory to be removed doesn't exist.
+pub fn remove_dir_all_idempotent(path: impl AsRef<Path>) -> anyhow::Result<()> {
+    match std::fs::remove_dir_all(path.as_ref()) {
+        Ok(_) => Ok(()),
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => Ok(()),
+            _ => Err(err).context(here!()),
+        },
+    }
+}
+
 /// A struct with methods that help when checking to see if a file is handwritten or
 /// automatically generated.
 ///

--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -269,15 +269,16 @@ fn setup_examples(sdk_examples_path: &Path, smithy_rs_path: &Path) -> Result<()>
     let from = from.as_os_str().to_string_lossy();
 
     eprintln!("\tcleaning examples...");
-    let _ = run(&["rm", "-rf", "aws/sdk/examples"], smithy_rs_path).context(here!())?;
+    fs::remove_dir_all_idempotent(smithy_rs_path.join("aws/sdk/examples")).context(here!())?;
 
     eprintln!(
         "\tcopying examples from '{}' to 'smithy-rs/aws/sdk/examples'...",
         from
     );
     let _ = run(&["cp", "-r", &from, "aws/sdk/examples"], smithy_rs_path).context(here!())?;
-    let _ = run(&["rm", "-rf", "aws/sdk/examples/.cargo"], smithy_rs_path).context(here!())?;
-    let _ = run(&["rm", "aws/sdk/examples/Cargo.toml"], smithy_rs_path).context(here!())?;
+    fs::remove_dir_all_idempotent(smithy_rs_path.join("aws/sdk/examples/.cargo"))
+        .context(here!())?;
+    std::fs::remove_file(smithy_rs_path.join("aws/sdk/examples/Cargo.toml")).context(here!())?;
     Ok(())
 }
 
@@ -294,7 +295,7 @@ fn build_sdk(sdk_examples_path: &Path, smithy_rs_path: &Path) -> Result<PathBuf>
         .expect("for our use case, this will always be UTF-8");
 
     // The output of running these commands isn't logged anywhere unless they fail
-    let _ = run(&["rm", "-rf", "aws/sdk/build"], smithy_rs_path).context(here!())?;
+    fs::remove_dir_all_idempotent(smithy_rs_path.join("aws/sdk/build")).context(here!())?;
     let _ = run(&[gradlew, ":aws:sdk:clean"], smithy_rs_path).context(here!())?;
     let _ = run(
         &[gradlew, "-Paws.fullsdk=true", ":aws:sdk:assemble"],


### PR DESCRIPTION
## Motivation and Context
The sync tool needs to include examples during SDK generation for them to end up in `aws-sdk-rust`.

## Testing
Tested the sync tool locally and verified examples ended up in the right place and successfully compiled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
