### PR TITLE
Remove superfluous use of the `async_trait` macro

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -257,7 +257,6 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                     Output(#{O}),
                     Error(#{E})
                 }
-                ##[#{AsyncTrait}::async_trait]
                 impl #{SmithyHttpServer}::response::IntoResponse for $outputName {
                     fn into_response(self) -> #{SmithyHttpServer}::response::Response {
                         $intoResponseImpl
@@ -289,7 +288,6 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
             rustTemplate(
                 """
                 pub(crate) struct $outputName(#{O});
-                ##[#{AsyncTrait}::async_trait]
                 impl #{SmithyHttpServer}::response::IntoResponse for $outputName {
                     fn into_response(self) -> #{SmithyHttpServer}::response::Response {
                         $intoResponseImpl


### PR DESCRIPTION
As noted by @hlbarber, the `IntoResponse` trait does not have any async functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
