### PR TITLE
Add a debug log entry for retries

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Log a debug event when a retry is going to be peformed"
+references = ["smithy-rs#1352"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "jdisanti"
+
+[[smithy-rs]]
+message = "Log a debug event when a retry is going to be peformed"
+references = ["smithy-rs#1352"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "jdisanti"

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -314,7 +314,12 @@ impl RetryHandler {
             }
         };
 
-        tracing::debug!("retrying after {:?}", dur);
+        tracing::debug!(
+            "attempt {} failed with {:?}; retrying after {:?}",
+            self.local.attempts,
+            retry_kind,
+            dur
+        );
         let sleep_future = sleep.sleep(dur);
         let fut = async move {
             sleep_future.await;

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -313,6 +313,8 @@ impl RetryHandler {
                 return None;
             }
         };
+
+        tracing::debug!("retrying after {:?}", dur);
         let sleep_future = sleep.sleep(dur);
         let fut = async move {
             sleep_future.await;


### PR DESCRIPTION
## Motivation and Context
This PR logs a debug event when a retry is going to be performed so that it's easier to tell retry is working by looking at logs (prompted by https://github.com/awslabs/aws-sdk-rust/issues/524).

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
