### PR TITLE
make build image commit has configurable

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -50,9 +50,6 @@ ARG rust_nightly_version=nightly-2022-03-29
 ARG cargo_udeps_version=0.1.27
 ARG cargo_hack_version=0.5.12
 ARG cargo_minimal_versions_version=0.1.3
-# If the `checkout_smithy_rs_tools` arg is set to true, then the Dockerfile will acquire the tools
-# source code by checking out awslabs/smithy-rs/main rather than copying them from the local directory.
-ARG checkout_smithy_rs_tools=false
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin/:${PATH} \
@@ -90,6 +87,11 @@ RUN set -eux; \
     cargo --version; \
     cargo +${rust_nightly_version} --version;
 COPY . tools/
+# when `checkout_smithy_rs_tools` is set to true, this commit will be checked out
+ARG smithy_rs_commit_hash=main
+# If the `checkout_smithy_rs_tools` arg is set to true, then the Dockerfile will acquire the tools
+# source code by checking out awslabs/smithy-rs/main rather than copying them from the local directory.
+ARG checkout_smithy_rs_tools=false
 RUN set -eux; \
     cargo +${rust_nightly_version} install cargo-udeps --version ${cargo_udeps_version}; \
     cargo install cargo-hack --version ${cargo_hack_version}; \
@@ -97,6 +99,7 @@ RUN set -eux; \
     if [[ "${checkout_smithy_rs_tools}" == "true" ]]; then \
         git clone https://github.com/awslabs/smithy-rs.git; \
         cd smithy-rs; \
+        git checkout ${smithy_rs_commit_hash}; \
     fi; \
     cargo install --path tools/publisher; \
     cargo +${rust_nightly_version} install --path tools/api-linter; \


### PR DESCRIPTION
## Motivation and Context
enable control of the specific smithy-rs version used by the build image

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
