### PR TITLE
Add support for removing crates from the SDK

### DIFF
--- a/tools/publisher/src/subcommand/tag_versions_manifest.rs
+++ b/tools/publisher/src/subcommand/tag_versions_manifest.rs
@@ -46,6 +46,7 @@ mod tests {
         let original = VersionsManifest {
             smithy_rs_revision: "some-revision-smithy-rs".into(),
             aws_doc_sdk_examples_revision: "some-revision-docs".into(),
+            manual_interventions: Default::default(),
             crates: [
                 (
                     "aws-config".to_string(),

--- a/tools/publisher/tests/hydrate_readme_e2e_test.rs
+++ b/tools/publisher/tests/hydrate_readme_e2e_test.rs
@@ -62,6 +62,7 @@ fn test_hydrate_readme() {
     VersionsManifest {
         smithy_rs_revision: "dontcare".into(),
         aws_doc_sdk_examples_revision: "dontcare".into(),
+        manual_interventions: Default::default(),
         crates: [
             (
                 "aws-config".to_string(),

--- a/tools/sdk-versioner/src/main.rs
+++ b/tools/sdk-versioner/src/main.rs
@@ -244,6 +244,7 @@ mod tests {
         VersionsManifest {
             smithy_rs_revision: "doesntmatter".into(),
             aws_doc_sdk_examples_revision: "doesntmatter".into(),
+            manual_interventions: Default::default(),
             crates: crates
                 .iter()
                 .map(|&(name, version)| {

--- a/tools/smithy-rs-tool-common/src/versions_manifest.rs
+++ b/tools/smithy-rs-tool-common/src/versions_manifest.rs
@@ -23,6 +23,12 @@ pub struct VersionsManifest {
     /// Git commit hash of the `aws-doc-sdk-examples` repository that was synced into this SDK
     pub aws_doc_sdk_examples_revision: String,
 
+    /// Optional manual interventions to apply to the next release.
+    /// These are intended to be filled out manually in the `versions.toml` via pull request
+    /// to `aws-sdk-rust`.
+    #[serde(default)]
+    pub manual_interventions: ManualInterventions,
+
     /// All SDK crate version metadata
     pub crates: BTreeMap<String, CrateVersion>,
 
@@ -58,6 +64,21 @@ impl FromStr for VersionsManifest {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         Ok(toml::from_str(value)?)
     }
+}
+
+/// The SDK release process has sanity checks sprinkled throughout it to make sure
+/// a release is done correctly. Sometimes, manual intervention is required to bypass
+/// these sanity checks. For example, when a service model is intentionally removed,
+/// without manual intervention, there would be no way to release that removal.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Eq, PartialEq)]
+pub struct ManualInterventions {
+    /// List of crate names that are being removed from the SDK in the next release.
+    ///
+    /// __Note:__ this only bypasses a release-time sanity check. The models for these crates
+    /// (if they're generated) need to be manually deleted, and the crates must be manually
+    /// yanked after the release (if necessary).
+    #[serde(default)]
+    pub crates_to_remove: Vec<String>,
 }
 
 /// Release metadata


### PR DESCRIPTION
## Motivation and Context
This PR updates the `generate-version-manifest` tool so that the unintentional crate removal sanity check can by bypassed by manually updating the `versions.toml` for #1512.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
