### PR TITLE
Remove FromRequest and IntoResponse trait

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -105,7 +105,6 @@ open class ServerOperationHandlerGenerator(
                     type Sealed = #{ServerOperationHandler}::sealed::Hidden;
                     async fn call(self, req: #{http}::Request<B>) -> #{http}::Response<#{SmithyHttpServer}::body::BoxBody> {
                         let mut req = #{SmithyHttpServer}::request::RequestParts::new(req);
-                        use #{SmithyHttpServer}::response::IntoResponse;
                         let input_wrapper = match $inputWrapperName::from_request(&mut req).await {
                             Ok(v) => v,
                             Err(runtime_error) => {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -105,7 +105,6 @@ open class ServerOperationHandlerGenerator(
                     type Sealed = #{ServerOperationHandler}::sealed::Hidden;
                     async fn call(self, req: #{http}::Request<B>) -> #{http}::Response<#{SmithyHttpServer}::body::BoxBody> {
                         let mut req = #{SmithyHttpServer}::request::RequestParts::new(req);
-                        use #{SmithyHttpServer}::request::FromRequest;
                         use #{SmithyHttpServer}::response::IntoResponse;
                         let input_wrapper = match $inputWrapperName::from_request(&mut req).await {
                             Ok(v) => v,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -317,7 +317,6 @@ class ServerProtocolTestGenerator(
         val operationName = "${operationSymbol.name}${ServerHttpBoundProtocolGenerator.OPERATION_INPUT_WRAPPER_SUFFIX}"
         rustTemplate(
             """
-            use #{SmithyHttpServer}::request::FromRequest;
             let mut http_request = #{SmithyHttpServer}::request::RequestParts::new(http_request);
             let rejection = super::$operationName::from_request(&mut http_request).await.expect_err("request was accepted but we expected it to be rejected");
             use #{SmithyHttpServer}::response::IntoResponse;
@@ -382,7 +381,6 @@ class ServerProtocolTestGenerator(
         val operationName = "${operationSymbol.name}${ServerHttpBoundProtocolGenerator.OPERATION_INPUT_WRAPPER_SUFFIX}"
         rustWriter.rustTemplate(
             """
-            use #{SmithyHttpServer}::request::FromRequest;
             let mut http_request = #{SmithyHttpServer}::request::RequestParts::new(http_request);
             let parsed = super::$operationName::from_request(&mut http_request).await.expect("failed to parse request").0;
             """,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -295,7 +295,6 @@ class ServerProtocolTestGenerator(
         rustTemplate(
             """
             let output = super::$operationImpl;
-            use #{SmithyHttpServer}::response::IntoResponse;
             let http_response = output.into_response();
             """,
             *codegenScope,
@@ -319,7 +318,6 @@ class ServerProtocolTestGenerator(
             """
             let mut http_request = #{SmithyHttpServer}::request::RequestParts::new(http_request);
             let rejection = super::$operationName::from_request(&mut http_request).await.expect_err("request was accepted but we expected it to be rejected");
-            use #{SmithyHttpServer}::response::IntoResponse;
             let http_response = rejection.into_response();
             """,
             *codegenScope,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -143,7 +143,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
     }
 
     /*
-     * Generation of `FromRequest` and `IntoResponse`.
+     * Generation of `from_request` and `IntoResponse`.
      * For non-streaming request bodies, that is, models without streaming traits
      * (https://awslabs.github.io/smithy/1.0/spec/core/stream-traits.html)
      * we require the HTTP body to be fully read in memory before parsing or deserialization.
@@ -166,7 +166,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                     if let Some(headers) = req.headers() {
                         if let Some(accept) = headers.get(#{http}::header::ACCEPT) {
                             if accept != "$contentType" {
-                                return Err(Self::Rejection {
+                                return Err(#{RuntimeError} {
                                     protocol: #{SmithyHttpServer}::protocols::Protocol::${codegenContext.protocol.name.toPascalCase()},
                                     kind: #{SmithyHttpServer}::runtime_error::RuntimeErrorKind::NotAcceptable,
                                 })
@@ -179,20 +179,19 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
             }
         }
 
-        // Implement `FromRequest` trait for input types.
+        // Implement `from_request` trait for input types.
         rustTemplate(
             """
             ##[derive(Debug)]
             pub(crate) struct $inputName(#{I});
-            ##[#{AsyncTrait}::async_trait]
-            impl<B> #{SmithyHttpServer}::request::FromRequest<B> for $inputName
-            where
-                B: #{SmithyHttpServer}::body::HttpBody + Send, ${streamingBodyTraitBounds(operationShape)}
-                B::Data: Send,
-                #{RequestRejection} : From<<B as #{SmithyHttpServer}::body::HttpBody>::Error>
+            impl $inputName
             {
-                type Rejection = #{RuntimeError};
-                async fn from_request(req: &mut #{SmithyHttpServer}::request::RequestParts<B>) -> Result<Self, Self::Rejection> {
+                pub async fn from_request<B>(req: &mut #{SmithyHttpServer}::request::RequestParts<B>) -> Result<Self, #{RuntimeError}>
+                where
+                    B: #{SmithyHttpServer}::body::HttpBody + Send, ${streamingBodyTraitBounds(operationShape)}
+                    B::Data: Send,
+                    #{RequestRejection} : From<<B as #{SmithyHttpServer}::body::HttpBody>::Error>
+                {
                     #{verify_response_content_type:W}
                     #{parse_request}(req)
                         .await

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -143,7 +143,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
     }
 
     /*
-     * Generation of `from_request` and `IntoResponse`.
+     * Generation of `from_request` and `into_response`.
      * For non-streaming request bodies, that is, models without streaming traits
      * (https://awslabs.github.io/smithy/1.0/spec/core/stream-traits.html)
      * we require the HTTP body to be fully read in memory before parsing or deserialization.
@@ -211,7 +211,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
             "verify_response_content_type" to verifyResponseContentType,
         )
 
-        // Implement `IntoResponse` for output types.
+        // Implement `into_response` for output types.
 
         val outputName = "${operationName}${ServerHttpBoundProtocolGenerator.OPERATION_OUTPUT_WRAPPER_SUFFIX}"
         val errorSymbol = operationShape.errorSymbol(symbolProvider)
@@ -256,9 +256,8 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                     Output(#{O}),
                     Error(#{E})
                 }
-                ##[#{AsyncTrait}::async_trait]
-                impl #{SmithyHttpServer}::response::IntoResponse for $outputName {
-                    fn into_response(self) -> #{SmithyHttpServer}::response::Response {
+                impl $outputName {
+                    pub fn into_response(self) -> #{SmithyHttpServer}::response::Response {
                         $intoResponseImpl
                     }
                 }
@@ -288,9 +287,8 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
             rustTemplate(
                 """
                 pub(crate) struct $outputName(#{O});
-                ##[#{AsyncTrait}::async_trait]
-                impl #{SmithyHttpServer}::response::IntoResponse for $outputName {
-                    fn into_response(self) -> #{SmithyHttpServer}::response::Response {
+                impl $outputName {
+                    pub fn into_response(self) -> #{SmithyHttpServer}::response::Response {
                         $intoResponseImpl
                     }
                 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
@@ -162,7 +162,7 @@ open class ProtocolGenerator(
     }
 
     /**
-     * The server implementation uses this method to generate implementations of the `from_request` and `IntoResponse`
+     * The server implementation uses this method to generate implementations of the `from_request` and `into_response`
      * traits for operation input and output shapes, respectively.
      */
     fun serverRenderOperation(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/protocol/ProtocolGenerator.kt
@@ -162,7 +162,7 @@ open class ProtocolGenerator(
     }
 
     /**
-     * The server implementation uses this method to generate implementations of the `FromRequest` and `IntoResponse`
+     * The server implementation uses this method to generate implementations of the `from_request` and `IntoResponse`
      * traits for operation input and output shapes, respectively.
      */
     fun serverRenderOperation(

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -32,23 +32,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-use async_trait::async_trait;
 use http::{Extensions, HeaderMap, Request, Uri};
-
-use crate::response::IntoResponse;
-
-/// Trait for extracting information from requests.
-///
-/// A type implementing the `FromRequest` trait is used to handle and extract information from an async handler taking in a `RequestParts` as input.
-#[async_trait]
-pub trait FromRequest<B>: Sized {
-    /// If the extractor fails it'll use this "rejection" type. A rejection is
-    /// a kind of error that can be converted into a response.
-    type Rejection: IntoResponse;
-
-    /// Perform the extraction.
-    async fn from_request(req: &mut RequestParts<B>) -> Result<Self, Self::Rejection>;
-}
 
 #[doc(hidden)]
 #[derive(Debug)]

--- a/rust-runtime/aws-smithy-http-server/src/response.rs
+++ b/rust-runtime/aws-smithy-http-server/src/response.rs
@@ -36,11 +36,3 @@ use crate::body::BoxBody;
 
 #[doc(hidden)]
 pub type Response<T = BoxBody> = http::Response<T>;
-
-/// Trait for generating responses.
-///
-/// Types that implement `IntoResponse` can be returned from handlers.
-pub trait IntoResponse {
-    /// Create a response.
-    fn into_response(self) -> Response;
-}

--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -12,7 +12,6 @@ use self::tiny_map::TinyMap;
 use crate::body::{boxed, Body, BoxBody, HttpBody};
 use crate::error::BoxError;
 use crate::protocols::Protocol;
-use crate::response::IntoResponse;
 use crate::runtime_error::{RuntimeError, RuntimeErrorKind};
 use http::{Request, Response, StatusCode};
 use std::{

--- a/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
@@ -21,10 +21,7 @@
 //! and converts into the corresponding `RuntimeError`, and then it uses the its
 //! [`crate::response::IntoResponse`] implementation to render and send a response.
 
-use crate::{
-    protocols::Protocol,
-    response::{IntoResponse, Response},
-};
+use crate::{protocols::Protocol, response::Response};
 
 #[derive(Debug)]
 pub enum RuntimeErrorKind {
@@ -59,8 +56,8 @@ pub struct RuntimeError {
     pub kind: RuntimeErrorKind,
 }
 
-impl IntoResponse for RuntimeError {
-    fn into_response(self) -> Response {
+impl RuntimeError {
+    pub fn into_response(self) -> Response {
         let status_code = match self.kind {
             RuntimeErrorKind::Serialization(_) => http::StatusCode::BAD_REQUEST,
             RuntimeErrorKind::InternalFailure(_) => http::StatusCode::INTERNAL_SERVER_ERROR,

--- a/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
@@ -9,7 +9,7 @@
 //!
 //! As opposed to rejection types (see [`crate::rejection`]), which are an internal detail about
 //! the framework, `RuntimeError` is surfaced to clients in HTTP responses: indeed, it implements
-//! [`crate::response::IntoResponse`]. Rejections can be "grouped" and converted into a
+//! [`RuntimeError::into_response`]. Rejections can be "grouped" and converted into a
 //! specific `RuntimeError` kind: for example, all request rejections due to serialization issues
 //! can be conflated under the [`RuntimeErrorKind::Serialization`] enum variant.
 //!
@@ -19,7 +19,7 @@
 //! Generated code works always works with [`crate::rejection`] types when deserializing requests
 //! and serializing response. Just before a response needs to be sent, the generated code looks up
 //! and converts into the corresponding `RuntimeError`, and then it uses the its
-//! [`crate::response::IntoResponse`] implementation to render and send a response.
+//! [`RuntimeError::into_response`] method to render and send a response.
 
 use crate::{protocols::Protocol, response::Response};
 


### PR DESCRIPTION
## Motivation and Context

`async fn` are currently not supported by Rust. To allow for such syntax today, the [async_trait](https://docs.rs/async-trait/latest/async_trait/) macro eagerly `Box::pin`s the `async` block. This incurs an unnecessary allocation.

One instance where `async_trait` is used is on the [FromRequest](https://docs.rs/axum/latest/axum/extract/trait.FromRequest.html) method (inherited from [axum](https://docs.rs/axum/latest/axum/)). The use case for `FromRequest` in `axum` does not exist in our case, it is therefore a candidate for removal.

While `IntoResponse` does not involve the same boxing as `FromRequest`, it also does not need to be a trait - and so we remove it for symmetry. 

## Description

* Remove `FromRequest` and replace it with a static method
* Remove `IntoResponse` and replace it with a static method