### PR TITLE
Make it possible to configure the default credentials cache

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -46,3 +46,9 @@ message = "`ClientBuilder` helpers `rustls()` and `native_tls()` now return `Dyn
 references = ["smithy-rs#1217", "aws-sdk-rust#467"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Made it possible to change settings, such as load timeout, on the credential cache used by the `DefaultCredentialsChain`."
+references = ["smithy-rs#1220", "aws-sdk-rust#462"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -114,7 +114,7 @@ impl Builder {
         self
     }
 
-    /// Timeout for the given [`ProvideCredentials`] implementation.
+    /// Timeout for the entire credential loading chain.
     ///
     /// Defaults to 5 seconds.
     pub fn load_timeout(mut self, timeout: Duration) -> Self {
@@ -122,7 +122,7 @@ impl Builder {
         self
     }
 
-    /// Timeout for the given [`ProvideCredentials`] implementation.
+    /// Timeout for the entire credential loading chain.
     ///
     /// Defaults to 5 seconds.
     pub fn set_load_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {

--- a/aws/rust-runtime/aws-config/src/meta/credentials/lazy_caching.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/lazy_caching.rs
@@ -167,41 +167,101 @@ mod builder {
         /// An implementation of [`ProvideCredentials`] that will be used to load
         /// the cached credentials once they're expired.
         pub fn load(mut self, loader: impl ProvideCredentials + 'static) -> Self {
-            self.load = Some(Arc::new(loader));
+            self.set_load(Some(loader));
             self
         }
 
-        /// Implementation of [`AsyncSleep`] to use for timeouts. This enables use of
-        /// the `LazyCachingCredentialsProvider` with other async runtimes.
+        /// An implementation of [`ProvideCredentials`] that will be used to load
+        /// the cached credentials once they're expired.
+        pub fn set_load(&mut self, loader: Option<impl ProvideCredentials + 'static>) -> &mut Self {
+            self.load = loader.map(|l| Arc::new(l) as Arc<dyn ProvideCredentials>);
+            self
+        }
+
+        /// Implementation of [`AsyncSleep`] to use for timeouts.
+        ///
+        /// This enables use of the `LazyCachingCredentialsProvider` with other async runtimes.
         /// If using Tokio as the async runtime, this should be set to an instance of
         /// [`TokioSleep`](aws_smithy_async::rt::sleep::TokioSleep).
         pub fn sleep(mut self, sleep: impl AsyncSleep + 'static) -> Self {
-            self.sleep = Some(Arc::new(sleep));
+            self.set_sleep(Some(sleep));
             self
         }
 
-        /// (Optional) Timeout for the given [`ProvideCredentials`] implementation.
+        /// Implementation of [`AsyncSleep`] to use for timeouts.
+        ///
+        /// This enables use of the `LazyCachingCredentialsProvider` with other async runtimes.
+        /// If using Tokio as the async runtime, this should be set to an instance of
+        /// [`TokioSleep`](aws_smithy_async::rt::sleep::TokioSleep).
+        pub fn set_sleep(&mut self, sleep: Option<impl AsyncSleep + 'static>) -> &mut Self {
+            self.sleep = sleep.map(|s| Arc::new(s) as Arc<dyn AsyncSleep>);
+            self
+        }
+
+        /// Timeout for the given [`ProvideCredentials`] implementation.
+        ///
         /// Defaults to 5 seconds.
         pub fn load_timeout(mut self, timeout: Duration) -> Self {
-            self.load_timeout = Some(timeout);
+            self.set_load_timeout(Some(timeout));
             self
         }
 
-        /// (Optional) Amount of time before the actual credential expiration time
-        /// where credentials are considered expired. For example, if credentials are expiring
-        /// in 15 minutes, and the buffer time is 10 seconds, then any requests made after
-        /// 14 minutes and 50 seconds will load new credentials. Defaults to 10 seconds.
+        /// Timeout for the given [`ProvideCredentials`] implementation.
+        ///
+        /// Defaults to 5 seconds.
+        pub fn set_load_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
+            self.load_timeout = timeout;
+            self
+        }
+
+        /// Amount of time before the actual credential expiration time
+        /// where credentials are considered expired.
+        ///
+        /// For example, if credentials are expiring in 15 minutes, and the buffer time is 10 seconds,
+        /// then any requests made after 14 minutes and 50 seconds will load new credentials.
+        ///
+        /// Defaults to 10 seconds.
         pub fn buffer_time(mut self, buffer_time: Duration) -> Self {
-            self.buffer_time = Some(buffer_time);
+            self.set_buffer_time(Some(buffer_time));
             self
         }
 
-        /// (Optional) Default expiration time to set on credentials if they don't
-        /// have an expiration time. This is only used if the given [`ProvideCredentials`]
-        /// returns [`Credentials`](aws_types::Credentials) that don't have their `expiry` set.
+        /// Amount of time before the actual credential expiration time
+        /// where credentials are considered expired.
+        ///
+        /// For example, if credentials are expiring in 15 minutes, and the buffer time is 10 seconds,
+        /// then any requests made after 14 minutes and 50 seconds will load new credentials.
+        ///
+        /// Defaults to 10 seconds.
+        pub fn set_buffer_time(&mut self, buffer_time: Option<Duration>) -> &mut Self {
+            self.buffer_time = buffer_time;
+            self
+        }
+
+        /// Default expiration time to set on credentials if they don't have an expiration time.
+        ///
+        /// This is only used if the given [`ProvideCredentials`] returns
+        /// [`Credentials`](aws_types::Credentials) that don't have their `expiry` set.
         /// This must be at least 15 minutes.
+        ///
+        /// Defaults to 15 minutes.
         pub fn default_credential_expiration(mut self, duration: Duration) -> Self {
-            self.default_credential_expiration = Some(duration);
+            self.set_default_credential_expiration(Some(duration));
+            self
+        }
+
+        /// Default expiration time to set on credentials if they don't have an expiration time.
+        ///
+        /// This is only used if the given [`ProvideCredentials`] returns
+        /// [`Credentials`](aws_types::Credentials) that don't have their `expiry` set.
+        /// This must be at least 15 minutes.
+        ///
+        /// Defaults to 15 minutes.
+        pub fn set_default_credential_expiration(
+            &mut self,
+            duration: Option<Duration>,
+        ) -> &mut Self {
+            self.default_credential_expiration = duration;
             self
         }
 


### PR DESCRIPTION
## Motivation and Context
This is for https://github.com/awslabs/aws-sdk-rust/issues/462. It is just making it possible to change settings on the lazy caching builder used by the default credentials provider builder.

This should enable customizing the credential load timeout with:
```rust
let default_provider = DefaultCredentialsChain::builder()
    .load_timeout(Duration::from_secs(20))
    .build();
```

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
