### PR TITLE
Fix deprecation warnings in `aws-smithy-http-server` examples

### DIFF
--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Smithy-rs Server Team <smithy-rs-server@amazon.com>"]
 description = "A smithy Rust service to retrieve information about Pokémon."
 
 [dependencies]
-clap = { version = "3", features = ["derive"] }
+clap = { version = "3.2.1", features = ["derive"] }
 hyper = {version = "0.14", features = ["server"] }
 tokio = "1"
 tower = "0.4"

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon_service/src/main.rs
@@ -17,10 +17,10 @@ use tower_http::trace::TraceLayer;
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// Hyper server bind address.
-    #[clap(short, long, default_value = "127.0.0.1")]
+    #[clap(short, long, action, default_value = "127.0.0.1")]
     address: String,
     /// Hyper server bind port.
-    #[clap(short, long, default_value = "13734")]
+    #[clap(short, long, action, default_value = "13734")]
     port: u16,
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
