### PR TITLE
Split codegen tests out into their own job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
       matrix:
         # These correspond to scripts in tools/ci-build/scripts that will be run in the Docker build image
         actions:
-        - action: check-style-and-lints
         - action: generate-aws-sdk
         - action: generate-aws-sdk-smoketest
         - action: generate-smithy-rs-runtime-bundle
@@ -66,8 +65,35 @@ jobs:
       with:
         action: ${{ matrix.actions.action }}
 
-  test:
-    name: Test
+  test-codegen:
+    name: Test Codegen
+    needs:
+    - acquire-base-image
+    runs-on: ubuntu-latest
+    # To avoid repeating setup boilerplate, we have the actual test commands
+    # in a matrix strategy. These commands get run in the steps after all the setup.
+    strategy:
+      fail-fast: false
+      matrix:
+        # These correspond to scripts in tools/ci-build/scripts that will be run in the Docker build image
+        test:
+        - action: check-style-and-lints
+        - action: check-client-codegen-integration-tests
+        - action: check-client-codegen-unit-tests
+        - action: check-sdk-codegen-unit-tests
+        - action: check-server-codegen-integration-tests
+        - action: check-server-codegen-unit-tests
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: smithy-rs
+    - name: Run ${{ matrix.test.action }}
+      uses: ./smithy-rs/.github/actions/docker-build
+      with:
+        action: ${{ matrix.test.action }}
+
+  test-runtimes-tools-and-sdk:
+    name: Test Rust Runtimes, Tools, and SDK
     needs:
     - acquire-base-image
     - generate
@@ -83,12 +109,7 @@ jobs:
         - action: check-aws-sdk-smoketest-additional-checks
         - action: check-aws-sdk-smoketest-docs-clippy-udeps
         - action: check-aws-sdk-smoketest-unit-tests
-        - action: check-client-codegen-integration-tests
-        - action: check-client-codegen-unit-tests
         - action: check-rust-runtimes-and-tools
-        - action: check-sdk-codegen-unit-tests
-        - action: check-server-codegen-integration-tests
-        - action: check-server-codegen-unit-tests
     steps:
     - uses: actions/checkout@v3
       with:
@@ -150,7 +171,8 @@ jobs:
     # Should NOT depend on check-sdk-examples since that's an optional check
     needs:
     - generate
-    - test
+    - test-codegen
+    - test-runtimes-tools-and-sdk
     - test-rust-windows
     # Run this job even if its dependency jobs fail
     if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
       with:
         action: ${{ matrix.actions.action }}
 
+  # Test the code generator and other parts (styles and lints) that don't require
+  # code to have already been generated in order to run.
   test-codegen:
     name: Test Codegen
     needs:
@@ -92,6 +94,8 @@ jobs:
       with:
         action: ${{ matrix.test.action }}
 
+  # Test all the things that require generated code. Note: the Rust runtimes require codegen
+  # to be checked since `aws-config` depends on the generated STS client.
   test-runtimes-tools-and-sdk:
     name: Test Rust Runtimes, Tools, and SDK
     needs:


### PR DESCRIPTION
## Motivation and Context
This should give faster feedback on codegen tests since they will no longer need to wait for the SDK to be generated in order to run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
