### PR TITLE
aws-smithy-client: Upgrade hyper-rustls to 0.23.0

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -25,3 +25,8 @@ message = "Re-export aws_types::SdkConfig in aws_config"
 references = ["smithy-rs#1457"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "calavera"
+
+[[aws-sdk-rust]]
+message = "aws-smithy-client: Upgrade hyper-rustls to 0.23.0"
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "joshtriplett"

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -25,7 +25,7 @@ fastrand = "1.4.0"
 http = "0.2.3"
 http-body = "0.4.4"
 hyper = { version = "0.14", features = ["client", "http2", "http1"], optional = true }
-hyper-rustls = { version = "0.22.1", optional = true, features = ["rustls-native-certs"] }
+hyper-rustls = { version = "0.23.0", optional = true, features = ["rustls-native-certs"] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project-lite = "0.2.7"


### PR DESCRIPTION
This avoids having two versions of hyper-rustls (and its dependencies)
in code that uses a custom hyper-rustls connector.

## Testing

Passes `cargo test -p aws-smithy-client`.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
