### PR TITLE
Allow both teams to release new smithy-rs versions independently

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,3 +3,6 @@
 /codegen-server-test/                           @awslabs/smithy-rs-server
 /rust-runtime/aws-smithy-http-server/           @awslabs/smithy-rs-server
 /rust-runtime/aws-smithy-http-server-python/    @awslabs/smithy-rs-server
+
+# Either team is able to modify this file to release new smithy-rs versions.
+gradle.properties                               @awslabs/rust-sdk-owners @awslabs/smithy-rs-server


### PR DESCRIPTION
This commit modifies the `CODEOWNERS` to allow both
`@awslabs/rust-sdk-owners` and `@awslabs/smithy-rs-server` teams to
release new versions of smithy-rs independently, without requiring peer
approval from the other team.

Syntax and semantics of `CODEOWNERS`: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
