### PR TITLE
Continuing the work on server benchmarks.

### DIFF
--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -9,7 +9,8 @@ on:
 env:
   java_version: 11
   rust_version: 1.56.1
-  dependencies: libssl-dev git gnuplot
+  rust_toolchain_components: clippy,rustfmt
+  apt_dependencies: libssl-dev git gnuplot
 
 jobs:
   run-e2e-integration-test:
@@ -33,6 +34,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
+        components: ${{ env.rust_toolchain_components }}
         default: true
     - name: Run integration tests
       run: |
@@ -65,15 +67,16 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
+        components: ${{ env.rust_toolchain_components }}
         default: true
     - name: Install benchmarks dependencies
-      run: sudo apt-get update && sudo apt-get install -y ${{ env.dependencies }}
+      run: sudo apt-get update && sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
     - name: Install wrk
       run: |
         git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
           cd /tmp/wrk-build && make -j8 && sudo cp wrk /usr/local/bin
-    - name: Run integration tests
+    - name: Run benchmark
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && wrk --help

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install wrk
       run: |
         git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
-          cd /tmp/wrk-build && make -j8 && sudo cp wrk /usr/local/bin
+          cd /tmp/wrk-build && make -j8 wrk && sudo cp wrk /usr/local/bin
     - name: Run benchmark
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -26,6 +26,11 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
+      # Pinned to the commit hash of v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
+      with:
+        sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        target-dir: ./target
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -59,6 +64,11 @@ jobs:
       with:
         path: ~/.wrk-api-bench
         key: ${{ runner.os }}-wrk-api-bench
+      # Pinned to the commit hash of v1.3.0
+    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
+      with:
+        sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
+        target-dir: ./target
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -65,7 +65,8 @@ jobs:
         path: ~/.wrk-api-bench
         key: ${{ runner.os }}-wrk-api-bench
       # Pinned to the commit hash of v1.3.0
-    - uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
       with:
         sharedKey: ${{ runner.os }}-${{ env.rust_version }}-${{ github.job }}
         target-dir: ./target
@@ -91,8 +92,9 @@ jobs:
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && cargo test --release --features benchmarks
-        echo "::set-output name=bot-message::$(cat tmp-variance/current_variance.txt)"
-    - uses: actions/github-script@v5
+        echo "::set-output name=bot-message::$(cat /tmp/current_variance.txt)"
+    - name: Post variance on PR
+      uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"
       if: ${{ github.head_ref != null }}
       with:

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -9,6 +9,7 @@ on:
 env:
   java_version: 11
   rust_version: 1.56.1
+  dependencies: wrk gnuplot
 
 jobs:
   run-end-to-end-integration-test:
@@ -24,16 +25,22 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    # JDK is needed to generate code
+    - uses: actions/cache@v2
+      name: Benchmarks Cache
+      with:
+        path: ~/.wrk-api-bench
+        key: ${{ runner.os }}-wrk-api-bench
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
         java-version: ${{ env.java_version }}
-    # Install Rust
-    - uses: actions-rs/toolchain@v1
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
       with:
         toolchain: ${{ env.rust_version }}
         default: true
+    - name: Install benchmarks dependencies
+      run: sudo apt-get update && sudo apt-get install -y ${{ env.dependencies }}
     - name: Run integration tests
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && cargo test --release --features benchmarks
-        echo -e "::set-output name=bot-message::$(cat /tmp/current_variance.txt)"
+        echo "::set-output name=bot-message::$(cat /tmp/current_variance.txt)"
     - name: Post variance on PR
       uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -12,8 +12,41 @@ env:
   dependencies: wrk gnuplot
 
 jobs:
-  run-end-to-end-integration-test:
+  run-e2e-integration-test:
     runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      name: Gradle Cache
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Set up JDK
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ env.java_version }}
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.rust_version }}
+        default: true
+    - name: Run integration tests
+      run: |
+        cd rust-runtime/aws-smithy-http-server/examples && \
+          make && cargo test
+
+  run-benchmark:
+    runs-on: ubuntu-latest
+    # Ubuntu 20.04 doesn't have wrk packaged, hence we need to
+    # run this build inside a container with ubuntu 21.04 🤦
+    container:
+      image: ubuntu:21.04
+      env:
+        DEBIAN_FRONTEND: noninteractive
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -44,4 +77,4 @@ jobs:
     - name: Run integration tests
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
-          make && cargo test
+          make && wrk --help

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -9,7 +9,7 @@ on:
 env:
   java_version: 11
   rust_version: 1.56.1
-  dependencies: wrk gnuplot
+  dependencies: libssl-dev git gnuplot
 
 jobs:
   run-e2e-integration-test:
@@ -41,12 +41,6 @@ jobs:
 
   run-benchmark:
     runs-on: ubuntu-latest
-    # Ubuntu 20.04 doesn't have wrk packaged, hence we need to
-    # run this build inside a container with ubuntu 21.04 🤦
-    container:
-      image: ubuntu:21.04
-      env:
-        DEBIAN_FRONTEND: noninteractive
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
@@ -74,6 +68,11 @@ jobs:
         default: true
     - name: Install benchmarks dependencies
       run: sudo apt-get update && sudo apt-get install -y ${{ env.dependencies }}
+    # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
+    - name: Install wrk
+      run: |
+        git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
+          cd /tmp/wrk-build && make -j8 && sudo cp wrk /usr/local/bin
     - name: Run integration tests
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -10,7 +10,7 @@ env:
   java_version: 11
   rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
-  apt_dependencies: libssl-dev git gnuplot
+  apt_dependencies: libssl-dev git gnuplot jq
 
 jobs:
   run-e2e-integration-test:
@@ -79,4 +79,8 @@ jobs:
     - name: Run benchmark
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
-          make && wrk --help
+          make && cargo test --release --features benchmarks && \
+          for x in ~/.wrk-api-bench/*; do
+            echo $x
+            cat $x |jq .
+          done

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && cargo test --release --features benchmarks
-        echo "::set-output name=bot-message::$(cat /tmp/current_variance.txt)"
+        echo -e "::set-output name=bot-message::$(cat /tmp/current_variance.txt)"
     - name: Post variance on PR
       uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -80,17 +80,26 @@ jobs:
         components: ${{ env.rust_toolchain_components }}
         default: true
     - name: Install benchmarks dependencies
-      run: sudo apt-get update && sudo apt-get install -y ${{ env.apt_dependencies }}
+      run: sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
     - name: Install wrk
       run: |
         git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
           cd /tmp/wrk-build && make -j8 wrk && sudo cp wrk /usr/local/bin
     - name: Run benchmark
+      id: run-benchmark
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
-          make && cargo test --release --features benchmarks && \
-          for x in ~/.wrk-api-bench/*; do
-            echo $x
-            cat $x |jq .
-          done
+          make && cargo test --release --features benchmarks
+        echo "::set-output name=bot-message::$(cat tmp-variance/current_variance.txt)"
+    - uses: actions/github-script@v5
+      # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"
+      if: ${{ github.head_ref != null }}
+      with:
+        script: |
+          await github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: '${{ steps.run-benchmark.outputs.bot-message }}'
+          })

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -10,7 +10,7 @@ env:
   java_version: 11
   rust_version: 1.56.1
   rust_toolchain_components: clippy,rustfmt
-  apt_dependencies: libssl-dev git gnuplot jq
+  apt_dependencies: libssl-dev gnuplot jq
 
 jobs:
   run-e2e-integration-test:
@@ -60,6 +60,12 @@ jobs:
         path: origin-main
         # ref: main
         ref: ${{ github.event.pull_request.head.sha }}
+    - name: Checkout wrk
+      uses: actions/checkout@v3
+      with:
+        repository: wg/wrk
+        path: wrk-build
+        ref: 4.2.0
     - uses: actions/cache@v2
       name: Gradle Cache
       with:
@@ -88,11 +94,9 @@ jobs:
     - name: Install benchmarks dependencies
       run: sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
-    # This will go away as soon as GitHub supports Ubuntu 22.04.
+    # This will go away as soon as GitHub supports Ubuntu 21.10.
     - name: Install wrk
-      run: |
-        git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
-          cd /tmp/wrk-build && make -j8 wrk && sudo cp wrk /usr/local/bin
+      run: cd wrk-build && make -j8 wrk && sudo cp wrk /usr/local/bin
     - name: Run benchmark
       id: run-benchmark
       run: |

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Run benchmark
       id: run-benchmark
       run: |
-        touch ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
+        mkdir -p ~/.wrk-api-bench && touch ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
         for x in ~/.wrk-api-bench/*; do

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -58,8 +58,7 @@ jobs:
       with:
         repository: awslabs/smithy-rs
         path: origin-main
-        # ref: main
-        ref: ${{ github.event.pull_request.head.sha }}
+        ref: main
     - name: Checkout wrk
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -96,7 +96,7 @@ jobs:
           make && RUN_BENCHMARKS=1 cargo test --release
         for x in ~/.wrk-api-bench/*; do
           echo "Benchmark $x"
-          cat $x | jq .
+          cat $x
           echo
         done
         echo "::set-output name=bot-message::$(cat ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt)"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,6 +92,7 @@ jobs:
     - name: Run benchmark
       id: run-benchmark
       run: |
+        touch ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
         for x in ~/.wrk-api-bench/*; do

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Install benchmarks dependencies
       run: sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
-    # This will go away as soon as GitHub supports Ubuntu 21.04.
+    # This will go away as soon as GitHub supports Ubuntu 22.04.
     - name: Install wrk
       run: |
         git clone https://github.com/wg/wrk.git /tmp/wrk-build && \

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -51,11 +51,13 @@ jobs:
     steps:
     - name: Checkout PR
       uses: actions/checkout@v3
+      with:
+        path: pull-request
     - name: Checkout origin/main
       uses: actions/checkout@v3
       with:
         repository: awslabs/smithy-rs
-        path: /~/smithy-rs-main
+        path: origin-main
         ref: main
     - uses: actions/cache@v2
       name: Gradle Cache
@@ -95,12 +97,12 @@ jobs:
       run: |
         mkdir -p ~/.wrk-api-bench
         # run the benchmark on origin/main
-        pushd ~/smithy-rs-main/rust-runtime/aws-smithy-http-server/examples
+        pushd origin-main/rust-runtime/aws-smithy-http-server/examples
         make && RUN_BENCHMARKS=1 cargo test --release
         popd
 
         # run the benchmark on current ref
-        pushd rust-runtime/aws-smithy-http-server/examples
+        pushd pull-request/rust-runtime/aws-smithy-http-server/examples
         make && RUN_BENCHMARKS=1 cargo test --release
         popd
         # Uncomment this for debugging purposes. It will print out the

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -96,14 +96,12 @@ jobs:
         # run the benchmark.
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
+
         # uncomment this for debugging purpose. it will print out the
         # content of all the benchmarks found in the cache + the last one
         # produced by the current run.
-        for x in ~/.wrk-api-bench/*; do
-          echo "Benchmark $x content:"
-          cat $x | jq .
-          echo
-        done
+        # for x in ~/.wrk-api-bench/*; do echo "Benchmark $x content:"; cat $x | jq .; echo; done
+
         # Ensure the output is available for the PR bot.
         echo "::set-output name=bot-message::$(cat /tmp/smithy_rs_benchmark_variance.txt)"
     - name: Post variance on PR

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,7 +92,10 @@ jobs:
     - name: Run benchmark
       id: run-benchmark
       run: |
-        mkdir -p ~/.wrk-api-bench && echo test > ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
+        # create the benchmark history folder and add a default message in case the benchmark fails.
+        mkdir -p ~/.wrk-api-bench && \
+          echo "### Unable to calculate server benchmark variance" > ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
+        # run the benchmark.
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
         for x in ~/.wrk-api-bench/*; do
@@ -100,6 +103,7 @@ jobs:
           cat $x
           echo
         done
+        # Ensure the output is available for the PR bot.
         echo "::set-output name=bot-message::$(cat ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt)"
         # remove the variance file to ensure we do not cache it.
         rm -f ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Install benchmarks dependencies
       run: sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
-    # This will go away as soon as github supports Ubuntu 21.04.
+    # This will go away as soon as GitHub supports Ubuntu 21.04.
     - name: Install wrk
       run: |
         git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
@@ -97,10 +97,10 @@ jobs:
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
 
-        # uncomment this for debugging purpose. it will print out the
+        # Uncomment this for debugging purposes. It will print out the
         # content of all the benchmarks found in the cache + the last one
         # produced by the current run.
-        # for x in ~/.wrk-api-bench/*; do echo "Benchmark $x content:"; cat $x | jq .; echo; done
+        # for x in ~/.wrk-api-bench/*; do echo "Benchmark $x content:"; jq . "$x"; echo; done
 
         # Ensure the output is available for the PR bot.
         echo "::set-output name=bot-message::$(cat /tmp/smithy_rs_benchmark_variance.txt)"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -63,7 +63,7 @@ jobs:
       name: Benchmarks Cache
       with:
         path: ~/.wrk-api-bench
-        key: ${{ runner.os }}-wrk-api-bench-${{ hashFiles('~/.wrk-api-bench/*.json') }}
+        key: ${{ runner.os }}-wrk-api-bench-${{ hashFiles('**/*.json') }}
         restore-keys: |
           ${{ runner.os }}-wrk-api-bench-
       # Pinned to the commit hash of v1.3.0

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: awslabs/smithy-rs
-        path: ~/smithy-rs-main
+        path: /~/smithy-rs-main
         ref: main
     - uses: actions/cache@v2
       name: Gradle Cache

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -91,8 +91,10 @@ jobs:
       id: run-benchmark
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
-          make && cargo test --release --features benchmarks
-        echo "::set-output name=bot-message::$(cat /tmp/current_variance.txt)"
+          make && RUN_BENCHMARKS=1 cargo test --release
+        echo "::set-output name=bot-message::$(cat ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt)"
+        # remove the variance file to ensure we do not cache it.
+        rm -f ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
     - name: Post variance on PR
       uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -96,9 +96,12 @@ jobs:
         # run the benchmark.
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
+        # uncomment this for debugging purpose. it will print out the
+        # content of all the benchmarks found in the cache + the last one
+        # produced by the current run.
         for x in ~/.wrk-api-bench/*; do
-          echo "Benchmark $x"
-          cat $x
+          echo "Benchmark $x content:"
+          cat $x | jq .
           echo
         done
         # Ensure the output is available for the PR bot.

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -59,13 +59,6 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
         restore-keys: |
           ${{ runner.os }}-gradle-
-    - uses: actions/cache@v2
-      name: Benchmarks Cache
-      with:
-        path: ~/.wrk-api-bench
-        key: ${{ runner.os }}-wrk-api-bench-${{ hashFiles('**/*.json') }}
-        restore-keys: |
-          ${{ runner.os }}-wrk-api-bench-
       # Pinned to the commit hash of v1.3.0
     - name: Rust Cache
       uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
@@ -93,10 +86,15 @@ jobs:
     - name: Run benchmark
       id: run-benchmark
       run: |
-        # run the benchmark.
-        cd rust-runtime/aws-smithy-http-server/examples && \
-          make && RUN_BENCHMARKS=1 cargo test --release
+        mkdir -p ~/.wrk-api-bench
+        pushd rust-runtime/aws-smithy-http-server/examples
+        # run the benchmark on origin/main
+        git checkout main
+        make && RUN_BENCHMARKS=1 cargo test --release && make distclean
 
+        # run the benchmark on current ref
+        git checkout ${{ github.event.pull_request.head.sha }}
+        make && RUN_BENCHMARKS=1 cargo test --release
         # Uncomment this for debugging purposes. It will print out the
         # content of all the benchmarks found in the cache + the last one
         # produced by the current run.

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Run benchmark
       id: run-benchmark
       run: |
-        mkdir -p ~/.wrk-api-bench && touch ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
+        mkdir -p ~/.wrk-api-bench && echo test > ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
         for x in ~/.wrk-api-bench/*; do

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -92,6 +92,11 @@ jobs:
       run: |
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
+        for x in ~/.wrk-api-bench/*; do
+          echo "Benchmark $x"
+          cat $x
+          echo
+        done
         echo "::set-output name=bot-message::$(cat ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt)"
         # remove the variance file to ensure we do not cache it.
         rm -f ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -58,7 +58,8 @@ jobs:
       with:
         repository: awslabs/smithy-rs
         path: origin-main
-        ref: main
+        # ref: main
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: actions/cache@v2
       name: Gradle Cache
       with:
@@ -111,8 +112,8 @@ jobs:
         # for x in ~/.wrk-api-bench/*; do echo "Benchmark $x content:"; jq . "$x"; echo; done
 
         # Ensure the output is available for the PR bot.
-        echo "::set-output name=bot-message::$(cat /tmp/smithy_rs_benchmark_variance.txt)"
-    - name: Post variance on PR
+        echo "::set-output name=bot-message::$(cat /tmp/smithy_rs_benchmark_deviation.txt)"
+    - name: Post deviation on PR
       uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"
       if: ${{ github.head_ref != null }}

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -85,6 +85,7 @@ jobs:
     - name: Install benchmarks dependencies
       run: sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
+    # This will go away as soon as github supports Ubuntu 21.04.
     - name: Install wrk
       run: |
         git clone https://github.com/wg/wrk.git /tmp/wrk-build && \
@@ -92,9 +93,6 @@ jobs:
     - name: Run benchmark
       id: run-benchmark
       run: |
-        # create the benchmark history folder and add a default message in case the benchmark fails.
-        mkdir -p ~/.wrk-api-bench && \
-          echo "### Unable to calculate server benchmark variance" > ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
         # run the benchmark.
         cd rust-runtime/aws-smithy-http-server/examples && \
           make && RUN_BENCHMARKS=1 cargo test --release
@@ -104,9 +102,7 @@ jobs:
           echo
         done
         # Ensure the output is available for the PR bot.
-        echo "::set-output name=bot-message::$(cat ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt)"
-        # remove the variance file to ensure we do not cache it.
-        rm -f ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt
+        echo "::set-output name=bot-message::$(cat /tmp/smithy_rs_benchmark_variance.txt)"
     - name: Post variance on PR
       uses: actions/github-script@v5
       # NOTE: if comments on each commit become bothersome, add a check that github.event.pull_request.action == "opened"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -63,7 +63,9 @@ jobs:
       name: Benchmarks Cache
       with:
         path: ~/.wrk-api-bench
-        key: ${{ runner.os }}-wrk-api-bench
+        key: ${{ runner.os }}-wrk-api-bench-${{ hashFiles('~/.wrk-api-bench/*.json') }}
+        restore-keys: |
+          ${{ runner.os }}-wrk-api-bench-
       # Pinned to the commit hash of v1.3.0
     - name: Rust Cache
       uses: Swatinem/rust-cache@842ef286fff290e445b90b4002cc9807c3669641
@@ -94,7 +96,7 @@ jobs:
           make && RUN_BENCHMARKS=1 cargo test --release
         for x in ~/.wrk-api-bench/*; do
           echo "Benchmark $x"
-          cat $x
+          cat $x | jq .
           echo
         done
         echo "::set-output name=bot-message::$(cat ~/.wrk-api-bench/smithy_rs_benchmark_variance.txt)"

--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -16,7 +16,7 @@ jobs:
   run-e2e-integration-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/cache@v2
       name: Gradle Cache
       with:
@@ -49,7 +49,14 @@ jobs:
   run-benchmark:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout PR
+      uses: actions/checkout@v3
+    - name: Checkout origin/main
+      uses: actions/checkout@v3
+      with:
+        repository: awslabs/smithy-rs
+        path: ~/smithy-rs-main
+        ref: main
     - uses: actions/cache@v2
       name: Gradle Cache
       with:
@@ -87,14 +94,15 @@ jobs:
       id: run-benchmark
       run: |
         mkdir -p ~/.wrk-api-bench
-        pushd rust-runtime/aws-smithy-http-server/examples
         # run the benchmark on origin/main
-        git checkout main
-        make && RUN_BENCHMARKS=1 cargo test --release && make distclean
+        pushd ~/smithy-rs-main/rust-runtime/aws-smithy-http-server/examples
+        make && RUN_BENCHMARKS=1 cargo test --release
+        popd
 
         # run the benchmark on current ref
-        git checkout ${{ github.event.pull_request.head.sha }}
+        pushd rust-runtime/aws-smithy-http-server/examples
         make && RUN_BENCHMARKS=1 cargo test --release
+        popd
         # Uncomment this for debugging purposes. It will print out the
         # content of all the benchmarks found in the cache + the last one
         # produced by the current run.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 /codegen-server/                        @awslabs/smithy-rs-server
 /codegen-server-test/                   @awslabs/smithy-rs-server
 /rust-runtime/aws-smithy-http-server/   @awslabs/smithy-rs-server
+/.github/workflows/server-benchmark.yml @awslabs/smithy-rs-server

--- a/codegen-server-test/model/pokemon.smithy
+++ b/codegen-server-test/model/pokemon.smithy
@@ -10,7 +10,7 @@ use aws.protocols#restJson1
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies],
-    operations: [GetServerStatistics],
+    operations: [GetServerStatistics, EmptyOperation],
 }
 
 /// A Pokémon species forms the basis for at least one Pokémon.
@@ -100,6 +100,20 @@ structure FlavorText {
     },
 ])
 string Language
+
+/// Empty operation, used to stress test the framework.
+@readonly
+@http(uri: "/empty-operation", method: "GET")
+operation EmptyOperation {
+    input: EmptyOperationInput,
+    output: EmptyOperationOutput,
+}
+
+@input
+structure EmptyOperationInput { }
+
+@output
+structure EmptyOperationOutput { }
 
 @error("client")
 @httpError(404)

--- a/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
+++ b/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
@@ -15,7 +15,7 @@ using [wrk](https://github.com/wg/wrk).
 
 ## 2022-03-04
 
-The benchmark run against the `empty_operation()` operation, which is just
+The benchmark runs against the `empty_operation()` operation, which is just
 returning an empty output and can be used to stress test the framework overhead.
 
 ### c6i.8xlarge
@@ -25,7 +25,7 @@ returning an empty output and can be used to stress test the framework overhead.
 * Benchmark:
     - Duration: 10 minutes
     - Connections: 1024
-    * Threads: 16
+    - Threads: 16
 * Result:
     - Request/sec: 1_608_742
     * RSS memory: 72200 bytes
@@ -57,10 +57,10 @@ Transfer/sec:    167.23MB
 * Benchmark:
     - Duration: 10 minutes
     - Connections: 1024
-    * Threads: 16
+    - Threads: 16
 * Result:
     - Request/sec: 1_379_942
-    * RSS memory: 70264 bytes
+    - RSS memory: 70264 bytes
 
 
 #### Full result

--- a/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
+++ b/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
@@ -13,12 +13,10 @@ using [wrk](https://github.com/wg/wrk).
 
 <!-- vim-markdown-toc -->
 
-## 2022-03-04
+## [2022-03-04](https://github.com/awslabs/smithy-rs/commit/d823f61156577ab42590709627906d1dc35a5f49)
 
 The benchmark runs against the `empty_operation()` operation, which is just
 returning an empty output and can be used to stress test the framework overhead.
-
-The benchmark has been run against commit [d823f61156577ab42590709627906d1dc35a5f49](https://github.com/awslabs/smithy-rs/commit/d823f61156577ab42590709627906d1dc35a5f49).
 
 ### c6i.8xlarge
 

--- a/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
+++ b/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
@@ -15,10 +15,8 @@ using [wrk](https://github.com/wg/wrk).
 
 ## 2022-03-04
 
-The benchmark run against the `get_pokemon_species()` operation, which is
-reading the Pokémon specie translation from an in memory hashmap and increasing
-an atomic counter. This operation performs both deserialization of input and
-serialization of output.
+The benchmark run against the `empty_operation()` operation, which is just
+returning an empty output and can be used to stress test the framework overhead.
 
 ### c6i.8xlarge
 
@@ -26,29 +24,30 @@ serialization of output.
 * 64 Gb memory
 * Benchmark:
     - Duration: 10 minutes
-    - Connections: 512
-    * Threads: 64
+    - Connections: 1024
+    * Threads: 16
 * Result:
-    - Request/sec: 1068053
-    * RSS memory: 39900 bytes
+    - Request/sec: 1_608_742
+    * RSS memory: 72200 bytes
 
 #### Full result
 
 ```
-❯❯❯ wrk -d 10m -c 512 -t 64 --latency http://localhost:13734/pokemon-species/pikachu
-Running 10m test @ http://localhost:13734/pokemon-species/pikachu
-  64 threads and 512 connections
+❯❯❯ wrk -t16 -c1024 -d10m --latency http://localhost:13734/empty-operation
+Running 10m test @ http://localhost:13734/empty-operation
+  16 threads and 1024 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency   485.78us  237.79us  33.22ms   78.98%
-    Req/Sec    16.77k   272.59    62.96k    79.93%
+    Latency     1.03ms    1.84ms 208.10ms   92.16%
+    Req/Sec   101.11k    17.59k  164.78k    70.99%
   Latency Distribution
-     50%  459.00us
-     75%  590.00us
-     90%  738.00us
-     99%    1.13ms
-  640938431 requests in 10.00m, 313.98GB read
-Requests/sec: 1068053.32
-Transfer/sec:    535.77MB
+     50%  475.00us
+     75%  784.00us
+     90%    2.12ms
+     99%    9.74ms
+  965396910 requests in 10.00m, 98.00GB read
+  Socket errors: connect 19, read 0, write 0, timeout 0
+Requests/sec: 1608742.65
+Transfer/sec:    167.23MB
 ```
 
 ### c6g.8xlarge
@@ -57,28 +56,29 @@ Transfer/sec:    535.77MB
 * 64 Gb memory
 * Benchmark:
     - Duration: 10 minutes
-    - Connections: 512
-    * Threads: 64
+    - Connections: 1024
+    * Threads: 16
 * Result:
-    - Request/sec: 791008
-    * RSS memory: 41540 bytes
+    - Request/sec: 1_379_942
+    * RSS memory: 70264 bytes
 
 
 #### Full result
 
 ```
-❯❯❯ wrk -d 10m -c 512 -t 64 --latency http://localhost:13734/pokemon-species/pikachu
-Running 10m test @ http://localhost:13734/pokemon-species/pikachu
-  64 threads and 512 connections
+❯❯❯ wrk -t16 -c1024 -d10m --latency http://localhost:13734/empty-operation
+Running 10m test @ http://localhost:13734/empty-operation
+  16 threads and 1024 connections
   Thread Stats   Avg      Stdev     Max   +/- Stdev
-    Latency   656.05us  324.72us  23.38ms   77.51%
-    Req/Sec    12.42k   297.47    48.07k    74.52%
+    Latency     1.26ms    2.22ms 210.68ms   91.99%
+    Req/Sec    86.76k    16.46k  141.30k    68.81%
   Latency Distribution
-     50%  618.00us
-     75%  805.00us
-     90%    1.01ms
-     99%    1.55ms
-  474684091 requests in 10.00m, 232.54GB read
-Requests/sec: 791008.58
-Transfer/sec:    396.80MB
+     50%  560.00us
+     75%    0.93ms
+     90%    2.53ms
+     99%   11.95ms
+  828097344 requests in 10.00m, 84.06GB read
+  Socket errors: connect 19, read 0, write 0, timeout 0
+Requests/sec: 1379942.45
+Transfer/sec:    143.45MB
 ```

--- a/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
+++ b/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
@@ -18,6 +18,8 @@ using [wrk](https://github.com/wg/wrk).
 The benchmark runs against the `empty_operation()` operation, which is just
 returning an empty output and can be used to stress test the framework overhead.
 
+The benchmark has been run against commit [d823f61156577ab42590709627906d1dc35a5f49](https://github.com/awslabs/smithy-rs/commit/d823f61156577ab42590709627906d1dc35a5f49).
+
 ### c6i.8xlarge
 
 * 32 cores Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz
@@ -28,7 +30,7 @@ returning an empty output and can be used to stress test the framework overhead.
     - Threads: 16
 * Result:
     - Request/sec: 1_608_742
-    * RSS memory: 72200 bytes
+    * RSS[^1] memory: 72200 bytes
 
 #### Full result
 
@@ -60,7 +62,7 @@ Transfer/sec:    167.23MB
     - Threads: 16
 * Result:
     - Request/sec: 1_379_942
-    - RSS memory: 70264 bytes
+    - RSS[^1] memory: 70264 bytes
 
 
 #### Full result
@@ -82,3 +84,5 @@ Running 10m test @ http://localhost:13734/empty-operation
 Requests/sec: 1379942.45
 Transfer/sec:    143.45MB
 ```
+
+[^1]: https://en.wikipedia.org/wiki/Resident_set_size

--- a/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
+++ b/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
@@ -3,11 +3,12 @@
 This Pokémon Service has been benchmarked on different type of EC2 instances
 using [wrk](https://github.com/wg/wrk).
 
-
 <!-- vim-markdown-toc Marked -->
 
 * [2022-03-04](#2022-03-04)
     * [c6i.8xlarge](#c6i.8xlarge)
+        * [Full result](#full-result)
+    * [c6g.8xlarge](#c6g.8xlarge)
         * [Full result](#full-result)
 
 <!-- vim-markdown-toc -->
@@ -32,6 +33,7 @@ serialization of output.
     * RSS memory: 39900 bytes
 
 #### Full result
+
 ```
 ❯❯❯ wrk -d 10m -c 512 -t 64 --latency http://localhost:13734/pokemon-species/pikachu
 Running 10m test @ http://localhost:13734/pokemon-species/pikachu
@@ -47,4 +49,36 @@ Running 10m test @ http://localhost:13734/pokemon-species/pikachu
   640938431 requests in 10.00m, 313.98GB read
 Requests/sec: 1068053.32
 Transfer/sec:    535.77MB
+```
+
+### c6g.8xlarge
+
+* 32 cores Amazon Graviton 2 @ 2.50GHz
+* 64 Gb memory
+* Benchmark:
+    - Duration: 10 minutes
+    - Connections: 512
+    * Threads: 64
+* Result:
+    - Request/sec: 791008
+    * RSS memory: 41540 bytes
+
+
+#### Full result
+
+```
+❯❯❯ wrk -d 10m -c 512 -t 64 --latency http://localhost:13734/pokemon-species/pikachu
+Running 10m test @ http://localhost:13734/pokemon-species/pikachu
+  64 threads and 512 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   656.05us  324.72us  23.38ms   77.51%
+    Req/Sec    12.42k   297.47    48.07k    74.52%
+  Latency Distribution
+     50%  618.00us
+     75%  805.00us
+     90%    1.01ms
+     99%    1.55ms
+  474684091 requests in 10.00m, 232.54GB read
+Requests/sec: 791008.58
+Transfer/sec:    396.80MB
 ```

--- a/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
+++ b/rust-runtime/aws-smithy-http-server/examples/BENCHMARKS.md
@@ -1,0 +1,50 @@
+# Smithy Rust Server SDK benchmarks
+
+This Pokémon Service has been benchmarked on different type of EC2 instances
+using [wrk](https://github.com/wg/wrk).
+
+
+<!-- vim-markdown-toc Marked -->
+
+* [2022-03-04](#2022-03-04)
+    * [c6i.8xlarge](#c6i.8xlarge)
+        * [Full result](#full-result)
+
+<!-- vim-markdown-toc -->
+
+## 2022-03-04
+
+The benchmark run against the `get_pokemon_species()` operation, which is
+reading the Pokémon specie translation from an in memory hashmap and increasing
+an atomic counter. This operation performs both deserialization of input and
+serialization of output.
+
+### c6i.8xlarge
+
+* 32 cores Intel(R) Xeon(R) Platinum 8375C CPU @ 2.90GHz
+* 64 Gb memory
+* Benchmark:
+    - Duration: 10 minutes
+    - Connections: 512
+    * Threads: 64
+* Result:
+    - Request/sec: 1068053
+    * RSS memory: 39900 bytes
+
+#### Full result
+```
+❯❯❯ wrk -d 10m -c 512 -t 64 --latency http://localhost:13734/pokemon-species/pikachu
+Running 10m test @ http://localhost:13734/pokemon-species/pikachu
+  64 threads and 512 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   485.78us  237.79us  33.22ms   78.98%
+    Req/Sec    16.77k   272.59    62.96k    79.93%
+  Latency Distribution
+     50%  459.00us
+     75%  590.00us
+     90%  738.00us
+     99%    1.13ms
+  640938431 requests in 10.00m, 313.98GB read
+Requests/sec: 1068053.32
+Transfer/sec:    535.77MB
+```

--- a/rust-runtime/aws-smithy-http-server/examples/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "pokemon_service_sdk",
     "pokemon_service_client"
 ]
+
+[profile.release]
+lto = true

--- a/rust-runtime/aws-smithy-http-server/examples/Makefile
+++ b/rust-runtime/aws-smithy-http-server/examples/Makefile
@@ -6,7 +6,7 @@ CLIENT_SDK_DST := $(CUR_DIR)/pokemon_service_client
 SERVER_SDK_SRC := $(SRC_DIR)/codegen-server-test/build/smithyprojections/codegen-server-test/pokemon_service_sdk/rust-server-codegen
 CLIENT_SDK_SRC := $(SRC_DIR)/codegen-test/build/smithyprojections/codegen-test/pokemon_service_client/rust-codegen
 
-all: build
+all: codegen
 
 codegen:
 	$(GRADLE) --project-dir $(SRC_DIR) :codegen-test:assemble

--- a/rust-runtime/aws-smithy-http-server/examples/README.md
+++ b/rust-runtime/aws-smithy-http-server/examples/README.md
@@ -13,7 +13,7 @@ build.
 Once the example has been built successfully the first time, idiomatic `cargo`
 can be used directly.
 
-`make dist-clean` can be used for a complete cleanup of all artefacts.
+`make distclean` can be used for a complete cleanup of all artefacts.
 
 ## Run
 
@@ -29,4 +29,4 @@ More info can be found in the `tests` folder of `pokemon_service` package.
 
 ## Benchmarks
 
-TBD.
+Please see [BENCHMARKS.md](/rust-runtime/aws-smithy-http-server/example/BENCHMARKS.md).

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -19,7 +19,7 @@ pokemon_service_sdk = { path = "../pokemon_service_sdk/" }
 [dev-dependencies]
 assert_cmd = "2.0"
 home = "0.5"
-wrk-api-bench = "0.0.2"
+wrk-api-bench = "0.0.3"
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -19,7 +19,7 @@ pokemon_service_sdk = { path = "../pokemon_service_sdk/" }
 [dev-dependencies]
 assert_cmd = "2.0"
 home = "0.5"
-wrk-api-bench = "0.0.4"
+wrk-api-bench = "0.0.5"
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -19,7 +19,7 @@ pokemon_service_sdk = { path = "../pokemon_service_sdk/" }
 [dev-dependencies]
 assert_cmd = "2.0"
 home = "0.5"
-wrk-api-bench = "0.0.3"
+wrk-api-bench = "0.0.4"
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -18,7 +18,12 @@ pokemon_service_sdk = { path = "../pokemon_service_sdk/" }
 
 [dev-dependencies]
 assert_cmd = "2.0"
+home = "0.5"
+wrk-api-bench = "0.0.2"
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }
 pokemon_service_client = { path = "../pokemon_service_client/" }
+
+[features]
+benchmarks = []

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -24,6 +24,3 @@ wrk-api-bench = "0.0.5"
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }
 pokemon_service_client = { path = "../pokemon_service_client/" }
-
-[features]
-benchmarks = []

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -19,7 +19,7 @@ pokemon_service_sdk = { path = "../pokemon_service_sdk/" }
 [dev-dependencies]
 assert_cmd = "2.0"
 home = "0.5"
-wrk-api-bench = "0.0.5"
+wrk-api-bench = "0.0.6"
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -19,7 +19,7 @@ pokemon_service_sdk = { path = "../pokemon_service_sdk/" }
 [dev-dependencies]
 assert_cmd = "2.0"
 home = "0.5"
-wrk-api-bench = "0.0.6"
+wrk-api-bench = "0.0.7"
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
@@ -129,7 +129,7 @@ pub async fn get_pokemon_species(
     input: input::GetPokemonSpeciesInput,
     state: Extension<Arc<State>>,
 ) -> Result<output::GetPokemonSpeciesOutput, error::GetPokemonSpeciesError> {
-    // state.0.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    state.0.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     // We only support retrieving information about Pikachu.
     let pokemon = state.0.pokemons_translations.get(&input.name);
     match pokemon.as_ref() {

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
@@ -129,7 +129,7 @@ pub async fn get_pokemon_species(
     input: input::GetPokemonSpeciesInput,
     state: Extension<Arc<State>>,
 ) -> Result<output::GetPokemonSpeciesOutput, error::GetPokemonSpeciesError> {
-    state.0.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    // state.0.call_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     // We only support retrieving information about Pikachu.
     let pokemon = state.0.pokemons_translations.get(&input.name);
     match pokemon.as_ref() {
@@ -181,6 +181,11 @@ pub async fn get_server_statistics(
         .unwrap_or(0);
     tracing::debug!("This instance served {} requests", counter);
     output::GetServerStatisticsOutput { calls_count }
+}
+
+/// Empty operation used to benchmark the service.
+pub async fn empty_operation(_input: input::EmptyOperationInput) -> output::EmptyOperationOutput {
+    output::EmptyOperationOutput {}
 }
 
 #[cfg(test)]

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use aws_smithy_http_server::{AddExtensionLayer, Router};
-use pokemon_service::{get_pokemon_species, get_server_statistics, setup_tracing, State};
+use pokemon_service::{empty_operation, get_pokemon_species, get_server_statistics, setup_tracing, State};
 use pokemon_service_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
@@ -21,6 +21,7 @@ pub async fn main() {
         // return the operation's output.
         .get_pokemon_species(get_pokemon_species)
         .get_server_statistics(get_server_statistics)
+        .empty_operation(empty_operation)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+// Files here are for running integration tests.
+// These tests only have access to your crate's public API.
+// See: https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::helpers::{client, PokemonService};
+use tokio::time;
+
+#[macro_use]
+mod helpers;
+
+#[cfg(feature = "benchmarks")]
+#[tokio::test]
+async fn banchmark() {
+    use wrk_api_bench::{BenchmarkBuilder, WrkBuilder};
+    let _program = PokemonService::run();
+    // Give PokemonSérvice some time to start up.
+
+    time::sleep(Duration::from_millis(50)).await;
+
+    let history_dir = home::home_dir().unwrap().join(".wrk-api-bench");
+    let mut wrk = WrkBuilder::default()
+        .url(String::from("http://localhost:13734/pokemon-species/pikachu"))
+        .history_dir(history_dir)
+        .build()
+        .unwrap();
+    let benches = vec![BenchmarkBuilder::default()
+        .duration(Duration::from_secs(5))
+        .build()
+        .unwrap()];
+    wrk.bench(&benches).unwrap()
+}

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -45,5 +45,5 @@ async fn banchmark() {
         .truncate(true)
         .open(Path::new("/tmp/current_variance.txt"))
         .unwrap();
-    file.write_all(variance.to_markdown().as_bytes()).unwrap();
+    file.write_all(variance.to_github_markdown().as_bytes()).unwrap();
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -34,12 +34,9 @@ async fn banchmark() {
         .build()
         .unwrap();
     let benches = vec![BenchmarkBuilder::default()
-        .duration(Duration::from_secs(30))
+        .duration(Duration::from_secs(5))
         .build()
         .unwrap()];
-    // Run benchmark twice to ensure we are not getting false results
-    // because the underlying hardware changed between runs.
-    wrk.bench(&benches).unwrap();
     wrk.bench(&benches).unwrap();
     let mut variance = wrk.variance(HistoryPeriod::Last).unwrap();
     let mut file = OpenOptions::new()

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -34,7 +34,7 @@ async fn banchmark() {
         .build()
         .unwrap();
     let benches = vec![BenchmarkBuilder::default()
-        .duration(Duration::from_secs(5))
+        .duration(Duration::from_secs(60))
         .build()
         .unwrap()];
     wrk.bench(&benches).unwrap();

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -7,6 +7,8 @@
 // These tests only have access to your crate's public API.
 // See: https://doc.rust-lang.org/book/ch11-03-test-organization.html#integration-tests
 
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::Path;
 use std::time::Duration;
 
@@ -19,7 +21,7 @@ mod helpers;
 #[cfg(feature = "benchmarks")]
 #[tokio::test]
 async fn banchmark() {
-    use wrk_api_bench::{BenchmarkBuilder, WrkBuilder};
+    use wrk_api_bench::{BenchmarkBuilder, HistoryPeriod, WrkBuilder};
     let _program = PokemonService::run();
     // Give PokemonSérvice some time to start up.
 
@@ -35,5 +37,12 @@ async fn banchmark() {
         .duration(Duration::from_secs(5))
         .build()
         .unwrap()];
-    wrk.bench(&benches).unwrap()
+    wrk.bench(&benches).unwrap();
+    let mut variance = wrk.variance(HistoryPeriod::Last).unwrap();
+    let mut file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .open(Path::new("tmp-variance/current_variance.txt"))
+        .unwrap();
+    file.write_all(variance.to_string().as_bytes()).unwrap();
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -42,7 +42,8 @@ async fn banchmark() {
     let mut file = OpenOptions::new()
         .create(true)
         .write(true)
+        .truncate(true)
         .open(Path::new("/tmp/current_variance.txt"))
         .unwrap();
-    file.write_all(variance.to_string().as_bytes()).unwrap();
+    file.write_all(variance.to_markdown().as_bytes()).unwrap();
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -42,7 +42,7 @@ async fn banchmark() {
     let mut file = OpenOptions::new()
         .create(true)
         .write(true)
-        .open(Path::new("tmp-variance/current_variance.txt"))
+        .open(Path::new("/tmp/current_variance.txt"))
         .unwrap();
     file.write_all(variance.to_string().as_bytes()).unwrap();
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -34,9 +34,12 @@ async fn banchmark() {
         .build()
         .unwrap();
     let benches = vec![BenchmarkBuilder::default()
-        .duration(Duration::from_secs(5))
+        .duration(Duration::from_secs(30))
         .build()
         .unwrap()];
+    // Run benchmark twice to ensure we are not getting false results
+    // because the underlying hardware changed between runs.
+    wrk.bench(&benches).unwrap();
     wrk.bench(&benches).unwrap();
     let mut variance = wrk.variance(HistoryPeriod::Last).unwrap();
     let mut file = OpenOptions::new()

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -31,7 +31,7 @@ async fn benchmark() -> Result<(), Box<dyn std::error::Error>> {
         };
 
         let mut wrk = WrkBuilder::default()
-            .url(String::from("http://localhost:13734/pokemon-species/pikachu"))
+            .url(String::from("http://localhost:13734/empty-operation"))
             .history_dir(history_dir)
             .build()?;
 

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -29,7 +29,6 @@ async fn banchmark() -> Result<(), Box<dyn std::error::Error>> {
         } else {
             Path::new(".").join(".wrk-api-bench")
         };
-        let variance_file = history_dir.join("smithy_rs_benchmark_variance.txt");
 
         let mut wrk = WrkBuilder::default()
             .url(String::from("http://localhost:13734/pokemon-species/pikachu"))
@@ -45,21 +44,14 @@ async fn banchmark() -> Result<(), Box<dyn std::error::Error>> {
         wrk.bench(&benches)?;
 
         // Calculate variance from last run and write it to disk.
-        match wrk.variance(HistoryPeriod::Last) {
-            Ok(variance) => {
-                println!("Here is the variance: {}", variance);
-                let mut variance_file = OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(true)
-                    .open(variance_file)
-                    .unwrap();
-                variance_file.write_all(variance.to_github_markdown().as_bytes())?;
-            }
-            Err(e) => {
-                panic!("Variance failed: {}", e);
-            }
-        }
+        let variance = wrk.variance(HistoryPeriod::Last)?;
+        let mut variance_file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open("/tmp/smithy_rs_benchmark_variance.txt")
+            .unwrap();
+        variance_file.write_all(variance.to_github_markdown().as_bytes())?;
     }
     Ok(())
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -45,14 +45,20 @@ async fn banchmark() -> Result<(), Box<dyn std::error::Error>> {
         wrk.bench(&benches)?;
 
         // Calculate variance from last run and write it to disk.
-        if let Ok(variance) = wrk.variance(HistoryPeriod::Last) {
-            let mut variance_file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(variance_file)
-                .unwrap();
-            variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+        match wrk.variance(HistoryPeriod::Last) {
+            Ok(variance) => {
+                println!("Here is the variance: {}", variance);
+                let mut variance_file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(variance_file)
+                    .unwrap();
+                variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+            }
+            Err(e) => {
+                panic!("Variance failed: {}", e);
+            }
         }
     }
     Ok(())

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -45,14 +45,15 @@ async fn banchmark() -> Result<(), Box<dyn std::error::Error>> {
         wrk.bench(&benches)?;
 
         // Calculate variance from last run and write it to disk.
-        let variance = wrk.variance(HistoryPeriod::Last)?;
-        let mut variance_file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open(variance_file)
-            .unwrap();
-        variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+        if let Ok(variance) = wrk.variance(HistoryPeriod::Last) {
+            let mut variance_file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(variance_file)
+                .unwrap();
+            variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+        }
     }
     Ok(())
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -13,12 +13,12 @@ use crate::helpers::PokemonService;
 mod helpers;
 
 #[tokio::test]
-async fn banchmark() -> Result<(), Box<dyn std::error::Error>> {
+async fn benchmark() -> Result<(), Box<dyn std::error::Error>> {
     // Benchmarks are expensive, so they run only if the environment
-    // variable RUN_BENCHMARKS is present.
+    // variable `RUN_BENCHMARKS` is present.
     if env::var_os("RUN_BENCHMARKS").is_some() {
         let _program = PokemonService::run();
-        // Give PokemonSérvice some time to start up.
+        // Give PokémonService some time to start up.
         time::sleep(Duration::from_millis(50)).await;
 
         // The history directory is cached inside GitHub actions under

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -44,14 +44,15 @@ async fn benchmark() -> Result<(), Box<dyn std::error::Error>> {
         wrk.bench(&benches)?;
 
         // Calculate variance from last run and write it to disk.
-        let variance = wrk.variance(HistoryPeriod::Last)?;
-        let mut variance_file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .truncate(true)
-            .open("/tmp/smithy_rs_benchmark_variance.txt")
-            .unwrap();
-        variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+        if let Ok(variance) = wrk.variance(HistoryPeriod::Last) {
+            let mut variance_file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open("/tmp/smithy_rs_benchmark_variance.txt")
+                .unwrap();
+            variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+        }
     }
     Ok(())
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/benchmark.rs
@@ -43,15 +43,15 @@ async fn benchmark() -> Result<(), Box<dyn std::error::Error>> {
             .build()?];
         wrk.bench(&benches)?;
 
-        // Calculate variance from last run and write it to disk.
-        if let Ok(variance) = wrk.variance(HistoryPeriod::Last) {
-            let mut variance_file = OpenOptions::new()
+        // Calculate deviation from last run and write it to disk.
+        if let Ok(deviation) = wrk.deviation(HistoryPeriod::Last) {
+            let mut deviation_file = OpenOptions::new()
                 .create(true)
                 .write(true)
                 .truncate(true)
-                .open("/tmp/smithy_rs_benchmark_variance.txt")
+                .open("/tmp/smithy_rs_benchmark_deviation.txt")
                 .unwrap();
-            variance_file.write_all(variance.to_github_markdown().as_bytes())?;
+            deviation_file.write_all(deviation.to_github_markdown().as_bytes())?;
         }
     }
     Ok(())

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/simple_integration_test.rs
@@ -15,6 +15,7 @@ use tokio::time;
 #[macro_use]
 mod helpers;
 
+#[cfg(not(feature = "benchmarks"))]
 #[tokio::test]
 async fn simple_integration_test() {
     let _program = PokemonService::run();

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/tests/simple_integration_test.rs
@@ -12,10 +12,8 @@ use std::time::Duration;
 use crate::helpers::{client, PokemonService};
 use tokio::time;
 
-#[macro_use]
 mod helpers;
 
-#[cfg(not(feature = "benchmarks"))]
 #[tokio::test]
 async fn simple_integration_test() {
     let _program = PokemonService::run();


### PR DESCRIPTION
## Motivation and Context
This PR introduce a benchmarking tool that is run as part of the GitHub actions to allow to spot performance regressions in the server implementation.

The "deviation" between the last and current benchmark is posted as a message in the pull request.

I want to let this run for a little so we can figure out if GitHub action capacity can give us consistent results, otherwise we will have to move this to some capacity we own.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
