### PR TITLE
Remove axum-core dependency

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
@@ -16,7 +16,6 @@ import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
  */
 object ServerCargoDependency {
     val AsyncTrait: CargoDependency = CargoDependency("async-trait", CratesIo("0.1"))
-    val AxumCore: CargoDependency = CargoDependency("axum-core", CratesIo("0.1"))
     val FuturesUtil: CargoDependency = CargoDependency("futures-util", CratesIo("0.3"))
     val Nom: CargoDependency = CargoDependency("nom", CratesIo("7"))
     val PinProjectLite: CargoDependency = CargoDependency("pin-project-lite", CratesIo("0.2"))

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -38,7 +38,6 @@ class ServerOperationHandlerGenerator(
     private val runtimeConfig = codegenContext.runtimeConfig
     private val codegenScope = arrayOf(
         "AsyncTrait" to ServerCargoDependency.AsyncTrait.asType(),
-        "AxumCore" to ServerCargoDependency.AxumCore.asType(),
         "PinProjectLite" to ServerCargoDependency.PinProjectLite.asType(),
         "Tower" to ServerCargoDependency.Tower.asType(),
         "FuturesUtil" to ServerCargoDependency.FuturesUtil.asType(),
@@ -106,9 +105,9 @@ class ServerOperationHandlerGenerator(
                     """
                     type Sealed = #{ServerOperationHandler}::sealed::Hidden;
                     async fn call(self, req: #{http}::Request<B>) -> #{http}::Response<#{SmithyHttpServer}::body::BoxBody> {
-                        let mut req = #{AxumCore}::extract::RequestParts::new(req);
-                        use #{AxumCore}::extract::FromRequest;
-                        use #{AxumCore}::response::IntoResponse;
+                        let mut req = #{SmithyHttpServer}::request::RequestParts::new(req);
+                        use #{SmithyHttpServer}::request::FromRequest;
+                        use #{SmithyHttpServer}::response::IntoResponse;
                         let input_wrapper = match $inputWrapperName::from_request(&mut req).await {
                             Ok(v) => v,
                             Err(runtime_error) => {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -79,7 +79,6 @@ class ServerProtocolTestGenerator(
         "SmithyHttp" to CargoDependency.SmithyHttp(codegenContext.runtimeConfig).asType(),
         "Http" to CargoDependency.Http.asType(),
         "Hyper" to CargoDependency.Hyper.asType(),
-        "AxumCore" to ServerCargoDependency.AxumCore.asType(),
         "SmithyHttpServer" to ServerCargoDependency.SmithyHttpServer(codegenContext.runtimeConfig).asType(),
         "AssertEq" to CargoDependency.PrettyAssertions.asType().member("assert_eq!")
     )
@@ -294,7 +293,7 @@ class ServerProtocolTestGenerator(
         rustTemplate(
             """
             let output = super::$operationImpl;
-            use #{AxumCore}::response::IntoResponse;
+            use #{SmithyHttpServer}::response::IntoResponse;
             let http_response = output.into_response();
             """,
             *codegenScope,
@@ -316,10 +315,10 @@ class ServerProtocolTestGenerator(
         val operationName = "${operationSymbol.name}${ServerHttpBoundProtocolGenerator.OPERATION_INPUT_WRAPPER_SUFFIX}"
         rustTemplate(
             """
-            use #{AxumCore}::extract::FromRequest;
-            let mut http_request = #{AxumCore}::extract::RequestParts::new(http_request);
+            use #{SmithyHttpServer}::request::FromRequest;
+            let mut http_request = #{SmithyHttpServer}::request::RequestParts::new(http_request);
             let rejection = super::$operationName::from_request(&mut http_request).await.expect_err("request was accepted but we expected it to be rejected");
-            use #{AxumCore}::response::IntoResponse;
+            use #{SmithyHttpServer}::response::IntoResponse;
             let http_response = rejection.into_response();
             """,
             *codegenScope,
@@ -381,8 +380,8 @@ class ServerProtocolTestGenerator(
         val operationName = "${operationSymbol.name}${ServerHttpBoundProtocolGenerator.OPERATION_INPUT_WRAPPER_SUFFIX}"
         rustWriter.rustTemplate(
             """
-            use #{AxumCore}::extract::FromRequest;
-            let mut http_request = #{AxumCore}::extract::RequestParts::new(http_request);
+            use #{SmithyHttpServer}::request::FromRequest;
+            let mut http_request = #{SmithyHttpServer}::request::RequestParts::new(http_request);
             let parsed = super::$operationName::from_request(&mut http_request).await.expect("failed to parse request").0;
             """,
             *codegenScope,

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -21,7 +21,6 @@ aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-json = { path = "../aws-smithy-json" }
 aws-smithy-xml = { path = "../aws-smithy-xml" }
 async-trait = "0.1"
-axum-core = "0.1.2"
 bytes = "1.1"
 futures-util = { version = "0.3", default-features = false }
 http = "0.2"

--- a/rust-runtime/aws-smithy-http-server/src/body.rs
+++ b/rust-runtime/aws-smithy-http-server/src/body.rs
@@ -10,9 +10,37 @@ pub use http_body::Body as HttpBody;
 #[doc(hidden)]
 pub use hyper::body::Body;
 
-// `boxed` is used in the codegen of the implementation of the operation `Handler` trait.
+use bytes::Bytes;
+
+use crate::error::{BoxError, Error};
+
 #[doc(hidden)]
-pub use axum_core::body::{boxed, BoxBody};
+pub type BoxBody = http_body::combinators::UnsyncBoxBody<Bytes, Error>;
+
+// `boxed` is used in the codegen of the implementation of the operation `Handler` trait.
+/// Convert a [`http_body::Body`] into a [`BoxBody`].
+#[doc(hidden)]
+pub fn boxed<B>(body: B) -> BoxBody
+where
+    B: http_body::Body<Data = Bytes> + Send + 'static,
+    B::Error: Into<BoxError>,
+{
+    try_downcast(body).unwrap_or_else(|body| body.map_err(Error::new).boxed_unsync())
+}
+
+#[doc(hidden)]
+pub(crate) fn try_downcast<T, K>(k: K) -> Result<T, K>
+where
+    T: 'static,
+    K: Send + 'static,
+{
+    let mut k = Some(k);
+    if let Some(k) = <dyn std::any::Any>::downcast_mut::<Option<T>>(&mut k) {
+        Ok(k.take().unwrap())
+    } else {
+        Err(k.unwrap())
+    }
+}
 
 pub(crate) fn empty() -> BoxBody {
     boxed(http_body::Empty::new())

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -48,8 +48,9 @@
 //!
 //! [extensions]: https://docs.rs/http/latest/http/struct.Extensions.html
 
-use axum_core::extract::RequestParts;
 use std::ops::Deref;
+
+use crate::request::RequestParts;
 
 /// Extension type used to store information about Smithy operations in HTTP responses.
 /// This extension type is set when it has been correctly determined that the request should be

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -20,6 +20,10 @@ pub mod protocols;
 #[doc(hidden)]
 pub mod rejection;
 #[doc(hidden)]
+pub mod request;
+#[doc(hidden)]
+pub mod response;
+#[doc(hidden)]
 pub mod runtime_error;
 
 #[doc(inline)]
@@ -29,9 +33,6 @@ pub use self::extension::Extension;
 pub use self::routing::Router;
 #[doc(inline)]
 pub use tower_http::add_extension::{AddExtension, AddExtensionLayer};
-
-/// Alias for a type-erased error type.
-pub(crate) use axum_core::BoxError;
 
 #[cfg(test)]
 mod test_helpers;

--- a/rust-runtime/aws-smithy-http-server/src/protocols.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocols.rs
@@ -5,7 +5,7 @@
 
 //! Protocol helpers.
 use crate::rejection::RequestRejection;
-use axum_core::extract::RequestParts;
+use crate::request::RequestParts;
 use paste::paste;
 
 /// Supported protocols.
@@ -85,7 +85,7 @@ mod tests {
 
     /// This macro validates the rejection type since we cannot implement `PartialEq`
     /// for `RequestRejection` as it is based on the crate error type, which uses
-    /// `axum_core::BoxError`.
+    /// `crate::error::BoxError`.
     macro_rules! validate_rejection_type {
         ($result:expr, $rejection:path) => {
             match $result {

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// This code was copied and then modified from Tokio's Axum.
+
+/* Copyright (c) 2022 Tower Contributors
+ *
+ * Permission is hereby granted, free of charge, to any
+ * person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the
+ * Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software
+ * is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice
+ * shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ * ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ * TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+ * SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+ * IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+use async_trait::async_trait;
+use http::{Extensions, HeaderMap, Request, Uri};
+
+use crate::response::IntoResponse;
+
+/// Trait for extracting information from requests.
+///
+/// A type implementing the `FromRequest` trait is used to handle and extract information from an async handler taking in a `RequestParts` as input.
+#[async_trait]
+pub trait FromRequest<B>: Sized {
+    /// If the extractor fails it'll use this "rejection" type. A rejection is
+    /// a kind of error that can be converted into a response.
+    type Rejection: IntoResponse;
+
+    /// Perform the extraction.
+    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection>;
+}
+
+#[doc(hidden)]
+#[derive(Debug)]
+pub struct RequestParts<B> {
+    uri: Uri,
+    headers: Option<HeaderMap>,
+    extensions: Option<Extensions>,
+    body: Option<B>,
+}
+
+impl<B> RequestParts<B> {
+    /// Create a new `RequestParts`.
+    ///
+    /// You generally shouldn't need to construct this type yourself, unless
+    /// using extractors outside of axum for example to implement a
+    /// [`tower::Service`].
+    ///
+    /// [`tower::Service`]: https://docs.rs/tower/lastest/tower/trait.Service.html
+    #[doc(hidden)]
+    pub fn new(req: Request<B>) -> Self {
+        let (
+            http::request::Parts {
+                uri,
+                headers,
+                extensions,
+                ..
+            },
+            body,
+        ) = req.into_parts();
+
+        RequestParts {
+            uri,
+            headers: Some(headers),
+            extensions: Some(extensions),
+            body: Some(body),
+        }
+    }
+
+    /// Gets a reference to the request headers.
+    ///
+    /// Returns `None` if the headers has been taken by another extractor.
+    #[doc(hidden)]
+    pub fn headers(&self) -> Option<&HeaderMap> {
+        self.headers.as_ref()
+    }
+
+    /// Takes the body out of the request, leaving a `None` in its place.
+    #[doc(hidden)]
+    pub fn take_body(&mut self) -> Option<B> {
+        self.body.take()
+    }
+
+    /// Gets a reference the request URI.
+    #[doc(hidden)]
+    pub fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    /// Gets a reference to the request extensions.
+    ///
+    /// Returns `None` if the extensions has been taken by another extractor.
+    #[doc(hidden)]
+    pub fn extensions(&self) -> Option<&Extensions> {
+        self.extensions.as_ref()
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/response.rs
+++ b/rust-runtime/aws-smithy-http-server/src/response.rs
@@ -5,7 +5,7 @@
 
 // This code was copied and then modified from Tokio's Axum.
 
-/* Copyright (c) 2021 Tower Contributors
+/* Copyright (c) 2022 Tower Contributors
  *
  * Permission is hereby granted, free of charge, to any
  * person obtaining a copy of this software and associated
@@ -32,33 +32,15 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-//! Error definition.
+use crate::body::BoxBody;
 
-use std::{error::Error as StdError, fmt};
+#[doc(hidden)]
+pub type Response<T = BoxBody> = http::Response<T>;
 
-/// Errors that can happen when using this crate.
-#[derive(Debug)]
-pub struct Error {
-    inner: BoxError,
-}
-
-pub(crate) type BoxError = Box<dyn StdError + Send + Sync>;
-
-impl Error {
-    /// Create a new `Error` from a boxable error.
-    pub(crate) fn new(error: impl Into<BoxError>) -> Self {
-        Self { inner: error.into() }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.fmt(f)
-    }
-}
-
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        Some(&*self.inner)
-    }
+/// Trait for generating responses.
+///
+/// Types that implement `IntoResponse` can be returned from handlers.
+pub trait IntoResponse {
+    /// Create a response.
+    fn into_response(self) -> Response;
 }

--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -10,10 +10,10 @@
 use self::future::RouterFuture;
 use self::request_spec::RequestSpec;
 use crate::body::{boxed, Body, BoxBody, HttpBody};
+use crate::error::BoxError;
 use crate::protocols::Protocol;
+use crate::response::IntoResponse;
 use crate::runtime_error::{RuntimeError, RuntimeErrorKind};
-use crate::BoxError;
-use axum_core::response::IntoResponse;
 use http::{Request, Response, StatusCode};
 use std::collections::HashMap;
 use std::{
@@ -365,7 +365,10 @@ where
 #[cfg(test)]
 mod rest_tests {
     use super::*;
-    use crate::{body::boxed, routing::request_spec::*};
+    use crate::{
+        body::{boxed, BoxBody},
+        routing::request_spec::*,
+    };
     use futures_util::Future;
     use http::{HeaderMap, Method};
     use std::pin::Pin;

--- a/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
@@ -9,7 +9,7 @@
 //!
 //! As opposed to rejection types (see [`crate::rejection`]), which are an internal detail about
 //! the framework, `RuntimeError` is surfaced to clients in HTTP responses: indeed, it implements
-//! [`axum_core::response::IntoResponse`]. Rejections can be "grouped" and converted into a
+//! [`crate::response::IntoResponse`]. Rejections can be "grouped" and converted into a
 //! specific `RuntimeError` kind: for example, all request rejections due to serialization issues
 //! can be conflated under the [`RuntimeErrorKind::Serialization`] enum variant.
 //!
@@ -19,9 +19,12 @@
 //! Generated code works always works with [`crate::rejection`] types when deserializing requests
 //! and serializing response. Just before a response needs to be sent, the generated code looks up
 //! and converts into the corresponding `RuntimeError`, and then it uses the its
-//! [`axum_core::response::IntoResponse`] implementation to render and send a response.
+//! [`crate::response::IntoResponse`] implementation to render and send a response.
 
-use crate::protocols::Protocol;
+use crate::{
+    protocols::Protocol,
+    response::{IntoResponse, Response},
+};
 
 #[derive(Debug)]
 pub enum RuntimeErrorKind {
@@ -55,8 +58,8 @@ pub struct RuntimeError {
     pub kind: RuntimeErrorKind,
 }
 
-impl axum_core::response::IntoResponse for RuntimeError {
-    fn into_response(self) -> axum_core::response::Response {
+impl IntoResponse for RuntimeError {
+    fn into_response(self) -> Response {
         let status_code = match self.kind {
             RuntimeErrorKind::Serialization(_) => http::StatusCode::BAD_REQUEST,
             RuntimeErrorKind::InternalFailure(_) => http::StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
This change removes the dependency on axum-core and brings in the
relevant resources we are using from that crate.

Issue: #1170

Signed-off-by: Daniele Ahmed <ahmeddan@amazon.de>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Closes https://github.com/awslabs/smithy-rs/issues/1170

## Description
<!--- Describe your changes in detail -->

The crate axum-core has been removed from the dependencies.
IntoResponse and FromRequest have been kept.
RequestParts has been kept because we need ownership of `body` to consume it in places such as [here](https://github.com/awslabs/smithy-rs/blob/ae9a5ed50a4b14296f4ede85b65f5313f1398df3/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt#L588) and have `&mut` requests, but the http crate provides it as a stream and requests are not `Clone`able.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`./gradlew :codegen-server-test:test` in the root directory
`cargo test` in `rust-runtime/aws-smithy-http-server`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
