### PR TITLE
Appease Clippy's `unnecessary_lazy_evaluations` in Rust 1.60

### DIFF
--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -209,7 +209,7 @@ impl DateTime {
             Format::DateTime => format::rfc3339::read(s)?,
             Format::HttpDate => format::http_date::read(s)?,
             Format::EpochSeconds => {
-                let split_point = s.find(delim).unwrap_or_else(|| s.len());
+                let split_point = s.find(delim).unwrap_or(s.len());
                 let (s, rest) = s.split_at(split_point);
                 (Self::from_str(s, format)?, rest)
             }

--- a/rust-runtime/inlineable/src/json_errors.rs
+++ b/rust-runtime/inlineable/src/json_errors.rs
@@ -97,7 +97,7 @@ pub fn parse_generic_error(
     let mut err_builder = SmithyError::builder();
     if let Some(code) = error_type_from_header(headers)
         .map_err(|_| DeserializeError::custom("X-Amzn-Errortype header was not valid UTF-8"))?
-        .or_else(|| code.as_deref())
+        .or(code.as_deref())
         .map(sanitize_error_code)
     {
         err_builder.code(code);


### PR DESCRIPTION
In Rust 1.60 we get Clippy lint warnings that make the build fail.

```
warning: unnecessary closure used to substitute value for `Option::None`
   --> inlineable/src/json_errors.rs:98:25
    |
98  |       if let Some(code) = error_type_from_header(headers)
    |  _________________________^
99  | |         .map_err(|_| DeserializeError::custom("X-Amzn-Errortype header was not valid UTF-8"))?
100 | |         .or_else(|| code.as_deref())
    | |____________________________________^
    |
    = note: `#[warn(clippy::unnecessary_lazy_evaluations)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
help: use `or` instead
    |
98  ~     if let Some(code) = error_type_from_header(headers)
99  +         .map_err(|_| DeserializeError::custom("X-Amzn-Errortype header was not valid UTF-8"))?.or(code.as_deref())
```

Since `len` is cheap and `deref` is supposed to be cheap, these resolve
to reading a pointer in assembly and they don't need to be lazily
evaluated.

https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_lazy_evaluations
https://github.com/rust-lang/rust-clippy/issues/8109
https://github.com/rust-lang/rust-clippy/blob/master/clippy_utils/src/eager_or_lazy.rs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
