### PR TITLE
Update: impl `Clone` for `DynMiddleware`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "`DynMiddleware` is now `clone`able"
+references = ["smithy-rs#1225"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "Velfi"

--- a/rust-runtime/aws-smithy-client/src/erase.rs
+++ b/rust-runtime/aws-smithy-client/src/erase.rs
@@ -187,13 +187,19 @@ impl Service<http::Request<SdkBody>> for DynConnector {
 /// to matter in all but the highest-performance settings.
 #[non_exhaustive]
 pub struct DynMiddleware<C>(
-    BoxCloneLayer<
+    ArcCloneLayer<
         aws_smithy_http_tower::dispatch::DispatchService<C>,
         aws_smithy_http::operation::Request,
         aws_smithy_http::operation::Response,
         aws_smithy_http_tower::SendOperationError,
     >,
 );
+
+impl<C> Clone for DynMiddleware<C> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 
 impl<C> fmt::Debug for DynMiddleware<C> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -204,7 +210,7 @@ impl<C> fmt::Debug for DynMiddleware<C> {
 impl<C> DynMiddleware<C> {
     /// Construct a new dynamically-dispatched Smithy middleware.
     pub fn new<M: bounds::SmithyMiddleware<C> + Send + Sync + 'static>(middleware: M) -> Self {
-        Self(BoxCloneLayer::new(middleware))
+        Self(ArcCloneLayer::new(middleware))
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
#1225 Will need this because `Handle`s will be responsible for creating `Client`s and they'll need to hold a `Middleware` for creating a `Client`.

## Description
<!--- Describe your changes in detail -->
update: impl `Clone` for `DynMiddleware`
rename: `BoxCloneLayer` to `ArcCloneLayer`
update: impl `Clone` for `ArcCloneLayer`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran existing tests to ensure nothing broke

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
