### PR TITLE
Remove TODO about required `httpHeader`-bound collection shapes

### DIFF
--- a/codegen-test/model/misc.smithy
+++ b/codegen-test/model/misc.smithy
@@ -11,23 +11,26 @@ use aws.protocols#restJson1
 @title("MiscService")
 service MiscService {
     operations: [
-        OperationWithInnerRequiredShape,
+        RequiredInnerShapeOperation,
+        RequiredHeaderCollectionOperation,
     ],
 }
 
 /// This operation tests that (de)serializing required values from a nested
 /// shape works correctly.
-@http(uri: "/operation", method: "GET")
-operation OperationWithInnerRequiredShape {
-    input: OperationWithInnerRequiredShapeInput,
-    output: OperationWithInnerRequiredShapeOutput,
+@http(uri: "/required-inner-shape-operation", method: "GET")
+operation RequiredInnerShapeOperation {
+    input: RequiredInnerShapeOperationInputOutput,
+    output: RequiredInnerShapeOperationInputOutput,
 }
 
-structure OperationWithInnerRequiredShapeInput {
-    inner: InnerShape
+@http(uri: "/required-header-collection-operation", method: "GET")
+operation RequiredHeaderCollectionOperation {
+    input: RequiredHeaderCollectionOperationInputOutput,
+    output: RequiredHeaderCollectionOperationInputOutput,
 }
 
-structure OperationWithInnerRequiredShapeOutput {
+structure RequiredInnerShapeOperationInputOutput {
     inner: InnerShape
 }
 
@@ -107,4 +110,22 @@ union AUnion {
     i32: Integer,
     string: String,
     time: Timestamp,
+}
+
+structure RequiredHeaderCollectionOperationInputOutput {
+    @required
+    @httpHeader("X-Required-List")
+    requiredHeaderList: HeaderList,
+
+    @required
+    @httpHeader("X-Required-Set")
+    requiredHeaderSet: HeaderSet,
+}
+
+list HeaderList {
+    member: String
+}
+
+set HeaderSet {
+    member: String
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/HttpBindingGenerator.kt
@@ -354,7 +354,6 @@ class HttpBindingGenerator(
                 rust("let $parsedValue = $parsedValue?;")
             }
         }
-        // TODO(https://github.com/awslabs/smithy-rs/issues/837): this doesn't support non-optional vectors
         when (rustType) {
             is RustType.Vec ->
                 rust(


### PR DESCRIPTION
We do support required `httpHeader`-bound collection shapes, as
evidenced by the test operation this commit adds, which is generated by
the server, that does not use `Option` for `required` member shapes.

This is because even though the deserialization always returns an
optional collection, we return `None` if no headers are found (as
opposed to an empty collection), so the call that sets the member field
on the operation structure does nothing; when `build()` gets called, a
`BuildError` is raised because the member is required.

## Testing

See added test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
