### PR TITLE
Fix path on git command

### DIFF
--- a/tools/ci-build/ci-output-build-image
+++ b/tools/ci-build/ci-output-build-image
@@ -14,7 +14,7 @@ if [[ $# -eq 1 ]]; then
 else
     # Otherwise, for the use-case where CI is being run directly on the main branch
     # without a pull request, use the commit hash of HEAD
-    BASE_REVISION="$(git rev-parse HEAD)"
+    BASE_REVISION="$(cd smithy-rs; git rev-parse HEAD)"
 fi
 
 SCRIPT_PATH="$(realpath "$(dirname "$0")")"


### PR DESCRIPTION
## Motivation and Context
Command needs to run inside smithy-rs, which is not the current directory when the script is run from GitHub Actions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
