### PR TITLE
Make `builderSymbol` return a `Symbol`

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/BuilderGenerator.kt
@@ -35,10 +35,16 @@ import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.util.dq
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
 
-fun StructureShape.builderSymbol(symbolProvider: RustSymbolProvider): RuntimeType {
-    val symbol = symbolProvider.toSymbol(this)
-    val builderNamespace = RustReservedWords.escapeIfNeeded(symbol.name.toSnakeCase())
-    return RuntimeType("Builder", null, "${symbol.namespace}::$builderNamespace")
+fun StructureShape.builderSymbol(symbolProvider: RustSymbolProvider): Symbol {
+    val structureSymbol = symbolProvider.toSymbol(this)
+    val builderNamespace = RustReservedWords.escapeIfNeeded(structureSymbol.name.toSnakeCase())
+    val rustType = RustType.Opaque("Builder", "${structureSymbol.namespace}::$builderNamespace")
+    return Symbol.builder()
+        .rustType(rustType)
+        .name(rustType.name)
+        .namespace(rustType.namespace, "::")
+        .definitionFile(structureSymbol.definitionFile)
+        .build()
 }
 
 fun RuntimeConfig.operationBuildError() = RuntimeType.operationModule(this).member("BuildError")


### PR DESCRIPTION
It currently returns a `RuntimeType`. It makes no actual difference
whatsoever, but `RuntimeType` is kept for types we don't code-generate,
but that we use from other crates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
