### PR TITLE
fix: Silence home directory warning in Lambda Extensions

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -38,5 +38,5 @@ author = "jdisanti"
 [[aws-sdk-rust]]
 message = "Suppress irrelevant `$HOME` expansion warning when running in a Lambda Extension"
 references = ["smithy-rs#1344"]
-meta = { "breaking" = false, "tada" = false, "bug" = false }
+meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "ryansb"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -34,3 +34,9 @@ message = "Upgrade to Smithy 1.21.0"
 references = ["smithy-rs#1330"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Suppress irrelevant `$HOME` expansion warning when running in a Lambda Extension"
+references = ["smithy-rs#1344"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "ryansb"

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -261,7 +261,7 @@ mod tests {
     #[traced_test]
     #[test]
     fn load_config_file_should_not_emit_warning_on_lambda() {
-        let env = Env::from_slice(&[("LAMBDA_TASK_ROOT", "/")]);
+        let env = Env::from_slice(&[("AWS_LAMBDA_FUNCTION_NAME", "someName")]);
         let fs = Fs::from_slice(&[]);
 
         let _src = load_config_file(FileKind::Config, &None, &fs, &env).now_or_never();

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -184,7 +184,9 @@ fn expand_home(
 /// that we can check.
 fn check_is_likely_running_on_a_lambda(environment: &aws_types::os_shim_internal::Env) -> bool {
     // LAMBDA_TASK_ROOT – The path to your Lambda function code.
-    environment.get("LAMBDA_TASK_ROOT").is_ok()
+    // AWS_LAMBDA_RUNTIME_API - Double-check because LAMBDA_TASK_ROOT is redacted to any code running in Extensions
+    // https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html
+    environment.get("LAMBDA_TASK_ROOT").is_ok() || environment.get("AWS_LAMBDA_RUNTIME_API").is_ok()
 }
 
 #[cfg(test)]

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -183,10 +183,8 @@ fn expand_home(
 /// [Lambdas set many environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-runtime)
 /// that we can check.
 fn check_is_likely_running_on_a_lambda(environment: &aws_types::os_shim_internal::Env) -> bool {
-    // LAMBDA_TASK_ROOT – The path to your Lambda function code.
-    // AWS_LAMBDA_RUNTIME_API - Double-check because LAMBDA_TASK_ROOT is redacted to any code running in Extensions
-    // https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html
-    environment.get("LAMBDA_TASK_ROOT").is_ok() || environment.get("AWS_LAMBDA_RUNTIME_API").is_ok()
+    // AWS_LAMBDA_FUNCTION_NAME – The name of the running Lambda function. Available both in Functions and Extensions
+    environment.get("AWS_LAMBDA_FUNCTION_NAME").is_ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Motivation and Context

Similar to [aws-sdk-rust #307](https://github.com/awslabs/aws-sdk-rust/issues/307), suppress the home directory expansion warning when in Lambda. The fix #893 worked for Lambda functions, but not for Extensions.

Related commit: fbb4bc

## Description

This PR follows on to https://github.com/awslabs/smithy-rs/pull/893 which added `LAMBDA_TASK_ROOT` check. When running as a [Lambda Extension](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-extensions-api.html) the environment variable for `LAMBDA_TASK_ROOT` is redacted, so it is not reliable for testing whether you are in Lambda.

To remedy this, I switched the check to use `AWS_LAMBDA_FUNCTION_NAME` so that the check returns correctly for both function handlers and extensions.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran the full test suite, and validated that this suppresses the warning by rebuilding my local SDK and using it in a Lambda Extension.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
