### PR TITLE
Fix tools dockerignore file

### DIFF
--- a/tools/.dockerignore
+++ b/tools/.dockerignore
@@ -1,4 +1,4 @@
 /target
 /ci-cdk/build
-node_modules
-cdk.out
+**/node_modules
+**/cdk.out


### PR DESCRIPTION
## Motivation and Context
Docker ignore files behave slightly differently than gitignore files, so the `**/` in front is necessary for them to actually exclude entries in nested directories.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
