### PR TITLE
Fix bug where where format argument is not a literal string

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/JsonParserGenerator.kt
@@ -370,7 +370,7 @@ class JsonParserGenerator(
                         if (StructureGenerator.fallibleBuilder(shape, symbolProvider)) {
                             rustTemplate(
                                 """.map_err(|err| #{Error}::new(
-                                #{ErrorReason}::Custom(format!({}, err).into()), None)
+                                #{ErrorReason}::Custom(format!("{}", err).into()), None)
                                 )?""",
                                 *codegenScope
                             )


### PR DESCRIPTION
## Motivation and Context
This bug is not exercised by the protocol tests. After this quick fix we should add a test to stress this behaviour.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
