### PR TITLE
update: `From<hyper::Body>` for `ByteStream` now delegates to `SdkBody::from`

### DIFF
--- a/rust-runtime/aws-smithy-http/src/body.rs
+++ b/rust-runtime/aws-smithy-http/src/body.rs
@@ -55,13 +55,16 @@ pub type BoxBody = http_body::combinators::BoxBody<Bytes, Error>;
 pin_project! {
     #[project = InnerProj]
     enum Inner {
+        // An in-memory body
         Once {
             inner: Option<Bytes>
         },
+        // A streaming body
         Streaming {
             #[pin]
             inner: hyper::Body
         },
+        // Also a streaming body
         Dyn {
             #[pin]
             inner: BoxBody

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -441,9 +441,7 @@ impl From<Vec<u8>> for ByteStream {
 
 impl From<hyper::Body> for ByteStream {
     fn from(input: hyper::Body) -> Self {
-        ByteStream::new(SdkBody::from_dyn(
-            input.map_err(|e| e.into_cause().unwrap()).boxed(),
-        ))
+        ByteStream::new(SdkBody::from(input))
     }
 }
 


### PR DESCRIPTION
This makes it easier to create streaming bodies without pulling in runtime crates.
Originally, `ByteStream::from::<hyper::Body>` would internally create a new `SdkBody` by calling `SdkBody::from_dyn` and boxing the `hyper::Body`. This PR updates it to instead call `SdkBody::from::<hyper::Body>`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
