### PR TITLE
Remove erroneous reference to the base `Symbol` when mapping Rust types

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolVisitor.kt
@@ -109,11 +109,15 @@ fun Symbol.makeOptional(): Symbol {
     }
 }
 
-/** Map the RustType of a symbol with [f] */
+/**
+ * Map the [RustType] of a symbol with [f].
+ *
+ * WARNING: This function does not set any `SymbolReference`s on the returned symbol. You will have to add those
+ * yourself if your logic relies on them.
+ **/
 fun Symbol.mapRustType(f: (RustType) -> RustType): Symbol {
     val newType = f(this.rustType())
     return Symbol.builder().rustType(newType)
-        .addReference(this)
         .name(newType.name)
         .build()
 }


### PR DESCRIPTION
`.addReference(this)` adds a reference to the `Symbol` on which
`.mapRustType` was called. This is correct only when `f` is a function
that _wraps_ its input `RustType`; for example, when `f` wraps it in a
`Box` or constructs a `Vec`. However, the code is incorrect for an
arbitrary `f`; for example, when `f` _swaps_ the type.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
