### PR TITLE
Update JAVA_HOME

### DIFF
--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -141,7 +141,7 @@ COPY --chown=build:build --from=install_rust /opt/rustup /opt/rustup
 ENV PATH=/opt/cargo/bin:/opt/nodejs/bin:$PATH \
     CARGO_HOME=/opt/cargo \
     RUSTUP_HOME=/opt/rustup \
-    JAVA_HOME=/usr/lib/jvm/jre-11-openjdk \
+    JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto.x86_64 \
     GRADLE_USER_HOME=/home/build/.gradle \
     RUST_STABLE_VERSION=${rust_stable_version} \
     RUST_NIGHTLY_VERSION=${rust_nightly_version} \


### PR DESCRIPTION
Recently CI is failing with

> ERROR: JAVA_HOME is set to an invalid directory: /usr/lib/jvm/jre-11-openjdk
> Please set the JAVA_HOME variable in your environment to match the
> location of your Java installation.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
