### PR TITLE
Bump MSRV to `1.56.1`

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -8,7 +8,7 @@ on:
 name: AWS SDK CI
 
 env:
-  rust_version: 1.54.0
+  rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
   java_version: 11
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 name: CI
 
 env:
-  rust_version: 1.54.0
+  rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
   java_version: 11
 

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -8,7 +8,7 @@ on:
     - synchronize
 env:
   java_version: 11
-  rust_version: 1.54.0
+  rust_version: 1.56.1
 
 jobs:
   generate-diff:

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "MSRV increased from `1.54` to `1.56.1` per our 2-behind MSRV policy."
+references = ["smithy-rs#1130"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = "MSRV increased from `1.54` to `1.56.1` per our 2-behind MSRV policy."
+references = ["smithy-rs#1130"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-http/src/lib.rs
+++ b/aws/rust-runtime/aws-http/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![warn(
     missing_docs,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     missing_debug_implementations,
     rust_2018_idioms,
     unreachable_pub

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![warn(
     missing_docs,
-    missing_crate_level_docs,
+    rustdoc::missing_crate_level_docs,
     missing_debug_implementations,
     rust_2018_idioms,
     unreachable_pub

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.54
+rust.msrv=1.56.1
 
 # Version number to use for the generated SDK
 # Note: these must always be full 3-segment semver versions


### PR DESCRIPTION
## Motivation and Context
This implements https://github.com/awslabs/smithy-rs/issues/1107. The current stable Rust version is 1.58.1, so per the two-behind policy established in the `aws-sdk-rust` README, the MSRV can be bumped to 1.56.1 which will allow us to reduce the resources used by CI in `aws-sdk-rust`.

There will be a corresponding `aws-sdk-rust/next` change after this is merged.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
