### PR TITLE
Add the ability to generate `pub(crate)` values

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeDependency.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeDependency.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rustsdk
 
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.smithy.RuntimeCrateLocation
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
@@ -43,12 +44,12 @@ fun RuntimeConfig.awsRoot(): RuntimeCrateLocation {
 object AwsRuntimeType {
     val S3Errors by lazy { RuntimeType.forInlineDependency(InlineAwsDependency.forRustFile("s3_errors")) }
     val Presigning by lazy {
-        RuntimeType.forInlineDependency(InlineAwsDependency.forRustFile("presigning", public = true))
+        RuntimeType.forInlineDependency(InlineAwsDependency.forRustFile("presigning", visibility = Visibility.PUBLIC))
     }
 
     fun RuntimeConfig.defaultMiddleware() = RuntimeType.forInlineDependency(
         InlineAwsDependency.forRustFile(
-            "middleware", public = true,
+            "middleware", visibility = Visibility.PUBLIC,
             CargoDependency.SmithyHttp(this),
             CargoDependency.SmithyHttpTower(this),
             CargoDependency.SmithyClient(this),

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/InlineAwsDependency.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/InlineAwsDependency.kt
@@ -7,8 +7,9 @@ package software.amazon.smithy.rustsdk
 
 import software.amazon.smithy.rust.codegen.rustlang.InlineDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustDependency
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 
 object InlineAwsDependency {
-    fun forRustFile(file: String, public: Boolean = false, vararg additionalDependency: RustDependency): InlineDependency =
-        InlineDependency.Companion.forRustFile(file, "aws-inlineable", public, *additionalDependency)
+    fun forRustFile(file: String, visibility: Visibility = Visibility.PRIVATE, vararg additionalDependency: RustDependency): InlineDependency =
+        InlineDependency.Companion.forRustFile(file, "aws-inlineable", visibility, *additionalDependency)
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerCombinedErrorGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerCombinedErrorGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -37,7 +38,7 @@ class ServerCombinedErrorGenerator(
         val symbol = operation.errorSymbol(symbolProvider)
         val meta = RustMetadata(
             derives = Attribute.Derives(setOf(RuntimeType.Debug)),
-            public = true
+            visibility = Visibility.PUBLIC
         )
 
         writer.rust("/// Error type for the `${operationSymbol.name}` operation.")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -25,6 +25,7 @@ import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.escape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -132,11 +133,11 @@ class ServerProtocolTestGenerator(
             val operationName = operationSymbol.name
             val testModuleName = "server_${operationName.toSnakeCase()}_test"
             val moduleMeta = RustMetadata(
-                public = false,
                 additionalAttributes = listOf(
                     Attribute.Cfg("test"),
                     Attribute.Custom("allow(unreachable_code, unused_variables)")
-                )
+                ),
+                visibility = Visibility.PRIVATE
             )
             writer.withModule(testModuleName, moduleMeta) {
                 renderAllTestCases(allTests)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/CargoDependency.kt
@@ -74,15 +74,15 @@ class InlineDependency(
             name: String,
             baseDir: String,
             vararg additionalDependencies: RustDependency
-        ): InlineDependency = forRustFile(name, baseDir, public = false, *additionalDependencies)
+        ): InlineDependency = forRustFile(name, baseDir, visibility = Visibility.PRIVATE, *additionalDependencies)
 
         fun forRustFile(
             name: String,
             baseDir: String,
-            public: Boolean,
+            visibility: Visibility,
             vararg additionalDependencies: RustDependency
         ): InlineDependency {
-            val module = RustModule.default(name, public)
+            val module = RustModule.default(name, visibility)
             val filename = "$name.rs"
             // The inline crate is loaded as a dependency on the runtime classpath
             val rustFile = this::class.java.getResource("/$baseDir/src/$filename")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustModule.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustModule.kt
@@ -13,15 +13,15 @@ data class RustModule(val name: String, val rustMetadata: RustMetadata, val docu
     }
 
     companion object {
-        fun default(name: String, public: Boolean, documentation: String? = null): RustModule {
-            return RustModule(name, RustMetadata(public = public), documentation)
+        fun default(name: String, visibility: Visibility, documentation: String? = null): RustModule {
+            return RustModule(name, RustMetadata(visibility = visibility), documentation)
         }
 
         fun public(name: String, documentation: String? = null): RustModule =
-            default(name, public = true, documentation = documentation)
+            default(name, visibility = Visibility.PUBLIC, documentation = documentation)
 
         fun private(name: String, documentation: String? = null): RustModule =
-            default(name, public = false, documentation = documentation)
+            default(name, visibility = Visibility.PRIVATE, documentation = documentation)
 
         val Config = public("config", documentation = "Configuration for the service.")
         val Error = public("error", documentation = "Errors that can occur when calling the service.")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustTypes.kt
@@ -269,13 +269,19 @@ fun RustType.isCopy(): Boolean = when (this) {
     else -> false
 }
 
+enum class Visibility {
+    PRIVATE,
+    PUBCRATE,
+    PUBLIC
+}
+
 /**
- * Meta information about a Rust construction (field, struct, or enum)
+ * Meta information about a Rust construction (field, struct, or enum).
  */
 data class RustMetadata(
     val derives: Attribute.Derives = Attribute.Derives.Empty,
     val additionalAttributes: List<Attribute> = listOf(),
-    val public: Boolean
+    val visibility: Visibility = Visibility.PRIVATE
 ) {
     fun withDerives(vararg newDerive: RuntimeType): RustMetadata =
         this.copy(derives = derives.copy(derives = derives.derives + newDerive))
@@ -293,9 +299,13 @@ data class RustMetadata(
     }
 
     fun renderVisibility(writer: RustWriter): RustMetadata {
-        if (public) {
-            writer.writeInline("pub ")
-        }
+        writer.writeInline(
+            when (visibility) {
+                Visibility.PRIVATE -> ""
+                Visibility.PUBCRATE -> "pub(crate) "
+                Visibility.PUBLIC -> "pub "
+            }
+        )
         return this
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -11,6 +11,7 @@ import org.jsoup.nodes.Element
 import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolWriter
+import software.amazon.smithy.codegen.core.SymbolWriter.Factory
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.BooleanShape
 import software.amazon.smithy.model.shapes.CollectionShape
@@ -416,7 +417,7 @@ class RustWriter private constructor(
      */
     fun withModule(
         moduleName: String,
-        rustMetadata: RustMetadata = RustMetadata(public = true),
+        rustMetadata: RustMetadata = RustMetadata(visibility = Visibility.PUBLIC),
         moduleWriter: RustWriter.() -> Unit
     ): RustWriter {
         // In Rust, modules must specify their own imports—they don't have access to the parent scope.

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.rustlang.InlineDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.smithy.generators.CargoTomlGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.smithy.generators.LibRsGenerator
@@ -94,7 +95,7 @@ open class RustCrate(
     ) {
         injectInlineDependencies()
         val modules = inner.writers.values.mapNotNull { it.module() }.filter { it != "lib" }
-            .map { modules[it] ?: RustModule.default(it, false) }
+            .map { modules[it] ?: RustModule.default(it, visibility = Visibility.PRIVATE) }
         inner.finalize(
             settings,
             model,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolMetadataProvider.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/SymbolMetadataProvider.kt
@@ -16,7 +16,7 @@ import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
-import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.PartialEq
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.util.hasTrait
 
 /**
@@ -78,11 +78,11 @@ class BaseSymbolMetadataProvider(
     private val containerDefault = RustMetadata(
         Attribute.Derives(defaultDerives.toSet()),
         additionalAttributes = additionalAttributes,
-        public = true
+        visibility = Visibility.PUBLIC
     )
 
     override fun memberMeta(memberShape: MemberShape): RustMetadata {
-        return RustMetadata(public = true)
+        return RustMetadata(visibility = Visibility.PUBLIC)
     }
 
     override fun structureMeta(structureShape: StructureShape): RustMetadata {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/NestedAccessorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/NestedAccessorGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
@@ -23,7 +24,7 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.lensName
 
 /** Generator for accessing nested fields through optional values **/
 class NestedAccessorGenerator(private val symbolProvider: RustSymbolProvider) {
-    private val module = RustModule("lens", RustMetadata(public = false), "Generated accessors for nested fields")
+    private val module = RustModule("lens", RustMetadata(visibility = Visibility.PUBLIC), "Generated accessors for nested fields")
     /**
      * Generate an accessor on [root] that consumes [root] and returns an `Option<T>` for the nested item
      */

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/PaginatorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/PaginatorGenerator.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.render
@@ -76,7 +77,7 @@ class PaginatorGenerator private constructor(
         idx.getPaginationInfo(service, operation).orNull() ?: PANIC("failed to load pagination info")
     private val module = RustModule(
         "paginator",
-        RustMetadata(public = true),
+        RustMetadata(visibility = Visibility.PUBLIC),
         documentation = "Paginators for the service"
     )
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/client/FluentClientDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/client/FluentClientDecorator.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asArgumentType
 import software.amazon.smithy.rust.codegen.rustlang.asOptional
@@ -297,7 +298,7 @@ class FluentClientGenerator(
 
         val clientModule = RustModule(
             "client",
-            RustMetadata(public = true),
+            RustMetadata(visibility = Visibility.PUBLIC),
             documentation = "Client and fluent builders for calling the service."
         )
     }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/CombinedErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/CombinedErrorGenerator.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.model.traits.RetryableTrait
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -62,7 +63,7 @@ class CombinedErrorGenerator(
         val meta = RustMetadata(
             derives = Attribute.Derives(setOf(RuntimeType.Debug)),
             additionalAttributes = listOf(Attribute.NonExhaustive),
-            public = true
+            visibility = Visibility.PUBLIC
         )
 
         writer.rust("/// Error type for the `${operationSymbol.name}` operation.")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/error/TopLevelErrorGenerator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -46,7 +47,7 @@ class TopLevelErrorGenerator(codegenContext: CodegenContext, private val operati
 
     private val sdkError = CargoDependency.SmithyHttp(codegenContext.runtimeConfig).asType().member("result::SdkError")
     fun render(crate: RustCrate) {
-        crate.withModule(RustModule.default("error_meta", false)) { writer ->
+        crate.withModule(RustModule.default("error_meta", visibility = Visibility.PRIVATE)) { writer ->
             writer.renderDefinition()
             writer.renderImplDisplay()
             // Every operation error can be converted into service::Error
@@ -102,7 +103,7 @@ class TopLevelErrorGenerator(codegenContext: CodegenContext, private val operati
         rust("/// All possible error types for this service.")
         RustMetadata(
             additionalAttributes = listOf(Attribute.NonExhaustive),
-            public = true
+            visibility = Visibility.PUBLIC
         ).withDerives(RuntimeType.Debug).render(this)
         rustBlock("enum Error") {
             allErrors.forEach { error ->

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -23,6 +23,7 @@ import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.escape
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -108,7 +109,7 @@ class ProtocolTestGenerator(
             val operationName = operationSymbol.name
             val testModuleName = "${operationName.toSnakeCase()}_request_test"
             val moduleMeta = RustMetadata(
-                public = false,
+                visibility = Visibility.PRIVATE,
                 additionalAttributes = listOf(
                     Attribute.Cfg("test"),
                     Attribute.Custom("allow(unreachable_code, unused_variables)")

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/generators/StructureGeneratorTest.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.docs
 import software.amazon.smithy.rust.codegen.rustlang.raw
 import software.amazon.smithy.rust.codegen.rustlang.rust
@@ -179,8 +180,11 @@ class StructureGeneratorTest {
         writer
             .withModule(
                 "model",
-                // By attaching this lint, any missing documentation becomes a compiler error
-                RustMetadata(additionalAttributes = listOf(Attribute.Custom("deny(missing_docs)")), public = true)
+                RustMetadata(
+                    // By attaching this lint, any missing documentation becomes a compiler error.
+                    additionalAttributes = listOf(Attribute.Custom("deny(missing_docs)")),
+                    visibility = Visibility.PUBLIC
+                )
             ) {
                 StructureGenerator(model, provider, this, model.lookup("com.test#Inner")).render()
                 StructureGenerator(model, provider, this, model.lookup("com.test#MyStruct")).render()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EndpointTraitBindingsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/EndpointTraitBindingsTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.traits.EndpointTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.CodegenContext
@@ -61,7 +62,7 @@ internal class EndpointTraitBindingsTest {
             operationShape.expectTrait(EndpointTrait::class.java)
         )
         val project = TestWorkspace.testProject()
-        project.withModule(RustModule.default("test", false)) {
+        project.withModule(RustModule.default("test", visibility = Visibility.PRIVATE)) {
             it.rust(
                 """
                 struct GetStatusInput {


### PR DESCRIPTION
A small commit adding the ability to generate `pub(crate)` values.
Currently we don't need to, but this is used in #1342. It's also nicer
to use an enum instead of passing around a boolean.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
