### PR TITLE
Improve AssumeRoleProvider

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -40,3 +40,15 @@ message = "Treat blank environment variable credentials (`AWS_ACCESS_KEY_ID` and
 references = ["aws-sdk-rust#1271"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "elrob"
+
+[[aws-sdk-rust]]
+message = "Add support for configuring the session length in [AssumeRoleProvider](https://docs.rs/aws-config/latest/aws_config/sts/struct.AssumeRoleProvider.html)"
+references = ["aws-sdk-rust#479", "smithy-rs#1296"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Add caching to [AssumeRoleProvider](https://docs.rs/aws-config/latest/aws_config/sts/struct.AssumeRoleProvider.html)"
+references = ["smithy-rs#1296"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"


### PR DESCRIPTION


## Motivation and Context
AssumeRoleProvider is used directly by a number of customers, but it isn't cached and is missing some key features.
- aws-sdk-rust#479

## Description
<!--- Describe your changes in detail -->
This adds to improvements to `AssumeRoleProvider`:
1. This adds a cache aroudn this provider. Since this provider is intended to be used directly by customers,
it should be cached to improve performance and predictability.

2. Add support for configuring the role session length.

## Testing
- [x] Adds UT

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
