### PR TITLE
Fix path to install `publisher` tool in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
         RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN: ${{ secrets.RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN }}
       run: |
         cargo login -- "${RELEASE_AUTOMATION_BOT_CRATESIO_TOKEN}"
-        cargo install --path ../smithy-rs/tools/publisher
+        cargo install --path "$(realpath ../smithy-rs/tools/publisher)"
         # Verify the publisher tool installed successfully
         publisher --version
 


### PR DESCRIPTION
## Motivation and Context
Cargo didn't like the `..` in the `cargo install` command used for getting the publisher tool ready, error below:
```
error: package `/home/runner/work/smithy-rs/smithy-rs/smithy-rs-release/smithy-rs/tools/publisher/Cargo.toml` is a member of the wrong workspace
expected: /home/runner/work/smithy-rs/smithy-rs/smithy-rs-release/crates-to-publish/../smithy-rs/tools/publisher/Cargo.toml
actual:   /home/runner/work/smithy-rs/smithy-rs/smithy-rs-release/smithy-rs/tools/publisher/Cargo.toml
Error: Process completed with exit code 101.
```
This PR passes the absolute path to Cargo.

## Testing
Successful dry-run release with these changes: https://github.com/awslabs/smithy-rs/actions/runs/2578834682

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
