### PR TITLE
Don't warn about home dir expansion for default profile paths

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -116,3 +116,13 @@ a version bump in all of them, but this should not be relied upon.
 references = ["smithy-rs#1540"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = """
+Only emit a warning about failing to expand a `~` to the home
+directory in a profile file's path if that path was explicitly
+set (don't emit it for the default paths)
+"""
+references = ["smithy-rs#1558", "aws-sdk-rust#583"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"


### PR DESCRIPTION
## Motivation and Context
This addresses https://github.com/awslabs/aws-sdk-rust/issues/583 by only emitting the warning if the path was explicitly overridden by the customer.

## Testing
- Unit tested

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
