### PR TITLE
Make `rustls` and `native_tls` client builder helpers dyn

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,15 @@ message = "`aws_smithy_types::primitive::Encoder` is now a struct rather than an
 references = ["smithy-rs#1209"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "`ClientBuilder` helpers `rustls()` and `native_tls()` now return `DynConnector` and use dynamic dispatch rather than returning their concrete connector type that would allow static dispatch. If static dispatch is desired, then manually construct a connector to give to the builder. For example, for rustls: `builder.connector(Adapter::builder().build(aws_smithy_client::conns::https()))` (where `Adapter` is in `aws_smithy_client::hyper_ext`)."
+references = ["smithy-rs#1217"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "`ClientBuilder` helpers `rustls()` and `native_tls()` now return `DynConnector` so that they once again work when constructing clients with custom middleware in the SDK."
+references = ["smithy-rs#1217", "aws-sdk-rust#467"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"


### PR DESCRIPTION
## Motivation and Context
This PR fixes https://github.com/awslabs/aws-sdk-rust/issues/467 which was caused by making the SDK clients use `DynConnector` in https://github.com/awslabs/smithy-rs/pull/1132.

There's a bit of conflict here between smithy-rs and SDK use-cases. Developers using smithy-rs want the flexibility to use static dispatch on the client's connector, but the SDK does not need this. I'm opting to make the SDK use-case easy and convenient, and it should even work for most smithy-rs use-cases. Those who need to use static dispatch will need to manually construct an adapter (for example, `builder.connector(Adapter::builder().build(aws_smithy_client::conns::https()))`) if the performance difference is a concern.

I considered adding `rustls_static` and `native_tls_static` equivalents for static dispatch, but I thought those might cause confusion.

## Testing
- Added a test to check the return types

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
