### PR TITLE
Add Pokemon service cmdline arguments using clap.

### DIFF
--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 hyper = {version = "0.14", features = ["server"] }
 tokio = "1"
 tower = "0.4"
-tower-http = { version = "0.2", features = ["trace"] }
+tower-http = { version = "0.3", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -3,8 +3,11 @@ name = "pokemon_service"
 version = "0.1.0"
 edition = "2021"
 publish = false
+authors = ["Smithy-rs Server Team <smithy-rs-server@amazon.com>"]
+description = "A smithy Rust service to retrieve information about Pokémon."
 
 [dependencies]
+clap = { version = "3", features = ["derive"] }
 hyper = {version = "0.14", features = ["server"] }
 tokio = "1"
 tower = "0.4"

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
@@ -125,6 +125,7 @@ impl Default for State {
 }
 
 /// Retrieves information about a Pokémon species.
+#[tracing::instrument(name = "GetPokemonSpecies", skip(input, state))]
 pub async fn get_pokemon_species(
     input: input::GetPokemonSpeciesInput,
     state: Extension<Arc<State>>,
@@ -167,6 +168,7 @@ pub async fn get_pokemon_species(
 }
 
 /// Calculates and reports metrics about this server instance.
+#[tracing::instrument(name = "GetServerStatistics", skip(_input, state))]
 pub async fn get_server_statistics(
     _input: input::GetServerStatisticsInput,
     state: Extension<Arc<State>>,
@@ -184,6 +186,7 @@ pub async fn get_server_statistics(
 }
 
 /// Empty operation used to benchmark the service.
+#[tracing::instrument(name = "EmptyOperation", skip(_input))]
 pub async fn empty_operation(_input: input::EmptyOperationInput) -> output::EmptyOperationOutput {
     output::EmptyOperationOutput {}
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/lib.rs
@@ -125,7 +125,6 @@ impl Default for State {
 }
 
 /// Retrieves information about a Pokémon species.
-#[tracing::instrument(name = "GetPokemonSpecies", skip(input, state))]
 pub async fn get_pokemon_species(
     input: input::GetPokemonSpeciesInput,
     state: Extension<Arc<State>>,
@@ -168,7 +167,6 @@ pub async fn get_pokemon_species(
 }
 
 /// Calculates and reports metrics about this server instance.
-#[tracing::instrument(name = "GetServerStatistics", skip(_input, state))]
 pub async fn get_server_statistics(
     _input: input::GetServerStatisticsInput,
     state: Extension<Arc<State>>,
@@ -186,7 +184,6 @@ pub async fn get_server_statistics(
 }
 
 /// Empty operation used to benchmark the service.
-#[tracing::instrument(name = "EmptyOperation", skip(_input))]
 pub async fn empty_operation(_input: input::EmptyOperationInput) -> output::EmptyOperationOutput {
     output::EmptyOperationOutput {}
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
@@ -21,7 +21,7 @@ struct Args {
     address: String,
     /// Hyper server bind port.
     #[clap(short, long, default_value = "13734")]
-    port: i32,
+    port: u16,
 }
 
 #[tokio::main]

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
@@ -4,16 +4,29 @@
  */
 
 // This program is exported as a binary named `pokemon_service`.
-use std::sync::Arc;
+use std::{net::SocketAddr, sync::Arc};
 
 use aws_smithy_http_server::{AddExtensionLayer, Router};
+use clap::Parser;
 use pokemon_service::{empty_operation, get_pokemon_species, get_server_statistics, setup_tracing, State};
 use pokemon_service_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
 
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Args {
+    /// Hyper server bind address.
+    #[clap(short, long, default_value = "127.0.0.1")]
+    address: String,
+    /// Hyper server bind port.
+    #[clap(short, long, default_value = "13734")]
+    port: i32,
+}
+
 #[tokio::main]
 pub async fn main() {
+    let args = Args::parse();
     setup_tracing();
     let app: Router = OperationRegistryBuilder::default()
         // Build a registry containing implementations to all the operations in the service. These
@@ -37,7 +50,10 @@ pub async fn main() {
     );
 
     // Start the [`hyper::Server`].
-    let server = hyper::Server::bind(&"0.0.0.0:13734".parse().unwrap()).serve(app.into_make_service());
+    let bind: SocketAddr = format!("{}:{}", args.address, args.port)
+        .parse()
+        .expect("Unable to parse the server bind address and port");
+    let server = hyper::Server::bind(&bind).serve(app.into_make_service());
 
     // Run forever-ish...
     if let Err(err) = server.await {

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
@@ -52,7 +52,7 @@ pub async fn main() {
     // Start the [`hyper::Server`].
     let bind: SocketAddr = format!("{}:{}", args.address, args.port)
         .parse()
-        .expect("Unable to parse the server bind address and port");
+        .expect("unable to parse the server bind address and port");
     let server = hyper::Server::bind(&bind).serve(app.into_make_service());
 
     // Run forever-ish...


### PR DESCRIPTION
## Description
* Update `tower-http` to latest upstream version.
* Add `tracing::instrument` to create a span per operation handler.
* Add command line arguments for address and port using `clap`.
* Default the bind address to `localhost`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
