### PR TITLE
`#[allow(clippy::type_complexity)]` globally

### DIFF
--- a/codegen-test/model/misc.smithy
+++ b/codegen-test/model/misc.smithy
@@ -13,26 +13,22 @@ use smithy.test#httpResponseTests
 @title("MiscService")
 service MiscService {
     operations: [
-        OperationWithInnerRequiredShape,
-        ResponseCodeRequired,
-        ResponseCodeHttpFallback,
-        ResponseCodeDefault,
+        InnerRequiredShapeOperation,
+        ResponseCodeRequiredOperation,
+        ResponseCodeHttpFallbackOperation,
+        ResponseCodeDefaultOperation,
     ],
 }
 
 /// This operation tests that (de)serializing required values from a nested
 /// shape works correctly.
-@http(uri: "/operation", method: "GET")
-operation OperationWithInnerRequiredShape {
-    input: OperationWithInnerRequiredShapeInput,
-    output: OperationWithInnerRequiredShapeOutput,
+@http(uri: "/innerRequiredShapeOperation", method: "GET")
+operation InnerRequiredShapeOperation {
+    input: InnerRequiredShapeOperationInputOutput,
+    output: InnerRequiredShapeOperationInputOutput,
 }
 
-structure OperationWithInnerRequiredShapeInput {
-    inner: InnerShape
-}
-
-structure OperationWithInnerRequiredShapeOutput {
+structure InnerRequiredShapeOperationInputOutput {
     inner: InnerShape
 }
 
@@ -114,64 +110,52 @@ union AUnion {
     time: Timestamp,
 }
 
-/// This operation tests that the response code defaults to 200 when no other code is set
+/// This operation tests that the response code defaults to 200 when no other
+/// code is set.
 @httpResponseTests([
     {
-        id: "ResponseCodeDefault",
+        id: "ResponseCodeDefaultOperation",
         protocol: "aws.protocols#restJson1",
         code: 200,
     }
 ])
-@http(method: "GET", uri: "/responseCodeDefault")
-operation ResponseCodeDefault {
-    input: ResponseCodeDefaultInput,
-    output: ResponseCodeDefaultOutput,
+@http(method: "GET", uri: "/responseCodeDefaultOperation")
+operation ResponseCodeDefaultOperation {
+    input: EmptyStructure,
+    output: EmptyStructure,
 }
 
-@input
-structure ResponseCodeDefaultInput {}
-
-@output
-structure ResponseCodeDefaultOutput {}
-
-/// This operation tests that the response code defaults to @http's code
+/// This operation tests that the response code defaults to `@http`'s code.
 @httpResponseTests([
     {
-        id: "ResponseCodeHttpFallback",
+        id: "ResponseCodeHttpFallbackOperation",
         protocol: "aws.protocols#restJson1",
         code: 418,
     }
 ])
-@http(method: "GET", uri: "/responseCodeHttpFallback", code: 418)
-operation ResponseCodeHttpFallback {
-    input: ResponseCodeHttpFallbackInput,
-    output: ResponseCodeHttpFallbackOutput,
+@http(method: "GET", uri: "/responseCodeHttpFallbackOperation", code: 418)
+operation ResponseCodeHttpFallbackOperation {
+    input: EmptyStructure,
+    output: EmptyStructure,
 }
 
-@input
-structure ResponseCodeHttpFallbackInput {}
+structure EmptyStructure {}
 
-@output
-structure ResponseCodeHttpFallbackOutput {}
-
-/// This operation tests that @httpResponseCode is @required
-/// and is used over @http's code
+/// This operation tests that `@httpResponseCode` is `@required`
+/// and is used over `@http's` code.
 @httpResponseTests([
     {
-        id: "ResponseCodeRequired",
+        id: "ResponseCodeRequiredOperation",
         protocol: "aws.protocols#restJson1",
         code: 201,
         params: {"responseCode": 201}
     }
 ])
-@http(method: "GET", uri: "/responseCodeRequired", code: 200)
-operation ResponseCodeRequired {
-    input: ResponseCodeRequiredInput,
+@http(method: "GET", uri: "/responseCodeRequiredOperation", code: 200)
+operation ResponseCodeRequiredOperation {
+    input: EmptyStructure,
     output: ResponseCodeRequiredOutput,
 }
-
-@input
-structure ResponseCodeRequiredInput {}
 
 @output
 structure ResponseCodeRequiredOutput {

--- a/codegen-test/model/misc.smithy
+++ b/codegen-test/model/misc.smithy
@@ -13,11 +13,41 @@ use smithy.test#httpResponseTests
 @title("MiscService")
 service MiscService {
     operations: [
+        TypeComplexityOperation,
         InnerRequiredShapeOperation,
         ResponseCodeRequiredOperation,
         ResponseCodeHttpFallbackOperation,
         ResponseCodeDefaultOperation,
     ],
+}
+
+/// An operation whose shapes generate complex Rust types.
+/// See https://rust-lang.github.io/rust-clippy/master/index.html#type_complexity.
+@http(uri: "/typeComplexityOperation", method: "GET")
+operation TypeComplexityOperation {
+    input: TypeComplexityOperationInputOutput,
+    output: TypeComplexityOperationInputOutput,
+}
+
+structure TypeComplexityOperationInputOutput {
+    list: ListA
+}
+
+list ListA {
+    member: ListB
+}
+
+list ListB {
+    member: ListC
+}
+
+list ListC {
+    member: MapA
+}
+
+map MapA {
+    key: String,
+    value: EmptyStructure
 }
 
 /// This operation tests that (de)serializing required values from a nested

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/AllowLintsGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customizations/AllowLintsGenerator.kt
@@ -11,26 +11,29 @@ import software.amazon.smithy.rust.codegen.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.smithy.generators.LibRsSection
 
 val ClippyAllowLints = listOf(
-    // Sometimes operations are named the same as our module e.g. output leading to `output::output`
+    // Sometimes operations are named the same as our module e.g. output leading to `output::output`.
     "module_inception",
 
-    // Currently, we don't recase acronyms in models, e.g. SSEVersion
+    // Currently, we don't recase acronyms in models, e.g. `SSEVersion`.
     "upper_case_acronyms",
 
-    // Large errors trigger this warning, we are unlikely to optimize this case currently
+    // Large errors trigger this warning, we are unlikely to optimize this case currently.
     "large_enum_variant",
 
-    // Some models have members with `is` in the name, which leads to builder functions with the wrong self convention
+    // Some models have members with `is` in the name, which leads to builder functions with the wrong self convention.
     "wrong_self_convention",
 
-    // models like ecs use method names like "add()" which confuses clippy
+    // Models like ecs use method names like `add()` which confuses Clippy.
     "should_implement_trait",
 
-    // protocol tests use silly names like `baz`, don't flag that
+    // Protocol tests use silly names like `baz`, don't flag that.
     "blacklisted_name",
 
-    // Forcing use of `vec![]` can make codegen harder in some cases
+    // Forcing use of `vec![]` can make codegen harder in some cases.
     "vec_init_then_push",
+
+    // Some models have shapes that generate complex Rust types (e.g. nested collection and map shapes).
+    "type_complexity",
 )
 
 val AllowDocsLints = listOf(


### PR DESCRIPTION
Because some models have shapes that generate complex Rust types (e.g.
nested collection and map shapes).

I've also taken the opportunity to homogenize the comments in
`AllowLintsGenerator.kt`, and to simplify the `misc.smithy` model and make it more like the others in style.

## Testing

The added operation fails to synthesize unless we allow `type_complexity`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
