### PR TITLE
Reintroduce `sdk-sync` parallelism by disabling Smithy parallelism

### DIFF
--- a/tools/sdk-sync/Cargo.lock
+++ b/tools/sdk-sync/Cargo.lock
@@ -103,6 +103,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +306,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mockall"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -426,6 +490,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "sdk-sync"
 version = "0.1.0"
 dependencies = [
@@ -477,8 +571,10 @@ dependencies = [
  "clap",
  "gitignore",
  "mockall",
+ "num_cpus",
  "once_cell",
  "pretty_assertions",
+ "rayon",
  "regex",
  "serde",
  "smithy-rs-tool-common",

--- a/tools/sdk-sync/Cargo.toml
+++ b/tools/sdk-sync/Cargo.toml
@@ -18,6 +18,8 @@ opt-level = 0
 anyhow = "1.0.56"
 clap = { version = "3.1.8", features = ["derive"] }
 gitignore = "1.0.7"
+num_cpus = "1.13.1"
+rayon = "1.5.2"
 serde = { version = "1.0.136", features = ["derive"] }
 smithy-rs-tool-common = { version = "0.1", path = "../smithy-rs-tool-common" }
 sysinfo = { version = "0.23.11", default-features = false }

--- a/tools/sdk-sync/src/main.rs
+++ b/tools/sdk-sync/src/main.rs
@@ -9,6 +9,10 @@ use sdk_sync::init_tracing;
 use sdk_sync::sync::Sync;
 use smithy_rs_tool_common::macros::here;
 use std::path::PathBuf;
+use sysinfo::{System, SystemExt};
+use tracing::info;
+
+const CODEGEN_MIN_RAM_REQUIRED_GB: usize = 2;
 
 /// A CLI tool to replay commits from smithy-rs, generate code, and commit that code to aws-rust-sdk.
 #[derive(Parser, Debug)]
@@ -45,6 +49,20 @@ struct Args {
 fn main() -> Result<()> {
     init_tracing();
     let args = Args::parse();
+
+    let sys = System::new_all();
+    let available_ram_gb = (sys.available_memory() / 1024 / 1024) as usize;
+    let num_cpus = num_cpus::get_physical();
+    let threads = (available_ram_gb / CODEGEN_MIN_RAM_REQUIRED_GB)
+        .max(1) // Must use at least 1 thread
+        .min(num_cpus); // Don't exceed the number of physical CPUs
+    info!("Available RAM (GB): {available_ram_gb}");
+    info!("Num physical CPUs: {num_cpus}");
+    info!("Thread pool size: {threads}");
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(threads)
+        .build_global()
+        .unwrap();
 
     let sync = Sync::new(
         &args.aws_doc_sdk_examples.canonicalize().context(here!())?,

--- a/tools/sdk-sync/src/sync.rs
+++ b/tools/sdk-sync/src/sync.rs
@@ -180,6 +180,8 @@ impl Sync {
     /// Run through all commits made to `smithy-rs` since last sync and "replay" them onto `aws-sdk-rust`.
     #[instrument(skip(self, versions))]
     fn sync_smithy_rs(&self, versions: &VersionsManifest) -> Result<()> {
+        use rayon::prelude::*;
+
         info!(
             "Checking for smithy-rs commits in range HEAD..{}",
             versions.smithy_rs_revision
@@ -206,7 +208,7 @@ impl Sync {
             let fs = self.fs.clone();
 
             commits
-                .iter()
+                .par_iter()
                 .enumerate()
                 .map(move |(commit_num, commit_hash)| {
                     let span = info_span!(

--- a/tools/sdk-sync/src/sync/gen.rs
+++ b/tools/sdk-sync/src/sync/gen.rs
@@ -112,8 +112,6 @@ impl DefaultSdkGenerator {
     fn aws_sdk_assemble(&self) -> Result<()> {
         info!("Generating the SDK...");
         let mut command = Command::new("./gradlew");
-        command.arg("--no-daemon"); // Don't let Gradle continue running after the build
-        command.arg("--info"); // Increase logging verbosity for failure debugging
         command.arg("-Paws.fullsdk=true");
         command.arg(format!(
             "-Paws.sdk.previous.release.versions.manifest={}",

--- a/tools/sdk-sync/src/sync/gen.rs
+++ b/tools/sdk-sync/src/sync/gen.rs
@@ -112,6 +112,11 @@ impl DefaultSdkGenerator {
     fn aws_sdk_assemble(&self) -> Result<()> {
         info!("Generating the SDK...");
         let mut command = Command::new("./gradlew");
+        command.arg("--no-daemon"); // Don't let Gradle continue running after the build
+        command.arg("--info"); // Increase logging verbosity for failure debugging
+
+        // Disable Smithy's codegen parallelism in favor of sdk-sync parallelism
+        command.arg("-Djava.util.concurrent.ForkJoinPool.common.parallelism=1");
         command.arg("-Paws.fullsdk=true");
         command.arg(format!(
             "-Paws.sdk.previous.release.versions.manifest={}",

--- a/tools/sdk-sync/src/sync/gen.rs
+++ b/tools/sdk-sync/src/sync/gen.rs
@@ -48,6 +48,7 @@ pub struct DefaultSdkGenerator {
     examples_path: PathBuf,
     fs: Arc<dyn Fs>,
     smithy_rs: Box<dyn Git>,
+    smithy_parallelism: usize,
     temp_dir: Arc<tempfile::TempDir>,
 }
 
@@ -60,6 +61,7 @@ impl DefaultSdkGenerator {
         fs: Arc<dyn Fs>,
         reset_to_commit: Option<CommitHash>,
         original_smithy_rs_path: &Path,
+        smithy_parallelism: usize,
     ) -> Result<Self> {
         let temp_dir = tempfile::tempdir().context(here!("create temp dir"))?;
         GitCLI::new(original_smithy_rs_path)
@@ -80,6 +82,7 @@ impl DefaultSdkGenerator {
             examples_path: examples_path.into(),
             fs,
             smithy_rs: Box::new(smithy_rs) as Box<dyn Git>,
+            smithy_parallelism,
             temp_dir: Arc::new(temp_dir),
         })
     }
@@ -116,7 +119,10 @@ impl DefaultSdkGenerator {
         command.arg("--info"); // Increase logging verbosity for failure debugging
 
         // Disable Smithy's codegen parallelism in favor of sdk-sync parallelism
-        command.arg("-Djava.util.concurrent.ForkJoinPool.common.parallelism=1");
+        command.arg(format!(
+            "-Djava.util.concurrent.ForkJoinPool.common.parallelism={}",
+            self.smithy_parallelism
+        ));
         command.arg("-Paws.fullsdk=true");
         command.arg(format!(
             "-Paws.sdk.previous.release.versions.manifest={}",

--- a/tools/sdk-sync/tests/e2e_test.rs
+++ b/tools/sdk-sync/tests/e2e_test.rs
@@ -92,6 +92,7 @@ fn test_without_model_changes() {
         &tmp_dir.as_ref().join("aws-doc-sdk-examples"),
         &tmp_dir.as_ref().join("aws-sdk-rust"),
         &tmp_dir.as_ref().join("smithy-rs"),
+        1,
     )
     .expect("create sync success");
     sync.sync().expect("sync success");
@@ -210,6 +211,7 @@ fn test_with_model_changes() {
         &tmp_dir.as_ref().join("aws-doc-sdk-examples"),
         &tmp_dir.as_ref().join("aws-sdk-rust"),
         &tmp_dir.as_ref().join("smithy-rs"),
+        1,
     )
     .expect("create sync success");
     sync.sync().expect("sync success");


### PR DESCRIPTION
## Motivation and Context
This reverts #1436 and configures the JVM so that Smithy codegen won't project services in parallel, and introduces a CLI arg to override the number of threads used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
