### PR TITLE
Only retry transient failures for idempotent operations

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -64,3 +64,15 @@ message = "Add endpoint resolver to SdkConfig. This enables overriding the endpo
 references = ["smithy-rs#1300"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "benesch"
+
+[[smithy-rs]]
+message = "Transient errors are now only retried when an operation is modeled as `@idempotent` or `@readonly`."
+references = ["smithy-rs#1315"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Transient errors are now only retried when an operation is modeled as `@idempotent` or `@readonly`."
+references = ["smithy-rs#1315"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/MakeOperationGeneratorTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.generators.protocol
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.smithy.CodegenVisitor
+import software.amazon.smithy.rust.codegen.smithy.customize.CombinedCodegenDecorator
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.smithy.generators.LibRsCustomization
+import software.amazon.smithy.rust.codegen.smithy.generators.LibRsSection
+import software.amazon.smithy.rust.codegen.smithy.generators.ManifestCustomizations
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.generatePluginContext
+import software.amazon.smithy.rust.codegen.util.runCommand
+
+class MakeOperationGeneratorTest {
+    @Test
+    fun `idempotent operations are marked to retry transient errors`() {
+        val model = """
+            namespace test
+            use aws.protocols#restJson1
+
+            @restJson1
+            service TestService {
+                version: "2022-02-22",
+                operations: [IdempotentOperation, ReadonlyOperation, NonIdempotentOperation],
+            }
+
+            structure SomeStruct {
+            }
+
+            @idempotent
+            @http(uri: "/idempotent", method: "POST")
+            operation IdempotentOperation {
+                input: SomeStruct,
+                output: SomeStruct,
+            }
+
+            @readonly
+            @http(uri: "/readonly", method: "POST")
+            operation ReadonlyOperation {
+                input: SomeStruct,
+                output: SomeStruct,
+            }
+
+            @http(uri: "/non-idempotent", method: "POST")
+            operation NonIdempotentOperation {
+                input: SomeStruct,
+                output: SomeStruct,
+            }
+        """.asSmithyModel()
+
+        val (pluginContext, testDir) = generatePluginContext(model)
+        CodegenVisitor(
+            pluginContext,
+            CombinedCodegenDecorator.fromClasspath(pluginContext).withDecorator(object : RustCodegenDecorator {
+                override val name: String = "TestMakeOperation"
+                override val order: Byte = 0
+
+                override fun crateManifestCustomizations(codegenContext: CodegenContext): ManifestCustomizations {
+                    return mapOf(
+                        "dependencies" to mapOf(
+                            "tokio" to mapOf(
+                                "version" to "1",
+                                "features" to listOf("full")
+                            )
+                        )
+                    )
+                }
+
+                override fun libRsCustomizations(
+                    codegenContext: CodegenContext,
+                    baseCustomizations: List<LibRsCustomization>
+                ): List<LibRsCustomization> = baseCustomizations + listOf(
+                    object : LibRsCustomization() {
+                        override fun section(section: LibRsSection): Writable = writable {
+                            when (section) {
+                                is LibRsSection.Body -> rustBlock("##[tokio::test] async fn test()") {
+                                    rust(
+                                        """
+                                        use crate::config::Config;
+                                        use crate::input::*;
+                                        use aws_smithy_client::retry::AllowOperationRetryOnTransientFailure;
+
+                                        let config = Config::builder().build();
+                                        let operation = IdempotentOperationInput::builder()
+                                            .build()
+                                            .expect("valid")
+                                            .make_operation(&config)
+                                            .await
+                                            .expect("success");
+                                        let properties = operation.properties();
+                                        assert!(properties.get::<AllowOperationRetryOnTransientFailure>().is_some());
+
+                                        let operation = ReadonlyOperationInput::builder()
+                                            .build()
+                                            .expect("valid")
+                                            .make_operation(&config)
+                                            .await
+                                            .expect("success");
+                                        let properties = operation.properties();
+                                        assert!(properties.get::<AllowOperationRetryOnTransientFailure>().is_some());
+
+                                        let operation = NonIdempotentOperationInput::builder()
+                                            .build()
+                                            .expect("valid")
+                                            .make_operation(&config)
+                                            .await
+                                            .expect("success");
+                                        let properties = operation.properties();
+                                        assert!(properties.get::<AllowOperationRetryOnTransientFailure>().is_none());
+                                        """
+                                    )
+                                }
+                                else -> emptySection
+                            }
+                        }
+                    }
+                )
+            })
+        ).execute()
+        "cargo test".runCommand(testDir)
+    }
+}

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -54,5 +54,5 @@ rustdoc-args = ["--cfg", "docsrs"]
 # End of docs.rs metadata
 
 [[test]]
-name = "e2e_test"
+name = "retry_test"
 required-features = ["test-util", "rt-tokio"]

--- a/rust-runtime/aws-smithy-client/tests/retry_test.rs
+++ b/rust-runtime/aws-smithy-client/tests/retry_test.rs
@@ -138,7 +138,7 @@ fn transient_err() -> http::Response<&'static str> {
 }
 
 #[tokio::test]
-async fn end_to_end_retry_test() {
+async fn retry_test() {
     // 1 failing response followed by 1 successful response
     let events = vec![
         // First operation
@@ -191,7 +191,7 @@ async fn end_to_end_retry_test() {
 }
 
 #[tokio::test]
-async fn end_to_end_retry_test_transients_not_retried() {
+async fn retry_test_transients_not_retried() {
     // 1 failing response followed by 1 successful response
     let events = vec![
         // First operation


### PR DESCRIPTION
## Motivation and Context
Transient failures can only safely be retried for operations modeled as  idempotent or readonly. This PR revises the `make_operation` code generator to conditionally add a marker struct to the operation property bag based on the Smithy `@idempotent` or `@readonly` operation traits, and modifies the Tower retry handler to check for that marker when retrying a transient error.

## Testing
- Unit tested the addition of the marker struct in MakeOperationGeneratorTest
- Unit tested the use of the marker struct in `retry_test`

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
