### PR TITLE
fix: treat blank env credentials as missing

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,9 @@ message = "Update all SDK and runtime crates to [edition 2021](https://blog.rust
 references = ["aws-sdk-rust#490"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "Velfi"
+
+[[aws-sdk-rust]]
+message = "Treat blank environment variable credentials (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) as missing instead of attempting to use them to sign requests."
+references = ["aws-sdk-rust#1271"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "elrob"

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -320,6 +320,7 @@ mod test {
     make_test!(web_identity_token_profile);
     make_test!(profile_name);
     make_test!(profile_overrides_web_identity);
+    make_test!(environment_variables_blank);
     make_test!(imds_token_fail);
 
     make_test!(imds_no_iam_role);

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/env.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/env.json
@@ -1,0 +1,6 @@
+{
+  "HOME": "/home",
+  "AWS_ACCESS_KEY_ID": " ",
+  "AWS_SECRET_ACCESS_KEY": " ",
+  "AWS_PROFILE": "some_profile"
+}

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/fs/home/.aws/config
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/fs/home/.aws/config
@@ -1,0 +1,9 @@
+[default]
+region = us-east-1
+aws_access_key_id = incorrect_key
+aws_secret_access_key = incorrect_secret
+
+[profile some_profile]
+region = us-east-2
+aws_access_key_id = correct_key
+aws_secret_access_key = correct_secret

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/http-traffic.json
@@ -1,0 +1,5 @@
+{
+  "events": [],
+  "docs": "test case uses static creds, no network requests",
+  "version": "V0"
+}

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/environment_variables_blank/test-case.json
@@ -1,0 +1,10 @@
+{
+    "name": "environment_variables_blank",
+    "docs": "verifies blank AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are treated as missing",
+    "result": {
+        "Ok": {
+            "access_key_id": "correct_key",
+            "secret_access_key": "correct_secret"
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Blank environment variable credentials should be disregarded.
`AWS_ACCESS_KEY_ID="" AWS_SECRET_ACCESS_KEY=""`

Some existing automation I work with deliberately sets these to blank so that alternative credentials providers are used.
Using the aws-sdk-rust, these blank env vars were picked up and auth fails rather than using profile credentials.

## Description
aws-sdk-js-v3 has this behaviour:
https://github.com/aws/aws-sdk-js-v3/blob/1aae04fcd420f9532f63b009090f97754cd0d631/packages/credential-provider-env/src/fromEnv.ts#L20

aws-sdk-java-v2 has this behaviour:
https://github.com/aws/aws-sdk-java-v2/blob/c8c1fd4a138d8602cd2905b0f59d2a3913efb5df/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/internal/SystemSettingsCredentialsProvider.java#L52

## Testing
Automated tests added together with the change. These fail if the change does not exist.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
