### PR TITLE
Add release metadata to `versions.toml`

### DIFF
--- a/aws/sdk-codegen-test/build.gradle.kts
+++ b/aws/sdk-codegen-test/build.gradle.kts
@@ -59,7 +59,7 @@ fun generateSmithyBuild(tests: List<CodegenTest>): String {
 task("generateSmithyBuild") {
     description = "generate smithy-build.json"
     doFirst {
-        projectDir.resolve("smithy-build.json").writeText(generateSmithyBuild(CodegenTests))
+        buildDir.resolve("smithy-build.json").writeText(generateSmithyBuild(CodegenTests))
     }
 }
 

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -348,13 +348,13 @@ tasks.register<ExecRustBuildTool>("generateVersionManifest") {
         "--smithy-build",
         buildDir.resolve("smithy-build.json").normalize().absolutePath,
         "--examples-revision",
-        properties.get("aws.sdk.examples.revision") ?: "missing",
-        "--release-tag",
-        "v" + getSdkVersion()
+        properties.get("aws.sdk.examples.revision") ?: "missing"
     ).apply {
         val previousReleaseManifestPath = getPreviousReleaseVersionManifestPath()?.let { manifestPath ->
             add("--previous-release-versions")
             add(manifestPath)
+            add("--release-tag")
+            add("v" + getSdkVersion())
         }
     }
 }

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -18,6 +18,10 @@ plugins {
     id("software.amazon.smithy").version("0.6.0")
 }
 
+configure<software.amazon.smithy.gradle.SmithyExtension> {
+    smithyBuildConfigs = files(buildDir.resolve("smithy-build.json"))
+}
+
 val smithyVersion: String by project
 val defaultRustFlags: String by project
 val defaultRustDocFlags: String by project

--- a/ci
+++ b/ci
@@ -17,5 +17,9 @@ if [[ $# -lt 1 ]]; then
     exit 1
 fi
 
+ACTION_NAME=$1
+shift
+ACTION_ARGS=("$@")
+
 cd ..
-make -f ./smithy-rs/ci.mk "$@"
+make -f ./smithy-rs/ci.mk "${ACTION_NAME}" ARGS="${ACTION_ARGS[*]}"

--- a/ci.mk
+++ b/ci.mk
@@ -8,6 +8,7 @@
 # with dependencies between targets included so that it's not necessary
 # to remember to generate a SDK for the targets that require one.
 
+ARGS=
 CI_BUILD=./smithy-rs/tools/ci-build
 CI_ACTION=$(CI_BUILD)/ci-action
 
@@ -17,80 +18,80 @@ acquire-build-image:
 
 .PHONY: check-aws-sdk-examples
 check-aws-sdk-examples: generate-aws-sdk
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-aws-sdk-services
 check-aws-sdk-services: generate-aws-sdk
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-aws-sdk-smoketest-additional-checks
 check-aws-sdk-smoketest-additional-checks: generate-aws-sdk-smoketest
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-aws-sdk-smoketest-docs-clippy-udeps
 check-aws-sdk-smoketest-docs-clippy-udeps: generate-aws-sdk-smoketest
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-aws-sdk-smoketest-unit-tests
 check-aws-sdk-smoketest-unit-tests: generate-aws-sdk-smoketest
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-client-codegen-integration-tests
 check-client-codegen-integration-tests:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-client-codegen-unit-tests
 check-client-codegen-unit-tests:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-rust-runtimes-and-tools
 check-rust-runtimes-and-tools: generate-aws-sdk-smoketest
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-sdk-codegen-unit-tests
 check-sdk-codegen-unit-tests:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-server-codegen-integration-tests
 check-server-codegen-integration-tests:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-server-codegen-unit-tests
 check-server-codegen-unit-tests:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-server-codegen-integration-tests-python
 check-server-codegen-integration-tests-python:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-server-codegen-unit-tests-python
 check-server-codegen-unit-tests-python:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-server-e2e-test
 check-server-e2e-test:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: check-style-and-lints
 check-style-and-lints:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: generate-aws-sdk-smoketest
 generate-aws-sdk-smoketest:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: generate-aws-sdk
 generate-aws-sdk:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: generate-codegen-diff
 generate-codegen-diff:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: generate-smithy-rs-runtime-bundle
 generate-smithy-rs-runtime-bundle:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)
 
 .PHONY: sanity-test
 sanity-test:
-	$(CI_ACTION) $@
+	$(CI_ACTION) $@ $(ARGS)

--- a/tools/api-linter/Cargo.lock
+++ b/tools/api-linter/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "serde",
+ "toml",
  "tracing",
 ]
 
@@ -504,6 +505,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
+ "indexmap",
  "serde",
 ]
 

--- a/tools/ci-build/scripts/generate-aws-sdk
+++ b/tools/ci-build/scripts/generate-aws-sdk
@@ -6,8 +6,14 @@
 
 C_YELLOW='\033[1;33m'
 C_RESET='\033[0m'
-
 set -eux
+
+# This script takes an optional argument to specify the path to the previous release's versions.toml file
+PREVIOUS_RELEASE_VERSIONS_ARG=
+if [[ $# -ge 1 ]]; then
+    echo "Given previous release manifest path: $1"
+    PREVIOUS_RELEASE_VERSIONS_ARG="-Paws.sdk.previous.release.versions.manifest=$1"
+fi
 
 echo -e "${C_YELLOW}Taking examples from 'awsdocs/aws-doc-sdk-examples'...${C_RESET}"
 examples_revision=$(cd aws-doc-sdk-examples; git rev-parse HEAD)
@@ -17,5 +23,12 @@ rm smithy-rs/aws/sdk/examples/Cargo.toml
 
 echo -e "${C_YELLOW}Generating services...${C_RESET}"
 cd smithy-rs
-./gradlew -Paws.fullsdk=true -Paws.sdk.examples.revision="${examples_revision}" aws:sdk:assemble
+
+# Intentionally not quoting PREVIOUS_RELEASE_VERSIONS_ARG so that if it has no value, it doesn't confuse gradle
+# shellcheck disable=SC2086
+./gradlew \
+    -Paws.fullsdk=true \
+    -Paws.sdk.examples.revision="${examples_revision}" \
+    ${PREVIOUS_RELEASE_VERSIONS_ARG} \
+    aws:sdk:assemble
 mv aws/sdk/build/aws-sdk ../artifacts/

--- a/tools/publisher/Cargo.lock
+++ b/tools/publisher/Cargo.lock
@@ -1266,6 +1266,7 @@ dependencies = [
  "async-trait",
  "serde",
  "tokio",
+ "toml",
  "tracing",
 ]
 

--- a/tools/publisher/src/main.rs
+++ b/tools/publisher/src/main.rs
@@ -3,15 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::subcommand::fix_manifests::{subcommand_fix_manifests, Mode};
+use crate::subcommand::fix_manifests::subcommand_fix_manifests;
 use crate::subcommand::publish::subcommand_publish;
 use crate::subcommand::yank_category::subcommand_yank_category;
 use anyhow::Result;
 use clap::Parser;
-use semver::Version;
-use std::path::PathBuf;
-use subcommand::generate_version_manifest::subcommand_generate_version_manifest;
-use subcommand::hydrate_readme::subcommand_hydrate_readme;
+use subcommand::fix_manifests::FixManifestsArgs;
+use subcommand::generate_version_manifest::{
+    subcommand_generate_version_manifest, GenerateVersionManifestArgs,
+};
+use subcommand::hydrate_readme::{subcommand_hydrate_readme, HydrateReadmeArgs};
+use subcommand::publish::PublishArgs;
+use subcommand::yank_category::YankCategoryArgs;
 
 mod cargo;
 mod fs;
@@ -30,58 +33,15 @@ pub const CRATE_OWNER: &str = "github:awslabs:rust-sdk-owners";
 #[clap(author, version, about)]
 enum Args {
     /// Fixes path dependencies in manifests to also have version numbers
-    FixManifests {
-        /// Path containing the manifests to fix. Manifests will be discovered recursively
-        #[clap(long)]
-        location: PathBuf,
-        /// Checks manifests rather than fixing them
-        #[clap(long)]
-        check: bool,
-    },
+    FixManifests(FixManifestsArgs),
     /// Publishes crates to crates.io
-    Publish {
-        /// Path containing the crates to publish. Crates will be discovered recursively
-        #[clap(long)]
-        location: PathBuf,
-    },
+    Publish(PublishArgs),
     /// Yanks a category of packages with the given version number
-    YankCategory {
-        /// Package category to yank (smithy-runtime, aws-runtime, or aws-sdk)
-        #[clap(long)]
-        category: String,
-        /// Version number to yank
-        #[clap(long)]
-        version: Version,
-        /// Path to `aws-sdk-rust` repo. The repo should be checked out at the
-        /// version that is being yanked so that the correct list of crate names
-        /// is used. This will be validated.
-        #[clap(long)]
-        location: PathBuf,
-    },
+    YankCategory(YankCategoryArgs),
     /// Hydrates the SDK README template file
-    HydrateReadme {
-        /// AWS Rust SDK version to put in the README
-        #[clap(long)]
-        sdk_version: Version,
-        /// Rust MSRV to put in the README
-        #[clap(long)]
-        msrv: String,
-        /// Path to output the hydrated readme into
-        #[clap(short, long)]
-        output: PathBuf,
-    },
+    HydrateReadme(HydrateReadmeArgs),
     /// Generates a version manifest file for a generated SDK
-    GenerateVersionManifest {
-        /// Path to `smithy-build.json`
-        #[clap(long)]
-        smithy_build: PathBuf,
-        /// Revision of `aws-doc-sdk-examples` repository used to retrieve examples
-        #[clap(long)]
-        examples_revision: String,
-        /// Path containing the generated SDK to generate a version manifest for
-        #[clap(long)]
-        location: PathBuf,
-    },
+    GenerateVersionManifest(GenerateVersionManifestArgs),
 }
 
 #[tokio::main]
@@ -93,38 +53,11 @@ async fn main() -> Result<()> {
         .init();
 
     match Args::parse() {
-        Args::Publish { location } => {
-            subcommand_publish(&location).await?;
-        }
-        Args::FixManifests { location, check } => {
-            let mode = match check {
-                true => Mode::Check,
-                false => Mode::Execute,
-            };
-            subcommand_fix_manifests(mode, &location).await?;
-        }
-        Args::YankCategory {
-            category,
-            version,
-            location,
-        } => {
-            subcommand_yank_category(&category, version, &location).await?;
-        }
-        Args::HydrateReadme {
-            sdk_version,
-            msrv,
-            output,
-        } => {
-            subcommand_hydrate_readme(sdk_version, msrv, &output).await?;
-        }
-        Args::GenerateVersionManifest {
-            smithy_build,
-            examples_revision,
-            location,
-        } => {
-            subcommand_generate_version_manifest(&smithy_build, &examples_revision, &location)
-                .await?;
-        }
+        Args::Publish(args) => subcommand_publish(&args).await?,
+        Args::FixManifests(args) => subcommand_fix_manifests(&args).await?,
+        Args::YankCategory(args) => subcommand_yank_category(&args).await?,
+        Args::HydrateReadme(args) => subcommand_hydrate_readme(&args).await?,
+        Args::GenerateVersionManifest(args) => subcommand_generate_version_manifest(&args).await?,
     }
     Ok(())
 }

--- a/tools/publisher/src/subcommand/fix_manifests.rs
+++ b/tools/publisher/src/subcommand/fix_manifests.rs
@@ -13,6 +13,7 @@ use crate::fs::Fs;
 use crate::package::{discover_package_manifests, parse_version};
 use crate::SDK_REPO_NAME;
 use anyhow::{bail, Context, Result};
+use clap::Parser;
 use semver::Version;
 use smithy_rs_tool_common::ci::running_in_ci;
 use std::collections::BTreeMap;
@@ -29,7 +30,23 @@ pub enum Mode {
     Execute,
 }
 
-pub async fn subcommand_fix_manifests(mode: Mode, location: &Path) -> Result<()> {
+#[derive(Parser, Debug)]
+pub struct FixManifestsArgs {
+    /// Path containing the manifests to fix. Manifests will be discovered recursively
+    #[clap(long)]
+    location: PathBuf,
+    /// Checks manifests rather than fixing them
+    #[clap(long)]
+    check: bool,
+}
+
+pub async fn subcommand_fix_manifests(
+    FixManifestsArgs { location, check }: &FixManifestsArgs,
+) -> Result<()> {
+    let mode = match check {
+        true => Mode::Check,
+        false => Mode::Execute,
+    };
     let manifest_paths = discover_package_manifests(location.into()).await?;
     let mut manifests = read_manifests(Fs::Real, manifest_paths).await?;
     let versions = package_versions(&manifests)?;

--- a/tools/publisher/src/subcommand/generate_version_manifest.rs
+++ b/tools/publisher/src/subcommand/generate_version_manifest.rs
@@ -6,19 +6,45 @@
 use crate::fs::Fs;
 use crate::package::{discover_package_manifests, read_packages};
 use anyhow::{bail, Context, Result};
-use serde::{Deserialize, Serialize};
+use clap::Parser;
+use semver::Version;
+use serde::Deserialize;
 use smithy_rs_tool_common::git::GetLastCommit;
 use smithy_rs_tool_common::package::PackageCategory;
 use smithy_rs_tool_common::shell::{self, ShellOperation};
+use smithy_rs_tool_common::versions_manifest::{CrateVersion, Release, VersionsManifest};
 use std::collections::BTreeMap;
 use std::fs::File;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tracing::info;
 
+#[derive(Parser, Debug)]
+pub struct GenerateVersionManifestArgs {
+    /// Path to `smithy-build.json`
+    #[clap(long)]
+    smithy_build: PathBuf,
+    /// Revision of `aws-doc-sdk-examples` repository used to retrieve examples
+    #[clap(long)]
+    examples_revision: String,
+    /// Path containing the generated SDK to generate a version manifest for
+    #[clap(long)]
+    location: PathBuf,
+    /// Optional tag for the release the newly generated `versions.toml` will be for
+    #[clap(long, requires("previous-release-versions"))]
+    release_tag: Option<String>,
+    /// Optional path to the `versions.toml` manifest from the previous SDK release
+    #[clap(long, requires("release-tag"))]
+    previous_release_versions: Option<PathBuf>,
+}
+
 pub async fn subcommand_generate_version_manifest(
-    smithy_build_path: &Path,
-    examples_revision: &str,
-    location: &Path,
+    GenerateVersionManifestArgs {
+        smithy_build,
+        examples_revision,
+        location,
+        release_tag,
+        previous_release_versions,
+    }: &GenerateVersionManifestArgs,
 ) -> Result<()> {
     verify_crate_hasher_available()?;
 
@@ -28,7 +54,7 @@ pub async fn subcommand_generate_version_manifest(
         .context("get smithy-rs revision")?;
     info!("Resolved smithy-rs revision to {}", smithy_rs_revision);
 
-    let smithy_build_root = SmithyBuildRoot::from_file(smithy_build_path)?;
+    let smithy_build_root = SmithyBuildRoot::from_file(smithy_build)?;
     let manifests = discover_package_manifests(location.into())
         .await
         .context("discover package manifests")?;
@@ -67,31 +93,91 @@ pub async fn subcommand_generate_version_manifest(
         );
     }
     info!("Discovered and hashed {} crates", crates.len());
-    let versions_manifest = VersionsManifest {
+    let mut versions_manifest = VersionsManifest {
         smithy_rs_revision,
         aws_doc_sdk_examples_revision: examples_revision.to_string(),
         crates,
+        release: None,
     };
-    let output = toml::to_string_pretty(&versions_manifest).context("serialize versions.toml")?;
+    versions_manifest.release =
+        generate_release_metadata(&versions_manifest, release_tag, previous_release_versions)?;
     let manifest_file_name = location.join("versions.toml");
     info!("Writing {:?}...", manifest_file_name);
-    std::fs::write(&manifest_file_name, output).context("write versions.toml")?;
+    versions_manifest.write_to_file(&manifest_file_name)?;
     Ok(())
 }
 
-#[derive(Debug, Serialize)]
-struct VersionsManifest {
-    smithy_rs_revision: String,
-    aws_doc_sdk_examples_revision: String,
-    crates: BTreeMap<String, CrateVersion>,
+fn generate_release_metadata(
+    versions_manifest: &VersionsManifest,
+    maybe_release_tag: &Option<String>,
+    maybe_previous_release_versions: &Option<PathBuf>,
+) -> Result<Option<Release>> {
+    match (maybe_release_tag, maybe_previous_release_versions) {
+        (Some(release_tag), Some(previous_release_versions)) => {
+            let old_versions = VersionsManifest::from_file(previous_release_versions)?;
+            Ok(Some(Release {
+                tag: release_tag.into(),
+                crates: find_released_versions(&old_versions, versions_manifest)?,
+            }))
+        }
+        _ => Ok(None),
+    }
 }
 
-#[derive(Debug, Serialize)]
-struct CrateVersion {
-    category: PackageCategory,
-    version: String,
-    source_hash: String,
-    model_hash: Option<String>,
+fn parse_version(name: &str, value: &str) -> Result<Version> {
+    match Version::parse(value) {
+        Ok(version) => Ok(version),
+        Err(err) => bail!(
+            "Failed to parse version number `{}` from `{}`: {}",
+            value,
+            name,
+            err
+        ),
+    }
+}
+
+fn find_released_versions(
+    unrecent_versions: &VersionsManifest,
+    recent_versions: &VersionsManifest,
+) -> Result<BTreeMap<String, String>> {
+    let mut released_versions = BTreeMap::new();
+    for (crate_name, recent_version) in &recent_versions.crates {
+        let recent_version = parse_version(crate_name, &recent_version.version)?;
+        if let Some(unrecent_version) = unrecent_versions.crates.get(crate_name) {
+            let unrecent_version = parse_version(crate_name, &unrecent_version.version)?;
+            if unrecent_version != recent_version {
+                // Sanity check: version numbers shouldn't decrease
+                if unrecent_version > recent_version {
+                    bail!(
+                        "Version number for `{}` decreased between releases (from `{}` to `{}`)",
+                        crate_name,
+                        unrecent_version,
+                        recent_version
+                    );
+                }
+
+                // If the crate is in both version manifests with differing version
+                // numbers, then it is part of the release
+                released_versions.insert(crate_name.clone(), recent_version.to_string());
+            }
+        } else {
+            // If the previous version manifest didn't have this crate, then it is part of this release
+            released_versions.insert(crate_name.clone(), recent_version.to_string());
+        }
+    }
+    // Sanity check: If a crate was previously included, but no longer is, we probably want to know about it
+    for unrecent_crate_name in unrecent_versions.crates.keys() {
+        if !recent_versions.crates.contains_key(unrecent_crate_name) {
+            bail!(
+                "Crate `{}` was included in the previous release's `versions.toml`, \
+                 but is not included in the upcoming release. If this is expected, update the \
+                 publisher tool to expect and allow it.",
+                unrecent_crate_name
+            )
+        }
+    }
+
+    Ok(released_versions)
 }
 
 fn verify_crate_hasher_available() -> Result<()> {
@@ -142,4 +228,100 @@ impl SmithyBuildRoot {
 #[derive(Debug, Deserialize)]
 struct SmithyBuildProjection {
     imports: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{find_released_versions, CrateVersion, VersionsManifest};
+    use smithy_rs_tool_common::package::PackageCategory;
+
+    fn fake_manifest(crates: &[(&str, &str)]) -> VersionsManifest {
+        VersionsManifest {
+            smithy_rs_revision: "dontcare".into(),
+            aws_doc_sdk_examples_revision: "dontcare".into(),
+            crates: crates
+                .iter()
+                .map(|(name, version)| (name.to_string(), fake_version(version)))
+                .collect(),
+            release: None,
+        }
+    }
+    fn fake_version(version: &str) -> CrateVersion {
+        CrateVersion {
+            category: PackageCategory::AwsSdk,
+            version: version.into(),
+            source_hash: "dontcare".into(),
+            model_hash: None,
+        }
+    }
+
+    #[test]
+    fn test_find_released_versions_dropped_crate_sanity_check() {
+        let result = find_released_versions(
+            &fake_manifest(&[
+                ("aws-config", "0.11.0"),
+                ("aws-sdk-s3", "0.13.0"),
+                ("aws-sdk-dynamodb", "0.12.0"),
+            ]),
+            &fake_manifest(&[
+                // oops, we lost aws-config
+                ("aws-sdk-s3", "0.13.0"),
+                ("aws-sdk-dynamodb", "0.12.0"),
+            ]),
+        );
+        assert!(result.is_err());
+        let error = format!("{}", result.err().unwrap());
+        assert!(
+            error.starts_with("Crate `aws-config` was included in"),
+            "Unexpected error: {}",
+            error
+        );
+    }
+
+    #[test]
+    fn test_find_released_versions_decreased_version_number_sanity_check() {
+        let result = find_released_versions(
+            &fake_manifest(&[
+                ("aws-config", "0.11.0"),
+                ("aws-sdk-s3", "0.13.0"),
+                ("aws-sdk-dynamodb", "0.12.0"),
+            ]),
+            &fake_manifest(&[
+                ("aws-config", "0.11.0"),
+                ("aws-sdk-s3", "0.12.0"), // oops, S3 went backwards
+                ("aws-sdk-dynamodb", "0.12.0"),
+            ]),
+        );
+        assert!(result.is_err());
+        let error = format!("{}", result.err().unwrap());
+        assert!(
+            error.starts_with("Version number for `aws-sdk-s3` decreased"),
+            "Unexpected error: {}",
+            error
+        );
+    }
+
+    #[test]
+    fn test_find_released_versions() {
+        let result = find_released_versions(
+            &fake_manifest(&[
+                ("aws-config", "0.11.0"),
+                ("aws-sdk-s3", "0.13.0"),
+                ("aws-sdk-dynamodb", "0.12.0"),
+            ]),
+            &fake_manifest(&[
+                ("aws-config", "0.12.0"),          // updated
+                ("aws-sdk-s3", "0.14.0"),          // updated
+                ("aws-sdk-dynamodb", "0.12.0"),    // same
+                ("aws-sdk-somethingnew", "0.1.0"), // new
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!("0.12.0", result.get("aws-config").unwrap());
+        assert_eq!("0.14.0", result.get("aws-sdk-s3").unwrap());
+        assert_eq!("0.1.0", result.get("aws-sdk-somethingnew").unwrap());
+        assert!(result.get("aws-sdk-dynamodb").is_none());
+        assert_eq!(3, result.len());
+    }
 }

--- a/tools/publisher/src/subcommand/hydrate_readme.rs
+++ b/tools/publisher/src/subcommand/hydrate_readme.rs
@@ -6,16 +6,32 @@
 use crate::repo::Repository;
 use crate::SMITHYRS_REPO_NAME;
 use anyhow::{Context, Result};
+use clap::Parser;
 use handlebars::Handlebars;
 use semver::Version;
 use serde_json::json;
 use std::fs;
-use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+pub struct HydrateReadmeArgs {
+    /// AWS Rust SDK version to put in the README
+    #[clap(long)]
+    sdk_version: Version,
+    /// Rust MSRV to put in the README
+    #[clap(long)]
+    msrv: String,
+    /// Path to output the hydrated readme into
+    #[clap(short, long)]
+    output: PathBuf,
+}
 
 pub async fn subcommand_hydrate_readme(
-    sdk_version: Version,
-    msrv: String,
-    output: &Path,
+    HydrateReadmeArgs {
+        sdk_version,
+        msrv,
+        output,
+    }: &HydrateReadmeArgs,
 ) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let repository = Repository::new(SMITHYRS_REPO_NAME, &cwd)?;
@@ -25,13 +41,13 @@ pub async fn subcommand_hydrate_readme(
     let template_string =
         String::from_utf8(template_contents).context("README template file was invalid UTF-8")?;
 
-    let hydrated = hydrate_template(&template_string, sdk_version, &msrv)?;
+    let hydrated = hydrate_template(&template_string, sdk_version, msrv)?;
     fs::write(output, hydrated.as_bytes())
         .with_context(|| format!("Failed to write hydrated README to {:?}", output))?;
     Ok(())
 }
 
-fn hydrate_template(template_string: &str, sdk_version: Version, msrv: &str) -> Result<String> {
+fn hydrate_template(template_string: &str, sdk_version: &Version, msrv: &str) -> Result<String> {
     let reg = Handlebars::new();
     reg.render_template(
         template_string,
@@ -56,7 +72,7 @@ mod tests {
             <!-- Included -->\n\
             Some {{sdk_version}} and {{msrv}} here.\n\
             ",
-            Version::new(0, 5, 1),
+            &Version::new(0, 5, 1),
             "1.54",
         )
         .unwrap();

--- a/tools/sdk-sync/Cargo.lock
+++ b/tools/sdk-sync/Cargo.lock
@@ -628,6 +628,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "serde",
+ "toml",
  "tracing",
 ]
 
@@ -712,6 +713,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
+ "indexmap",
  "serde",
 ]
 

--- a/tools/sdk-sync/src/fs.rs
+++ b/tools/sdk-sync/src/fs.rs
@@ -39,6 +39,9 @@ pub trait Fs: Send + Sync {
 
     /// Recursively copies files.
     fn recursive_copy(&self, source: &Path, destination: &Path) -> Result<()>;
+
+    /// Copies a file, overwriting it if it exists.
+    fn copy(&self, source: &Path, destination: &Path) -> Result<()>;
 }
 
 #[derive(Debug, Default)]
@@ -141,6 +144,11 @@ impl Fs for DefaultFs {
 
         let output = command.output()?;
         handle_failure("recursive_copy", &output)?;
+        Ok(())
+    }
+
+    fn copy(&self, source: &Path, destination: &Path) -> Result<()> {
+        std::fs::copy(source, destination)?;
         Ok(())
     }
 }

--- a/tools/sdk-sync/src/versions.rs
+++ b/tools/sdk-sync/src/versions.rs
@@ -7,6 +7,7 @@ use crate::fs::{DefaultFs, Fs};
 use crate::git::CommitHash;
 use anyhow::Result;
 use std::path::Path;
+use std::str::FromStr;
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct VersionsManifest {

--- a/tools/sdk-sync/src/versions.rs
+++ b/tools/sdk-sync/src/versions.rs
@@ -5,8 +5,7 @@
 
 use crate::fs::{DefaultFs, Fs};
 use crate::git::CommitHash;
-use anyhow::{Context, Result};
-use serde::Deserialize;
+use anyhow::Result;
 use std::path::Path;
 
 #[derive(Debug, Eq, PartialEq)]
@@ -29,13 +28,9 @@ impl DefaultVersions {
     }
 
     fn load_from(&self, fs: &dyn Fs, path: &Path) -> Result<VersionsManifest> {
-        #[derive(Deserialize)]
-        pub struct Deser {
-            smithy_rs_revision: String,
-            aws_doc_sdk_examples_revision: String,
-        }
         let contents = fs.read_to_string(&path.join("versions.toml"))?;
-        let manifest: Deser = toml::from_str(&contents).context("parse versions.toml")?;
+        let manifest =
+            smithy_rs_tool_common::versions_manifest::VersionsManifest::from_str(&contents)?;
         Ok(VersionsManifest {
             smithy_rs_revision: CommitHash::from(manifest.smithy_rs_revision),
             aws_doc_sdk_examples_revision: CommitHash::from(manifest.aws_doc_sdk_examples_revision),

--- a/tools/sdk-sync/tests/create-test-workspace
+++ b/tools/sdk-sync/tests/create-test-workspace
@@ -89,8 +89,14 @@ echo "Some handwritten file" > some_handwritten
     echo "some_handwritten"; \
 ) > .handwritten
 ( \
+    echo '# special test comment: this came from the previous release'; \
     echo 'smithy_rs_revision = "'"${SMITHY_RS_HEAD}"'"'; \
     echo 'aws_doc_sdk_examples_revision = "'"${EXAMPLES_HEAD}"'"'; \
+    echo '[crates.aws-sdk-s3]'; \
+    echo 'category = "AwsSdk"'; \
+    echo 'version = "0.1.0"'; \
+    echo 'source_hash = "doesntmatterhere"'; \
+    echo 'model_hash = "doesntmatterhere"'; \
 ) > versions.toml
 git add .
 git -c user.name="Test Dev" -c user.email="testdev@example.com" commit -m "Initial commit"

--- a/tools/sdk-sync/tests/fake-sdk-assemble
+++ b/tools/sdk-sync/tests/fake-sdk-assemble
@@ -10,6 +10,7 @@
 import sys
 import subprocess
 import shlex
+import os.path
 
 
 def get_cmd_output(command):
@@ -17,13 +18,37 @@ def get_cmd_output(command):
     return result.stdout.decode("utf-8").strip()
 
 
-def get_examples_revision():
+def get_property(name):
+    prefix = f"-P{name}="
     for arg in sys.argv:
-        prefix = "-Paws.sdk.examples.revision="
         if arg.startswith(prefix):
             return arg[len(prefix):]
     return None
 
+
+def get_examples_revision():
+    return get_property("aws.sdk.examples.revision")
+
+
+def get_previous_release_versions():
+    return get_property("aws.sdk.previous.release.versions.manifest")
+
+
+if get_property("aws.fullsdk") != "true":
+    sys.exit(1)
+
+# Verify the versions manifest path was set correctly
+previous_release_versions = get_previous_release_versions()
+if previous_release_versions is None or not os.path.exists(previous_release_versions):
+    print("Previous release versions file didn't exist")
+    sys.exit(1)
+else:
+    # Verify its the right file by looking for our special comment
+    with open(previous_release_versions, 'r') as file:
+        contents = file.read()
+        if "# special test comment: this came from the previous release" not in contents:
+            print("Wrong previous release versions.toml given to aws:sdk:assemble")
+            sys.exit(1)
 
 examples_revision = get_examples_revision()
 smithy_rs_revision = get_cmd_output("git rev-parse HEAD")

--- a/tools/sdk-versioner/Cargo.lock
+++ b/tools/sdk-versioner/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "serde",
+ "toml",
  "tracing",
 ]
 

--- a/tools/smithy-rs-tool-common/Cargo.lock
+++ b/tools/smithy-rs-tool-common/Cargo.lock
@@ -20,10 +20,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
 
 [[package]]
 name = "lazy_static"
@@ -83,6 +105,7 @@ dependencies = [
  "async-trait",
  "serde",
  "tokio",
+ "toml",
  "tracing",
 ]
 
@@ -116,6 +139,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "indexmap",
+ "serde",
 ]
 
 [[package]]

--- a/tools/smithy-rs-tool-common/Cargo.toml
+++ b/tools/smithy-rs-tool-common/Cargo.toml
@@ -18,6 +18,7 @@ opt-level = 0
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-tokio = { version = "1", features = ["rt", "macros"], optional = true }
-tracing = "0.1"
 serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["rt", "macros"], optional = true }
+toml = { version = "0.5.8", features = ["preserve_order"] }
+tracing = "0.1"

--- a/tools/smithy-rs-tool-common/src/lib.rs
+++ b/tools/smithy-rs-tool-common/src/lib.rs
@@ -9,3 +9,4 @@ pub mod git;
 pub mod macros;
 pub mod package;
 pub mod shell;
+pub mod versions_manifest;

--- a/tools/smithy-rs-tool-common/src/package.rs
+++ b/tools/smithy-rs-tool-common/src/package.rs
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 pub const SMITHY_PREFIX: &str = "aws-smithy-";
 pub const SDK_PREFIX: &str = "aws-sdk-";
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Deserialize, Serialize)]
 pub enum PackageCategory {
     SmithyRuntime,
     AwsRuntime,

--- a/tools/smithy-rs-tool-common/src/versions_manifest.rs
+++ b/tools/smithy-rs-tool-common/src/versions_manifest.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
+use std::str::FromStr;
 
 /// Root struct representing a `versions.toml` manifest
 #[derive(Debug, Deserialize, Serialize)]
@@ -34,10 +35,6 @@ pub struct VersionsManifest {
 }
 
 impl VersionsManifest {
-    pub fn from_str(value: &str) -> Result<VersionsManifest> {
-        Ok(toml::from_str(value)?)
-    }
-
     pub fn from_file(path: impl AsRef<Path>) -> Result<VersionsManifest> {
         Self::from_str(
             &fs::read_to_string(path.as_ref())
@@ -52,6 +49,14 @@ impl VersionsManifest {
         fs::write(path.as_ref(), serialized)
             .with_context(|| format!("failed to write to {:?}", path.as_ref()))?;
         Ok(())
+    }
+}
+
+impl FromStr for VersionsManifest {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(toml::from_str(value)?)
     }
 }
 

--- a/tools/smithy-rs-tool-common/src/versions_manifest.rs
+++ b/tools/smithy-rs-tool-common/src/versions_manifest.rs
@@ -1,0 +1,82 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! This module provides structs with ser/de for working with the `versions.toml` file
+//! in the root of the `aws-sdk-rust` repository.
+
+use crate::package::PackageCategory;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+
+/// Root struct representing a `versions.toml` manifest
+#[derive(Debug, Deserialize, Serialize)]
+pub struct VersionsManifest {
+    /// Git commit hash of the version of smithy-rs used to generate this SDK
+    pub smithy_rs_revision: String,
+
+    /// Git commit hash of the `aws-doc-sdk-examples` repository that was synced into this SDK
+    pub aws_doc_sdk_examples_revision: String,
+
+    /// All SDK crate version metadata
+    pub crates: BTreeMap<String, CrateVersion>,
+
+    /// Crate versions that were a part of this SDK release.
+    /// Releases may not release every single crate, which can happen if a crate has no changes.
+    ///
+    /// This member is optional since a one-off smoke test SDK in local development
+    /// isn't going to have a previous release to reflect upon to determine release metadata.
+    pub release: Option<Release>,
+}
+
+impl VersionsManifest {
+    pub fn from_str(value: &str) -> Result<VersionsManifest> {
+        Ok(toml::from_str(value)?)
+    }
+
+    pub fn from_file(path: impl AsRef<Path>) -> Result<VersionsManifest> {
+        Self::from_str(
+            &fs::read_to_string(path.as_ref())
+                .with_context(|| format!("Failed to read {:?}", path.as_ref()))?,
+        )
+        .with_context(|| format!("Failed to parse {:?}", path.as_ref()))
+    }
+
+    pub fn write_to_file(&self, path: impl AsRef<Path>) -> Result<()> {
+        let serialized = toml::to_string_pretty(self)
+            .context("failed to serialize versions manifest into TOML")?;
+        fs::write(path.as_ref(), serialized)
+            .with_context(|| format!("failed to write to {:?}", path.as_ref()))?;
+        Ok(())
+    }
+}
+
+/// Release metadata
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Release {
+    /// The release tag associated with this `versions.toml`
+    pub tag: String,
+
+    /// Which crate versions were published with this release
+    pub crates: BTreeMap<String, String>,
+}
+
+/// Version metadata for a crate
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CrateVersion {
+    /// What kind of crate this is. Is it the Smithy runtime? AWS runtime? SDK crate?
+    pub category: PackageCategory,
+
+    /// Version of the crate.
+    pub version: String,
+
+    /// The hash of the crate source code as determined by the `crate-hasher` tool in smithy-rs.
+    pub source_hash: String,
+
+    /// The SHA-256 hash of the AWS model file(s) used to generate this crate (if this is a SDK crate).
+    pub model_hash: Option<String>,
+}


### PR DESCRIPTION
## Motivation and Context
As we start unsynchronizing SDK crate version numbers, we will need to know exactly which crates went out with a given release so that if we need to yank that release, it will actually be possible. This PR revises SDK generation via the `sdk-sync` tool to feed information from the previous release's `versions.toml` into the creation of the next release's `versions.toml` so that this information of which crates actually changed can be retained.

The publisher tool was also modified to read an expected tag from the `versions.toml` file rather than expecting the `aws-config` version number. This will be required also since `aws-config`'s version number won't match the release tag in the future when versions aren't synchronized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
