### PR TITLE
Fix the canary runner

### DIFF
--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -19,6 +19,7 @@ use cloudwatch::model::StandardUnit;
 use s3::ByteStream;
 use semver::Version;
 use smithy_rs_tool_common::git;
+use smithy_rs_tool_common::macros::here;
 use smithy_rs_tool_common::shell::ShellOperation;
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime};
@@ -114,7 +115,7 @@ pub async fn run(opt: RunOpt) -> Result<()> {
     request_builder
         .send()
         .await
-        .context("failed to emit metrics")?;
+        .context(here!("failed to emit metrics"))?;
 
     result.map(|_| ())
 }
@@ -124,10 +125,14 @@ async fn run_canary(opt: RunOpt, config: &aws_config::Config) -> Result<Duration
     env::set_current_dir(repo_root.join("smithy-rs/tools/ci-cdk/canary-lambda"))
         .context("failed to change working directory")?;
 
-    use_correct_revision(&opt).await?;
+    use_correct_revision(&opt)
+        .await
+        .context(here!("failed to select correct revision of smithy-rs"))?;
 
     info!("Generating canary Cargo.toml...");
-    generate_cargo_toml(&opt.sdk_version).await?;
+    generate_cargo_toml(&opt.sdk_version)
+        .await
+        .context(here!())?;
 
     info!("Building the canary...");
     let bundle_path = build_bundle(&opt.sdk_version).await?;
@@ -144,7 +149,8 @@ async fn run_canary(opt: RunOpt, config: &aws_config::Config) -> Result<Duration
         bundle_file_name,
         &bundle_path,
     )
-    .await?;
+    .await
+    .context(here!())?;
 
     info!(
         "Creating the canary Lambda function named {}...",
@@ -158,7 +164,8 @@ async fn run_canary(opt: RunOpt, config: &aws_config::Config) -> Result<Duration
         &opt.lambda_code_s3_bucket_name,
         &opt.lambda_test_s3_bucket_name,
     )
-    .await?;
+    .await
+    .context(here!())?;
 
     info!("Invoking the canary Lambda...");
     let invoke_start_time = SystemTime::now();
@@ -166,7 +173,9 @@ async fn run_canary(opt: RunOpt, config: &aws_config::Config) -> Result<Duration
     let invoke_time = invoke_start_time.elapsed().expect("time in range");
 
     info!("Deleting the canary Lambda...");
-    delete_lambda_fn(lambda_client, bundle_name).await?;
+    delete_lambda_fn(lambda_client, bundle_name)
+        .await
+        .context(here!())?;
 
     invoke_result.map(|_| invoke_time)
 }
@@ -181,10 +190,11 @@ async fn use_correct_revision(opt: &RunOpt) -> Result<()> {
             "SDK version {} requires smithy-rs@{} to successfully compile the canary",
             version, commit_hash
         );
-        let smithy_rs_root = git::find_git_repository_root("smithy-rs", ".")?;
+        let smithy_rs_root = git::find_git_repository_root("smithy-rs", ".").context(here!())?;
         git::CheckoutRevision::new(smithy_rs_root, *commit_hash)
             .spawn()
-            .await?;
+            .await
+            .context(here!())?;
     }
     Ok(())
 }
@@ -194,7 +204,8 @@ async fn generate_cargo_toml(sdk_version: &str) -> Result<()> {
         .arg("--sdk-version")
         .arg(sdk_version)
         .status()
-        .await?;
+        .await
+        .context(here!("failed to run write-cargo-toml.py"))?;
     if !status.success() {
         bail!("Failed to generate canary Cargo.toml");
     }
@@ -207,7 +218,8 @@ async fn build_bundle(sdk_version: &str) -> Result<PathBuf> {
         .arg(sdk_version)
         .stderr(std::process::Stdio::inherit())
         .output()
-        .await?;
+        .await
+        .context(here!())?;
     if !output.status.success() {
         error!(
             "{}",
@@ -215,7 +227,9 @@ async fn build_bundle(sdk_version: &str) -> Result<PathBuf> {
         );
         bail!("Failed to build the canary bundle");
     } else {
-        Ok(PathBuf::from(String::from_utf8(output.stdout)?.trim()))
+        Ok(PathBuf::from(
+            String::from_utf8(output.stdout).context(here!())?.trim(),
+        ))
     }
 }
 
@@ -232,11 +246,11 @@ async fn upload_bundle(
         .body(
             ByteStream::from_path(bundle_path)
                 .await
-                .context("failed to load bundle file")?,
+                .context(here!("failed to load bundle file"))?,
         )
         .send()
         .await
-        .context("failed to upload bundle to S3")?;
+        .context(here!("failed to upload bundle to S3"))?;
     Ok(())
 }
 
@@ -276,7 +290,7 @@ async fn create_lambda_fn(
         .timeout(60)
         .send()
         .await
-        .context("failed to create canary Lambda function")?;
+        .context(here!("failed to create canary Lambda function"))?;
 
     let mut attempts = 0;
     let mut state = State::Pending;
@@ -288,7 +302,7 @@ async fn create_lambda_fn(
             .function_name(bundle_name)
             .send()
             .await
-            .context("failed to get Lambda function status")?;
+            .context(here!("failed to get Lambda function status"))?;
         state = configuration.state.unwrap();
         attempts += 1;
     }
@@ -310,7 +324,7 @@ async fn invoke_lambda(lambda_client: lambda::Client, bundle_name: &str) -> Resu
         .payload(Blob::new(&b"{}"[..]))
         .send()
         .await
-        .context("failed to invoke the canary Lambda")?;
+        .context(here!("failed to invoke the canary Lambda"))?;
 
     if let Some(log_result) = response.log_result {
         info!(
@@ -336,7 +350,7 @@ async fn delete_lambda_fn(lambda_client: lambda::Client, bundle_name: &str) -> R
         .function_name(bundle_name)
         .send()
         .await
-        .context("failed to delete Lambda")?;
+        .context(here!("failed to delete Lambda"))?;
     Ok(())
 }
 

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -122,7 +122,7 @@ pub async fn run(opt: RunOpt) -> Result<()> {
 
 async fn run_canary(opt: RunOpt, config: &aws_config::Config) -> Result<Duration> {
     let repo_root = git_root().await?;
-    env::set_current_dir(repo_root.join("smithy-rs/tools/ci-cdk/canary-lambda"))
+    env::set_current_dir(repo_root.join("tools/ci-cdk/canary-lambda"))
         .context("failed to change working directory")?;
 
     use_correct_revision(&opt)

--- a/tools/smithy-rs-sync/src/fs.rs
+++ b/tools/smithy-rs-sync/src/fs.rs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-use super::here;
 use anyhow::Context;
 use gitignore::Pattern;
+use smithy_rs_tool_common::macros::here;
 use std::error::Error;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};

--- a/tools/smithy-rs-sync/src/main.rs
+++ b/tools/smithy-rs-sync/src/main.rs
@@ -9,6 +9,7 @@ use crate::fs::{delete_all_generated_files_and_folders, find_handwritten_files_a
 use anyhow::{bail, Context, Result};
 use git2::{Commit, Oid, Repository, ResetType};
 use smithy_rs_tool_common::git::GetLastCommit;
+use smithy_rs_tool_common::macros::here;
 use smithy_rs_tool_common::shell::ShellOperation;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -41,17 +42,6 @@ const BOT_NAME: &str = "AWS SDK Rust Bot";
 const BOT_EMAIL: &str = "aws-sdk-rust-primary@amazon.com";
 const BOT_COMMIT_PREFIX: &str = "[autosync]";
 const COMMIT_HASH_FILENAME: &str = ".smithyrs-githash";
-
-/// A macro for attaching info to error messages pointing to the line of code responsible for the error.
-/// [Thanks to dtolnay for this macro](https://github.com/dtolnay/anyhow/issues/22#issuecomment-542309452)
-macro_rules! here {
-    () => {
-        concat!("error at ", file!(), ":", line!(), ":", column!())
-    };
-}
-
-// export this macro for use in other modules in this crate
-pub(crate) use here;
 
 /// Run this app in order to keep aws-sdk-rust in sync with smithy-rs.
 ///

--- a/tools/smithy-rs-tool-common/Cargo.toml
+++ b/tools/smithy-rs-tool-common/Cargo.toml
@@ -2,7 +2,7 @@
 name = "smithy-rs-tool-common"
 version = "0.1.0"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
-edition = "2021"
+edition = "2018"
 license = "Apache-2.0"
 publish = false
 

--- a/tools/smithy-rs-tool-common/src/git.rs
+++ b/tools/smithy-rs-tool-common/src/git.rs
@@ -18,7 +18,7 @@ pub use get_last_commit::GetLastCommit;
 
 /// Attempts to find git repository root from the given location.
 pub fn find_git_repository_root(repo_name: &str, location: impl AsRef<Path>) -> Result<PathBuf> {
-    let mut current_dir = location.as_ref().canonicalize()?.to_path_buf();
+    let mut current_dir = location.as_ref().canonicalize()?;
     let os_name = OsStr::new(repo_name);
     loop {
         if is_git_root(&current_dir) {

--- a/tools/smithy-rs-tool-common/src/lib.rs
+++ b/tools/smithy-rs-tool-common/src/lib.rs
@@ -5,5 +5,7 @@
 
 pub mod git;
 pub mod github_actions;
+#[macro_use]
+pub mod macros;
 pub mod package;
 pub mod shell;

--- a/tools/smithy-rs-tool-common/src/macros.rs
+++ b/tools/smithy-rs-tool-common/src/macros.rs
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/// A macro for attaching info to error messages pointing to the line of code responsible for the error.
+/// [Thanks to dtolnay for this macro](https://github.com/dtolnay/anyhow/issues/22#issuecomment-542309452)
+#[macro_export]
+macro_rules! here {
+    () => {
+        concat!("error at ", file!(), ":", line!(), ":", column!())
+    };
+    ($message:tt) => {
+        concat!($message, " (", here!(), ")")
+    };
+}
+
+// export this macro for use in other modules in this crate
+pub use here;


### PR DESCRIPTION
## Motivation and Context
Moving the canary runner into smithy-rs introduced some bugs. This PR fixes them so that the canary can pass again. [Passing run here using this branch](https://github.com/awslabs/aws-sdk-rust/runs/5060244375).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
