### PR TITLE
Use `apt-get update` before installing packages in server CI

### DIFF
--- a/.github/workflows/server-benchmark.yml
+++ b/.github/workflows/server-benchmark.yml
@@ -91,7 +91,7 @@ jobs:
         components: ${{ env.rust_toolchain_components }}
         default: true
     - name: Install benchmarks dependencies
-      run: sudo apt-get install -y ${{ env.apt_dependencies }}
+      run: sudo apt-get update && sudo apt-get install -y ${{ env.apt_dependencies }}
     # Ubuntu 20.04 doesn't have wrk packaged, hence we need to build it 🤦
     # This will go away as soon as GitHub supports Ubuntu 21.10.
     - name: Install wrk


### PR DESCRIPTION
## Motivation and Context
Use apt-get update before installing packages in server CI.

Prevents failures like https://github.com/awslabs/smithy-rs/runs/5494406634?check_suite_focus=true#step:9:75

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
