### PR TITLE
update: gradle.properties for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 <!-- Do not manually edit this file, use `update-changelogs` -->
-0.40.1 (April 14th, 2022)
+0.40.2 (April 14th, 2022)
 =========================
-**New this release:**
-- Undo the MSRV bump from v1.56.1 to v1.58.1
 
-0.40.0 (April 13th, 2022)
-=========================
 **Breaking Changes:**
 - ⚠ ([aws-sdk-rust#490](https://github.com/awslabs/aws-sdk-rust/issues/490)) Update all runtime crates to [edition 2021](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
 

--- a/aws/SDK_CHANGELOG.md
+++ b/aws/SDK_CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- Do not manually edit this file, use `update-changelogs` -->
-0.10.0 (April 13th, 2022)
+0.10.1 (April 14th, 2022)
 =========================
+
 **Breaking Changes:**
 - ⚠ ([aws-sdk-rust#490](https://github.com/awslabs/aws-sdk-rust/issues/490)) Update all SDK and runtime crates to [edition 2021](https://blog.rust-lang.org/2021/10/21/Rust-1.56.0.html)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ rust.msrv=1.56.1
 aws.sdk.version=0.10.0
 
 # Version number to use for the generated runtime crates
-smithy.rs.runtime.crate.version=0.40.0
+smithy.rs.runtime.crate.version=0.40.2
 
 kotlin.code.style=official
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ rust.msrv=1.56.1
 
 # Version number to use for the generated SDK
 # Note: these must always be full 3-segment semver versions
-aws.sdk.version=0.10.0
+aws.sdk.version=0.10.1
 
 # Version number to use for the generated runtime crates
 smithy.rs.runtime.crate.version=0.40.2


### PR DESCRIPTION
I made a mistake by forgetting to update the gradle version number to 0.40.1 for the last release and didn't catch it until I was running the publish command and saw it was publishing aws-smithy-types v0.40.0

It needs to be update to 0.40.2 so I can do a third release and fix it

This PR fixes that
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
