### PR TITLE
Fix simple model error 

### DIFF
--- a/codegen-server-test/model/simple.smithy
+++ b/codegen-server-test/model/simple.smithy
@@ -108,7 +108,7 @@ structure HealthcheckOutputResponse {
 }
 
 @readonly
-@http(method: "GET", uri: "/service/{id}/blob")
+@http(method: "POST", uri: "/service/{id}/blob")
 @documentation("Stores a blob for a service id")
 operation StoreServiceBlob {
     input: StoreServiceBlobInput,


### PR DESCRIPTION
## Description

Fix the error

```
DANGER: com.amazonaws.simple#StoreServiceBlob (HttpMethodSemantics)
     @ /home/ANT.AMAZON.COM/matbigoi/github/smithy-rs/codegen-server-test/python/model/simple.smithy
     |
 111 | @http(method: "GET", uri: "/service/{id}/blob")
     |       ^
     = This operation uses the `GET` method in the `http` trait, but the `content` member is sent as the payload of the request because it is marked with the `httpPayload` trait. Many HTTP clients do not support payloads with GET requests. Consider binding this member to other parts of the HTTP request such as a query string parameter using the `httpQuery` trait, a header using the `httpHeader` trait, or a path segment using the `httpLabel` trait.
```

This is a fix to prevent issue with the Python generation. However, the root cause is still unknown: https://github.com/awslabs/smithy-rs/issues/1489

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
