### PR TITLE
Remove warning for valid IMDS provider use-case

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -116,3 +116,9 @@ a version bump in all of them, but this should not be relied upon.
 references = ["smithy-rs#1540"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Remove warning for valid IMDS provider use-case"
+references = ["smithy-rs#1559", "aws-sdk-rust#582"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -63,9 +63,6 @@ impl Builder {
     ///
     /// For more information about IMDS client configuration loading see [`imds::Client`]
     pub fn imds_client(mut self, client: imds::Client) -> Self {
-        if self.provider_config.is_some() {
-            tracing::warn!("provider config override by a full client override");
-        }
         self.imds_override = Some(client);
         self
     }


### PR DESCRIPTION
## Motivation and Context
This addresses https://github.com/awslabs/aws-sdk-rust/issues/582. The warning shouldn't be there since the `env` from the `ProviderConfig` gets used by the built provider even if its underlying client is overridden.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
