### PR TITLE
Expose `sleep_impl` configuration in `SdkConfig`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -116,3 +116,9 @@ a version bump in all of them, but this should not be relied upon.
 references = ["smithy-rs#1540"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "The `sleep_impl` methods on the `SdkConfig` builder are now exposed and documented."
+references = ["smithy-rs#1556"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -208,7 +208,6 @@ impl Builder {
         self
     }
 
-    #[doc(hidden)]
     /// Set the sleep implementation for the builder. The sleep implementation is used to create
     /// timeout futures.
     ///
@@ -236,7 +235,6 @@ impl Builder {
         self
     }
 
-    #[doc(hidden)]
     /// Set the sleep implementation for the builder. The sleep implementation is used to create
     /// timeout futures.
     ///


### PR DESCRIPTION
## Motivation and Context
Customers need to be able to customize the `sleep_impl`, and currently, that's not easy to discover. This PR removes the `#[doc(hidden)]` on these builder methods.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
