### PR TITLE
Add a trailing slash to iam/security-credentials/ when querying IMDS

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -15,3 +15,9 @@ message = "Upgrade to Gradle 7. This change is not a breaking change, however, u
 references = ["smithy-rs#1411", "smithy-rs#1167"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "rcoh"
+
+[[aws-sdk-rust]]
+message = "Add a trailing slash to the URI `/latest/meta-data/iam/security-credentials/ when loading credentials from IMDS"
+references = ["aws-sdk-rust#560", "smithy-rs#1487"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -46,7 +46,7 @@ impl Builder {
     /// Override the [instance profile](instance-profile) used for this provider.
     ///
     /// When retrieving IMDS credentials, a call must first be made to
-    /// `<IMDS_BASE_URL>/latest/meta-data/iam/security-credentials`. This returns the instance
+    /// `<IMDS_BASE_URL>/latest/meta-data/iam/security-credentials/`. This returns the instance
     /// profile used. By setting this parameter, retrieving the profile is skipped
     /// and the provided value is used instead.
     ///
@@ -129,7 +129,7 @@ impl ImdsCredentialsProvider {
         match self
             .client()
             .await?
-            .get("/latest/meta-data/iam/security-credentials")
+            .get("/latest/meta-data/iam/security-credentials/")
             .await
         {
             Ok(profile) => Ok(profile),
@@ -223,7 +223,7 @@ mod test {
                     token_response(21600, TOKEN_A),
                 ),
                 (
-                    imds_request("http://169.254.169.254/latest/meta-data/iam/security-credentials", TOKEN_A),
+                    imds_request("http://169.254.169.254/latest/meta-data/iam/security-credentials/", TOKEN_A),
                     imds_response(r#"profile-name"#),
                 ),
                 (
@@ -231,7 +231,7 @@ mod test {
                     imds_response("{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-20T21:42:26Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"ASIARTEST\",\n  \"SecretAccessKey\" : \"testsecret\",\n  \"Token\" : \"testtoken\",\n  \"Expiration\" : \"2021-09-21T04:16:53Z\"\n}"),
                 ),
                 (
-                    imds_request("http://169.254.169.254/latest/meta-data/iam/security-credentials", TOKEN_A),
+                    imds_request("http://169.254.169.254/latest/meta-data/iam/security-credentials/", TOKEN_A),
                     imds_response(r#"different-profile"#),
                 ),
                 (

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_assume_role/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_assume_role/http-traffic.json
@@ -89,7 +89,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "x-aws-ec2-metadata-token": [
                                 "imdssesiontoken=="

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_config_with_no_creds/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_config_with_no_creds/http-traffic.json
@@ -89,7 +89,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "x-amz-user-agent": [
                                 "aws-sdk-rust/0.1.0 api/imds/0.1.0 os/linux lang/rust/1.52.1"

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_error/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_error/http-traffic.json
@@ -89,7 +89,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "user-agent": [
                                 "aws-sdk-rust/0.1.0 os/linux lang/rust/1.52.1"

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_retries/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_retries/http-traffic.json
@@ -143,7 +143,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "x-amz-user-agent": [
                                 "aws-sdk-rust/0.1.0 api/imds/0.1.0 os/linux lang/rust/1.52.1"
@@ -197,7 +197,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "x-aws-ec2-metadata-token": [
                                 "imdstoken"

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_success/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_success/http-traffic.json
@@ -89,7 +89,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "x-amz-user-agent": [
                                 "aws-sdk-rust/0.1.0 api/imds/0.1.0 os/linux lang/rust/1.52.1"

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_no_iam_role/http-traffic.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_no_iam_role/http-traffic.json
@@ -89,7 +89,7 @@
             "action": {
                 "Request": {
                     "request": {
-                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials",
+                        "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
                         "headers": {
                             "user-agent": [
                                 "aws-sdk-rust/0.1.0 os/linux lang/rust/1.52.1"


### PR DESCRIPTION
## Motivation and Context
- aws-sdk-rust#560

## Description
The canonical URL from IMDS is `security-credentials/`. This updates the IMDS client to include the trailing slash.

## Testing
- [x] Updated recorded traffic tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
