### PR TITLE
Clean generated SDK before assembling a new one

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -357,6 +357,11 @@ task("finalizeSdk") {
     )
 }
 
+tasks.register<Delete>("deleteSdk") {
+    delete = setOf(outputDir)
+}
+tasks["clean"].dependsOn("deleteSdk")
+
 tasks["smithyBuildJar"].apply {
     inputs.file(projectDir.resolve("smithy-build.json"))
     inputs.dir(projectDir.resolve("aws-models"))
@@ -365,6 +370,7 @@ tasks["smithyBuildJar"].apply {
     outputs.upToDateWhen { false }
 }
 tasks["assemble"].apply {
+    dependsOn("deleteSdk")
     dependsOn("smithyBuildJar")
     finalizedBy("finalizeSdk")
 }


### PR DESCRIPTION
## Motivation and Context
When switching between generating a full SDK and smoketest SDK locally, the smoketest SDK can fail to assemble due to the `smithy-build.json` being inconsistent with the generated crates that are on disk. This breaks the `publisher generate-version-manifest` tool since it relies on `smithy-build.json` to hash to the service models, and at the same time, relies on the file system to discover which service crates exist.

## Testing
- Ran `g -Paws.fullsdk=true aws:sdk:assemble` and then `g aws:sdk:cargoCheck`. Before this PR, this would fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
