### PR TITLE
Remove unneeded doc parser

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,8 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+[[smithy-rs]]
+message = "Refactor `Document` shape parser generation"
+references = ["smithy-rs#1123"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/http/ServerRequestBindingGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/http/ServerRequestBindingGenerator.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy.generators.http
 
-
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
@@ -29,14 +28,12 @@ class ServerRequestBindingGenerator(
         operationShape: OperationShape,
         binding: HttpBindingDescriptor,
         errorT: RuntimeType,
-        structuredHandler: RustWriter.(String) -> Unit,
-        docHandler: RustWriter.(String) -> Unit
+        structuredHandler: RustWriter.(String) -> Unit
     ): RuntimeType = httpBindingGenerator.generateDeserializePayloadFn(
         operationShape,
         binding,
         errorT,
         structuredHandler,
-        docHandler,
         HttpMessageType.REQUEST
     )
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpProtocolGenerator.kt
@@ -561,12 +561,6 @@ private class ServerHttpProtocolImplGenerator(
         return when (binding.location) {
             HttpLocation.HEADER -> writable { serverRenderHeaderParser(this, binding, operationShape) }
             HttpLocation.PAYLOAD -> {
-                val docShapeHandler: RustWriter.(String) -> Unit = { body ->
-                    rust(
-                        "#T($body)",
-                        structuredDataParser.documentParser(operationShape),
-                    )
-                }
                 val structureShapeHandler: RustWriter.(String) -> Unit = { body ->
                     rust("#T($body)", structuredDataParser.payloadParser(binding.member))
                 }
@@ -574,7 +568,6 @@ private class ServerHttpProtocolImplGenerator(
                     operationShape,
                     binding,
                     errorSymbol,
-                    docHandler = docShapeHandler,
                     structuredHandler = structureShapeHandler
                 )
                 return if (binding.member.isStreaming(model)) {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
@@ -160,10 +160,8 @@ class HttpBindingGenerator(
         operationShape: OperationShape,
         binding: HttpBindingDescriptor,
         errorT: RuntimeType,
-        // Deserialize a single structure or union member marked as a payload
-        structuredHandler: RustWriter.(String) -> Unit,
-        // Deserialize a document type marked as a payload
-        docHandler: RustWriter.(String) -> Unit,
+        // Deserialize a single structure, union or document member marked as a payload
+        payloadParser: RustWriter.(String) -> Unit,
         httpMessageType: HttpMessageType = HttpMessageType.RESPONSE
     ): RuntimeType {
         check(binding.location == HttpBinding.Location.PAYLOAD)
@@ -190,8 +188,7 @@ class HttpBindingGenerator(
                     deserializePayloadBody(
                         binding,
                         errorT,
-                        structuredHandler = structuredHandler,
-                        docShapeHandler = docHandler,
+                        structuredHandler = payloadParser,
                         httpMessageType
                     )
                 }
@@ -239,7 +236,6 @@ class HttpBindingGenerator(
         binding: HttpBindingDescriptor,
         errorSymbol: RuntimeType,
         structuredHandler: RustWriter.(String) -> Unit,
-        docShapeHandler: RustWriter.(String) -> Unit,
         httpMessageType: HttpMessageType = HttpMessageType.RESPONSE
     ) {
         val member = binding.member
@@ -248,7 +244,7 @@ class HttpBindingGenerator(
         // of an empty instance of the response type.
         withBlock("(!body.is_empty()).then(||{", "}).transpose()") {
             when (targetShape) {
-                is StructureShape, is UnionShape -> this.structuredHandler("body")
+                is StructureShape, is UnionShape, is DocumentShape -> this.structuredHandler("body")
                 is StringShape -> {
                     when (httpMessageType) {
                         HttpMessageType.RESPONSE -> {
@@ -274,7 +270,6 @@ class HttpBindingGenerator(
                     "Ok(#T::new(body))",
                     RuntimeType.Blob(runtimeConfig)
                 )
-                is DocumentShape -> this.docShapeHandler("body")
                 // `httpPayload` can be applied to set/map/list shapes.
                 // However, none of the AWS protocols support it.
                 // Smithy CLI will refuse to build the model if you apply the trait to these shapes, so this branch

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/ResponseBindingGenerator.kt
@@ -29,13 +29,11 @@ class ResponseBindingGenerator(
         operationShape: OperationShape,
         binding: HttpBindingDescriptor,
         errorT: RuntimeType,
-        structuredHandler: RustWriter.(String) -> Unit,
-        docHandler: RustWriter.(String) -> Unit
+        payloadParser: RustWriter.(String) -> Unit
     ): RuntimeType = httpBindingGenerator.generateDeserializePayloadFn(
         operationShape,
         binding,
         errorT,
-        structuredHandler,
-        docHandler
+        payloadParser
     )
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -361,22 +361,14 @@ class HttpBoundProtocolTraitImplGenerator(
                 null
             }
             HttpLocation.PAYLOAD -> {
-                val docShapeHandler: RustWriter.(String) -> Unit = { body ->
-                    rust(
-                        "#T($body).map_err(#T::unhandled)",
-                        structuredDataParser.documentParser(operationShape),
-                        errorSymbol
-                    )
-                }
-                val structureShapeHandler: RustWriter.(String) -> Unit = { body ->
+                val payloadParser: RustWriter.(String) -> Unit = { body ->
                     rust("#T($body).map_err(#T::unhandled)", structuredDataParser.payloadParser(member), errorSymbol)
                 }
                 val deserializer = httpBindingGenerator.generateDeserializePayloadFn(
                     operationShape,
                     binding,
                     errorSymbol,
-                    docHandler = docShapeHandler,
-                    structuredHandler = structureShapeHandler
+                    payloadParser = payloadParser
                 )
                 return if (binding.member.isStreaming(model)) {
                     writable { rust("Some(#T(response.body_mut())?)", deserializer) }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamer.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/InlineFunctionNamer.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.smithy.protocols
 
+import software.amazon.smithy.model.shapes.DocumentShape
 import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
@@ -66,6 +67,7 @@ private fun RustSymbolProvider.shapeFunctionName(prefix: String, shape: Shape): 
         is SetShape -> "set_${shape.id.toRustIdentifier()}"
         is StructureShape -> "structure_$symbolNameSnakeCase"
         is UnionShape -> "union_$symbolNameSnakeCase"
+        is DocumentShape -> "document"
         else -> PANIC("SerializerFunctionNamer.name: $shape")
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -126,9 +126,15 @@ class JsonParserGenerator(
                 *codegenScope,
                 "Shape" to symbolProvider.toSymbol(shape)
             ) {
+                val input = if (shape is DocumentShape) {
+                    "input"
+                } else {
+                    "#{or_empty}(input)"
+                }
+
                 rustTemplate(
                     """
-                    let mut tokens_owned = #{json_token_iter}(#{or_empty}(input)).peekable();
+                    let mut tokens_owned = #{json_token_iter}($input).peekable();
                     let tokens = &mut tokens_owned;
                     """,
                     *codegenScope
@@ -363,8 +369,9 @@ class JsonParserGenerator(
                     withBlock("Ok(Some(builder.build()", "))") {
                         if (StructureGenerator.fallibleBuilder(shape, symbolProvider)) {
                             rustTemplate(
-                                ".map_err(|err| #{Error}::new(#{ErrorReason}::Custom(" +
-                                    "format!(\"{}\", err).into()), None))?",
+                                """.map_err(|err| #{Error}::new(
+                                #{ErrorReason}::Custom(format!({}, err).into()), None)
+                                )?""",
                                 *codegenScope
                             )
                         }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/StructuredDataParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/StructuredDataParserGenerator.kt
@@ -48,15 +48,6 @@ interface StructuredDataParserGenerator {
     fun errorParser(errorShape: StructureShape): RuntimeType?
 
     /**
-     * ```rust
-     * fn parse_document(inp: &[u8]) -> Result<Document, Error> {
-     *   ...
-     * }
-     * ```
-     */
-    fun documentParser(operationShape: OperationShape): RuntimeType
-
-    /**
      * Generate a parser for a server operation input structure
      * ```rust
      * fn deser_operation_crate_operation_my_operation_input(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -241,10 +241,6 @@ class XmlBindingTraitParserGenerator(
         }
     }
 
-    override fun documentParser(operationShape: OperationShape): RuntimeType {
-        PANIC("Document shapes are not supported by rest XML")
-    }
-
     override fun serverInputParser(operationShape: OperationShape): RuntimeType? {
         val inputShape = operationShape.inputShape(model)
         val fnName = symbolProvider.deserializeFunctionName(operationShape)

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -120,7 +120,6 @@ class JsonParserGeneratorTest {
             ::restJsonFieldName
         )
         val operationGenerator = parserGenerator.operationParser(model.lookup("test#Op"))
-        val documentGenerator = parserGenerator.documentParser(model.lookup("test#Op"))
         val payloadGenerator = parserGenerator.payloadParser(model.lookup("test#OpOutput\$top"))
         val errorParser = parserGenerator.errorParser(model.lookup("test#Error"))
 
@@ -132,7 +131,6 @@ class JsonParserGeneratorTest {
                 use model::Choice;
 
                 // Generate the document serializer even though it's not tested directly
-                // ${writer.format(documentGenerator)}
                 // ${writer.format(payloadGenerator)}
 
                 let json = br#"


### PR DESCRIPTION
## Motivation and Context
@aajtodd thoughtfully pointed out that our separate documentParser is actually totally unnecessary (this is handled correctly by payload parser already!)


## Description
- remove documentParser
- rename some fields to clarify
- remove old asserts
## Testing
- [x] IT / UT
- [x] review generated code diff 
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
