### PR TITLE
Add `From` implementation for SdkConfig to Builder

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -12,6 +12,18 @@
 # author = "rcoh"
 
 [[smithy-rs]]
+message = "Add `From` implementation to convert from an SdkConfig to Builder"
+references = []
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "jackos"
+
+[[aws-sdk-rust]]
+message = "Add `From` implementation to convert from an SdkConfig to Builder"
+references = []
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "jackos"
+
+[[smithy-rs]]
 message = "Add ability to sign a request with all headers, or to change which headers are excluded from signing"
 references = ["smithy-rs#1381"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -411,3 +411,18 @@ impl SdkConfig {
         Builder::default()
     }
 }
+
+impl From<SdkConfig> for Builder {
+    fn from(config: SdkConfig) -> Self {
+        Builder {
+            app_name: config.app_name,
+            credentials_provider: config.credentials_provider,
+            endpoint_resolver: config.endpoint_resolver,
+            http_connector: config.http_connector,
+            region: config.region,
+            retry_config: config.retry_config,
+            timeout_config: config.timeout_config,
+            sleep_impl: config.sleep_impl,
+        }
+    }
+}


### PR DESCRIPTION
## Motivation and Context

This example context is if you're building a CLI that allows arguments to change something like AWS Profile, and then you pass that `SdkConfig` to your library for dealing with AWS Services, you may want to change fields in the SdkConfig, but there are no setter methods and the fields are private, and you also can't convert back to a builder.

The example below is a common requirement, when using `LocalStack` we want to change all endpoints to our local machine:

```rust
/// Checks for LOCALSTACK_ENDPOINT env var, if it exists build a new SdkConfig from the old one
/// then apply the endpoint from the env var.
/// SdkConfig has no public fields or setter methods, so we must build a new one
pub fn check_localstack_bad(config: SdkConfig) -> SdkConfig {
    if let Ok(endpoint) = std::env::var("LOCALSTACK_ENDPOINT") {
        let mut builder = aws_types::SdkConfig::builder();

        if let Some(x) = config.credentials_provider() {
            builder = builder.credentials_provider(x.clone());
        }
        if let Some(x) = config.http_connector() {
            builder = builder.http_connector(x.clone());
        }
        if let Some(x) = config.region() {
            builder = builder.region(x.clone());
        }
        if let Some(x) = config.retry_config() {
            builder = builder.retry_config(x.clone());
        }
        if let Some(x) = config.timeout_config() {
            builder = builder.timeout_config(x.clone());
        }

        let e = Endpoint::immutable(
            Uri::from_str(&endpoint).expect("LOCALSTACK_ENDPOINT is not a valid uri"),
        );
        return builder.endpoint_resolver(e).build();
    }
    config
}
```
Which are extra allocations and also takes a long time for a user to look through `aws_smithy_types`, `aws_types`, and `aws_config` before realizing there is no better way (maybe there is, but I couldn't find one).

## Description
This change allows you to:
```rust
pub fn check_localstack(config: SdkConfig) -> SdkConfig {
    if let Ok(endpoint) = std::env::var("LOCALSTACK_ENDPOINT") {
        let e = Endpoint::immutable(
            Uri::from_str(&endpoint).expect("LOCALSTACK_ENDPOINT is not a valid uri"),
        );
        return Builder::from(config).endpoint_resolver(e).build();
    }
    config
}
```
And also is idiomatic for Rust, allowing other associated conversion methods:
```rust
let builder: Builder = config.into();
```
This doesn't compromise the builder pattern that's being used but makes `SdkConfig` much more ergonomic.

## Testing
On Arch Linux x86_64 with toolchain:
```
stable-x86_64-unknown-linux-gnu (default)
rustc 1.61.0 (fe5b13d68 2022-05-18)
```
- Tested using client code that makes use of `aws-types`, `aws-smithy-types` and `aws-config` which didn't break anything.
- Did a `cargo test`, all passing

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
