### PR TITLE
Fix platform issue when determining module name from file

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -27,3 +27,9 @@ message = "Add comments for docker settings needed when using this sdk"
 references = ["aws-sdk-rust#540"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jmklix"
+
+[[smithy-rs]]
+message = "Fix issue with codegen on Windows where module names were incorrectly determined from filenames"
+references = ["smithy-rs#1505"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "kiiadi"

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/RustWriter.kt
@@ -24,6 +24,7 @@ import software.amazon.smithy.rust.codegen.smithy.isOptional
 import software.amazon.smithy.rust.codegen.smithy.rustType
 import software.amazon.smithy.rust.codegen.util.orNull
 import software.amazon.smithy.utils.AbstractCodeWriter
+import java.io.File
 import java.util.function.BiFunction
 
 /**
@@ -393,7 +394,7 @@ class RustWriter private constructor(
     }
 
     fun module(): String? = if (filename.startsWith("src") && filename.endsWith(".rs")) {
-        filename.removeSuffix(".rs").split('/').last()
+        filename.removeSuffix(".rs").substringAfterLast(File.separatorChar)
     } else null
 
     fun safeName(prefix: String = "var"): String {

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/lang/RustWriterTest.kt
@@ -143,4 +143,10 @@ class RustWriterTest {
         )
         sut.toString().shouldContain("inner: hello, regular: http::foo")
     }
+
+    @Test
+    fun `can handle file paths properly when determining module`() {
+        val sut = RustWriter.forModule("src/module_name")
+        sut.module().shouldBe("module_name")
+    }
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Code generation fails on Windows

## Description
<!--- Describe your changes in detail -->
Module name determination from filename wasn't working on Windows because of the path separator difference.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
