### PR TITLE
Remove excess cargo test passes from additional-ci

### DIFF
--- a/aws/rust-runtime/aws-config/additional-ci
+++ b/aws/rust-runtime/aws-config/additional-ci
@@ -17,7 +17,7 @@ cargo tree -d --edges normal --all-features
 # `aws-config` is not part of the `rust-runtime` workspace. As a result it is not run through
 # `check-rust-runtimes-and-tools` and does not get `cargo test --all-features` prior to this point. As a result we do
 # not apply `--exclude-all-features` here.
-echo "### Testing each feature in isolation"
+echo "### Testing every combination of features"
 cargo hack test --feature-powerset
 
 echo "### Checking that compiling with the minimal versions succeeds"

--- a/aws/rust-runtime/aws-config/additional-ci
+++ b/aws/rust-runtime/aws-config/additional-ci
@@ -18,7 +18,7 @@ echo "### Testing with all features enabled"
 cargo test --all-features
 
 echo "### Testing each feature in isolation"
-cargo hack test --feature-powerset
+cargo hack test --feature-powerset --exclude-all-features
 
 echo "### Checking that compiling with the minimal versions succeeds"
 cargo "+${RUST_NIGHTLY_VERSION:-nightly}" minimal-versions check --all-features

--- a/aws/rust-runtime/aws-config/additional-ci
+++ b/aws/rust-runtime/aws-config/additional-ci
@@ -14,8 +14,11 @@ cargo "+${RUST_NIGHTLY_VERSION:-nightly}" api-linter --all-features --config api
 echo "### Checking for duplicate dependency versions in the normal dependency graph with all features enabled"
 cargo tree -d --edges normal --all-features
 
+# `aws-config` is not part of the `rust-runtime` workspace. As a result it is not run through
+# `check-rust-runtimes-and-tools` and does not get `cargo test --all-features` prior to this point. As a result we do
+# not apply `--exclude-all-features` here.
 echo "### Testing each feature in isolation"
-cargo hack test --feature-powerset --exclude-all-features
+cargo hack test --feature-powerset
 
 echo "### Checking that compiling with the minimal versions succeeds"
 cargo "+${RUST_NIGHTLY_VERSION:-nightly}" minimal-versions check --all-features

--- a/aws/rust-runtime/aws-config/additional-ci
+++ b/aws/rust-runtime/aws-config/additional-ci
@@ -14,9 +14,6 @@ cargo "+${RUST_NIGHTLY_VERSION:-nightly}" api-linter --all-features --config api
 echo "### Checking for duplicate dependency versions in the normal dependency graph with all features enabled"
 cargo tree -d --edges normal --all-features
 
-echo "### Testing with all features enabled"
-cargo test --all-features
-
 echo "### Testing each feature in isolation"
 cargo hack test --feature-powerset --exclude-all-features
 

--- a/rust-runtime/aws-smithy-async/additional-ci
+++ b/rust-runtime/aws-smithy-async/additional-ci
@@ -12,4 +12,4 @@ echo "### Checking for duplicate dependency versions in the normal dependency gr
 cargo tree -d --edges normal --all-features
 
 echo "### Checking each feature"
-cargo hack test --feature-powerset
+cargo hack test --feature-powerset --exclude-all-features

--- a/rust-runtime/aws-smithy-async/additional-ci
+++ b/rust-runtime/aws-smithy-async/additional-ci
@@ -11,5 +11,5 @@ set -e
 echo "### Checking for duplicate dependency versions in the normal dependency graph with all features enabled"
 cargo tree -d --edges normal --all-features
 
-echo "### Checking each feature"
+echo "### Testing every combination of features (excluding --all-features)"
 cargo hack test --feature-powerset --exclude-all-features

--- a/rust-runtime/aws-smithy-eventstream/additional-ci
+++ b/rust-runtime/aws-smithy-eventstream/additional-ci
@@ -12,4 +12,4 @@ echo "### Checking for duplicate dependency versions in the normal dependency gr
 cargo tree -d --edges normal --all-features
 
 echo "### Checking each feature"
-cargo hack test --feature-powerset
+cargo hack test --feature-powerset --exclude-all-features

--- a/rust-runtime/aws-smithy-eventstream/additional-ci
+++ b/rust-runtime/aws-smithy-eventstream/additional-ci
@@ -11,5 +11,5 @@ set -e
 echo "### Checking for duplicate dependency versions in the normal dependency graph with all features enabled"
 cargo tree -d --edges normal --all-features
 
-echo "### Checking each feature"
+echo "### Testing every combination of features (excluding --all-features)"
 cargo hack test --feature-powerset --exclude-all-features

--- a/rust-runtime/aws-smithy-http/additional-ci
+++ b/rust-runtime/aws-smithy-http/additional-ci
@@ -8,5 +8,5 @@
 
 set -e
 
-echo "### Testing feature powerset"
+echo "### Testing every combination of features (excluding --all-features)"
 cargo hack test --feature-powerset --exclude-all-features

--- a/rust-runtime/aws-smithy-http/additional-ci
+++ b/rust-runtime/aws-smithy-http/additional-ci
@@ -9,4 +9,4 @@
 set -e
 
 echo "### Testing feature powerset"
-cargo hack test --feature-powerset
+cargo hack test --feature-powerset --exclude-all-features


### PR DESCRIPTION
## Motivation and Context

https://github.com/awslabs/smithy-rs/pull/1550#discussion_r930987565

## Description

- Add `--exclude-all-features` to `cargo hack test --all-features` in `additional-ci`.
- Remove excess `cargo test --all-features`.

## Testing

Observe CI still has same coverage.
