### PR TITLE
Add client creation example to SDK crate READMEs

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -142,3 +142,9 @@ An example from the SDK is in [transcribe streaming](https://github.com/awslabs/
 references = ["smithy-rs#1157"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "82marbag"
+
+[[aws-sdk-rust]]
+message = "SDK crate READMEs now include an example of creating a client"
+references = ["smithy-rs#1571", "smithy-rs#1385"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "jdisanti"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
@@ -42,6 +42,8 @@ class AwsReadmeDecorator : RustCodegenDecorator<ClientCodegenContext> {
                 codegenContext.settings.getService(codegenContext.model).getTrait<DocumentationTrait>()?.value ?: ""
             )
             val moduleName = codegenContext.settings.moduleName
+            val snakeCaseModuleName = moduleName.replace('-', '_')
+            val shortModuleName = moduleName.removePrefix("aws-sdk-")
 
             writer.raw(
                 """
@@ -67,6 +69,25 @@ class AwsReadmeDecorator : RustCodegenDecorator<ClientCodegenContext> {
                     $moduleName = "${codegenContext.settings.moduleVersion}"
                     tokio = { version = "1", features = ["full"] }
                     ```
+
+                    Then in code, a client can be created with the following:
+
+                    ```rust
+                    use $snakeCaseModuleName as $shortModuleName;
+
+                    #[tokio::main]
+                    async fn main() -> Result<(), $shortModuleName::Error> {
+                        let config = aws_config::load_from_env().await;
+                        let client = $shortModuleName::Client::new(&config);
+
+                        // ... make some calls with the client
+
+                        Ok(())
+                    }
+                    ```
+
+                    See the [client documentation](https://docs.rs/$moduleName/latest/$snakeCaseModuleName/client/struct.Client.html)
+                    for information on what calls can be made, and the inputs and outputs for each of those calls.
 
                     ## Using the SDK
 


### PR DESCRIPTION
## Motivation and Context
Fixes #1385

## Testing
- Generated the SDK locally and verified the README Markdown renders correctly, that the code compiles when copy/pasted, and that the new link works.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
