### PR TITLE
Add impl of `From<DynConnector>` for `HttpConnector`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -25,3 +25,9 @@ message = "Re-export aws_types::SdkConfig in aws_config"
 references = ["smithy-rs#1457"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "calavera"
+
+[[aws-sdk-rust]]
+message = "Add `From<aws_smithy_client::erase::DynConnector>` impl for `aws_smithy_client::http_connector::HttpConnector`"
+references = ["aws-sdk-rust#581"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "Velfi"

--- a/rust-runtime/aws-smithy-client/src/erase.rs
+++ b/rust-runtime/aws-smithy-client/src/erase.rs
@@ -11,7 +11,7 @@
 pub mod boxclone;
 use boxclone::*;
 
-use crate::{bounds, retry, Client};
+use crate::{bounds, http_connector::HttpConnector, retry, Client};
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::result::ConnectorError;
 use std::fmt;
@@ -175,6 +175,12 @@ impl Service<http::Request<SdkBody>> for DynConnector {
 
     fn call(&mut self, req: http::Request<SdkBody>) -> Self::Future {
         self.0.call(req)
+    }
+}
+
+impl From<DynConnector> for HttpConnector {
+    fn from(connector: DynConnector) -> Self {
+        HttpConnector::Prebuilt(Some(connector))
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-rust#581

## Description
<!--- Describe your changes in detail -->
exactly what it says on the tin

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
none needed

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
