### PR TITLE
Make `sdk-versioner` work with example git dependencies

### DIFF
--- a/tools/sdk-versioner/src/main.rs
+++ b/tools/sdk-versioner/src/main.rs
@@ -124,6 +124,8 @@ fn update_dependency_value(crate_name: &str, value: &mut Table, opt: &Opt) {
     );
 
     // Remove keys that will be replaced
+    value.remove("git");
+    value.remove("branch");
     value.remove("version");
     value.remove("path");
 


### PR DESCRIPTION
## Motivation and Context
The example manifests now use `git` and `branch` to point to the `aws-sdk-rust/next` branch, so the `sdk-versioner` tool needs to remove these values when it updates the manifests to point to the build artifact by adding a `path`.

## Testing
CI will pass if this is working correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
