### PR TITLE
Health check in Pokemon service

### DIFF
--- a/codegen-server-test/model/pokemon.smithy
+++ b/codegen-server-test/model/pokemon.smithy
@@ -10,7 +10,7 @@ use aws.protocols#restJson1
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies, Storage],
-    operations: [GetServerStatistics, EmptyOperation, CapturePokemonOperation],
+    operations: [GetServerStatistics, EmptyOperation, CapturePokemonOperation, HealthCheckOperation],
 }
 
 /// A Pokémon species forms the basis for at least one Pokémon.
@@ -240,6 +240,20 @@ structure EmptyOperationInput { }
 
 @output
 structure EmptyOperationOutput { }
+
+/// Health check operation, to check the service is up
+@readonly
+@http(uri: "/ping", method: "GET")
+operation HealthCheckOperation {
+    input: HealthCheckOperationInput,
+    output: HealthCheckOperationOutput,
+}
+
+@input
+structure HealthCheckOperationInput { }
+
+@output
+structure HealthCheckOperationOutput { }
 
 @error("client")
 @httpError(404)

--- a/codegen-server-test/model/pokemon.smithy
+++ b/codegen-server-test/model/pokemon.smithy
@@ -242,18 +242,11 @@ structure EmptyOperationInput { }
 structure EmptyOperationOutput { }
 
 /// Health check operation, to check the service is up
+/// Not yet a deep check
 @readonly
 @http(uri: "/ping", method: "GET")
 operation HealthCheckOperation {
-    input: HealthCheckOperationInput,
-    output: HealthCheckOperationOutput,
 }
-
-@input
-structure HealthCheckOperationInput { }
-
-@output
-structure HealthCheckOperationOutput { }
 
 @error("client")
 @httpError(404)

--- a/codegen-server-test/python/model/pokemon.smithy
+++ b/codegen-server-test/python/model/pokemon.smithy
@@ -13,7 +13,7 @@ use aws.protocols#restJson1
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies],
-    operations: [GetServerStatistics, EmptyOperation],
+    operations: [GetServerStatistics, EmptyOperation, HealthCheckOperation],
 }
 
 /// A Pokémon species forms the basis for at least one Pokémon.
@@ -122,6 +122,13 @@ structure EmptyOperationInput { }
 
 @output
 structure EmptyOperationOutput { }
+
+/// Health check operation, to check the service is up
+/// Not yet a deep check
+@readonly
+@http(uri: "/ping", method: "GET")
+operation HealthCheckOperation {
+}
 
 @error("client")
 @httpError(404)

--- a/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/tests/simple_integration_test.rs
@@ -47,4 +47,6 @@ async fn simple_integration_test() {
 
     let service_statistics_out = client().get_server_statistics().send().await.unwrap();
     assert_eq!(2, service_statistics_out.calls_count.unwrap());
+
+    let _health_check = client().health_check_operation().send().await.unwrap();
 }

--- a/rust-runtime/aws-smithy-http-server-python/examples/pokemon_service.py
+++ b/rust-runtime/aws-smithy-http-server-python/examples/pokemon_service.py
@@ -12,10 +12,10 @@ import threading
 from libpokemon_service_server_sdk.error import \
     ResourceNotFoundException
 from libpokemon_service_server_sdk.input import (
-    EmptyOperationInput, GetPokemonSpeciesInput, GetServerStatisticsInput)
+    EmptyOperationInput, GetPokemonSpeciesInput, GetServerStatisticsInput, HealthCheckOperationInput)
 from libpokemon_service_server_sdk.model import FlavorText, Language
 from libpokemon_service_server_sdk.output import (
-    EmptyOperationOutput, GetPokemonSpeciesOutput, GetServerStatisticsOutput)
+    EmptyOperationOutput, GetPokemonSpeciesOutput, GetServerStatisticsOutput, HealthCheckOperationOutput)
 from libpokemon_service_server_sdk import App
 
 
@@ -135,6 +135,10 @@ def get_server_statistics(
     calls_count = context.get_calls_count()
     logging.debug("The service handled %d requests", calls_count)
     return GetServerStatisticsOutput(calls_count=calls_count)
+
+@app.health_check_operation
+def health_check_operation(_: HealthCheckOperationInput) -> HealthCheckOperationOutput:
+    return HealthCheckOperationOutput()
 
 ###########################################################
 # Run the server.

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
@@ -277,6 +277,11 @@ pub async fn empty_operation(_input: input::EmptyOperationInput) -> output::Empt
     output::EmptyOperationOutput {}
 }
 
+/// Operation used to show the service is running.
+pub async fn health_check_operation(_input: input::HealthCheckOperationInput) -> output::HealthCheckOperationOutput {
+    output::HealthCheckOperationOutput {}
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
@@ -9,7 +9,7 @@ use std::{net::SocketAddr, sync::Arc};
 use aws_smithy_http_server::{AddExtensionLayer, Router};
 use clap::Parser;
 use pokemon_service::{
-    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, health_check_operation,
+    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, get_storage, health_check_operation,
     setup_tracing, State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
@@ -9,7 +9,8 @@ use std::{net::SocketAddr, sync::Arc};
 use aws_smithy_http_server::{AddExtensionLayer, Router};
 use clap::Parser;
 use pokemon_service::{
-    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, get_storage, setup_tracing, State,
+    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, health_check_operation,
+    setup_tracing, State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
@@ -39,6 +40,7 @@ pub async fn main() {
         .get_server_statistics(get_server_statistics)
         .capture_pokemon_operation(capture_pokemon)
         .empty_operation(empty_operation)
+        .health_check_operation(health_check_operation)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
@@ -47,6 +47,16 @@ fn get_pokemon_to_capture() -> String {
 
 #[tokio::test]
 #[serial]
+async fn test_health_check_operation() {
+    let _program = PokemonService::run();
+    // Give PokémonService some time to start up.
+    time::sleep(Duration::from_millis(500)).await;
+
+    let _health_check = client().health_check_operation().send().await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
 async fn simple_integration_test() {
     let _program = PokemonService::run();
     // Give PokémonService some time to start up.


### PR DESCRIPTION

This change adds a common operation, a health check to verify the service is running.

I'm leaving the empty operation because it's used in benchmarks, has a different URI and serves a different purpose, albeit with the same input and output. If it is better, I can remove the empty operation and leave only the health check.

## Testing
`cargo test` in the Pokemon service folder.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
