### PR TITLE
Sort inline dependencies alphabetically by key

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenDelegator.kt
@@ -117,12 +117,14 @@ open class RustCrate(
                 .filter { !writtenDependencies.contains(it.key()) }
         }
         while (unloadedDependencies().isNotEmpty()) {
-            unloadedDependencies().forEach { dep ->
-                writtenDependencies.add(dep.key())
-                this.withModule(dep.module) {
-                    dep.renderer(it)
+            unloadedDependencies()
+                .sortedBy { it.key() }
+                .forEach { dep ->
+                    writtenDependencies.add(dep.key())
+                    this.withModule(dep.module) {
+                        dep.renderer(it)
+                    }
                 }
-            }
         }
     }
 


### PR DESCRIPTION
## Motivation and Context
This PR makes code pieces emitted by `forInlineFun` sorted alphabetically by key. This should make refactoring back and forth between `forInlineFun` and normal codegen generate less of a diff.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
