### PR TITLE
Add minimal tracing to server framework

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
@@ -22,6 +22,7 @@ object ServerCargoDependency {
     val PinProjectLite: CargoDependency = CargoDependency("pin-project-lite", CratesIo("0.2"))
     val SerdeUrlEncoded: CargoDependency = CargoDependency("serde_urlencoded", CratesIo("0.7"))
     val Tower: CargoDependency = CargoDependency("tower", CratesIo("0.4"))
+    val Tracing: CargoDependency = CargoDependency("tracing", CratesIo("0.1"))
 
     fun SmithyHttpServer(runtimeConfig: RuntimeConfig) = runtimeConfig.runtimeCrate("http-server")
 }

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1"
 tokio = { version = "1.0", features = ["full"] }
 tower = { version = "0.4.11", features = ["util", "make"], default-features = false }
 tower-http = { version = "0.2.1", features = ["add-extension", "map-response-body"] }
+tracing = "0.1"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/rust-runtime/aws-smithy-http-server/examples/Makefile
+++ b/rust-runtime/aws-smithy-http-server/examples/Makefile
@@ -18,7 +18,7 @@ build: codegen
 	cargo build
 
 run: codegen
-	cargo run
+	RUST_LOG=DEBUG cargo run
 
 doc-open: codegen
 	cargo doc --no-deps --open

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
@@ -124,6 +124,8 @@ impl Default for State {
     }
 }
 
+// Operation handler implementations get automatically instrumented at the callsite within a new
+// `tracing::span::Span`.
 /// Retrieves information about a Pokémon species.
 pub async fn get_pokemon_species(
     input: input::GetPokemonSpeciesInput,
@@ -156,7 +158,7 @@ pub async fn get_pokemon_species(
             Ok(output)
         }
         None => {
-            tracing::error!("Requested Pokémon {} not available", input.name);
+            tracing::error!("Requested Pokémon `{}` not available", input.name);
             Err(error::GetPokemonSpeciesError::ResourceNotFoundException(
                 error::ResourceNotFoundException {
                     message: String::from("Requested Pokémon not available"),


### PR DESCRIPTION
This commit adds minimal tracing at the `DEBUG` level to the
code-generated `OperationHandler` trait implementations for each
operation, logging the deserialized operation input as well as any
errors. The router also has some minimal tracing to detect requests that
are not routed successfully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Examples

Successful `pokemon-species` operation:

```
2022-04-12T16:59:06.780701Z DEBUG hyper::proto::h1::io: 205: parsed 3 headers
2022-04-12T16:59:06.780743Z DEBUG hyper::proto::h1::conn: 217: incoming body is empty
2022-04-12T16:59:06.781142Z DEBUG router: aws_smithy_http_server::routing: 157: request routed successfully to operation
2022-04-12T16:59:06.781286Z DEBUG request{method=GET uri=/pokemon-species/pikachu version=HTTP/1.1}: tower_http::trace::on_request: 91: started processing request
2022-04-12T16:59:06.781383Z DEBUG request{method=GET uri=/pokemon-species/pikachu version=HTTP/1.1}: pokemon_service: 139: Requested Pokémon is pikachu
2022-04-12T16:59:06.781549Z DEBUG request{method=GET uri=/pokemon-species/pikachu version=HTTP/1.1}: tower_http::trace::on_response: 254: finished processing request latency=0 ms status=200
2022-04-12T16:59:06.781694Z DEBUG hyper::proto::h1::io: 312: flushed 526 bytes
2022-04-12T16:59:06.781850Z DEBUG hyper::proto::h1::conn: 276: read eof
```

Unsuccessful `pokemon-species` operation:

```
2022-04-12T16:59:52.865557Z DEBUG hyper::proto::h1::io: 205: parsed 3 headers
2022-04-12T16:59:52.865598Z DEBUG hyper::proto::h1::conn: 217: incoming body is empty
2022-04-12T16:59:52.865985Z DEBUG router: aws_smithy_http_server::routing: 157: request routed successfully to operation
2022-04-12T16:59:52.866123Z DEBUG request{method=GET uri=/pokemon-species/magikarp version=HTTP/1.1}: tower_http::trace::on_request: 91: started processing request
2022-04-12T16:59:52.866234Z ERROR request{method=GET uri=/pokemon-species/magikarp version=HTTP/1.1}: pokemon_service: 161: Requested Pokémon `magikarp` not available
2022-04-12T16:59:52.866387Z DEBUG request{method=GET uri=/pokemon-species/magikarp version=HTTP/1.1}: tower_http::trace::on_response: 254: finished processing request latency=0 ms status=404
2022-04-12T16:59:52.866532Z DEBUG hyper::proto::h1::io: 312: flushed 206 bytes
2022-04-12T16:59:52.866658Z DEBUG hyper::proto::h1::conn: 276: read eof
```

Unsuccessful routing:

```
2022-04-12T17:00:44.832441Z DEBUG hyper::proto::h1::io: 205: parsed 3 headers
2022-04-12T17:00:44.832487Z DEBUG hyper::proto::h1::conn: 217: incoming body is empty
2022-04-12T17:00:44.832733Z DEBUG router: aws_smithy_http_server::routing: 166: request does not match any operation route method=GET uri=/not-found headers={"host": "localhost:13734", "user-agent": "curl/7.79.1", "accept": "*/*"} version=HTTP/1.1
2022-04-12T17:00:44.832898Z DEBUG hyper::proto::h1::io: 312: flushed 82 bytes
2022-04-12T17:00:44.833046Z DEBUG hyper::proto::h1::conn: 276: read eof
```

