### PR TITLE
Fix SDK assemble Gradle pathing issue

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
@@ -26,9 +26,10 @@ class IntegrationTestDecorator : RustCodegenDecorator {
         codegenContext: CodegenContext,
         baseCustomizations: List<LibRsCustomization>
     ): List<LibRsCustomization> {
-        val integrationTestPath = Paths.get("aws/sdk/integration-tests")
+        val integrationTestPath = Paths.get(SdkSettings.from(codegenContext.settings).integrationTestPath)
         check(Files.exists(integrationTestPath)) {
-            "IntegrationTestDecorator expects to be run from the smithy-rs package root"
+            "Failed to find the AWS SDK integration tests. Make sure the integration test path is configured " +
+                "correctly in the smithy-build.json."
         }
 
         val moduleName = codegenContext.moduleName.substring("aws-sdk-".length)

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+package software.amazon.smithy.rustsdk
+
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.rust.codegen.smithy.RustSettings
+import software.amazon.smithy.rust.codegen.util.orNull
+
+/**
+ * SDK-specific settings within the Rust codegen `customizationConfig.awsSdk` object.
+ */
+class SdkSettings private constructor(private val awsSdk: ObjectNode?) {
+    companion object {
+        fun from(rustSettings: RustSettings): SdkSettings =
+            SdkSettings(rustSettings.customizationConfig?.getObjectMember("awsSdk")?.orNull())
+    }
+
+    /** Path to AWS SDK integration tests */
+    val integrationTestPath: String get() =
+        awsSdk?.getStringMember("integrationTestPath")?.orNull()?.value ?: "aws/sdk/integration-tests"
+}

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -15,7 +15,7 @@ extra["moduleName"] = "software.amazon.smithy.rust.awssdk"
 tasks["jar"].enabled = false
 
 plugins {
-    id("software.amazon.smithy").version("0.5.3")
+    id("software.amazon.smithy").version("0.6.0")
 }
 
 val smithyVersion: String by project
@@ -105,7 +105,12 @@ fun generateSmithyBuild(services: AwsServices): String {
                         "moduleDescription": "${service.moduleDescription}",
                         ${service.examplesUri(project)?.let { """"examples": "$it",""" } ?: ""}
                         "moduleRepository": "https://github.com/awslabs/aws-sdk-rust",
-                        "license": "Apache-2.0"
+                        "license": "Apache-2.0",
+                        "customizationConfig": {
+                            "awsSdk": {
+                                "integrationTestPath": "${project.projectDir.resolve("integration-tests")}"
+                            }
+                        }
                         ${service.extraConfig ?: ""}
                     }
                 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustSettings.kt
@@ -26,6 +26,7 @@ private const val MODULE_REPOSITORY = "moduleRepository"
 private const val RUNTIME_CONFIG = "runtimeConfig"
 private const val LICENSE = "license"
 private const val EXAMPLES = "examples"
+private const val CUSTOMIZATION_CONFIG = "customizationConfig"
 const val CODEGEN_SETTINGS = "codegen"
 
 /**
@@ -81,7 +82,8 @@ class RustSettings(
     val runtimeConfig: RuntimeConfig,
     val codegenConfig: CodegenConfig,
     val license: String?,
-    val examplesUri: String? = null
+    val examplesUri: String? = null,
+    val customizationConfig: ObjectNode? = null
 ) {
 
     /**
@@ -135,7 +137,8 @@ class RustSettings(
                     RUNTIME_CONFIG,
                     CODEGEN_SETTINGS,
                     EXAMPLES,
-                    LICENSE
+                    LICENSE,
+                    CUSTOMIZATION_CONFIG
                 )
             )
 
@@ -154,7 +157,8 @@ class RustSettings(
                 runtimeConfig = RuntimeConfig.fromNode(runtimeConfig),
                 codegenConfig,
                 license = config.getStringMember(LICENSE).orNull()?.value,
-                examplesUri = config.getStringMember(EXAMPLES).orNull()?.value
+                examplesUri = config.getStringMember(EXAMPLES).orNull()?.value,
+                customizationConfig = config.getObjectMember(CUSTOMIZATION_CONFIG).orNull()
             )
         }
 


### PR DESCRIPTION
## Motivation and Context

On M1 Macs, Gradle's working directory is the path of the Gradle daemon
rather than the project root. The SDK's `IntegrationTestDecorator` was
assuming that the working directory would always be the project root, so
assemble was failing on this setup.

This commit adds SDK-specific settings so that the integration test
directory can be configured in `smithy-build.json`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
