### PR TITLE
feature: conversion method for `ByteStream` into `AsyncRead` implementor

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,15 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+ [[aws-sdk-rust]]
+ message = "Add method `ByteStream::into_async_read`. This makes it easy to convert `ByteStream`s into a struct implementing `tokio:io::AsyncRead`. Available on **crate feature** `rt-tokio` only."
+ references = ["smithy-rs#1390"]
+ meta = { "breaking" = false, "tada" = true, "bug" = false }
+ author = "Velfi"
+
+ [[smithy-rs]]
+ message = "Add method `ByteStream::into_async_read`. This makes it easy to convert `ByteStream`s into a struct implementing `tokio:io::AsyncRead`. Available on **crate feature** `rt-tokio` only."
+ references = ["smithy-rs#1390"]
+ meta = { "breaking" = false, "tada" = true, "bug" = false }
+ author = "Velfi"

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -149,8 +149,9 @@ pub use self::bytestream_util::FsBuilder;
 ///
 /// `ByteStream` provides two primary mechanisms for accessing the data:
 /// 1. With `.collect()`:
-/// [`.collect()`](crate::byte_stream::ByteStream::collect) reads the complete ByteStream into memory and stores it in `AggregatedBytes`,
-/// a non-contiguous ByteBuffer.
+///
+///     [`.collect()`](crate::byte_stream::ByteStream::collect) reads the complete ByteStream into memory and stores it in `AggregatedBytes`,
+///     a non-contiguous ByteBuffer.
 ///     ```no_run
 ///     use aws_smithy_http::byte_stream::{ByteStream, AggregatedBytes};
 ///     use aws_smithy_http::body::SdkBody;
@@ -165,7 +166,7 @@ pub use self::bytestream_util::FsBuilder;
 ///     ```
 /// 2. Via [`impl Stream`](futures_core::Stream):
 ///
-///     _Note: An import of `StreamExt` is required to use `try_next()`._
+///     _Note: An import of `StreamExt` is required to use `.try_next()`._
 ///
 ///     For use-cases where holding the entire ByteStream in memory is unnecessary, use the
 ///     `Stream` implementation:
@@ -189,6 +190,28 @@ pub use self::bytestream_util::FsBuilder;
 ///            digest.write(&bytes);
 ///        }
 ///        println!("digest: {}", digest.finish());
+///        Ok(())
+///     }
+///     ```
+///
+/// 3. Via [`.into_async_read()`](crate::byte_stream::ByteStream::into_async_read):
+///
+///     _Note: The `rt-tokio` feature must be active to use `.into_async_read()`._
+///
+///     It's possible to convert a `ByteStream` into a struct that implements [`tokio::io::AsyncRead`](tokio::io::AsyncRead).
+///     Then, you can use pre-existing tools like [`tokio::io::BufReader`](tokio::io::BufReader):
+///     ```no_run
+///     use aws_smithy_http::byte_stream::ByteStream;
+///     use aws_smithy_http::body::SdkBody;
+///     use tokio::io::{AsyncBufReadExt, BufReader};
+///     async fn example() -> std::io::Result<()> {
+///        let stream = ByteStream::new(SdkBody::from("hello!\nThis is some data"));
+///        // Wrap the stream in a BufReader
+///        let buf_reader = BufReader::new(stream.into_async_read());
+///        let mut lines = buf_reader.lines();
+///        assert_eq!(lines.next_line().await?, Some("hello!".to_owned()));
+///        assert_eq!(lines.next_line().await?, Some("This is some data".to_owned()));
+///        assert_eq!(lines.next_line().await?, None);
 ///        Ok(())
 ///     }
 ///     ```
@@ -347,10 +370,24 @@ impl ByteStream {
         self.0.with_body_callback(body_callback);
         self
     }
-}
 
-#[cfg(feature = "rt-tokio")]
-impl ByteStream {
+    #[cfg(feature = "rt-tokio")]
+    /// Convert this `ByteStream` into a struct that implements [`AsyncRead`](tokio::io::AsyncRead).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tokio::io::{BufReader, AsyncBufReadExt};
+    /// use aws_smithy_http::byte_stream::ByteStream;
+    ///
+    /// # async fn dox(my_bytestream: ByteStream) -> std::io::Result<()> {
+    /// let mut lines =  BufReader::new(my_bytestream.into_async_read()).lines();
+    /// while let Some(line) = lines.next_line().await? {
+    ///   // Do something line by line
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn into_async_read(self) -> impl tokio::io::AsyncRead {
         tokio_util::io::StreamReader::new(self)
     }

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -538,7 +538,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::byte_stream::{ByteStream, Inner};
+    use crate::byte_stream::Inner;
     use bytes::Bytes;
 
     #[tokio::test]
@@ -614,6 +614,7 @@ mod tests {
     #[cfg(feature = "rt-tokio")]
     #[tokio::test]
     async fn bytestream_into_async_read() {
+        use super::ByteStream;
         use tokio::io::AsyncBufReadExt;
 
         let byte_stream = ByteStream::from_static(b"data 1\ndata 2\ndata 3");

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -204,6 +204,7 @@ pub use self::bytestream_util::FsBuilder;
 ///     use aws_smithy_http::byte_stream::ByteStream;
 ///     use aws_smithy_http::body::SdkBody;
 ///     use tokio::io::{AsyncBufReadExt, BufReader};
+///     #[cfg(feature = "rt-tokio")]
 ///     async fn example() -> std::io::Result<()> {
 ///        let stream = ByteStream::new(SdkBody::from("hello!\nThis is some data"));
 ///        // Wrap the stream in a BufReader


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
smithy-rs#1387
smithy-rs#1390

## Description
<!--- Describe your changes in detail -->
This adds an easy way for users to convert `ByteStream`s into a struct implementing `tokio:io::AsyncRead`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
