### PR TITLE
Pin nightly to `nightly-2022-02-08` in CI

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -11,6 +11,7 @@ env:
   rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
   java_version: 11
+  nightly_version: nightly-2022-02-08
 
 jobs:
   generate-smoke-test:
@@ -68,7 +69,7 @@ jobs:
         - name: Clippy
           run: cargo clippy
         - name: Unused Dependencies
-          run: cargo +nightly udeps
+          run: cargo +${{ env.nightly_version }} udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/ ../tools/ci-cdk/
     env:
@@ -87,7 +88,7 @@ jobs:
         default: true
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: ${{ env.nightly_version }}
         default: false
     - name: Cache cargo bin
       uses: actions/cache@v2
@@ -97,7 +98,7 @@ jobs:
     - name: Install additional cargo binaries
       run: |
         if [[ ! -f ~/.cargo/bin/cargo-udeps ]]; then
-          cargo +nightly install cargo-udeps
+          cargo +${{ env.nightly_version }} install cargo-udeps
         fi
         if [[ ! -f ~/.cargo/bin/cargo-hack ]]; then
           cargo install cargo-hack
@@ -117,7 +118,7 @@ jobs:
       with:
         sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
         target-dir: ../target
-    # This runs the commands from the matrix strategy
+      # This runs the commands from the matrix strategy
     - name: ${{ matrix.test.name }}
       run: ${{ matrix.test.run }}
       working-directory: aws-sdk
@@ -153,7 +154,7 @@ jobs:
         toolchain: ${{ env.rust_version }}
         components: ${{ env.rust_toolchain_components }}
         default: true
-    # The integration tests path-depend on crates in the build/ path, so we have to download a generated SDK
+      # The integration tests path-depend on crates in the build/ path, so we have to download a generated SDK
     - name: Generate a name for the SDK
       id: gen-name
       run: echo "name=${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -11,7 +11,6 @@ env:
   rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
   java_version: 11
-  nightly_version: nightly-2022-02-08
 
 jobs:
   generate-smoke-test:
@@ -69,7 +68,7 @@ jobs:
         - name: Clippy
           run: cargo clippy
         - name: Unused Dependencies
-          run: cargo "+${NIGHTLY_VERSION}" udeps
+          run: cargo +nightly-2022-02-08 udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/ ../tools/ci-cdk/
     env:
@@ -79,7 +78,6 @@ jobs:
       # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
       # so we have to manually restore the target directory override
       CARGO_TARGET_DIR: ../target
-      NIGHTLY_VERSION: ${{ env.nightly_version }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -89,7 +87,7 @@ jobs:
         default: true
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: ${{ env.nightly_version }}
+        toolchain: nightly-2022-02-08
         default: false
     - name: Cache cargo bin
       uses: actions/cache@v2
@@ -99,7 +97,7 @@ jobs:
     - name: Install additional cargo binaries
       run: |
         if [[ ! -f ~/.cargo/bin/cargo-udeps ]]; then
-          cargo "+${NIGHTLY_VERSION}" install cargo-udeps
+          cargo +nightly-2022-02-08 install cargo-udeps
         fi
         if [[ ! -f ~/.cargo/bin/cargo-hack ]]; then
           cargo install cargo-hack

--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -69,7 +69,7 @@ jobs:
         - name: Clippy
           run: cargo clippy
         - name: Unused Dependencies
-          run: cargo +${{ env.nightly_version }} udeps
+          run: cargo "+${NIGHTLY_VERSION}" udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/ ../tools/ci-cdk/
     env:
@@ -79,6 +79,7 @@ jobs:
       # Note: the .cargo/config.toml is lost because we untar the SDK rather than checking out the repo,
       # so we have to manually restore the target directory override
       CARGO_TARGET_DIR: ../target
+      NIGHTLY_VERSION: ${{ env.nightly_version }}
     steps:
     - uses: actions/checkout@v2
     - uses: actions-rs/toolchain@v1
@@ -98,7 +99,7 @@ jobs:
     - name: Install additional cargo binaries
       run: |
         if [[ ! -f ~/.cargo/bin/cargo-udeps ]]; then
-          cargo +${{ env.nightly_version }} install cargo-udeps
+          cargo "+${NIGHTLY_VERSION}" install cargo-udeps
         fi
         if [[ ! -f ~/.cargo/bin/cargo-hack ]]; then
           cargo install cargo-hack


### PR DESCRIPTION
## Motivation and Context
Nightly currently has a stable-to-nightly regression. This pins to the previous version that the SDK would successfully compile against.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
