### PR TITLE
Feature: make retry strategy exponential backoff multiplier configurable

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -39,9 +39,9 @@ author = "calavera"
 
 [[smithy-rs]]
 message = """
-Updated the smithy client's retry behavior to allow for a configurable initial_backoff. Previously, the backoff multiplier
+Updated the smithy client's retry behavior to allow for a configurable initial backoff. Previously, the initial backoff
 (named `r` in the code) was set to 2 seconds. This is not an ideal default for services that expect clients to quickly
-retry failed request attempts. Now, users can set quicker (or slower) multipliers according to their needs.
+retry failed request attempts. Now, users can set quicker (or slower) backoffs according to their needs.
 """
 references = ["aws-sdk-rust#567"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
@@ -49,9 +49,9 @@ author = "Velfi"
 
 [[aws-sdk-rust]]
 message = """
-Updated SDK Client retry behavior to allow for a configurable backoff multiplier. Previously, the backoff multiplier
+Updated SDK Client retry behavior to allow for a configurable initial backoff. Previously, the initial backoff
 (named `r` in the code) was set to 2 seconds. This is not an ideal default for services like DynamoDB that expect
-clients to quickly retry failed request attempts. Now, users can set quicker (or slower) multipliers according to their
+clients to quickly retry failed request attempts. Now, users can set quicker (or slower) backoffs according to their
 needs.
 
 ```rust

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -25,3 +25,53 @@ message = "Re-export aws_types::SdkConfig in aws_config"
 references = ["smithy-rs#1457"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "calavera"
+
+[[smithy-rs]]
+message = """
+Updated the smithy client's retry behavior to allow for a configurable backoff_multiplier. Previously, the backoff multiplier
+(named `r` in the code) was set to 2 seconds. This is not an ideal default for services that expect clients to quickly
+retry failed request attempts. Now, users can set quicker (or slower) multipliers according to their needs.
+"""
+references = ["aws-sdk-rust#567"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "Velfi"
+
+[[aws-sdk-rust]]
+message = """
+Updated SDK Client retry behavior to allow for a configurable backoff multiplier. Previously, the backoff multiplier
+(named `r` in the code) was set to 2 seconds. This is not an ideal default for services like DynamoDB that expect
+clients to quickly retry failed request attempts. Now, users can set quicker (or slower) multipliers according to their
+needs.
+
+```rust
+#[tokio::main]
+async fn main() -> Result<(), aws_sdk_dynamodb::Error> {
+    let retry_config = aws_smithy_types::retry::RetryConfigBuilder::new()
+        .max_attempts(4)
+        .backoff_multiplier(Duration::from_millis(20));
+
+    let shared_config = aws_config::from_env()
+        .retry_config(retry_config)
+        .load()
+        .await;
+
+    let client = aws_sdk_dynamodb::Client::new(&shared_config);
+
+    // Given the 20ms backoff multiplier, and assuming this request fails 3 times before succeeding,
+    // the first retry would take place between 0-20ms after the initial request,
+    // the second retry would take place between 0-40ms after the first retry,
+    // and the third retry would take place between 0-80ms after the second retry.
+    let request = client
+        .put_item()
+        .table_name("users")
+        .item("username", "Velfi")
+        .item("account_type", "Developer")
+        .send().await?;
+
+    Ok(())
+}
+```
+"""
+references = ["aws-sdk-rust#567"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "Velfi"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -39,7 +39,7 @@ author = "calavera"
 
 [[smithy-rs]]
 message = """
-Updated the smithy client's retry behavior to allow for a configurable backoff_multiplier. Previously, the backoff multiplier
+Updated the smithy client's retry behavior to allow for a configurable initial_backoff. Previously, the backoff multiplier
 (named `r` in the code) was set to 2 seconds. This is not an ideal default for services that expect clients to quickly
 retry failed request attempts. Now, users can set quicker (or slower) multipliers according to their needs.
 """
@@ -59,7 +59,7 @@ needs.
 async fn main() -> Result<(), aws_sdk_dynamodb::Error> {
     let retry_config = aws_smithy_types::retry::RetryConfigBuilder::new()
         .max_attempts(4)
-        .backoff_multiplier(Duration::from_millis(20));
+        .initial_backoff(Duration::from_millis(20));
 
     let shared_config = aws_config::from_env()
         .retry_config(retry_config)

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -128,19 +128,3 @@ async fn test_presigned_upload_part() -> Result<(), Box<dyn Error>> {
     );
     Ok(())
 }
-
-pub async fn send(
-    self,
-) -> std::result::Result<
-    crate::output::ListBucketsOutput,
-    aws_smithy_http::result::SdkError<crate::error::ListBucketsError>,
-> {
-    let op = self
-        .inner
-        .build()
-        .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?
-        .make_operation(&self.handle.conf)
-        .await
-        .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?;
-    self.handle.client.call(op).await
-}

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -128,3 +128,19 @@ async fn test_presigned_upload_part() -> Result<(), Box<dyn Error>> {
     );
     Ok(())
 }
+
+pub async fn send(
+    self,
+) -> std::result::Result<
+    crate::output::ListBucketsOutput,
+    aws_smithy_http::result::SdkError<crate::error::ListBucketsError>,
+> {
+    let op = self
+        .inner
+        .build()
+        .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?
+        .make_operation(&self.handle.conf)
+        .await
+        .map_err(|err| aws_smithy_http::result::SdkError::ConstructionFailure(err.into()))?;
+    self.handle.client.call(op).await
+}

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 use crate::{SdkError, SdkSuccess};
 
 use aws_smithy_async::rt::sleep::AsyncSleep;
-use aws_smithy_http::operation;
 use aws_smithy_http::operation::Operation;
 use aws_smithy_http::retry::ClassifyResponse;
 use aws_smithy_types::retry::{ErrorKind, RetryKind};
@@ -284,15 +283,7 @@ impl RetryHandler {
 /// - the second retry will occur after 0 to 60 milliseconds
 /// - the third retry will occur after 0 to 120 milliseconds
 fn calculate_exponential_backoff(base: f64, initial_backoff: f64, attempts: u32) -> f64 {
-    if attempts == 0 {
-        panic!(
-            "calculate_exponential_backoff is only intended to calculate the backoff of retries."
-        )
-    } else if attempts == 1 {
-        base * initial_backoff
-    } else {
-        base * initial_backoff * 2_u32.pow(attempts) as f64 / 2.0
-    }
+    base * initial_backoff * 2_u32.pow(attempts) as f64 / 2.0
 }
 
 impl RetryHandler {
@@ -373,8 +364,7 @@ impl RetryHandler {
     }
 }
 
-impl<Handler, R, T, E>
-    tower::retry::Policy<operation::Operation<Handler, R>, SdkSuccess<T>, SdkError<E>>
+impl<Handler, R, T, E> tower::retry::Policy<Operation<Handler, R>, SdkSuccess<T>, SdkError<E>>
     for RetryHandler
 where
     Handler: Clone,

--- a/rust-runtime/aws-smithy-client/tests/e2e_test.rs
+++ b/rust-runtime/aws-smithy-client/tests/e2e_test.rs
@@ -138,7 +138,7 @@ async fn end_to_end_retry_test() {
     let retry_config = aws_smithy_client::retry::Config::default()
         .with_max_attempts(4)
         // This is the default, just setting it to be explicit
-        .with_backoff_multiplier(Duration::from_secs(1))
+        .with_initial_backoff(Duration::from_secs(1))
         .with_base(|| 1_f64);
     let client = Client::<TestConnection<_>, Identity>::new(conn.clone())
         .with_retry_config(retry_config)

--- a/rust-runtime/aws-smithy-client/tests/e2e_test.rs
+++ b/rust-runtime/aws-smithy-client/tests/e2e_test.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::test_operation::TestPolicy;
+use crate::test_operation::{TestOperationParser, TestPolicy};
 use aws_smithy_async::rt::sleep::TokioSleep;
 
 use aws_smithy_client::test_connection::TestConnection;
@@ -14,7 +14,6 @@ use aws_smithy_http::operation::Operation;
 use aws_smithy_http::result::SdkError;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::time::Instant;
 use tower::layer::util::Identity;
 
 mod test_operation {
@@ -89,14 +88,14 @@ mod test_operation {
     }
 }
 
-fn test_operation() -> Operation<test_operation::TestOperationParser, test_operation::TestPolicy> {
+fn test_operation() -> Operation<TestOperationParser, TestPolicy> {
     let req = operation::Request::new(
         http::Request::builder()
             .uri("https://test-service.test-region.amazonaws.com/")
             .body(SdkBody::from("request body"))
             .unwrap(),
     );
-    Operation::new(req, test_operation::TestOperationParser).with_retry_policy(TestPolicy)
+    Operation::new(req, TestOperationParser).with_retry_policy(TestPolicy)
 }
 
 #[tokio::test]
@@ -138,6 +137,8 @@ async fn end_to_end_retry_test() {
     let conn = TestConnection::new(events);
     let retry_config = aws_smithy_client::retry::Config::default()
         .with_max_attempts(4)
+        // This is the default, just setting it to be explicit
+        .with_backoff_multiplier(Duration::from_secs(1))
         .with_base(|| 1_f64);
     let client = Client::<TestConnection<_>, Identity>::new(conn.clone())
         .with_retry_config(retry_config)
@@ -174,7 +175,7 @@ async fn end_to_end_retry_test() {
 /// Validate that time has passed with a 5ms tolerance
 ///
 /// This is to account for some non-determinism in the Tokio timer
-fn assert_time_passed(initial: Instant, passed: Duration) {
+fn assert_time_passed(initial: tokio::time::Instant, passed: Duration) {
     let now = tokio::time::Instant::now();
     let delta = now - initial;
     if (delta.as_millis() as i128 - passed.as_millis() as i128).abs() > 5 {

--- a/rust-runtime/aws-smithy-types/src/retry.rs
+++ b/rust-runtime/aws-smithy-types/src/retry.rs
@@ -134,7 +134,7 @@ impl FromStr for RetryMode {
 pub struct RetryConfigBuilder {
     mode: Option<RetryMode>,
     max_attempts: Option<u32>,
-    backoff_multiplier: Option<Duration>,
+    initial_backoff: Option<Duration>,
 }
 
 impl RetryConfigBuilder {
@@ -167,15 +167,15 @@ impl RetryConfigBuilder {
         self
     }
 
-    /// Set the backoff_multiplier duration. This duration should be non-zero.
-    pub fn set_backoff_multiplier(&mut self, backoff_multiplier: Option<Duration>) -> &mut Self {
-        self.backoff_multiplier = backoff_multiplier;
+    /// Set the initial_backoff duration. This duration should be non-zero.
+    pub fn set_initial_backoff(&mut self, initial_backoff: Option<Duration>) -> &mut Self {
+        self.initial_backoff = initial_backoff;
         self
     }
 
-    /// Set the backoff_multiplier duration. This duration should be non-zero.
-    pub fn backoff_multiplier(mut self, backoff_multiplier: Duration) -> Self {
-        self.set_backoff_multiplier(Some(backoff_multiplier));
+    /// Set the initial_backoff duration. This duration should be non-zero.
+    pub fn initial_backoff(mut self, initial_backoff: Duration) -> Self {
+        self.set_initial_backoff(Some(initial_backoff));
         self
     }
 
@@ -199,7 +199,7 @@ impl RetryConfigBuilder {
         Self {
             mode: self.mode.or(other.mode),
             max_attempts: self.max_attempts.or(other.max_attempts),
-            backoff_multiplier: self.backoff_multiplier.or(other.backoff_multiplier),
+            initial_backoff: self.initial_backoff.or(other.initial_backoff),
         }
     }
 
@@ -208,8 +208,8 @@ impl RetryConfigBuilder {
         RetryConfig {
             mode: self.mode.unwrap_or(RetryMode::Standard),
             max_attempts: self.max_attempts.unwrap_or(3),
-            backoff_multiplier: self
-                .backoff_multiplier
+            initial_backoff: self
+                .initial_backoff
                 .unwrap_or_else(|| Duration::from_secs(1)),
         }
     }
@@ -221,7 +221,7 @@ impl RetryConfigBuilder {
 pub struct RetryConfig {
     mode: RetryMode,
     max_attempts: u32,
-    backoff_multiplier: Duration,
+    initial_backoff: Duration,
 }
 
 impl RetryConfig {
@@ -256,17 +256,17 @@ impl RetryConfig {
     ///
     /// ## Example
     ///
-    /// *For a request that gets retried 3 times, when backoff_multiplier is 1 seconds:*
+    /// *For a request that gets retried 3 times, when initial_backoff is 1 seconds:*
     /// - the first retry will occur after 0 to 1 seconds
     /// - the second retry will occur after 0 to 2 seconds
     /// - the third retry will occur after 0 to 4 seconds
     ///
-    /// *For a request that gets retried 3 times, when backoff_multiplier is 30 milliseconds:*
+    /// *For a request that gets retried 3 times, when initial_backoff is 30 milliseconds:*
     /// - the first retry will occur after 0 to 30 milliseconds
     /// - the second retry will occur after 0 to 60 milliseconds
     /// - the third retry will occur after 0 to 120 milliseconds
-    pub fn with_backoff_multiplier(mut self, backoff_multiplier: Duration) -> Self {
-        self.backoff_multiplier = backoff_multiplier;
+    pub fn with_initial_backoff(mut self, initial_backoff: Duration) -> Self {
+        self.initial_backoff = initial_backoff;
         self
     }
 
@@ -281,8 +281,8 @@ impl RetryConfig {
     }
 
     /// Returns the backoff multiplier duration.
-    pub fn backoff_multiplier(&self) -> Duration {
-        self.backoff_multiplier
+    pub fn initial_backoff(&self) -> Duration {
+        self.initial_backoff
     }
 }
 
@@ -291,7 +291,7 @@ impl Default for RetryConfig {
         Self {
             mode: RetryMode::Standard,
             max_attempts: 3,
-            backoff_multiplier: Duration::from_secs(1),
+            initial_backoff: Duration::from_secs(1),
         }
     }
 }

--- a/rust-runtime/aws-smithy-types/src/retry.rs
+++ b/rust-runtime/aws-smithy-types/src/retry.rs
@@ -250,16 +250,16 @@ impl RetryConfig {
 
     /// Set the multiplier used when calculating backoff times as part of an
     /// [exponential backoff with jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)
-    /// strategy. Most services should work fine with the default duration of 2 seconds, but if you
+    /// strategy. Most services should work fine with the default duration of 1 second, but if you
     /// find that your requests are taking too long due to excessive retry backoff, try lowering
     /// this value.
     ///
     /// ## Example
     ///
-    /// *For a request that gets retried 3 times, when backoff_multiplier is 2 seconds:*
-    /// - the first retry will occur after 0 to 2 seconds
-    /// - the second retry will occur after 0 to 4 seconds
-    /// - the third retry will occur after 0 to 8 seconds
+    /// *For a request that gets retried 3 times, when backoff_multiplier is 1 seconds:*
+    /// - the first retry will occur after 0 to 1 seconds
+    /// - the second retry will occur after 0 to 2 seconds
+    /// - the third retry will occur after 0 to 4 seconds
     ///
     /// *For a request that gets retried 3 times, when backoff_multiplier is 30 milliseconds:*
     /// - the first retry will occur after 0 to 30 milliseconds
@@ -291,7 +291,7 @@ impl Default for RetryConfig {
         Self {
             mode: RetryMode::Standard,
             max_attempts: 3,
-            backoff_multiplier: Duration::from_secs(2),
+            backoff_multiplier: Duration::from_secs(1),
         }
     }
 }

--- a/rust-runtime/aws-smithy-types/src/retry.rs
+++ b/rust-runtime/aws-smithy-types/src/retry.rs
@@ -210,7 +210,7 @@ impl RetryConfigBuilder {
             max_attempts: self.max_attempts.unwrap_or(3),
             backoff_multiplier: self
                 .backoff_multiplier
-                .unwrap_or_else(|| Duration::from_secs(2)),
+                .unwrap_or_else(|| Duration::from_secs(1)),
         }
     }
 }


### PR DESCRIPTION
_NOTE: I plan to allow for user-defined retry strategies in a separate PR._

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-rust#567

## Description
Updated SDK Client retry behavior to allow for a configurable backoff multiplier.

Previously, the backoff multiplier (named `r` in the code) was set to 2 seconds. This is not an ideal default for services like DynamoDB that expect clients to quickly retry failed request attempts. Now, users can set quicker (or slower) multipliers according to their needs.

```rust
#[tokio::main]
async fn main() -> Result<(), aws_sdk_dynamodb::Error> {
    let retry_config = aws_smithy_types::retry::RetryConfigBuilder::new()
        .max_attempts(4)
        .backoff_multiplier(Duration::from_millis(20));

    let shared_config = aws_config::from_env()
        .retry_config(retry_config)
        .load()
        .await;

    let client = aws_sdk_dynamodb::Client::new(&shared_config);

    // Given the 20ms backoff multiplier, and assuming this request fails 3 times before succeeding,
    // the first retry would take place between 0-20ms after the initial request,
    // the second retry would take place between 0-40ms after the first retry,
    // and the third retry would take place between 0-80ms after the second retry.
    let request = client
        .put_item()
        .table_name("users")
        .item("username", "Velfi")
        .item("account_type", "Developer")
        .send().await?;

    Ok(())
}
```

**For a request that gets retried 3 times, when base is 1 and initial_backoff is 2 seconds:**
- the first retry will occur after 0 to 2 seconds
- the second retry will occur after 0 to 4 seconds
- the third retry will occur after 0 to 8 seconds

**For a request that gets retried 3 times, when base is 1 and initial_backoff is 30 milliseconds:**
- the first retry will occur after 0 to 30 milliseconds
- the second retry will occur after 0 to 60 milliseconds
- the third retry will occur after 0 to 120 milliseconds

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote some test for the backoff calculation and ran existing retry tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
