### PR TITLE
Fix Docker build-image `cargo-udeps` build

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -47,9 +47,9 @@ RUN set -eux; \
 FROM bare_base_image AS install_rust
 ARG rust_stable_version=1.58.1
 ARG rust_nightly_version=nightly-2022-03-29
-ARG cargo_udeps_version=0.1.27
-ARG cargo_hack_version=0.5.12
-ARG cargo_minimal_versions_version=0.1.3
+ARG cargo_udeps_version=0.1.29
+ARG cargo_hack_version=0.5.14
+ARG cargo_minimal_versions_version=0.1.4
 ENV RUSTUP_HOME=/opt/rustup \
     CARGO_HOME=/opt/cargo \
     PATH=/opt/cargo/bin/:${PATH} \
@@ -93,21 +93,21 @@ ARG smithy_rs_commit_hash=main
 # source code by checking out awslabs/smithy-rs/main rather than copying them from the local directory.
 ARG checkout_smithy_rs_tools=false
 RUN set -eux; \
-    cargo +${rust_nightly_version} install cargo-udeps --version ${cargo_udeps_version}; \
-    cargo install cargo-hack --version ${cargo_hack_version}; \
+    cargo +${rust_nightly_version} install cargo-udeps --locked --version ${cargo_udeps_version}; \
+    cargo install cargo-hack --locked --version ${cargo_hack_version}; \
     cargo install cargo-minimal-versions --version ${cargo_minimal_versions_version}; \
     if [[ "${checkout_smithy_rs_tools}" == "true" ]]; then \
         git clone https://github.com/awslabs/smithy-rs.git; \
         cd smithy-rs; \
         git checkout ${smithy_rs_commit_hash}; \
     fi; \
-    cargo install --path tools/publisher; \
-    cargo +${rust_nightly_version} install --path tools/api-linter; \
-    cargo install --path tools/changelogger; \
-    cargo install --path tools/crate-hasher; \
-    cargo install --path tools/sdk-lints; \
-    cargo install --path tools/sdk-sync; \
-    cargo install --path tools/sdk-versioner; \
+    cargo install --locked --path tools/publisher; \
+    cargo +${rust_nightly_version} install --locked --path tools/api-linter; \
+    cargo install --locked --path tools/changelogger; \
+    cargo install --locked --path tools/crate-hasher; \
+    cargo install --locked --path tools/sdk-lints; \
+    cargo install --locked --path tools/sdk-sync; \
+    cargo install --locked --path tools/sdk-versioner; \
     chmod g+rw -R /opt/cargo/registry
 
 #


### PR DESCRIPTION
## Motivation and Context
The `cargo-udeps` build in the Docker build image started failing with the following due to a dependency release:

```
 error[E0599]: no method named `iter` found for opaque type `impl Iterator<Item = &OsString>` in the current scope
  --> /opt/cargo/registry/src/github.com-1ecc6299db9ec823/cargo-0.60.0/src/cargo/core/compiler/build_plan.rs:81:35
   |
81 |         for arg in cmd.get_args().iter() {
   |                                   ^^^^ method not found in `impl Iterator<Item = &OsString>`
```

This PR updates it to the latest version, and adds the `--locked` arg to use the bundled lock files for tools like `cargo-udeps`. It should also detect outdated lock files for our tools in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
