### PR TITLE
Change `sdk-sync` failure to warning to help release decoupling

### DIFF
--- a/tools/sdk-sync/src/sync.rs
+++ b/tools/sdk-sync/src/sync.rs
@@ -7,7 +7,7 @@ use self::gen::{CodeGenSettings, DefaultSdkGenerator, SdkGenerator};
 use crate::fs::{DefaultFs, Fs};
 use crate::git::{Commit, Git, GitCLI};
 use crate::versions::{DefaultVersions, Versions, VersionsManifest};
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use smithy_rs_tool_common::macros::here;
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use systemstat::{ByteSize, Platform, System};
-use tracing::{debug, info, info_span};
+use tracing::{debug, info, info_span, warn};
 use tracing_attributes::instrument;
 
 pub mod gen;
@@ -422,7 +422,8 @@ impl Sync {
             .find_handwritten_files_and_folders(self.aws_sdk_rust.path(), generated_sdk_path)
             .context(here!())?;
         if !handwritten_files_in_generated_sdk_folder.is_empty() {
-            bail!(
+            // TODO(https://github.com/awslabs/smithy-rs/issues/1493): This can be changed back to `bail!` after release decoupling is completed
+            warn!(
                 "found one or more 'handwritten' files/folders in generated code: {:#?}\nhint: if this file is newly generated, remove it from .handwritten",
                 handwritten_files_in_generated_sdk_folder
             );


### PR DESCRIPTION
## Motivation and Context
Decoupling the release of smithy-rs from aws-sdk-rust requires that the SDK changelog move its source of truth into aws-sdk-rust, which means it is no longer a generated file. During the transition, the `sdk-sync` tool can't be allowed to fail on this file not being cleared out from aws-sdk-rust before copy.

See https://github.com/awslabs/aws-sdk-rust/pull/563 for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
