### PR TITLE
Enclose some types in backticks in `aws-smithy-json` docs

### DIFF
--- a/rust-runtime/aws-smithy-json/src/deserialize.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize.rs
@@ -15,13 +15,13 @@ use ErrorReason::*;
 
 /// JSON token parser as a Rust iterator
 ///
-/// This parser will parse and yield exactly one [Token] per iterator `next()` call.
+/// This parser will parse and yield exactly one [`Token`] per iterator `next()` call.
 /// Validation is done on the fly, so it is possible for it to parse an invalid JSON document
-/// until it gets to the first [Error].
+/// until it gets to the first [`Error`].
 ///
-/// JSON string values are left escaped in the [Token::ValueString] as an [EscapedStr],
+/// JSON string values are left escaped in the [`Token::ValueString`] as an [`EscapedStr`],
 /// which is a new type around a slice of original `input` bytes so that the caller can decide
-/// when to unescape and allocate into a [String].
+/// when to unescape and allocate into a [`String`].
 ///
 /// The parser *will* accept multiple valid JSON values. For example, `b"null true"` will
 /// yield `ValueNull` and `ValueTrue`. It is the responsibility of the caller to handle this for

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -48,7 +48,7 @@ impl Offset {
     }
 }
 
-/// Enum representing the different JSON tokens that can be returned by json_token_iter.
+/// Enum representing the different JSON tokens that can be returned by [`json_token_iter`].
 #[derive(Debug, PartialEq)]
 pub enum Token<'a> {
     StartArray {

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -48,7 +48,8 @@ impl Offset {
     }
 }
 
-/// Enum representing the different JSON tokens that can be returned by [`json_token_iter`].
+/// Enum representing the different JSON tokens that can be returned by
+/// [`crate::deserialize::json_token_iter`].
 #[derive(Debug, PartialEq)]
 pub enum Token<'a> {
     StartArray {


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
