### PR TITLE
Add missing arg to release publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,5 +91,5 @@ jobs:
           echo "Checking cargo auth token..."
           cargo owner --list aws-smithy-types
         else
-          publisher publish --location .
+          publisher publish -y --location .
         fi


### PR DESCRIPTION
## Motivation and Context
The `-y` arg to skip confirmation was omitted, which caused the crate publish step to hang indefinitely waiting on `stdin` in the [last automated smithy-rs release](https://github.com/awslabs/smithy-rs/runs/7102602467?check_suite_focus=true). This PR will fix this issue for next time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
