### PR TITLE
Rename `aws_types::config::Config` to `sdk_config::SdkConfig`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -20,7 +20,7 @@ author = "Velfi"
 [[aws-sdk-rust]]
 message = """
 `aws_types::config::Config` has been renamed to `aws_types::sdk_config::SdkConfig`. This is to better differentiate it
-from service-specific configs like `aws_s3_sdk::Config`. If you were creating shared configs with
+from service-specific configs like `aws_sdk_s3::Config`. If you were creating shared configs with
 `aws_config::load_from_env()`, then you don't have to do anything. If you were directly referring to a shared config,
 update your `use` statements and `struct` names.
 

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -16,3 +16,73 @@ message = "`DynMiddleware` is now `clone`able"
 references = ["smithy-rs#1225"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "Velfi"
+
+[[aws-sdk-rust]]
+message = """
+`aws_types::config::Config` has been renamed to `aws_types::sdk_config::SdkConfig`. This is to better differentiate it
+from service-specific configs like `aws_s3_sdk::Config`. If you were creating shared configs with
+`aws_config::load_from_env()`, then you don't have to do anything. If you were directly referring to a shared config,
+update your `use` statements and `struct` names.
+
+_Before:_
+```rust
+use aws_types::config::Config;
+
+fn main() {
+    let config = Config::builder()
+    // config builder methods...
+    .build()
+    .await;
+}
+```
+
+_After:_
+```rust
+use aws_types::sdk_config::SdkConfig;
+
+fn main() {
+    let config = SdkConfig::builder()
+    // config builder methods...
+    .build()
+    .await;
+}
+```
+"""
+references = ["aws-sdk-rust#406"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "Velfi"
+
+[[smithy-rs]]
+message = """
+`aws_types::config::Config` has been renamed to `aws_types:sdk_config::SdkConfig`. This is to better differentiate it
+from service-specific configs like `aws_s3_sdk::Config`. If you were creating shared configs with
+`aws_config::load_from_env()`, then you don't have to do anything. If you were directly referring to a shared config,
+update your `use` statements and `struct` names.
+
+_Before:_
+```rust
+use aws_types::config::Config;
+
+fn main() {
+    let config = Config::builder()
+    // config builder methods...
+    .build()
+    .await;
+}
+```
+
+_After:_
+```rust
+use aws_types::sdk_config::SdkConfig;
+
+fn main() {
+    let config = SdkConfig::builder()
+    // config builder methods...
+    .build()
+    .await;
+}
+```
+"""
+references = ["aws-sdk-rust#406"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "Velfi"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -38,7 +38,8 @@ fn main() {
 
 _After:_
 ```rust
-use aws_types::sdk_config::SdkConfig;
+// We re-export this type from the root module so it's easier to reference
+use aws_types::SdkConfig;
 
 fn main() {
     let config = SdkConfig::builder()
@@ -73,7 +74,7 @@ fn main() {
 
 _After:_
 ```rust
-use aws_types::sdk_config::SdkConfig;
+use aws_types::SdkConfig;
 
 fn main() {
     let config = SdkConfig::builder()

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -115,7 +115,6 @@ pub async fn load_from_env() -> aws_types::SdkConfig {
 pub use loader::ConfigLoader;
 
 mod loader {
-    use hyper::client::HttpConnector;
     use std::sync::Arc;
 
     use crate::connector::default_connector;

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`from_env`]/[`ConfigLoader`] or ad-hoc individual credential and region providers.
 //!
 //! [`ConfigLoader`](ConfigLoader) can combine different configuration sources into an AWS shared-config:
-//! [`SdkConfig`](aws_types::sdk_config::SdkConfig). [`SdkConfig`](aws_types::sdk_config::SdkConfig) can be used configure
+//! [`SdkConfig`](aws_types::SdkConfig). [`SdkConfig`](aws_types::SdkConfig) can be used configure
 //! an AWS service client.
 //!
 //! # Examples
@@ -20,7 +20,7 @@
 //! # mod aws_sdk_dynamodb {
 //! #   pub struct Client;
 //! #   impl Client {
-//! #     pub fn new(config: &aws_types::sdk_config::SdkConfig) -> Self { Client }
+//! #     pub fn new(config: &aws_types::SdkConfig) -> Self { Client }
 //! #   }
 //! # }
 //! # async fn docs() {
@@ -34,7 +34,7 @@
 //! # mod aws_sdk_dynamodb {
 //! #   pub struct Client;
 //! #   impl Client {
-//! #     pub fn new(config: &aws_types::sdk_config::SdkConfig) -> Self { Client }
+//! #     pub fn new(config: &aws_types::SdkConfig) -> Self { Client }
 //! #   }
 //! # }
 //! # async fn docs() {
@@ -107,7 +107,7 @@ pub fn from_env() -> ConfigLoader {
 /// Load a default configuration from the environment
 ///
 /// Convenience wrapper equivalent to `aws_config::from_env().load().await`
-pub async fn load_from_env() -> aws_types::sdk_config::SdkConfig {
+pub async fn load_from_env() -> aws_types::SdkConfig {
     from_env().load().await
 }
 
@@ -115,6 +115,7 @@ pub async fn load_from_env() -> aws_types::sdk_config::SdkConfig {
 pub use loader::ConfigLoader;
 
 mod loader {
+    use hyper::client::HttpConnector;
     use std::sync::Arc;
 
     use crate::connector::default_connector;
@@ -124,13 +125,13 @@ mod loader {
     use aws_smithy_types::timeout::TimeoutConfig;
     use aws_types::app_name::AppName;
     use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
-    use aws_types::sdk_config::SdkConfig;
+    use aws_types::SdkConfig;
 
     use crate::default_provider::{app_name, credentials, region, retry_config, timeout_config};
     use crate::meta::region::ProvideRegion;
     use crate::provider_config::ProviderConfig;
 
-    /// Load a cross-service [`SdkConfig`](aws_types::sdk_config::SdkConfig) from the environment
+    /// Load a cross-service [`SdkConfig`](aws_types::SdkConfig) from the environment
     ///
     /// This builder supports overriding individual components of the generated config. Overriding a component
     /// will skip the standard resolution chain from **for that component**. For example,
@@ -149,7 +150,7 @@ mod loader {
     }
 
     impl ConfigLoader {
-        /// Override the region used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
+        /// Override the region used to build [`SdkConfig`](aws_types::SdkConfig).
         ///
         /// # Examples
         /// ```no_run
@@ -165,7 +166,7 @@ mod loader {
             self
         }
 
-        /// Override the retry_config used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
+        /// Override the retry_config used to build [`SdkConfig`](aws_types::SdkConfig).
         ///
         /// # Examples
         /// ```no_run
@@ -181,7 +182,7 @@ mod loader {
             self
         }
 
-        /// Override the timeout config used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
+        /// Override the timeout config used to build [`SdkConfig`](aws_types::SdkConfig).
         /// **Note: This only sets timeouts for calls to AWS services.** Timeouts for the credentials
         /// provider chain are configured separately.
         ///
@@ -210,13 +211,13 @@ mod loader {
             self
         }
 
-        /// Override the [`HttpConnector`] used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
+        /// Override the [`HttpConnector`] used to build [`SdkConfig`](aws_types::SdkConfig).
         pub fn http_connector(mut self, http_connector: HttpConnector) -> Self {
             self.http_connector = Some(http_connector);
             self
         }
 
-        /// Override the credentials provider used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
+        /// Override the credentials provider used to build [`SdkConfig`](aws_types::SdkConfig).
         ///
         /// # Examples
         ///
@@ -272,7 +273,7 @@ mod loader {
         ///
         /// NOTE: When an override is provided, the default implementation is **not** used as a fallback.
         /// This means that if you provide a region provider that does not return a region, no region will
-        /// be set in the resulting [`SdkConfig`](aws_types::sdk_config::SdkConfig)
+        /// be set in the resulting [`SdkConfig`](aws_types::SdkConfig)
         pub async fn load(self) -> SdkConfig {
             let conf = self.provider_config.unwrap_or_default();
             let region = if let Some(provider) = self.region {

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -10,7 +10,7 @@
 //! [`from_env`]/[`ConfigLoader`] or ad-hoc individual credential and region providers.
 //!
 //! [`ConfigLoader`](ConfigLoader) can combine different configuration sources into an AWS shared-config:
-//! [`Config`](aws_types::config::Config). [`Config`](aws_types::config::Config) can be used configure
+//! [`SdkConfig`](aws_types::sdk_config::SdkConfig). [`SdkConfig`](aws_types::sdk_config::SdkConfig) can be used configure
 //! an AWS service client.
 //!
 //! # Examples
@@ -20,7 +20,7 @@
 //! # mod aws_sdk_dynamodb {
 //! #   pub struct Client;
 //! #   impl Client {
-//! #     pub fn new(config: &aws_types::config::Config) -> Self { Client }
+//! #     pub fn new(config: &aws_types::sdk_config::SdkConfig) -> Self { Client }
 //! #   }
 //! # }
 //! # async fn docs() {
@@ -34,7 +34,7 @@
 //! # mod aws_sdk_dynamodb {
 //! #   pub struct Client;
 //! #   impl Client {
-//! #     pub fn new(config: &aws_types::config::Config) -> Self { Client }
+//! #     pub fn new(config: &aws_types::sdk_config::SdkConfig) -> Self { Client }
 //! #   }
 //! # }
 //! # async fn docs() {
@@ -90,7 +90,6 @@ pub use aws_smithy_types::timeout::TimeoutConfig;
 
 // Re-export types from aws-types
 pub use aws_types::app_name::{AppName, InvalidAppName};
-pub use aws_types::config::Config;
 
 /// Create an environment loader for AWS Configuration
 ///
@@ -108,7 +107,7 @@ pub fn from_env() -> ConfigLoader {
 /// Load a default configuration from the environment
 ///
 /// Convenience wrapper equivalent to `aws_config::from_env().load().await`
-pub async fn load_from_env() -> aws_types::config::Config {
+pub async fn load_from_env() -> aws_types::sdk_config::SdkConfig {
     from_env().load().await
 }
 
@@ -124,14 +123,14 @@ mod loader {
     use aws_smithy_types::retry::RetryConfig;
     use aws_smithy_types::timeout::TimeoutConfig;
     use aws_types::app_name::AppName;
-    use aws_types::config::Config;
     use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
+    use aws_types::sdk_config::SdkConfig;
 
     use crate::default_provider::{app_name, credentials, region, retry_config, timeout_config};
     use crate::meta::region::ProvideRegion;
     use crate::provider_config::ProviderConfig;
 
-    /// Load a cross-service [`Config`](aws_types::config::Config) from the environment
+    /// Load a cross-service [`SdkConfig`](aws_types::sdk_config::SdkConfig) from the environment
     ///
     /// This builder supports overriding individual components of the generated config. Overriding a component
     /// will skip the standard resolution chain from **for that component**. For example,
@@ -150,7 +149,7 @@ mod loader {
     }
 
     impl ConfigLoader {
-        /// Override the region used to build [`Config`](aws_types::config::Config).
+        /// Override the region used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
         ///
         /// # Examples
         /// ```no_run
@@ -166,7 +165,7 @@ mod loader {
             self
         }
 
-        /// Override the retry_config used to build [`Config`](aws_types::config::Config).
+        /// Override the retry_config used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
         ///
         /// # Examples
         /// ```no_run
@@ -182,7 +181,7 @@ mod loader {
             self
         }
 
-        /// Override the timeout config used to build [`Config`](aws_types::config::Config).
+        /// Override the timeout config used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
         /// **Note: This only sets timeouts for calls to AWS services.** Timeouts for the credentials
         /// provider chain are configured separately.
         ///
@@ -211,13 +210,13 @@ mod loader {
             self
         }
 
-        /// Override the [`HttpConnector`] used to build [`Config`](aws_types::config::Config).
+        /// Override the [`HttpConnector`] used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
         pub fn http_connector(mut self, http_connector: HttpConnector) -> Self {
             self.http_connector = Some(http_connector);
             self
         }
 
-        /// Override the credentials provider used to build [`Config`](aws_types::config::Config).
+        /// Override the credentials provider used to build [`SdkConfig`](aws_types::sdk_config::SdkConfig).
         ///
         /// # Examples
         ///
@@ -273,8 +272,8 @@ mod loader {
         ///
         /// NOTE: When an override is provided, the default implementation is **not** used as a fallback.
         /// This means that if you provide a region provider that does not return a region, no region will
-        /// be set in the resulting [`Config`](aws_types::config::Config)
-        pub async fn load(self) -> aws_types::config::Config {
+        /// be set in the resulting [`SdkConfig`](aws_types::sdk_config::SdkConfig)
+        pub async fn load(self) -> SdkConfig {
             let conf = self.provider_config.unwrap_or_default();
             let region = if let Some(provider) = self.region {
                 provider.region().await
@@ -344,7 +343,7 @@ mod loader {
                 SharedCredentialsProvider::new(builder.build().await)
             };
 
-            let mut builder = Config::builder()
+            let mut builder = SdkConfig::builder()
                 .region(region)
                 .retry_config(retry_config)
                 .timeout_config(timeout_config)

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+#![deny(missing_docs)]
+
+//! AWS Shared Config (deprecated, replaced with [`aws_types::SdkConfig`](aws_types::SdkConfig))
+//!
+//! This module contains an shared configuration representation that is agnostic from a specific service.
+
+#[deprecated(since = "0.9.0", note = "renamed to aws_types::SdkConfig")]
+/// AWS Shared Configuration
+pub type Config = super::SdkConfig;

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -5,7 +5,7 @@
 
 #![deny(missing_docs)]
 
-//! AWS Shared Config (deprecated, replaced with [`crate::SdkConfig`](crate::SdkConfig))
+//! AWS Shared Config _(deprecated, replaced with [`sdk_config`](crate::sdk_config))_
 //!
 //! This module contains an shared configuration representation that is agnostic from a specific service.
 

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -5,10 +5,10 @@
 
 #![deny(missing_docs)]
 
-//! AWS Shared Config (deprecated, replaced with [`aws_types::SdkConfig`](aws_types::SdkConfig))
+//! AWS Shared Config (deprecated, replaced with [`crate::SdkConfig`](crate::SdkConfig))
 //!
 //! This module contains an shared configuration representation that is agnostic from a specific service.
 
-#[deprecated(since = "0.9.0", note = "renamed to aws_types::SdkConfig")]
+#[deprecated(since = "0.9.0", note = "renamed to crate::SdkConfig")]
 /// AWS Shared Configuration
 pub type Config = super::SdkConfig;

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -5,10 +5,10 @@
 
 #![deny(missing_docs)]
 
-//! AWS Shared Config (deprecated, replaced with [`aws_smithy_types::SdkConfig`](aws_smithy_types::SdkConfig))
+//! AWS Shared Config (deprecated, replaced with [`aws_types::SdkConfig`](aws_types::SdkConfig))
 //!
 //! This module contains an shared configuration representation that is agnostic from a specific service.
 
-#[deprecated(since = "0.39.0", note = "renamed to aws_smithy_types::SdkConfig")]
+#[deprecated(since = "0.9.0", note = "renamed to aws_types::SdkConfig")]
 /// AWS Shared Configuration
 pub type Config = super::SdkConfig;

--- a/aws/rust-runtime/aws-types/src/config.rs
+++ b/aws/rust-runtime/aws-types/src/config.rs
@@ -5,10 +5,10 @@
 
 #![deny(missing_docs)]
 
-//! AWS Shared Config (deprecated, replaced with [`aws_types::SdkConfig`](aws_types::SdkConfig))
+//! AWS Shared Config (deprecated, replaced with [`aws_smithy_types::SdkConfig`](aws_smithy_types::SdkConfig))
 //!
 //! This module contains an shared configuration representation that is agnostic from a specific service.
 
-#[deprecated(since = "0.9.0", note = "renamed to aws_types::SdkConfig")]
+#[deprecated(since = "0.39.0", note = "renamed to aws_smithy_types::SdkConfig")]
 /// AWS Shared Configuration
 pub type Config = super::SdkConfig;

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod app_name;
 pub mod build_metadata;
+#[deprecated(since = "0.9.0", note = "renamed to sdk_config")]
 pub mod config;
 pub mod credentials;
 #[doc(hidden)]

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod app_name;
 pub mod build_metadata;
+pub mod config;
 pub mod credentials;
 #[doc(hidden)]
 pub mod os_shim_internal;

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -23,6 +23,7 @@ pub mod sdk_config;
 
 pub use aws_smithy_client::http_connector;
 pub use credentials::Credentials;
+pub use sdk_config::SdkConfig;
 
 use std::borrow::Cow;
 

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -15,11 +15,11 @@
 
 pub mod app_name;
 pub mod build_metadata;
-pub mod config;
 pub mod credentials;
 #[doc(hidden)]
 pub mod os_shim_internal;
 pub mod region;
+pub mod sdk_config;
 
 pub use aws_smithy_client::http_connector;
 pub use credentials::Credentials;

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -49,7 +49,7 @@ impl Builder {
     ///
     /// # Examples
     /// ```rust
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     /// use aws_types::region::Region;
     /// let config = SdkConfig::builder().region(Region::new("us-east-1")).build();
     /// ```
@@ -66,7 +66,7 @@ impl Builder {
     ///     // ...
     ///     # None
     /// }
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     /// use aws_types::region::Region;
     /// let mut builder = SdkConfig::builder();
     /// if let Some(region) = region_override() {
@@ -83,7 +83,7 @@ impl Builder {
     ///
     /// # Examples
     /// ```rust
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     /// use aws_smithy_types::retry::RetryConfig;
     ///
     /// let retry_config = RetryConfig::new().with_max_attempts(5);
@@ -121,7 +121,7 @@ impl Builder {
     ///
     /// ```rust
     /// # use std::time::Duration;
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     /// use aws_smithy_types::timeout::TimeoutConfig;
     ///
     /// let timeout_config = TimeoutConfig::new()
@@ -166,7 +166,7 @@ impl Builder {
     /// ```rust
     /// use std::sync::Arc;
     /// use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     ///
     /// ##[derive(Debug)]
     /// pub struct ForeverSleep;
@@ -221,7 +221,7 @@ impl Builder {
     /// # Examples
     /// ```rust
     /// use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     /// fn make_provider() -> impl ProvideCredentials {
     ///   // ...
     ///   # use aws_types::Credentials;
@@ -242,7 +242,7 @@ impl Builder {
     /// # Examples
     /// ```rust
     /// use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
-    /// use aws_types::sdk_config::SdkConfig;
+    /// use aws_types::SdkConfig;
     /// fn make_provider() -> impl ProvideCredentials {
     ///   // ...
     ///   # use aws_types::Credentials;

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -22,7 +22,7 @@ use crate::region::Region;
 
 /// AWS Shared Configuration
 #[derive(Debug, Clone)]
-pub struct Config {
+pub struct SdkConfig {
     app_name: Option<AppName>,
     credentials_provider: Option<SharedCredentialsProvider>,
     region: Option<Region>,
@@ -49,9 +49,9 @@ impl Builder {
     ///
     /// # Examples
     /// ```rust
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     /// use aws_types::region::Region;
-    /// let config = Config::builder().region(Region::new("us-east-1")).build();
+    /// let config = SdkConfig::builder().region(Region::new("us-east-1")).build();
     /// ```
     pub fn region(mut self, region: impl Into<Option<Region>>) -> Self {
         self.set_region(region);
@@ -66,9 +66,9 @@ impl Builder {
     ///     // ...
     ///     # None
     /// }
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     /// use aws_types::region::Region;
-    /// let mut builder = Config::builder();
+    /// let mut builder = SdkConfig::builder();
     /// if let Some(region) = region_override() {
     ///     builder.set_region(region);
     /// }
@@ -83,11 +83,11 @@ impl Builder {
     ///
     /// # Examples
     /// ```rust
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     /// use aws_smithy_types::retry::RetryConfig;
     ///
     /// let retry_config = RetryConfig::new().with_max_attempts(5);
-    /// let config = Config::builder().retry_config(retry_config).build();
+    /// let config = SdkConfig::builder().retry_config(retry_config).build();
     /// ```
     pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
         self.set_retry_config(Some(retry_config));
@@ -98,7 +98,7 @@ impl Builder {
     ///
     /// # Examples
     /// ```rust
-    /// use aws_types::config::{Config, Builder};
+    /// use aws_types::sdk_config::{SdkConfig, Builder};
     /// use aws_smithy_types::retry::RetryConfig;
     ///
     /// fn disable_retries(builder: &mut Builder) {
@@ -106,7 +106,7 @@ impl Builder {
     ///     builder.set_retry_config(Some(retry_config));
     /// }
     ///
-    /// let mut builder = Config::builder();
+    /// let mut builder = SdkConfig::builder();
     /// disable_retries(&mut builder);
     /// let config = builder.build();
     /// ```
@@ -121,12 +121,12 @@ impl Builder {
     ///
     /// ```rust
     /// # use std::time::Duration;
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     /// use aws_smithy_types::timeout::TimeoutConfig;
     ///
     /// let timeout_config = TimeoutConfig::new()
     ///     .with_api_call_attempt_timeout(Some(Duration::from_secs(1)));
-    /// let config = Config::builder().timeout_config(timeout_config).build();
+    /// let config = SdkConfig::builder().timeout_config(timeout_config).build();
     /// ```
     pub fn timeout_config(mut self, timeout_config: TimeoutConfig) -> Self {
         self.set_timeout_config(Some(timeout_config));
@@ -138,7 +138,7 @@ impl Builder {
     /// # Examples
     /// ```rust
     /// # use std::time::Duration;
-    /// use aws_types::config::{Config, Builder};
+    /// use aws_types::sdk_config::{SdkConfig, Builder};
     /// use aws_smithy_types::timeout::TimeoutConfig;
     ///
     /// fn set_preferred_timeouts(builder: &mut Builder) {
@@ -148,7 +148,7 @@ impl Builder {
     ///     builder.set_timeout_config(Some(timeout_config));
     /// }
     ///
-    /// let mut builder = Config::builder();
+    /// let mut builder = SdkConfig::builder();
     /// set_preferred_timeouts(&mut builder);
     /// let config = builder.build();
     /// ```
@@ -166,7 +166,7 @@ impl Builder {
     /// ```rust
     /// use std::sync::Arc;
     /// use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     ///
     /// ##[derive(Debug)]
     /// pub struct ForeverSleep;
@@ -178,7 +178,7 @@ impl Builder {
     /// }
     ///
     /// let sleep_impl = Arc::new(ForeverSleep);
-    /// let config = Config::builder().sleep_impl(sleep_impl).build();
+    /// let config = SdkConfig::builder().sleep_impl(sleep_impl).build();
     /// ```
     pub fn sleep_impl(mut self, sleep_impl: Arc<dyn AsyncSleep>) -> Self {
         self.set_sleep_impl(Some(sleep_impl));
@@ -192,7 +192,7 @@ impl Builder {
     /// # Examples
     /// ```rust
     /// # use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
-    /// # use aws_types::config::{Builder, Config};
+    /// # use aws_types::sdk_config::{Builder, SdkConfig};
     /// #[derive(Debug)]
     /// pub struct ForeverSleep;
     ///
@@ -207,7 +207,7 @@ impl Builder {
     ///     builder.set_sleep_impl(Some(sleep_impl));
     /// }
     ///
-    /// let mut builder = Config::builder();
+    /// let mut builder = SdkConfig::builder();
     /// set_never_ending_sleep_impl(&mut builder);
     /// let config = builder.build();
     /// ```
@@ -221,14 +221,14 @@ impl Builder {
     /// # Examples
     /// ```rust
     /// use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     /// fn make_provider() -> impl ProvideCredentials {
     ///   // ...
     ///   # use aws_types::Credentials;
     ///   # Credentials::new("test", "test", None, None, "example")
     /// }
     ///
-    /// let config = Config::builder()
+    /// let config = SdkConfig::builder()
     ///     .credentials_provider(SharedCredentialsProvider::new(make_provider()))
     ///     .build();
     /// ```
@@ -242,7 +242,7 @@ impl Builder {
     /// # Examples
     /// ```rust
     /// use aws_types::credentials::{ProvideCredentials, SharedCredentialsProvider};
-    /// use aws_types::config::Config;
+    /// use aws_types::sdk_config::SdkConfig;
     /// fn make_provider() -> impl ProvideCredentials {
     ///   // ...
     ///   # use aws_types::Credentials;
@@ -254,7 +254,7 @@ impl Builder {
     ///   # true
     /// }
     ///
-    /// let mut builder = Config::builder();
+    /// let mut builder = SdkConfig::builder();
     /// if override_provider() {
     ///     builder.set_credentials_provider(Some(SharedCredentialsProvider::new(make_provider())));
     /// }
@@ -298,9 +298,9 @@ impl Builder {
         self
     }
 
-    /// Build a [`Config`](Config) from this builder
-    pub fn build(self) -> Config {
-        Config {
+    /// Build a [`SdkConfig`](SdkConfig) from this builder
+    pub fn build(self) -> SdkConfig {
+        SdkConfig {
             app_name: self.app_name,
             credentials_provider: self.credentials_provider,
             region: self.region,
@@ -312,7 +312,7 @@ impl Builder {
     }
 }
 
-impl Config {
+impl SdkConfig {
     /// Configured region
     pub fn region(&self) -> Option<&Region> {
         self.region.as_ref()

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -29,7 +29,7 @@ val DECORATORS = listOf(
     IntegrationTestDecorator(),
     AwsFluentClientDecorator(),
     CrateLicenseDecorator(),
-    SharedConfigDecorator(),
+    SdkConfigDecorator(),
     ServiceConfigDecorator(),
     AwsPresigningDecorator(),
     AwsReadmeDecorator(),

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -151,8 +151,8 @@ private class AwsFluentClientExtensions(types: Types) {
 
                 /// Creates a new client from a shared config.
                 ##[cfg(any(feature = "rustls", feature = "native-tls"))]
-                pub fn new(config: &#{aws_types}::config::Config) -> Self {
-                    Self::from_conf(config.into())
+                pub fn new(sdk_config: &#{aws_types}::sdk_config::SdkConfig) -> Self {
+                    Self::from_conf(sdk_config.into())
                 }
 
                 /// Creates a new client from the service [`Config`](crate::Config).

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -18,10 +18,10 @@ import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustom
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ServiceConfig
 
 /**
- * Adds functionality for constructing `<service>::Config` objects from `aws_types::sdk_config::SdkConfig`s
+ * Adds functionality for constructing `<service>::Config` objects from `aws_types::SdkConfig`s
  *
- * - `From<&aws_types::sdk_config::SdkConfig> for <service>::config::Builder`: Enabling customization
- * - `pub fn new(&aws_types::sdk_config::SdkConfig) -> <service>::Config`: Direct construction without customization
+ * - `From<&aws_types::SdkConfig> for <service>::config::Builder`: Enabling customization
+ * - `pub fn new(&aws_types::SdkConfig) -> <service>::Config`: Direct construction without customization
  */
 class SdkConfigDecorator : RustCodegenDecorator {
     override val name: String = "SdkConfig"
@@ -39,7 +39,7 @@ class SdkConfigDecorator : RustCodegenDecorator {
             "SdkConfig" to awsTypes(runtimeConfig = codegenContext.runtimeConfig).asType().member("sdk_config::SdkConfig")
         )
         rustCrate.withModule(RustModule.Config) {
-            // !!NOTE!! As more items are added to aws_types::sdk_config::SdkConfig, use them here to configure the config builder
+            // !!NOTE!! As more items are added to aws_types::SdkConfig, use them here to configure the config builder
             it.rustTemplate(
                 """
                 impl From<&#{SdkConfig}> for Builder {
@@ -76,7 +76,7 @@ class NewFromShared(runtimeConfig: RuntimeConfig) : ConfigCustomization() {
             ServiceConfig.ConfigImpl -> writable {
                 rustTemplate(
                     """
-                    /// Creates a new [service config](crate::Config) from a [shared `config`](aws_types::sdk_config::SdkConfig).
+                    /// Creates a new [service config](crate::Config) from a [shared `config`](#{SdkConfig}).
                     pub fn new(config: &#{SdkConfig}) -> Self {
                         Builder::from(config).build()
                     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -18,13 +18,13 @@ import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustom
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ServiceConfig
 
 /**
- * Adds functionality for constructing <service>::Config objects from aws_types::config::Config (SharedConfig)
+ * Adds functionality for constructing `<service>::Config` objects from `aws_types::sdk_config::SdkConfig`s
  *
- * - `From<&aws_types::config::Config> for <service>::config::Builder`: Enabling customization
- * - `pub fn new(&aws_types::config::Config) -> <service>::Config`: Direct construction without customization
+ * - `From<&aws_types::sdk_config::SdkConfig> for <service>::config::Builder`: Enabling customization
+ * - `pub fn new(&aws_types::sdk_config::SdkConfig) -> <service>::Config`: Direct construction without customization
  */
-class SharedConfigDecorator : RustCodegenDecorator {
-    override val name: String = "SharedConfig"
+class SdkConfigDecorator : RustCodegenDecorator {
+    override val name: String = "SdkConfig"
     override val order: Byte = 0
 
     override fun configCustomizations(
@@ -36,14 +36,14 @@ class SharedConfigDecorator : RustCodegenDecorator {
 
     override fun extras(codegenContext: CodegenContext, rustCrate: RustCrate) {
         val codegenScope = arrayOf(
-            "Config" to awsTypes(runtimeConfig = codegenContext.runtimeConfig).asType().member("config::Config")
+            "SdkConfig" to awsTypes(runtimeConfig = codegenContext.runtimeConfig).asType().member("sdk_config::SdkConfig")
         )
         rustCrate.withModule(RustModule.Config) {
-            // !!NOTE!! As more items are added to aws_types::config::Config, use them here to configure the config builder
+            // !!NOTE!! As more items are added to aws_types::sdk_config::SdkConfig, use them here to configure the config builder
             it.rustTemplate(
                 """
-                impl From<&#{Config}> for Builder {
-                    fn from(input: &#{Config}) -> Self {
+                impl From<&#{SdkConfig}> for Builder {
+                    fn from(input: &#{SdkConfig}) -> Self {
                         let mut builder = Builder::default();
                         builder = builder.region(input.region().cloned());
                         builder.set_retry_config(input.retry_config().cloned());
@@ -55,9 +55,9 @@ class SharedConfigDecorator : RustCodegenDecorator {
                     }
                 }
 
-                impl From<&#{Config}> for Config {
-                    fn from(config: &#{Config}) -> Self {
-                        Builder::from(config).build()
+                impl From<&#{SdkConfig}> for Config {
+                    fn from(sdk_config: &#{SdkConfig}) -> Self {
+                        Builder::from(sdk_config).build()
                     }
                 }
                 """,
@@ -69,15 +69,15 @@ class SharedConfigDecorator : RustCodegenDecorator {
 
 class NewFromShared(runtimeConfig: RuntimeConfig) : ConfigCustomization() {
     private val codegenScope = arrayOf(
-        "Config" to awsTypes(runtimeConfig = runtimeConfig).asType().member("config::Config")
+        "SdkConfig" to awsTypes(runtimeConfig = runtimeConfig).asType().member("sdk_config::SdkConfig")
     )
     override fun section(section: ServiceConfig): Writable {
         return when (section) {
             ServiceConfig.ConfigImpl -> writable {
                 rustTemplate(
                     """
-                    /// Creates a new [service config](crate::Config) from a [shared `config`](aws_types::config::Config).
-                    pub fn new(config: &#{Config}) -> Self {
+                    /// Creates a new [service config](crate::Config) from a [shared `config`](aws_types::sdk_config::SdkConfig).
+                    pub fn new(config: &#{SdkConfig}) -> Self {
                         Builder::from(config).build()
                     }
                     """,

--- a/aws/sdk/integration-tests/dynamodb/tests/cloning.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/cloning.rs
@@ -10,7 +10,7 @@ use aws_types::Credentials;
 // compiling this function validates that fluent builders are cloneable
 #[allow(dead_code)]
 async fn ensure_builders_clone() {
-    let shared_config = aws_types::sdk_config::SdkConfig::builder()
+    let shared_config = aws_types::SdkConfig::builder()
         .region(Region::new("us-east-4"))
         .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
             "asdf", "asdf", None, None, "test",

--- a/aws/sdk/integration-tests/dynamodb/tests/cloning.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/cloning.rs
@@ -10,7 +10,7 @@ use aws_types::Credentials;
 // compiling this function validates that fluent builders are cloneable
 #[allow(dead_code)]
 async fn ensure_builders_clone() {
-    let shared_config = aws_types::config::Config::builder()
+    let shared_config = aws_types::sdk_config::SdkConfig::builder()
         .region(Region::new("us-east-4"))
         .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
             "asdf", "asdf", None, None, "test",

--- a/aws/sdk/integration-tests/dynamodb/tests/shared-config.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/shared-config.rs
@@ -9,7 +9,7 @@ use http::Uri;
 /// Iterative test of loading clients from shared configuration
 #[tokio::test]
 async fn shared_config_testbed() {
-    let shared_config = aws_types::config::Config::builder()
+    let shared_config = aws_types::sdk_config::SdkConfig::builder()
         .region(Region::new("us-east-4"))
         .build();
     let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)

--- a/aws/sdk/integration-tests/dynamodb/tests/shared-config.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/shared-config.rs
@@ -9,7 +9,7 @@ use http::Uri;
 /// Iterative test of loading clients from shared configuration
 #[tokio::test]
 async fn shared_config_testbed() {
-    let shared_config = aws_types::sdk_config::SdkConfig::builder()
+    let shared_config = aws_types::SdkConfig::builder()
         .region(Region::new("us-east-4"))
         .build();
     let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-rust#406

## Description
<!--- Describe your changes in detail -->
rename `aws_types::config::Config` to `sdk_config::SdkConfig` and update everything referencing the old name

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran existing tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
