### PR TITLE
Fix the hardcoded credentials example in `aws-types`

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -64,9 +64,9 @@ jobs:
         - name: Unit Tests
           run: cargo test --all-features
         - name: Docs
-          run: cargo doc --no-deps --document-private-items
+          run: cargo doc --no-deps --document-private-items --all-features
         - name: Clippy
-          run: cargo clippy
+          run: cargo clippy --all-features
         - name: Unused Dependencies
           run: cargo +nightly udeps
         - name: Additional per-crate checks

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
       # windows doesn't support using --check like this
       if: ${{ matrix.os == 'ubuntu-latest' }}
     - name: clippy check
-      run: cargo clippy -- -D warnings
+      run: cargo clippy --all-features -- -D warnings
       working-directory: ${{ matrix.runtime }}
       # don't bother running Clippy twice, it will have the same results on Windows
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -244,3 +244,9 @@ remove their trait bounds.
 references = ["smithy-rs#1132"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Fixed example showing how to use hardcoded credentials in `aws-types`"
+references = ["smithy-rs#1180"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-types/src/credentials/credentials_impl.rs
+++ b/aws/rust-runtime/aws-types/src/credentials/credentials_impl.rs
@@ -97,22 +97,36 @@ impl Credentials {
     /// [`ProvideCredentials`](crate::credentials::ProvideCredentials) directly, so no custom provider
     /// implementation is required when wiring these up to a client:
     /// ```rust
-    /// use aws_types::Credentials;
-    /// # mod dynamodb {
-    /// # use aws_types::credentials::ProvideCredentials;
-    /// # pub struct Config;
-    /// # impl Config {
-    /// #    pub fn builder() -> Self {
-    /// #        Config
-    /// #    }
-    /// #    pub fn credentials_provider(self, provider: impl ProvideCredentials + 'static) -> Self {
-    /// #       self
-    /// #    }
+    /// use aws_types::{Credentials, Region};
+    /// # mod service {
+    /// #     use aws_types::credentials::ProvideCredentials;
+    /// #     pub struct Config;
+    /// #     impl Config {
+    /// #        pub fn builder() -> Self {
+    /// #            Config
+    /// #        }
+    /// #        pub fn credentials_provider(self, provider: impl ProvideCredentials + 'static) -> Self {
+    /// #            self
+    /// #        }
+    /// #        pub fn region(self, region: Region) -> Self {
+    /// #            self
+    /// #        }
+    /// #     }
+    /// #     pub struct Client;
+    /// #     impl Client {
+    /// #        pub fn from_conf(config: Config) -> Self {
+    /// #            Client
+    /// #        }
+    /// #     }
     /// # }
-    /// # }
+    /// # use service::Config;
     ///
-    /// let my_creds = Credentials::from_keys("akid", "secret_key", None);
-    /// let conf = dynamodb::Config::builder().credentials_provider(my_creds);
+    /// let creds = Credentials::from_keys("akid", "secret_key", None);
+    /// let config = Config::builder()
+    ///     .credentials_provider(creds)
+    ///     .region(Region::new("us-east-1"))
+    ///     .build();
+    /// let client = Client::from_conf(config);
     /// ```
     #[cfg(feature = "hardcoded-credentials")]
     pub fn from_keys(

--- a/aws/rust-runtime/aws-types/src/credentials/credentials_impl.rs
+++ b/aws/rust-runtime/aws-types/src/credentials/credentials_impl.rs
@@ -97,9 +97,11 @@ impl Credentials {
     /// [`ProvideCredentials`](crate::credentials::ProvideCredentials) directly, so no custom provider
     /// implementation is required when wiring these up to a client:
     /// ```rust
-    /// use aws_types::{Credentials, Region};
+    /// use aws_types::Credentials;
+    /// use aws_types::region::Region;
     /// # mod service {
     /// #     use aws_types::credentials::ProvideCredentials;
+    /// #     use aws_types::region::Region;
     /// #     pub struct Config;
     /// #     impl Config {
     /// #        pub fn builder() -> Self {
@@ -111,6 +113,7 @@ impl Credentials {
     /// #        pub fn region(self, region: Region) -> Self {
     /// #            self
     /// #        }
+    /// #        pub fn build(self) -> Config { Config }
     /// #     }
     /// #     pub struct Client;
     /// #     impl Client {
@@ -119,7 +122,7 @@ impl Credentials {
     /// #        }
     /// #     }
     /// # }
-    /// # use service::Config;
+    /// # use service::{Config, Client};
     ///
     /// let creds = Credentials::from_keys("akid", "secret_key", None);
     /// let config = Config::builder()


### PR DESCRIPTION
## Motivation and Context
The example previously would compile, but would fail to run since it didn't set a region. This PR makes it clearer how to successfully use it.

Also noticed that CI isn't consistently applying `--all-features` for clippy and doc. This fixes that as well.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
