### PR TITLE
update: MSRV from 1.56.1 to 1.58.1

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -14,7 +14,7 @@
 [[aws-sdk-rust]]
 message = "Bump [MSRV](https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv) from 1.56.1 to 1.58.1 per our \"two versions behind\" policy."
 references = ["smithy-rs#1318"]
-meta = { "breaking" = false, "tada" = false, "bug" = false }
+meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "Velfi"
 
 [[smithy-rs]]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -20,5 +20,5 @@ author = "Velfi"
 [[smithy-rs]]
 message = "Bump [MSRV](https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv) from 1.56.1 to 1.58.1 per our \"two versions behind\" policy."
 references = ["smithy-rs#1318"]
-meta = { "breaking" = false, "tada" = false, "bug" = false }
+meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "Velfi"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Bump [MSRV](https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv) from 1.56.1 to 1.58.1 per our \"two versions behind\" policy."
+references = ["smithy-rs#1318"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "Velfi"
+
+[[smithy-rs]]
+message = "Bump [MSRV](https://github.com/awslabs/aws-sdk-rust#supported-rust-versions-msrv) from 1.56.1 to 1.58.1 per our \"two versions behind\" policy."
+references = ["smithy-rs#1318"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "Velfi"

--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -131,6 +131,7 @@ impl ProvideCredentials for EcsCredentialsProvider {
 
 /// Inner Provider that can record failed configuration state
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 enum Provider {
     Configured(HttpCredentialProvider),
     NotConfigured,

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -480,7 +480,7 @@ impl<'a> fmt::Display for StringToSign<'a> {
             "{}\n{}\n{}\n{}",
             HMAC_256,
             format_date_time(self.time),
-            self.scope.to_string(),
+            self.scope,
             self.hashed_creq
         )
     }

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -287,7 +287,7 @@ fn build_authorization_header(
         "{} Credential={}/{}, SignedHeaders={}, Signature={}",
         HMAC_256,
         access_key,
-        sts.scope.to_string(),
+        sts.scope,
         creq.values.signed_headers().as_str(),
         signature
     ))

--- a/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
+++ b/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
@@ -39,7 +39,7 @@ async fn test_success() {
         match event {
             TranscriptResultStream::TranscriptEvent(transcript_event) => {
                 let transcript = transcript_event.transcript.unwrap();
-                for result in transcript.results.unwrap_or_else(|| Vec::new()) {
+                for result in transcript.results.unwrap_or_else(Vec::new) {
                     if !result.is_partial {
                         let first_alternative = &result.alternatives.as_ref().unwrap()[0];
                         full_message += first_alternative.transcript.as_ref().unwrap();

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.56.1
+rust.msrv=1.58.1
 
 # Version number to use for the generated SDK
 # Note: these must always be full 3-segment semver versions

--- a/rust-runtime/aws-smithy-json/src/serialize.rs
+++ b/rust-runtime/aws-smithy-json/src/serialize.rs
@@ -144,7 +144,7 @@ impl<'a> JsonObjectWriter<'a> {
         self.json.push_str(&escape_string(key));
         self.json.push_str("\":");
 
-        JsonValueWriter::new(&mut self.json)
+        JsonValueWriter::new(self.json)
     }
 
     /// Finishes the object.
@@ -170,7 +170,7 @@ impl<'a> JsonArrayWriter<'a> {
     /// Starts a new value in the array.
     pub fn value(&mut self) -> JsonValueWriter {
         self.comma_delimit();
-        JsonValueWriter::new(&mut self.json)
+        JsonValueWriter::new(self.json)
     }
 
     /// Finishes the array.

--- a/rust-runtime/aws-smithy-xml/src/decode.rs
+++ b/rust-runtime/aws-smithy-xml/src/decode.rs
@@ -300,7 +300,7 @@ impl<'inp> ScopedDecoder<'inp, '_> {
 
     fn nested_decoder<'a>(&'a mut self, start_el: StartEl<'inp>) -> ScopedDecoder<'inp, 'a> {
         ScopedDecoder {
-            doc: &mut self.doc,
+            doc: self.doc,
             start_el,
             terminated: false,
         }

--- a/rust-runtime/inlineable/src/json_errors.rs
+++ b/rust-runtime/inlineable/src/json_errors.rs
@@ -98,7 +98,7 @@ pub fn parse_generic_error(
     if let Some(code) = error_type_from_header(headers)
         .map_err(|_| DeserializeError::custom("X-Amzn-Errortype header was not valid UTF-8"))?
         .or_else(|| code.as_deref())
-        .map(|c| sanitize_error_code(c))
+        .map(sanitize_error_code)
     {
         err_builder.code(code);
     }

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -38,7 +38,7 @@ RUN set -eux; \
 # Rust & Tools Installation Stage
 #
 FROM bare_base_image AS install_rust
-ARG rust_stable_version=1.56.1
+ARG rust_stable_version=1.58.1
 ARG rust_nightly_version=nightly-2022-03-29
 ARG cargo_udeps_version=0.1.27
 ARG cargo_hack_version=0.5.12
@@ -95,7 +95,7 @@ RUN set -eux; \
 # Final image
 #
 FROM bare_base_image AS final_image
-ARG rust_stable_version=1.56.1
+ARG rust_stable_version=1.58.1
 ARG rust_nightly_version=nightly-2022-03-29
 RUN set -eux; \
     yum -y updateinfo; \

--- a/tools/ci-cdk/canary-lambda/src/transcribe_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/transcribe_canary.rs
@@ -48,7 +48,7 @@ pub async fn transcribe_canary(
         match event {
             TranscriptResultStream::TranscriptEvent(transcript_event) => {
                 let transcript = transcript_event.transcript.unwrap();
-                for result in transcript.results.unwrap_or_else(|| Vec::new()) {
+                for result in transcript.results.unwrap_or_else(Vec::new) {
                     if !result.is_partial {
                         let first_alternative = &result.alternatives.as_ref().unwrap()[0];
                         full_message += first_alternative.transcript.as_ref().unwrap();

--- a/tools/sdk-lints/src/copyright.rs
+++ b/tools/sdk-lints/src/copyright.rs
@@ -59,7 +59,7 @@ fn check_copyright_header(path: impl AsRef<Path>) -> Vec<LintError> {
 }
 
 fn needs_copyright_header(path: &Path) -> bool {
-    let mut need_extensions = NEEDS_HEADER.iter().map(|s| OsStr::new(s));
+    let mut need_extensions = NEEDS_HEADER.iter().map(OsStr::new);
     need_extensions.any(|extension| path.extension().unwrap_or_default() == extension)
 }
 

--- a/tools/sdk-versioner/Cargo.lock
+++ b/tools/sdk-versioner/Cargo.lock
@@ -283,6 +283,20 @@ name = "serde"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.133"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "smithy-rs-tool-common"
@@ -290,6 +304,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "serde",
  "tracing",
 ]
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
#1318 

## Description
<!--- Describe your changes in detail -->
This PR bumps the SDK's MSRV from 1.56.1 to 1.58.1 per our MSRV "2 versions behind" policy. It also fixes many issues highlighted by the latest clippy lints.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran existing tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
