### PR TITLE
Fixes for RustWriter bugs #1465 & #1459

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -22,3 +22,9 @@ message = "Add `Debug` implementation to several types in `aws-config`"
 references = ["smithy-rs#1421"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Fix RustWriter bugs for `rustTemplate` and `docs` utility methods"
+references = ["smithy-rs#1427", "smithy-rs#1465", "smithy-rs#1459"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -136,8 +136,9 @@ fun <T : AbstractCodeWriter<T>> T.rust(
 /* rewrite #{foo} to #{foo:T} (the smithy template format) */
 private fun transformTemplate(template: String, scope: Array<out Pair<String, Any>>): String {
     check(scope.distinctBy { it.first.lowercase() }.size == scope.size) { "Duplicate cased keys not supported" }
-    return template.replace(Regex("""#\{([a-zA-Z_0-9]+)\}""")) { matchResult ->
+    return template.replace(Regex("""#\{([a-zA-Z_0-9]+)(:\w)?\}""")) { matchResult ->
         val keyName = matchResult.groupValues[1]
+        val templateType = matchResult.groupValues[2].ifEmpty { ":T" }
         if (!scope.toMap().keys.contains(keyName)) {
             throw CodegenException(
                 "Rust block template expected `$keyName` but was not present in template.\n  hint: Template contains: ${
@@ -145,7 +146,7 @@ private fun transformTemplate(template: String, scope: Array<out Pair<String, An
                 }"
             )
         }
-        "#{${keyName.lowercase()}:T}"
+        "#{${keyName.lowercase()}$templateType}"
     }.trim()
 }
 
@@ -259,6 +260,9 @@ fun <T : AbstractCodeWriter<T>> T.docs(text: String, vararg args: Any, newlinePr
             // Rustdoc warns on tabs in documentation
             it.trimStart().replace("\t", "  ")
         }
+    // Because writing docs relies on the newline prefix, ensure that there was a new line written
+    // before we write the docs
+    this.ensureNewline()
     write(cleaned, *args)
     popState()
     return this


### PR DESCRIPTION
## Motivation and Context
- Fixes #1465
- Fixes #1459 

## Description
Fix for two longstanding RustWriter bugs:
1. `docs` didn't call `ensureNewLine()` which meant that when it was invoked after a call to `writeInline` the leading `///` was never written
2. formatting with `:W` didn't go through template rewriting which meant that it didn't work with case sensitivity.

This resolves both of those issues and adds unit tests.
## Testing
- unit test
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
