### PR TITLE
Fix developer guide URL

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "Fix link to Developer Guide in crate's README.md"
+references = ["smithy-rs#1262"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "liubin"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -16,3 +16,9 @@ message = "Fix link to Developer Guide in crate's README.md"
 references = ["smithy-rs#1262"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "liubin"
+
+[[aws-sdk-rust]]
+message = "Fix link to Developer Guide in crate's README.md"
+references = ["smithy-rs#1262"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "liubin"

--- a/aws/rust-runtime/aws-config/README.md
+++ b/aws/rust-runtime/aws-config/README.md
@@ -46,7 +46,7 @@ tokio = { version = "1", features = ["full"] }
 
 ## Using the SDK
 
-Until the SDK is released, we will be adding information about using the SDK to the [Guide]. Feel free to suggest additional sections for the guide by opening an issue and describing what you are trying to do.
+Until the SDK is released, we will be adding information about using the SDK to the [Developer Guide](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/welcome.html). Feel free to suggest additional sections for the guide by opening an issue and describing what you are trying to do.
 
 ## Getting Help
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
@@ -71,7 +71,7 @@ class AwsReadmeDecorator : RustCodegenDecorator {
                     ## Using the SDK
 
                     Until the SDK is released, we will be adding information about using the SDK to the
-                    [Guide](https://github.com/awslabs/aws-sdk-rust/blob/main/Guide.md). Feel free to suggest
+                    [Developer Guide](https://docs.aws.amazon.com/sdk-for-rust/latest/dg/welcome.html). Feel free to suggest
                     additional sections for the guide by opening an issue and describing what you are trying to do.
 
                     ## Getting Help


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Guide link in crate.io, for example, https://crates.io/crates/aws-sdk-s3, is pointing at an old page that has been deleted.

## Description
<!--- Describe your changes in detail -->

Fix it by using the new link https://docs.aws.amazon.com/sdk-for-rust/latest/dg/welcome.html

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

Though I have updated the generated README.md, it's only a typo fix, should I update CHANGELOG too?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
