### PR TITLE
Update crates to Rust 2021

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -69,3 +69,9 @@ for chunk in byte_streams {
 references = ["aws-sdk-rust#494", "aws-sdk-rust#519"]
 meta = { "breaking" = true, "tada" = true, "bug" = false }
 author = "Velfi"
+
+[[smithy-rs]]
+message = "Update generated crates to Rust 2021"
+references = ["smithy-rs#1332"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "82marbag"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -560,7 +560,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                 """
                 let status = output.$memberName
                     .ok_or(#{ResponseRejection}::MissingHttpStatusCode)?;
-                let http_status: u16 = std::convert::TryFrom::<i32>::try_from(status)
+                let http_status: u16 = status.try_into()
                     .map_err(|_| #{ResponseRejection}::InvalidHttpStatusCode)?;
                 """.trimIndent(),
                 *codegenScope,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
@@ -60,7 +60,7 @@ class CargoTomlGenerator(
                 "version" to settings.moduleVersion,
                 "authors" to settings.moduleAuthors,
                 settings.moduleDescription?.let { "description" to it },
-                "edition" to "2018",
+                "edition" to "2021",
                 "license" to settings.license,
                 "repository" to settings.moduleRepository,
             ).toMap(),

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
@@ -478,7 +478,6 @@ class HttpBindingGenerator(
                 rustBlock("if !$safeName.is_empty()") {
                     rustTemplate(
                         """
-                        use std::convert::TryFrom;
                         let header_value = $safeName;
                         let header_value = http::header::HeaderValue::try_from(&*header_value).map_err(|err| {
                             #{build_error}::InvalidField { field: "$memberName", details: format!("`{}` cannot be used as a header value: {}", &${
@@ -517,7 +516,6 @@ class HttpBindingGenerator(
                     let header_name = http::header::HeaderName::from_str(&format!("{}{}", "${httpBinding.locationName}", &k)).map_err(|err| {
                         #{build_error}::InvalidField { field: "$memberName", details: format!("`{}` cannot be used as a header name: {}", k, err)}
                     })?;
-                    use std::convert::TryFrom;
                     let header_value = ${headerFmtFun(this, target, memberShape, "v", listHeader)};
                     let header_value = http::header::HeaderValue::try_from(&*header_value).map_err(|err| {
                         #{build_error}::InvalidField {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -141,7 +141,6 @@ class XmlBindingTraitParserGenerator(
                 val shapeName = XmlName(xmlIndex.payloadShapeName(member))
                 rustTemplate(
                     """
-                    use std::convert::TryFrom;
                     let mut doc = #{Document}::try_from(inp)?;
                     ##[allow(unused_mut)]
                     let mut decoder = doc.root_element()?;
@@ -190,7 +189,6 @@ class XmlBindingTraitParserGenerator(
             ) {
                 rustTemplate(
                     """
-                    use std::convert::TryFrom;
                     let mut doc = #{Document}::try_from(inp)?;
 
                     ##[allow(unused_mut)]
@@ -226,7 +224,6 @@ class XmlBindingTraitParserGenerator(
                 if (members.isNotEmpty()) {
                     rustTemplate(
                         """
-                        use std::convert::TryFrom;
                         let mut document = #{Document}::try_from(inp)?;
                         ##[allow(unused_mut)]
                         let mut error_decoder = #{xml_errors}::error_scope(&mut document)?;
@@ -258,7 +255,6 @@ class XmlBindingTraitParserGenerator(
             ) {
                 rustTemplate(
                     """
-                    use std::convert::TryFrom;
                     let mut doc = #{Document}::try_from(inp)?;
 
                     ##[allow(unused_mut)]


### PR DESCRIPTION
Generate crates using Rust 2021 instead of Rust 2018
Remove use std::convert::TryFrom which is in the prelude

Closes #1332

Signed-off-by: Daniele Ahmed <ahmeddan@amazon.de>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`./gradlew :codegen-server-test:test`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
