### PR TITLE
Add local publish configuration to rust-runtime

### DIFF
--- a/rust-runtime/build.gradle.kts
+++ b/rust-runtime/build.gradle.kts
@@ -6,6 +6,8 @@
 description = "Rust Runtime"
 plugins {
     kotlin("jvm")
+    maven
+    `maven-publish`
 }
 
 group = "software.amazon.rustruntime"
@@ -56,4 +58,13 @@ tasks.register<ExecRustBuildTool>("fixManifests") {
     binaryName = "publisher"
     arguments = listOf("fix-manifests", "--location", runtimeOutputDir.absolutePath)
     dependsOn("fixRuntimeCrateVersions")
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("default") {
+            from(components["java"])
+        }
+    }
+    repositories { maven { url = uri("$buildDir/repository") } }
 }

--- a/rust-runtime/build.gradle.kts
+++ b/rust-runtime/build.gradle.kts
@@ -6,7 +6,6 @@
 description = "Rust Runtime"
 plugins {
     kotlin("jvm")
-    maven
     `maven-publish`
 }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
It's useful to be able to publish the `rust-runtime` to maven local for local development

## Description
<!--- Describe your changes in detail -->
Add publish configuration for `rust-runtime`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
n/a - build configuration

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
