### PR TITLE
Fix docs for `aws_smithy_types::Number` converters

### DIFF
--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -88,8 +88,10 @@ pub enum Number {
 }
 
 macro_rules! to_num_fn {
-    ($name:ident, $typ:ident) => {
-        /// Converts to a `$typ`. This conversion may be lossy.
+    ($name:ident, $typ:ident, $styp:expr) => {
+        #[doc = "Converts to a `"]
+        #[doc = $styp]
+        #[doc = "`. This conversion may be lossy."]
         pub fn $name(self) -> $typ {
             match self {
                 Number::PosInt(val) => val as $typ,
@@ -97,6 +99,10 @@ macro_rules! to_num_fn {
                 Number::Float(val) => val as $typ,
             }
         }
+    };
+
+    ($name:ident, $typ:ident) => {
+        to_num_fn!($name, $typ, stringify!($typ));
     };
 }
 


### PR DESCRIPTION
Current docs: https://docs.rs/aws-smithy-types/0.38.0/aws_smithy_types/enum.Number.html

I learnt this trick from https://stackoverflow.com/a/43353854.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
