### PR TITLE
Add decorator to allow to make all operations fallible

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/FallibleOperationsDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/FallibleOperationsDecorator.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy.customizations
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.ErrorTrait
+import software.amazon.smithy.model.traits.RequiredTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+
+/**
+ * Force all operations in the model to be fallible.
+ *
+ * When this decorator is applied, operations that do not have a Smithy error attatched,
+ * will return `Result<OperationOutput, InternalServerError>`.
+ *
+ * To enable this decorator, create a file called `META-INF/services/software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator`
+ * containing `codegen-server/src/main/resources/META-INF/services/software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator`.
+ */
+class FallibleOperationsDecorator : RustCodegenDecorator {
+    override val name: String = "FallibleOperations"
+    override val order: Byte = 0
+
+    override fun transformModel(service: ServiceShape, model: Model): Model {
+        val namespace = service.id.getNamespace()
+        val message = MemberShape.builder().id("$namespace#InternalServerError\$message")
+            .target("smithy.api#String").addTrait(RequiredTrait()).build()
+        val errorShape = StructureShape.builder().id("$namespace#InternalServerError")
+            .addTrait(ErrorTrait("server")).addMember(message).build()
+        val modelShapes = model.toBuilder().addShapes(listOf(errorShape)).build()
+        return ModelTransformer.create().mapShapes(modelShapes) { shape ->
+            if (shape is OperationShape && shape.errors.isEmpty()) {
+                shape.toBuilder().addError(errorShape).build()
+            } else {
+                shape
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Force all operations in the model to be fallible.

When this decorator is applied, operations that do not have a Smithy error attatched, will return `Result<OperationOutput, InternalServerError>`.

To enable this decorator, create a file called `META-INF/service/software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator` containing `codegen-server/src/main/resources/META-INF/services/software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator`.

Closes: #1150

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
