### PR TITLE
Pin nightly to `2022-02-22` to fix CI

### DIFF
--- a/.github/workflows/ci-sdk.yaml
+++ b/.github/workflows/ci-sdk.yaml
@@ -68,7 +68,7 @@ jobs:
         - name: Clippy
           run: cargo clippy --all-features
         - name: Unused Dependencies
-          run: cargo +nightly udeps
+          run: cargo +nightly-2022-02-22 udeps
         - name: Additional per-crate checks
           run: ../tools/additional-per-crate-checks.sh ./sdk/ ../tools/ci-cdk/
     env:
@@ -87,7 +87,7 @@ jobs:
         default: true
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: nightly
+        toolchain: nightly-2022-02-22
         default: false
     - name: Cache cargo bin
       uses: actions/cache@v2
@@ -97,7 +97,7 @@ jobs:
     - name: Install additional cargo binaries
       run: |
         if [[ ! -f ~/.cargo/bin/cargo-udeps ]]; then
-          cargo +nightly install cargo-udeps
+          cargo +nightly-2022-02-22 install cargo-udeps
         fi
         if [[ ! -f ~/.cargo/bin/cargo-hack ]]; then
           cargo install cargo-hack

--- a/rust-runtime/aws-smithy-types/additional-ci
+++ b/rust-runtime/aws-smithy-types/additional-ci
@@ -12,4 +12,4 @@ echo "### Checking for duplicate dependency versions in the normal dependency gr
 cargo tree -d --edges normal --all-features
 
 echo "### Running api-linter"
-cargo +nightly api-linter --all-features
+cargo +nightly-2022-02-22 api-linter --all-features

--- a/tools/api-linter/additional-ci
+++ b/tools/api-linter/additional-ci
@@ -7,4 +7,4 @@ set -e
 cd "$(dirname $0)"
 
 cargo clippy
-cargo +nightly test
+cargo +nightly-2022-02-22 test


### PR DESCRIPTION
## Motivation and Context
The latest nightly introduced a new rustdoc format version that breaks the api-linter tool. This PR pins nightly to give us more time to update to the latest format version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
