### PR TITLE
Use md5 implementation of RustCrypto organization

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -28,3 +28,21 @@ author = "alonlud"
  references = ["smithy-rs#1390"]
  meta = { "breaking" = false, "tada" = true, "bug" = false }
  author = "Velfi"
+
+[[smithy-rs]]
+message = "Add ability to specify a different rust crate name than the one derived from the package name"
+references = ["smithy-rs#1404"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "petrosagg"
+
+[[smithy-rs]]
+message = "Switch to [RustCrypto](https://github.com/RustCrypto)'s implementation of MD5."
+references = ["smithy-rs#1404"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "petrosagg"
+
+[[aws-sdk-rust]]
+message = "Switch to [RustCrypto](https://github.com/RustCrypto)'s implementation of MD5."
+references = ["smithy-rs#1404"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "petrosagg"

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -115,8 +115,7 @@ class InlineDependency(
     }
 }
 
-fun CargoDependency.asType(): RuntimeType =
-    RuntimeType(null, dependency = this, namespace = this.name.replace("-", "_"))
+fun CargoDependency.asType(): RuntimeType = RuntimeType(null, dependency = this, namespace = rustName)
 
 data class Feature(val name: String, val default: Boolean, val deps: List<String>)
 
@@ -129,7 +128,7 @@ data class CargoDependency(
     val scope: DependencyScope = DependencyScope.Compile,
     val optional: Boolean = false,
     val features: Set<String> = emptySet(),
-    val crateName: String = name.replace("-", "_")
+    val rustName: String = name.replace("-", "_")
 ) : RustDependency(name) {
     val key: Triple<String, DependencyLocation, DependencyScope> get() = Triple(name, location, scope)
 
@@ -144,7 +143,7 @@ data class CargoDependency(
         is Local -> "local"
     }
 
-    fun rustName(name: String): RuntimeType = RuntimeType(name, this, this.crateName)
+    fun rustName(name: String): RuntimeType = RuntimeType(name, this, this.rustName)
 
     fun toMap(): Map<String, Any> {
         val attribs = mutableMapOf<String, Any>()
@@ -200,7 +199,7 @@ data class CargoDependency(
         val Hyper: CargoDependency = CargoDependency("hyper", CratesIo("0.14"))
         val HyperWithStream: CargoDependency = Hyper.withFeature("stream")
         val LazyStatic: CargoDependency = CargoDependency("lazy_static", CratesIo("1.4"))
-        val Md5: CargoDependency = CargoDependency("md-5", CratesIo("0.10"), crateName = "md5")
+        val Md5: CargoDependency = CargoDependency("md-5", CratesIo("0.10"), rustName = "md5")
         val PercentEncoding: CargoDependency = CargoDependency("percent-encoding", CratesIo("2"))
         val PrettyAssertions: CargoDependency = CargoDependency("pretty_assertions", CratesIo("1"), scope = DependencyScope.Dev)
         val Regex: CargoDependency = CargoDependency("regex", CratesIo("1"))

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -128,7 +128,8 @@ data class CargoDependency(
     private val location: DependencyLocation,
     val scope: DependencyScope = DependencyScope.Compile,
     val optional: Boolean = false,
-    val features: Set<String> = emptySet()
+    val features: Set<String> = emptySet(),
+    val crateName: String = name.replace("-", "_")
 ) : RustDependency(name) {
     val key: Triple<String, DependencyLocation, DependencyScope> get() = Triple(name, location, scope)
 
@@ -143,7 +144,7 @@ data class CargoDependency(
         is Local -> "local"
     }
 
-    fun rustName(name: String): RuntimeType = RuntimeType(name, this, this.name.replace("-", "_"))
+    fun rustName(name: String): RuntimeType = RuntimeType(name, this, this.crateName)
 
     fun toMap(): Map<String, Any> {
         val attribs = mutableMapOf<String, Any>()
@@ -199,7 +200,7 @@ data class CargoDependency(
         val Hyper: CargoDependency = CargoDependency("hyper", CratesIo("0.14"))
         val HyperWithStream: CargoDependency = Hyper.withFeature("stream")
         val LazyStatic: CargoDependency = CargoDependency("lazy_static", CratesIo("1.4"))
-        val Md5: CargoDependency = CargoDependency("md5", CratesIo("0.7"))
+        val Md5: CargoDependency = CargoDependency("md-5", CratesIo("0.10"), crateName = "md5")
         val PercentEncoding: CargoDependency = CargoDependency("percent-encoding", CratesIo("2"))
         val PrettyAssertions: CargoDependency = CargoDependency("pretty_assertions", CratesIo("1"), scope = DependencyScope.Dev)
         val Regex: CargoDependency = CargoDependency("regex", CratesIo("1"))

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/HttpChecksumRequiredGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/HttpChecksumRequiredGenerator.kt
@@ -42,7 +42,7 @@ class HttpChecksumRequiredGenerator(
                             .body()
                             .bytes()
                             .expect("checksum can only be computed for non-streaming operations");
-                        let checksum = #{md5}::compute(data);
+                        let checksum = <#{md5}::Md5 as #{md5}::Digest>::digest(data);
                         req.headers_mut().insert(
                             #{http}::header::HeaderName::from_static("content-md5"),
                             #{base64_encode}(&checksum[..]).parse().expect("checksum is valid header value")


### PR DESCRIPTION
## Motivation and Context

I noticed that the S3 SDK was depending to the `md5` crate which is not part of the `RustCrypto` organization. The `RustCrypto` organization is the de-facto standard of cryptographic primitive implementations in Rust with an active community and already used by `aws-smithy-checksums` for its `sha1` and `sha2` checksums.

## Description

I changed the `md5` crate to the one provided by `RustCrypto`. 

## Testing

No behavior changes to be tested

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
