### PR TITLE
Use Rust 2021 edition for pre-commit's `rustfmt`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,5 +26,5 @@ repos:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
   - id: pretty-format-rust
-    entry: rustfmt --edition 2018
+    entry: rustfmt --edition 2021
     files: ^.*\.rs$


### PR DESCRIPTION
In #1268, runtime crates were updated to Rust 2021 edition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
