### PR TITLE
Fix payload deserialization where we need to return an Optional type when the member is non-streaming

### DIFF
--- a/codegen-server-test/model/simple.smithy
+++ b/codegen-server-test/model/simple.smithy
@@ -16,6 +16,7 @@ service SimpleService {
     ],
     operations: [
         Healthcheck,
+        StoreServiceBlob,
     ],
 }
 
@@ -103,5 +104,28 @@ structure HealthcheckInputRequest {
 
 @documentation("Service healthcheck input structure")
 structure HealthcheckOutputResponse {
+
+}
+
+@readonly
+@http(method: "GET", uri: "/service/{id}/blob")
+@documentation("Stores a blob for a service id")
+operation StoreServiceBlob {
+    input: StoreServiceBlobInput,
+    output: StoreServiceBlobOutput
+}
+
+@documentation("Store a blob for a service id input structure")
+structure StoreServiceBlobInput {
+    @required
+    @httpLabel
+    id: ServiceId,
+    @required
+    @httpPayload
+    content: Blob,
+}
+
+@documentation("Store a blob for a service id input structure")
+structure StoreServiceBlobOutput {
 
 }

--- a/codegen-server-test/model/simple.smithy
+++ b/codegen-server-test/model/simple.smithy
@@ -125,7 +125,7 @@ structure StoreServiceBlobInput {
     content: Blob,
 }
 
-@documentation("Store a blob for a service id input structure")
+@documentation("Store a blob for a service id output structure")
 structure StoreServiceBlobOutput {
 
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
@@ -181,10 +181,10 @@ class HttpBindingGenerator(
         httpMessageType: HttpMessageType = HttpMessageType.RESPONSE
     ): RuntimeType {
         check(binding.location == HttpBinding.Location.PAYLOAD)
-        val outputT = symbolProvider.toSymbol(binding.member)
         val fnName = "deser_payload_${fnName(operationShape, binding)}"
         return RuntimeType.forInlineFun(fnName, httpSerdeModule) { rustWriter ->
             if (binding.member.isStreaming(model)) {
+                val outputT = symbolProvider.toSymbol(binding.member)
                 rustWriter.rustBlock(
                     "pub fn $fnName(body: &mut #T) -> std::result::Result<#T, #T>",
                     RuntimeType.sdkBody(runtimeConfig),
@@ -200,6 +200,9 @@ class HttpBindingGenerator(
                     }
                 }
             } else {
+                // The output needs to be Optional when deserializing the payload body or the caller signature
+                // will not match.
+                val outputT = symbolProvider.toSymbol(binding.member).makeOptional()
                 rustWriter.rustBlock("pub fn $fnName(body: &[u8]) -> std::result::Result<#T, #T>", outputT, errorT) {
                     deserializePayloadBody(
                         binding,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
@@ -170,7 +170,7 @@ class HttpBindingGenerator(
     }
 
     /**
-     * Generate a function to deserialize `[binding]` from the response payload.
+     * Generate a function to deserialize `[binding]` from the request / response payload.
      */
     fun generateDeserializePayloadFn(
         operationShape: OperationShape,


### PR DESCRIPTION
Fixes: #1159

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
