### PR TITLE
aws-smithy-query: bump to urlencoding v2.1

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -52,3 +52,9 @@ message = "Add caching to [AssumeRoleProvider](https://docs.rs/aws-config/latest
 references = ["smithy-rs#1296"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[smithy-rs]]
+message = "Update urlencoding crate to v2.1.0"
+references = ["smithy-rs#1301"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "benesch"

--- a/rust-runtime/aws-smithy-query/Cargo.toml
+++ b/rust-runtime/aws-smithy-query/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types" }
-urlencoding = "1.3"
+urlencoding = "2.1"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Motivation and Context

urlencoding v2.1 is a SemVer-breaking change. We use `urlencoding` in our own crates downstream, and we want to have only one copy of `urlencoding`, so we need `aws-smithy-query` to upgrade to.

## Description

Bumps `aws-smithy-query` from urlencoding v1.3 to urlencoding v2.1.

## Testing

CI coverage should be enough!

## Checklist

- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
