### PR TITLE
Make `ServerOperationRegistryGenerator` protocol-agnostic

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonCodegenServerPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonCodegenServerPlugin.kt
@@ -17,10 +17,10 @@ import software.amazon.smithy.rust.codegen.smithy.BaseSymbolMetadataProvider
 import software.amazon.smithy.rust.codegen.smithy.EventStreamSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.StreamingShapeMetadataProvider
+import software.amazon.smithy.rust.codegen.smithy.StreamingShapeSymbolProvider
 import software.amazon.smithy.rust.codegen.smithy.SymbolVisitor
 import software.amazon.smithy.rust.codegen.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.smithy.customize.CombinedCodegenDecorator
-import software.amazon.smithy.rust.codegen.smithy.StreamingShapeSymbolProvider
 import java.util.logging.Level
 import java.util.logging.Logger
 

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -143,8 +143,8 @@ class PythonServerCodegenVisitor(
             rustCrate,
             protocolGenerator,
             protocolGeneratorFactory.support(),
-            protocolGeneratorFactory.protocol(codegenContext).httpBindingResolver,
-            codegenContext,
+            protocolGeneratorFactory.protocol(codegenContext),
+            codegenContext
         )
             .render()
     }

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerServiceGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerServiceGenerator.kt
@@ -13,21 +13,21 @@ import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
-import software.amazon.smithy.rust.codegen.smithy.protocols.HttpBindingResolver
+import software.amazon.smithy.rust.codegen.smithy.protocols.Protocol
 
 /**
  * PythonServerServiceGenerator
  *
- * Service generator is the main codegeneration entry point for Smithy services. Individual structures and unions are
+ * Service generator is the main code generation entry point for Smithy services. Individual structures and unions are
  * generated in codegen visitor, but this class handles all protocol-specific code generation (i.e. operations).
  */
 class PythonServerServiceGenerator(
     private val rustCrate: RustCrate,
     protocolGenerator: ProtocolGenerator,
     protocolSupport: ProtocolSupport,
-    httpBindingResolver: HttpBindingResolver,
+    protocol: Protocol,
     private val context: CoreCodegenContext,
-) : ServerServiceGenerator(rustCrate, protocolGenerator, protocolSupport, httpBindingResolver, context) {
+) : ServerServiceGenerator(rustCrate, protocolGenerator, protocolSupport, protocol, context) {
 
     override fun renderCombinedErrors(writer: RustWriter, operation: OperationShape) {
         PythonServerCombinedErrorGenerator(context.model, context.symbolProvider, operation).render(writer)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustCodegenServerPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustCodegenServerPlugin.kt
@@ -45,7 +45,7 @@ class RustCodegenServerPlugin : SmithyBuildPlugin {
             CombinedCodegenDecorator.fromClasspath(context, ServerRequiredCustomizations())
 
         // ServerCodegenVisitor is the main driver of code generation that traverses the model and generates code
-        logger.info("Loaded plugin to generate pure Rust bindings for the server SSDK")
+        logger.info("Loaded plugin to generate pure Rust bindings for the server SDK")
         ServerCodegenVisitor(context, codegenDecorator).execute()
     }
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -223,8 +223,8 @@ open class ServerCodegenVisitor(
             rustCrate,
             protocolGenerator,
             protocolGeneratorFactory.support(),
-            protocolGeneratorFactory.protocol(codegenContext).httpBindingResolver,
-            codegenContext,
+            protocolGeneratorFactory.protocol(codegenContext),
+            codegenContext
         )
             .render()
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -34,7 +34,6 @@ open class ServerOperationHandlerGenerator(
     private val model = coreCodegenContext.model
     private val protocol = coreCodegenContext.protocol
     private val symbolProvider = coreCodegenContext.symbolProvider
-    private val operationNames = operations.map { symbolProvider.toSymbol(it).name }
     private val runtimeConfig = coreCodegenContext.runtimeConfig
     private val codegenScope = arrayOf(
         "AsyncTrait" to ServerCargoDependency.AsyncTrait.asType(),
@@ -52,7 +51,7 @@ open class ServerOperationHandlerGenerator(
         renderHandlerImplementations(writer, true)
     }
 
-    /*
+    /**
      * Renders the implementation of the `Handler` trait for all operations.
      * Handlers are implemented for `FnOnce` function types whose signatures take in state or not.
      */
@@ -128,7 +127,7 @@ open class ServerOperationHandlerGenerator(
         }
     }
 
-    /*
+    /**
      * Generates the trait bounds of the `Handler` trait implementation, depending on:
      *     - the presence of state; and
      *     - whether the operation is fallible or not.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -14,19 +14,19 @@ import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
-import software.amazon.smithy.rust.codegen.smithy.protocols.HttpBindingResolver
+import software.amazon.smithy.rust.codegen.smithy.protocols.Protocol
 
 /**
  * ServerServiceGenerator
  *
- * Service generator is the main codegeneration entry point for Smithy services. Individual structures and unions are
+ * Service generator is the main code generation entry point for Smithy services. Individual structures and unions are
  * generated in codegen visitor, but this class handles all protocol-specific code generation (i.e. operations).
  */
 open class ServerServiceGenerator(
     private val rustCrate: RustCrate,
     private val protocolGenerator: ProtocolGenerator,
     private val protocolSupport: ProtocolSupport,
-    private val httpBindingResolver: HttpBindingResolver,
+    private val protocol: Protocol,
     private val coreCodegenContext: CoreCodegenContext,
 ) {
     private val index = TopDownIndex.of(coreCodegenContext.model)
@@ -84,6 +84,6 @@ open class ServerServiceGenerator(
 
     // Render operations registry.
     private fun renderOperationRegistry(writer: RustWriter, operations: List<OperationShape>) {
-        ServerOperationRegistryGenerator(coreCodegenContext, httpBindingResolver, operations).render(writer)
+        ServerOperationRegistryGenerator(coreCodegenContext, protocol, operations).render(writer)
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerAwsJson.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerAwsJson.kt
@@ -27,7 +27,7 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.serialize.JsonSerial
 import software.amazon.smithy.rust.codegen.smithy.protocols.serialize.StructuredDataSerializerGenerator
 import software.amazon.smithy.rust.codegen.util.hasTrait
 
-/*
+/**
  * AwsJson 1.0 and 1.1 server-side protocol factory. This factory creates the [ServerHttpBoundProtocolGenerator]
  * with AwsJson specific configurations.
  */
@@ -57,7 +57,7 @@ class ServerAwsJsonFactory(private val version: AwsJsonVersion) :
 }
 
 /**
- * AwsJson requires errors to be serialized with an additional "__type" field. This
+ * AwsJson requires errors to be serialized in server responses with an additional `__type` field. This
  * customization writes the right field depending on the version of the AwsJson protocol.
  */
 class ServerAwsJsonError(private val awsJsonVersion: AwsJsonVersion) : JsonCustomization() {
@@ -79,15 +79,22 @@ class ServerAwsJsonError(private val awsJsonVersion: AwsJsonVersion) : JsonCusto
 }
 
 /**
- * AwsJson requires errors to be serialized with an additional "__type" field. This class
+ * AwsJson requires operation errors to be serialized in server response with an additional `__type` field. This class
  * customizes [JsonSerializerGenerator] to add this functionality.
+ *
+ * https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#operation-error-serialization
  */
 class ServerAwsJsonSerializerGenerator(
     private val coreCodegenContext: CoreCodegenContext,
     private val httpBindingResolver: HttpBindingResolver,
     private val awsJsonVersion: AwsJsonVersion,
     private val jsonSerializerGenerator: JsonSerializerGenerator =
-        JsonSerializerGenerator(coreCodegenContext, httpBindingResolver, ::awsJsonFieldName, customizations = listOf(ServerAwsJsonError(awsJsonVersion)))
+        JsonSerializerGenerator(
+            coreCodegenContext,
+            httpBindingResolver,
+            ::awsJsonFieldName,
+            customizations = listOf(ServerAwsJsonError(awsJsonVersion))
+        )
 ) : StructuredDataSerializerGenerator by jsonSerializerGenerator
 
 class ServerAwsJson(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerRestJsonFactory.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerRestJsonFactory.kt
@@ -12,7 +12,7 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolGeneratorFactory
 import software.amazon.smithy.rust.codegen.smithy.protocols.RestJson
 
-/*
+/**
  * RestJson1 server-side protocol factory. This factory creates the [ServerHttpProtocolGenerator]
  * with RestJson1 specific configurations.
  */

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationRegistryGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationRegistryGeneratorTest.kt
@@ -76,45 +76,46 @@ class ServerOperationRegistryGeneratorTest {
         generator.render(writer)
 
         writer.toString() shouldContain
-                """
-                /// ```rust
-                /// use std::net::SocketAddr;
-                /// use service::{input, output, error};
-                /// use service::operation_registry::OperationRegistryBuilder;
-                /// use aws_smithy_http_server::routing::Router;
-                ///
-                /// #[tokio::main]
-                /// pub async fn main() {
-                ///    let app: Router = OperationRegistryBuilder::default()
-                ///        .frobnify(frobnify)
-                ///        .say_hello(say_hello)
-                ///        .build()
-                ///        .expect("unable to build operation registry")
-                ///        .into();
-                ///
-                ///    let bind: SocketAddr = format!("{}:{}", "127.0.0.1", "6969")
-                ///        .parse()
-                ///        .expect("unable to parse the server bind address and port");
-                ///
-                ///    let server = hyper::Server::bind(&bind).serve(app.into_make_service());
-                ///
-                ///    // Run your service!
-                ///    // if let Err(err) = server.await {
-                ///    //   eprintln!("server error: {}", err);
-                ///    // }
-                /// }
-                ///
-                /// /// Only the Frobnify operation is documented,
-                /// /// over multiple lines.
-                /// /// And here are #hash #tags!
-                /// async fn frobnify(input: input::FrobnifyInputOutput) -> Result<output::FrobnifyInputOutput, error::FrobnifyError> {
-                ///     todo!()
-                /// }
-                ///
-                /// async fn say_hello(input: input::SayHelloInputOutput) -> output::SayHelloInputOutput {
-                ///     todo!()
-                /// }
-                /// ```
-                ///""".trimIndent()
+            """
+            /// ```rust
+            /// use std::net::SocketAddr;
+            /// use service::{input, output, error};
+            /// use service::operation_registry::OperationRegistryBuilder;
+            /// use aws_smithy_http_server::routing::Router;
+            ///
+            /// #[tokio::main]
+            /// pub async fn main() {
+            ///    let app: Router = OperationRegistryBuilder::default()
+            ///        .frobnify(frobnify)
+            ///        .say_hello(say_hello)
+            ///        .build()
+            ///        .expect("unable to build operation registry")
+            ///        .into();
+            ///
+            ///    let bind: SocketAddr = format!("{}:{}", "127.0.0.1", "6969")
+            ///        .parse()
+            ///        .expect("unable to parse the server bind address and port");
+            ///
+            ///    let server = hyper::Server::bind(&bind).serve(app.into_make_service());
+            ///
+            ///    // Run your service!
+            ///    // if let Err(err) = server.await {
+            ///    //   eprintln!("server error: {}", err);
+            ///    // }
+            /// }
+            ///
+            /// /// Only the Frobnify operation is documented,
+            /// /// over multiple lines.
+            /// /// And here are #hash #tags!
+            /// async fn frobnify(input: input::FrobnifyInputOutput) -> Result<output::FrobnifyInputOutput, error::FrobnifyError> {
+            ///     todo!()
+            /// }
+            ///
+            /// async fn say_hello(input: input::SayHelloInputOutput) -> output::SayHelloInputOutput {
+            ///     todo!()
+            /// }
+            /// ```
+            ///
+            """.trimIndent()
     }
 }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationRegistryGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationRegistryGeneratorTest.kt
@@ -69,9 +69,9 @@ class ServerOperationRegistryGeneratorTest {
 
         val index = TopDownIndex.of(serverCodegenContext.model)
         val operations = index.getContainedOperations(serverCodegenContext.serviceShape).sortedBy { it.id }
-        val httpBindingResolver = protocolGeneratorFactory.protocol(serverCodegenContext).httpBindingResolver
+        val protocol = protocolGeneratorFactory.protocol(serverCodegenContext)
 
-        val generator = ServerOperationRegistryGenerator(serverCodegenContext, httpBindingResolver, operations)
+        val generator = ServerOperationRegistryGenerator(serverCodegenContext, protocol, operations)
         val writer = RustWriter.forModule("operation_registry")
         generator.render(writer)
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customize/RustCodegenDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customize/RustCodegenDecorator.kt
@@ -18,7 +18,7 @@ import software.amazon.smithy.rust.codegen.smithy.generators.ManifestCustomizati
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.smithy.protocols.ProtocolMap
 import software.amazon.smithy.rust.codegen.util.deepMergeWith
-import java.util.*
+import java.util.ServiceLoader
 import java.util.logging.Logger
 
 /**

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RestRequestSpecGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RestRequestSpecGenerator.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.generators.http
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.protocols.HttpBindingResolver
+
+/**
+ * [RestRequestSpecGenerator] generates a restJson1 or restXml specific `RequestSpec`. Both protocols are routed the same.
+ *
+ * This class has to live in the `codegen` subproject instead of in the `codegen-server` subproject because it is used
+ * by the implementations of the `serverRouterRequestSpec` of the [Protocol] interface, which is used by both subprojects
+ * (even though only the `codegen-server` subproject calls `serverRouterRequestSpec`).
+ */
+class RestRequestSpecGenerator(
+    private val httpBindingResolver: HttpBindingResolver, private val requestSpecModule: RuntimeType
+) {
+    fun generate(operationShape: OperationShape): Writable {
+        val httpTrait = httpBindingResolver.httpTrait(operationShape)
+        val extraCodegenScope =
+            arrayOf(
+                "RequestSpec",
+                "UriSpec",
+                "PathAndQuerySpec",
+                "PathSpec",
+                "QuerySpec",
+                "PathSegment",
+                "QuerySegment"
+            ).map {
+                it to requestSpecModule.member(it)
+            }.toTypedArray()
+
+        // TODO(https://github.com/awslabs/smithy-rs/issues/950): Support the `endpoint` trait.
+        val pathSegmentsVec = writable {
+            withBlock("vec![", "]") {
+                for (segment in httpTrait.uri.segments) {
+                    val variant = when {
+                        segment.isGreedyLabel -> "Greedy"
+                        segment.isLabel -> "Label"
+                        else -> """Literal(String::from("${segment.content}"))"""
+                    }
+                    rustTemplate(
+                        "#{PathSegment}::$variant,",
+                        *extraCodegenScope
+                    )
+                }
+            }
+        }
+
+        val querySegmentsVec = writable {
+            withBlock("vec![", "]") {
+                for (queryLiteral in httpTrait.uri.queryLiterals) {
+                    val variant = if (queryLiteral.value == "") {
+                        """Key(String::from("${queryLiteral.key}"))"""
+                    } else {
+                        """KeyValue(String::from("${queryLiteral.key}"), String::from("${queryLiteral.value}"))"""
+                    }
+                    rustTemplate("#{QuerySegment}::$variant,", *extraCodegenScope)
+                }
+            }
+        }
+
+        return writable {
+            rustTemplate(
+                """
+                #{RequestSpec}::new(
+                    #{Method}::${httpTrait.method},
+                    #{UriSpec}::new(
+                        #{PathAndQuerySpec}::new(
+                            #{PathSpec}::from_vector_unchecked(#{PathSegmentsVec:W}),
+                            #{QuerySpec}::from_vector_unchecked(#{QuerySegmentsVec:W})
+                        )
+                    ),
+                )
+                """,
+                *extraCodegenScope,
+                "PathSegmentsVec" to pathSegmentsVec,
+                "QuerySegmentsVec" to querySegmentsVec,
+                "Method" to CargoDependency.Http.asType().member("Method"),
+            )
+        }
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RestRequestSpecGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/http/RestRequestSpecGenerator.kt
@@ -23,7 +23,8 @@ import software.amazon.smithy.rust.codegen.smithy.protocols.HttpBindingResolver
  * (even though only the `codegen-server` subproject calls `serverRouterRequestSpec`).
  */
 class RestRequestSpecGenerator(
-    private val httpBindingResolver: HttpBindingResolver, private val requestSpecModule: RuntimeType
+    private val httpBindingResolver: HttpBindingResolver,
+    private val requestSpecModule: RuntimeType
 ) {
     fun generate(operationShape: OperationShape): Writable {
         val httpTrait = httpBindingResolver.httpTrait(operationShape)

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/AwsQuery.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
@@ -106,4 +107,17 @@ class AwsQueryProtocol(private val coreCodegenContext: CoreCodegenContext) : Pro
                 rust("#T::parse_generic_error(payload.as_ref())", awsQueryErrors)
             }
         }
+
+    override fun serverRouterRequestSpec(
+        operationShape: OperationShape,
+        operationName: String,
+        serviceName: String,
+        requestSpecModule: RuntimeType
+    ): Writable {
+        TODO("Not yet implemented")
+    }
+
+    override fun serverRouterRuntimeConstructor(): String {
+        TODO("Not yet implemented")
+    }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Ec2Query.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
@@ -98,4 +99,17 @@ class Ec2QueryProtocol(private val coreCodegenContext: CoreCodegenContext) : Pro
                 rust("#T::parse_generic_error(payload.as_ref())", ec2QueryErrors)
             }
         }
+
+    override fun serverRouterRequestSpec(
+        operationShape: OperationShape,
+        operationName: String,
+        serviceName: String,
+        requestSpecModule: RuntimeType
+    ): Writable {
+        TODO("Not yet implemented")
+    }
+
+    override fun serverRouterRuntimeConstructor(): String {
+        TODO("Not yet implemented")
+    }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Protocol.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/Protocol.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.Trait
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
@@ -74,6 +75,22 @@ interface Protocol {
      * there are no response headers or statuses available to further inform the error parsing.
      */
     fun parseEventStreamGenericError(operationShape: OperationShape): RuntimeType
+
+    /**
+     * Returns a writable for the `RequestSpec` for an operation.
+     */
+    fun serverRouterRequestSpec(
+        operationShape: OperationShape,
+        operationName: String,
+        serviceName: String,
+        requestSpecModule: RuntimeType
+    ): Writable
+
+    /**
+     * Returns the name of the constructor to be used on the `Router` type, to instantiate a `Router` using this
+     * protocol.
+     */
+    fun serverRouterRuntimeConstructor(): String
 }
 
 typealias ProtocolMap<C> = Map<ShapeId, ProtocolGeneratorFactory<ProtocolGenerator, C>>

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestJson.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestJson.kt
@@ -16,11 +16,13 @@ import software.amazon.smithy.model.traits.StreamingTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.http.RestRequestSpecGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.smithy.protocols.parse.JsonParserGenerator
 import software.amazon.smithy.rust.codegen.smithy.protocols.parse.StructuredDataParserGenerator
@@ -141,6 +143,15 @@ class RestJson(private val coreCodegenContext: CoreCodegenContext) : Protocol {
                 *errorScope
             )
         }
+
+    override fun serverRouterRequestSpec(
+        operationShape: OperationShape,
+        operationName: String,
+        serviceName: String,
+        requestSpecModule: RuntimeType
+    ): Writable = RestRequestSpecGenerator(httpBindingResolver, requestSpecModule).generate(operationShape)
+
+    override fun serverRouterRuntimeConstructor() = "new_rest_json_router"
 }
 
 fun restJsonFieldName(member: MemberShape): String {

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -11,12 +11,14 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rust
 import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.generators.http.RestRequestSpecGenerator
 import software.amazon.smithy.rust.codegen.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.smithy.protocols.parse.RestXmlParserGenerator
 import software.amazon.smithy.rust.codegen.smithy.protocols.parse.StructuredDataParserGenerator
@@ -101,4 +103,13 @@ open class RestXml(private val coreCodegenContext: CoreCodegenContext) : Protoco
                 rust("#T::parse_generic_error(payload.as_ref())", restXmlErrors)
             }
         }
+
+    override fun serverRouterRequestSpec(
+        operationShape: OperationShape,
+        operationName: String,
+        serviceName: String,
+        requestSpecModule: RuntimeType
+    ): Writable = RestRequestSpecGenerator(httpBindingResolver, requestSpecModule).generate(operationShape)
+
+    override fun serverRouterRuntimeConstructor() = "new_rest_xml_router"
 }


### PR DESCRIPTION
`ServerOperationRegistryGenerator` is the only server generator that is
currently not protocol-agnostic, in the sense that it is the only
generator that contains protocol-specific logic, as opposed to
delegating to the `Protocol` interface like other generators do.

With this change, we should be good to implement a
`RustCodegenDecorator` loaded from the classpath that implements support
for any protocol, provided the decorator provides a class implementing
the `Protocol` interface.

This commit also contains some style changes that are making `ktlint`
fail. It seems like our `ktlint` config was recently broken and some
style violations slipped through the cracks in previous commits that
touched these files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
