### PR TITLE
Auto-update design docs in GitHub pages

### DIFF
--- a/.github/workflows/github-pages.yaml
+++ b/.github/workflows/github-pages.yaml
@@ -1,0 +1,36 @@
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+    - design/**
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - uses: actions-rs/toolchain@v1
+    - name: Generate docs
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config --local user.name "AWS SDK Rust Bot"
+        git config --local user.email "aws-sdk-rust-primary@amazon.com"
+        git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}
+        git fetch origin github-pages
+
+        pushd design &>/dev/null
+        cargo install mdbook
+        mdbook build --dest-dir ../../output
+        popd &>/dev/null
+
+        git checkout origin/github-pages
+        rm -rf design
+        mv ../output design
+        git add design
+        git commit -m "Update design docs"
+        git push origin github-pages

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Smithy Rust ![status](https://github.com/awslabs/smithy-rs/workflows/CI/badge.svg)
-Smithy code generators for Rust
+Smithy Rust ![status](https://github.com/awslabs/smithy-rs/workflows/CI/badge.svg)
+==================================================================================
 
-The nightly SDK build can be found under `Actions -> CI (take latest run) -> Artifacts`
+Smithy code generators for Rust that generate clients, servers, and the entire AWS SDK.
+The latest unreleased SDK build can be found in [aws-sdk-rust/next](https://github.com/awslabs/aws-sdk-rust/tree/next).
 
-[Design documentation (WIP)](https://awslabs.github.io/smithy-rs/)
+[Design documentation](https://awslabs.github.io/smithy-rs/design)
 
 **All internal and external interfaces are considered unstable and subject to change without notice.**
 
@@ -19,6 +20,7 @@ The generated SDK will be placed in `aws/sdk/build/aws-sdk`.
 ./gradlew :aws:sdk:test # Run all the tests
 ./gradlew :aws:sdk:cargoCheck # only validate that it compiles
 ```
+
 ## Run tests
 ```./test.sh```
 


### PR DESCRIPTION
## Motivation and Context
The smithy-rs readme references a GitHub pages location that used to exist, but was unintentionally deleted at some point. This PR creates a GitHub Actions workflow to automatically update these GitHub pages when changes are made to the design documentation. The [`github-pages` branch](https://github.com/awslabs/smithy-rs/tree/github-pages) has been created and set up to host pages for the repository.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
