### PR TITLE
Enable presigning for two more S3 operations

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -16,3 +16,9 @@ message = "`DynMiddleware` is now `clone`able"
 references = ["smithy-rs#1225"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "Velfi"
+
+[[aws-sdk-rust]]
+message = "Enable presigning for S3 operations UploadPart and DeleteObject"
+references = ["aws-sdk-rust#475", "aws-sdk-rust#473"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "rcoh"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -63,8 +63,11 @@ private val SYNTHESIZE_SPEECH_OP = ShapeId.from("com.amazonaws.polly#SynthesizeS
 internal val PRESIGNABLE_OPERATIONS by lazy {
     mapOf(
         // S3
+        // TODO(https://github.com/awslabs/aws-sdk-rust/issues/488) Technically, all S3 operations support presigning
         ShapeId.from("com.amazonaws.s3#GetObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#PutObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
+        ShapeId.from("com.amazonaws.s3#UploadPart") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
+        ShapeId.from("com.amazonaws.s3#DeleteObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
 
         // Polly
         SYNTHESIZE_SPEECH_OP to PresignableOperation(

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -112,3 +112,19 @@ async fn test_presigning_with_payload_headers() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_presigned_upload_part() -> Result<(), Box<dyn Error>> {
+    let presigned = presign_input!(s3::input::UploadPartInput::builder()
+        .content_length(12345)
+        .bucket("bucket")
+        .key("key")
+        .part_number(0)
+        .upload_id("upload-id")
+        .build()?);
+    assert_eq!(
+        presigned.uri().to_string(),
+        "https://s3.us-east-1.amazonaws.com/bucket/key?x-id=UploadPart&uploadId=upload-id&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F20090213%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20090213T233131Z&X-Amz-Expires=30&X-Amz-SignedHeaders=content-length%3Bhost&X-Amz-Signature=e50e1a4d1dae7465bb7731863a565bdf4137393e3ab4119b5764fb49f5f60b14&X-Amz-Security-Token=notarealsessiontoken"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Motivation and Context
- aws-sdk-rust#473
- aws-sdk-rust#475

## Description
Add presigning for two more S3 operations

## Testing
I manually verified both of these functions. For posterity:
```rust
use std::{error::Error, time::Duration};

use aws_sdk_s3::{
    model::{CompletedMultipartUpload, CompletedPart},
    presigning::config::PresigningConfig,
};
#[tokio::main]
async fn main() -> Result<(), Box<dyn Error>> {
    tracing_subscriber::fmt::init();
    let bucket = "<your bucket here>";
    let key = "multipart-test";
    let conf = aws_config::load_from_env().await;
    let client = aws_sdk_s3::Client::new(&conf);
    let upload_id = client
        .create_multipart_upload()
        .bucket(bucket)
        .key(key)
        .send()
        .await?
        .upload_id
        .unwrap();
    let parts = vec![
        "a".repeat(5 * 1024 * 1024),
        "b".repeat(5 * 1024 * 1024),
        "cde".to_string(),
    ];
    let reqwest_client = reqwest::Client::new();
    let mut upload = CompletedMultipartUpload::builder();
    for (i, part) in parts.into_iter().enumerate() {
        let request = client
            .upload_part()
            .bucket(bucket)
            .part_number((i + 1) as i32)
            .bucket(bucket)
            .upload_id(&upload_id)
            .key(key)
            .presigned(
                PresigningConfig::builder()
                    .expires_in(Duration::from_secs(360))
                    .build()
                    .unwrap(),
            )
            .await?;
        let resp = reqwest_client
            .request(request.method().clone(), request.uri().to_string())
            .headers(request.headers().clone())
            .body(part)
            .send()
            .await?;
        upload = upload.parts(
            CompletedPart::builder()
                .part_number((i + 1) as i32)
                .e_tag(resp.headers().get("ETag").unwrap().to_str().unwrap())
                .build(),
        );
    }
    client
        .complete_multipart_upload()
        .bucket(bucket)
        .multipart_upload(upload.build())
        .key(key)
        .upload_id(&upload_id)
        .send()
        .await?;

    let request = client
        .delete_object()
        .bucket(bucket)
        .key(key)
        .presigned(
            PresigningConfig::builder()
                .expires_in(Duration::from_secs(360))
                .build()
                .unwrap(),
        )
        .await?;
    reqwest_client
        .request(request.method().clone(), request.uri().to_string())
        .send()
        .await?;
    Ok(())
}
```

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
