### PR TITLE
Add handling for mfa_serial in ~/.aws/config

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,3 +22,9 @@ message = "Log a debug event when a retry is going to be peformed"
 references = ["smithy-rs#1352"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Add support for providing MFA tokens. MFA token providers can now be configured via `.mfa_token()` while building a `DefaultCredentialChain`. The default implementation if none is provided will not resolve an MFA token - you will need to bring your own provider to make use of this feature."
+references = ["smithy-rs#1359", "aws-sdk-rust#527"]
+meta = { "breaking" = false, "tada" = true, "bug" = false}
+author = "jelford"

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -220,7 +220,7 @@ impl Builder {
         self
     }
 
-    /// MFA token
+    /// Provide a mechanism to request an MFA token from the user if required for authenticationº
     pub fn mfa_token(mut self, mfa_provider: impl ProvideMfaToken + 'static) -> Self {
         self.profile_file_builder = self.profile_file_builder.mfa_token(mfa_provider);
         self

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -12,6 +12,7 @@ use tracing::Instrument;
 use crate::environment::credentials::EnvironmentVariableCredentialsProvider;
 use crate::meta::credentials::{CredentialsProviderChain, LazyCachingCredentialsProvider};
 use crate::meta::region::ProvideRegion;
+use crate::profile::mfa_token::ProvideMfaToken;
 use crate::provider_config::ProviderConfig;
 
 #[cfg(any(feature = "rustls", feature = "native-tls"))]
@@ -216,6 +217,12 @@ impl Builder {
     pub fn configure(mut self, config: ProviderConfig) -> Self {
         self.region_chain = self.region_chain.configure(&config);
         self.conf = Some(config);
+        self
+    }
+
+    /// MFA token
+    pub fn mfa_token(mut self, mfa_provider: impl ProvideMfaToken + 'static) -> Self {
+        self.profile_file_builder = self.profile_file_builder.mfa_token(mfa_provider);
         self
     }
 

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -403,6 +403,7 @@ impl Builder {
         self
     }
 
+    /// Provide a mechanism to resolve an MFA token code if required
     pub fn mfa_token(mut self, mfa_token: impl ProvideMfaToken + 'static) -> Self {
         self.mfa_token_provider = Some(Box::new(mfa_token));
         self

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -25,7 +25,6 @@ use tracing::Instrument;
 use crate::profile::mfa_token::ProvideMfaToken;
 
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct AssumeRoleProvider {
     role_arn: String,
     external_id: Option<String>,
@@ -34,7 +33,6 @@ pub struct AssumeRoleProvider {
 }
 
 #[derive(Debug)]
-#[non_exhaustive]
 pub struct ClientConfiguration {
     pub(crate) sts_client: aws_smithy_client::Client<DynConnector, DefaultMiddleware>,
     pub(crate) region: Option<Region>,

--- a/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
@@ -97,6 +97,9 @@ pub struct RoleArn<'a> {
 
     /// session name parameter to pass to the assume role provider
     pub session_name: Option<&'a str>,
+
+    /// The identification number of an MFA device to use when assuming a role
+    pub mfa_serial: Option<&'a str>,
 }
 
 /// Resolve a ProfileChain from a ProfileSet or return an error
@@ -188,6 +191,7 @@ mod role {
     pub const ROLE_ARN: &str = "role_arn";
     pub const EXTERNAL_ID: &str = "external_id";
     pub const SESSION_NAME: &str = "role_session_name";
+    pub const MFA_SERIAL: &str = "mfa_serial";
 
     pub const CREDENTIAL_SOURCE: &str = "credential_source";
     pub const SOURCE_PROFILE: &str = "source_profile";
@@ -261,10 +265,12 @@ fn role_arn_from_profile(profile: &Profile) -> Option<RoleArn> {
     let role_arn = profile.get(role::ROLE_ARN)?;
     let session_name = profile.get(role::SESSION_NAME);
     let external_id = profile.get(role::EXTERNAL_ID);
+    let mfa_serial = profile.get(role::MFA_SERIAL);
     Some(RoleArn {
         role_arn,
         external_id,
         session_name,
+        mfa_serial
     })
 }
 

--- a/aws/rust-runtime/aws-config/src/profile/mfa_token.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mfa_token.rs
@@ -1,19 +1,34 @@
+//! Accept MFA tokens from user input when assuming a role
+//!
+
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 use crate::profile::mfa_token::MfaTokenFetchError::ProviderError;
 
+/// The value provided by the user's MFA device, if required to authenticate the session
 pub struct MfaToken(pub(crate) String);
 
+/// An error fetching MFA token input from the user or MFA token source
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum MfaTokenFetchError {
+    /// MFA token is required to assume the requested role, but no MFA token provider has been configured.
     NoMfaTokenProviderConfigured,
+
+    /// The provider experienced an error while fetching credentials from the user.
+    ///
+    /// This may include errors like the user closing a dialog box that requests an MFA token
+    #[non_exhaustive]
     ProviderError {
+        /// Underlying cause of the error
         cause: Box<dyn Error + Send + Sync + 'static>,
     },
 }
 
 impl MfaTokenFetchError {
+    /// The MFA token provider returned an error
+    ///
+    /// This may include errors like the user closing a dialog box that requests an MFA token
     pub fn provider_error(cause: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
         ProviderError { cause: cause.into() }
     }
@@ -27,7 +42,7 @@ impl Display for MfaTokenFetchError {
                 f,
                 "An MFA token was requested but no provider was configured"
             ),
-            MfaTokenFetchError::ProviderError { cause } => write!(
+            ProviderError { cause } => write!(
                 f,
                 "An error occurred while fetching an MFA token: {}",
                 cause
@@ -40,12 +55,12 @@ impl Error for MfaTokenFetchError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             MfaTokenFetchError::NoMfaTokenProviderConfigured => None,
-            MfaTokenFetchError::ProviderError { cause } => Some(cause.as_ref()),
-            _ => None
+            ProviderError { cause } => Some(cause.as_ref()),
         }
     }
 }
 
+/// Result type for MFA token providers
 pub type Result = std::result::Result<MfaToken, MfaTokenFetchError>;
 
 impl<T: Into<String>> From<T> for MfaToken {
@@ -71,10 +86,12 @@ pub mod future {
     pub struct ProvideMfaToken<'a>(NowOrLater<super::Result, Pin<Box<dyn Future<Output=super::Result> + Send + 'a>>>);
 
     impl<'a> ProvideMfaToken<'a> {
+        /// Creates a `ProvideMfaToken` from a resolved MFA token
         pub fn ready(mfa_token: super::Result) -> Self {
             ProvideMfaToken(NowOrLater::ready(mfa_token))
         }
 
+        /// Creates a `ProvideMfaToken` from future that will resolve to an MFA token
         pub fn new(future: impl Future<Output=super::Result> + Send + 'a) -> Self {
             ProvideMfaToken(NowOrLater::new(Box::pin(future)))
         }
@@ -89,10 +106,23 @@ pub mod future {
     }
 }
 
+/// Request an MFA token from the user as part of authentication flow.
+///
+/// Implementations are expected to prompt the user to provide a token
+/// from their MFA device.
 pub trait ProvideMfaToken: Send + Sync + Debug {
+    /// Request an MFA token from the user
+    ///
+    /// `mfa_serial` specified the serial number of the MFA token in use,
+    /// and may be displayed to the user in order for them to identify
+    /// which MFA device they should use.
     fn mfa_token(&self, mfa_serial: &str) -> future::ProvideMfaToken;
 }
 
+/// The default implementation will fail to resolve MFA tokens during authentication
+///
+/// Application authors must provide their own `ProvideMfaToken` implementation if they
+/// wish to source MFA tokens from their users.
 #[derive(Debug, Default)]
 pub(crate) struct DefaultProvideNoMfaToken {}
 

--- a/aws/rust-runtime/aws-config/src/profile/mfa_token.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mfa_token.rs
@@ -1,0 +1,104 @@
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+use crate::profile::mfa_token::MfaTokenFetchError::ProviderError;
+
+pub struct MfaToken(pub(crate) String);
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum MfaTokenFetchError {
+    NoMfaTokenProviderConfigured,
+    ProviderError {
+        cause: Box<dyn Error + Send + Sync + 'static>,
+    },
+}
+
+impl MfaTokenFetchError {
+    pub fn provider_error(cause: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+        ProviderError { cause: cause.into() }
+    }
+}
+
+
+impl Display for MfaTokenFetchError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MfaTokenFetchError::NoMfaTokenProviderConfigured => write!(
+                f,
+                "An MFA token was requested but no provider was configured"
+            ),
+            MfaTokenFetchError::ProviderError { cause } => write!(
+                f,
+                "An error occurred while fetching an MFA token: {}",
+                cause
+            ),
+        }
+    }
+}
+
+impl Error for MfaTokenFetchError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            MfaTokenFetchError::NoMfaTokenProviderConfigured => None,
+            MfaTokenFetchError::ProviderError { cause } => Some(cause.as_ref()),
+            _ => None
+        }
+    }
+}
+
+pub type Result = std::result::Result<MfaToken, MfaTokenFetchError>;
+
+impl<T: Into<String>> From<T> for MfaToken {
+    fn from(s: T) -> Self {
+        MfaToken(s.into())
+    }
+}
+
+
+/// Future wrapper returned by [`ProvideMfaToken`]
+///
+/// Note: this module should only be used when implementing your own mfa token providers.
+pub mod future {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use aws_smithy_async::future::now_or_later::NowOrLater;
+
+    /// Future returned by [`ProvideMfaToken`](super::ProvideMfaToken)
+    ///
+    /// - When wrapping an already loaded mfa_token, use [`ready`](MfaToken::ready).
+    /// - When wrapping an asynchronously loaded mfa_token, use [`new`](MfaToken::new).
+    pub struct ProvideMfaToken<'a>(NowOrLater<super::Result, Pin<Box<dyn Future<Output=super::Result> + Send + 'a>>>);
+
+    impl<'a> ProvideMfaToken<'a> {
+        pub fn ready(mfa_token: super::Result) -> Self {
+            ProvideMfaToken(NowOrLater::ready(mfa_token))
+        }
+
+        pub fn new(future: impl Future<Output=super::Result> + Send + 'a) -> Self {
+            ProvideMfaToken(NowOrLater::new(Box::pin(future)))
+        }
+    }
+
+    impl<'a> Future for ProvideMfaToken<'a> {
+        type Output = super::Result;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            Pin::new(&mut self.0).poll(cx)
+        }
+    }
+}
+
+pub trait ProvideMfaToken: Send + Sync + Debug {
+    fn mfa_token(&self, mfa_serial: &str) -> future::ProvideMfaToken;
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DefaultProvideNoMfaToken {}
+
+impl ProvideMfaToken for DefaultProvideNoMfaToken {
+    fn mfa_token(&self, mfa_serial: &str) -> future::ProvideMfaToken {
+        tracing::info!(mfa_serial=%mfa_serial, "MFA code is required as mfa_serial was set, but no MFA token provider has been configured");
+        future::ProvideMfaToken::ready(Err(MfaTokenFetchError::NoMfaTokenProviderConfigured))
+    }
+}

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -17,6 +17,7 @@ pub mod credentials;
 pub mod region;
 pub mod retry_config;
 pub mod timeout_config;
+pub mod mfa_token;
 
 #[doc(inline)]
 pub use credentials::ProfileFileCredentialsProvider;


### PR DESCRIPTION
## Motivation and Context
Fixes: https://github.com/awslabs/aws-sdk-rust/issues/527

## Description
Adds trait and configuration machinery for supplying MFA tokens. The goal is to fit into the `AssumeRole` workflow in a similar way to what happens in `boto3`.

The default provider will just log/return an error if an MFA token is requested, but users can plug their own ProvideMfaToken implementations (e.g. to read from stdin). There are a few outstanding things I know about for the PR to be ready:
- [ ] better testing
- [x] doc strings

But I'd also like to get some feedback before addressing those on the general shape of the PR (I think it's about in line with what was discussed in https://github.com/awslabs/aws-sdk-rust/issues/527), and I wasn't sure on a few code structure things - in particular:
- is `profile::credentials::exec::AssumeRoleProvider::credentials()` the right place to be calling out to users? One thing that's a little awkward about this is that by the time we get to this point in the implementation, we're already being wrapped in a (rather short) timeout for the cache... which might be a bit of a smell, if we're then pausing for user input?
- is `aws_config` the right place for the new `mfa_provider` module? I notice that `ProvideCredentials` and friends come from `aws_types` - but I'm not sure that the MFA code is really "shared" between services in a way that would qualify it for the `aws_types` crate?
- is `aws_config::profile` the right place? Maybe it should go beneath `profile::credentials` ? I'm not totally clear on the structure here.
- general naming stuff - I've _broadly_ tried to keep things similar to e.g. `ProvideCredentials`, is that about right?

One thing that I proposed in https://github.com/awslabs/aws-sdk-rust/issues/527 was to add a default `ProvideMfaToken` implementation that would read the code from `stdin`, analogously to how [boto uses `getpass`](https://github.com/boto/botocore/blob/fb366b91cfb7d47b30c1580170f7ff0554cabe14/botocore/credentials.py#L1369). @Velfi suggested over there that it would probably be worth an RFC for something like this, and having done [a rough implementation for testing](https://github.com/jelford/aws_mfa_token_provider), I think they were right - there are a few choices to be made for implementation (I don't think Rust has a convenient `getpass` that we can reach for), so a more conservative approach seems appropriate. I would think it would be convenient at _some point_ to have parity with other SDKs here, but this initial implementation at least gives us the ability to bring our own (and maybe gives the ecosystem space to play around and find the right / minimal way of doing it).

Here's a sample implementation of `ProvideMfaToken` that grabs the token from stdin using the `atty` and `rpassword` crates:

```rust
impl ProvideMfaToken for ProvideMfaTokenFromStdin {
    fn mfa_token(&self, serial: &str) -> ProvideMfaFuture {
        if !atty::is(atty::Stream::Stdin) {
            return ProvideMfaFuture::ready(
                Err(MfaTokenFetchError::provider_error(ProvideMfaTokenFromStdinError::NotATty)));
        }
        match rpassword::prompt_password(format!("Enter MFA code for {}: ", serial)) {
            Err(e) => {
                ProvideMfaFuture::ready(Err(MfaTokenFetchError::provider_error(e)))
            }
            Ok(t) => {
                ProvideMfaFuture::ready(Ok(MfaToken::from(t)))
            }
        }
    }
}
```

## Testing
- [ ] to add: automated testing
- Here's a sample repository that's had these changes patched in via `Cargo.toml` overrides (assuming `smithy-rs` is checked out in a neighbouring repository): https://github.com/jelford/aws_mfa_token_provider. That's what I've been using for exploratory testing, and have verified that:
  - A bad MFA code (randomly typed letters) results in a sensible error percolating through from the API backend 
  - A good MFA code successfully authenticates
- When not specifying a custom `ProvideMfaToken` implementation, a reasonably friendly error comes back to the user.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
