### PR TITLE
Relax behavior of profile parser

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false }
 # author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Fix bug in profile file credential provider where a missing `default` profile lead to an unintended error."
+references = ["aws-sdk-rust#547", "smithy-rs#1458"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -333,6 +333,7 @@ mod test {
 
     make_test!(ecs_assume_role);
     make_test!(ecs_credentials);
+    make_test!(ecs_credentials_invalid_profile);
 
     make_test!(sso_assume_role);
     make_test!(sso_no_token_file);

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/env.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/env.json
@@ -1,0 +1,5 @@
+{
+  "HOME": "/home",
+  "AWS_REGION": "us-east-1",
+  "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/52b19262-e7aa-4f56-a1cd-b958dcde8f3b"
+}

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/fs/home/.aws/config
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/fs/home/.aws/config
@@ -1,0 +1,3 @@
+# a profile that isn't the `default` profile
+[profile notdefault]
+a = b

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/http-traffic.json
@@ -1,0 +1,87 @@
+{
+  "events": [
+    {
+      "connection_id": 0,
+      "action": {
+        "Request": {
+          "request": {
+            "uri": "http://169.254.170.2/v2/credentials/52b19262-e7aa-4f56-a1cd-b958dcde8f3b",
+            "headers": {
+              "accept": [
+                "application/json"
+              ]
+            },
+            "method": "GET"
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Response": {
+          "response": {
+            "Ok": {
+              "status": 200,
+              "version": "HTTP/1.1",
+              "headers": {
+                "content-type": [
+                  "application/json"
+                ],
+                "x-rate-limit-duration": [
+                  "1"
+                ],
+                "x-rate-limit-limit": [
+                  "40"
+                ],
+                "x-rate-limit-request-forwarded-for": [
+                  ""
+                ],
+                "x-rate-limit-request-remote-addr": [
+                  "169.254.172.2:35484"
+                ],
+                "date": [
+                  "Fri, 15 Oct 2021 15:23:49 GMT"
+                ],
+                "content-length": [
+                  "1231"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"RoleArn\":\"arn:aws:iam::123456789:role/ecs-task-role\",\"AccessKeyId\":\"ASIARCORRECT\",\"SecretAccessKey\":\"secretkeycorrect\",\"Token\":\"tokencorrect\",\"Expiration\" : \"2009-02-13T23:31:30Z\"}"
+          },
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Response"
+        }
+      }
+    }
+  ],
+  "docs": "Load ECS credentials",
+  "version": "V0"
+}

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/ecs_credentials_invalid_profile/test-case.json
@@ -1,0 +1,12 @@
+{
+  "name": "ecs-credentials",
+  "docs": "load credentials directly from ECS",
+  "result": {
+    "Ok": {
+      "access_key_id": "ASIARCORRECT",
+      "secret_access_key": "secretkeycorrect",
+      "session_token": "tokencorrect",
+      "expiry": 1234567890
+    }
+  }
+}


### PR DESCRIPTION



## Motivation and Context
- Fixes aws-sdk-rust#547

## Description
Previously, if no default profile was defined and no explicit profile was selected, the profile file provider would return an error. This relaxes that behavior to allow provider chains to move onto the next provider when that is the case.

## Testing
- [x] aws-config static IT

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
