### PR TITLE
Add codegen version to generated package

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "sdk" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "Add codegen version to generated package metadata"
+references = ["smithy-rs#1612"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "unexge"

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -61,7 +61,7 @@ val generateSmithyRuntimeCrateVersion by tasks.registering {
     val crateVersion = project.properties["smithy.rs.runtime.crate.version"].toString()
     inputs.property("crateVersion", crateVersion)
     // version format must be in sync with `software.amazon.smithy.rust.codegen.smithy.Version`
-    val version = "$crateVersion-${gitCommitHash()}"
+    val version = "$crateVersion\n${gitCommitHash()}"
     sourceSets.main.get().output.dir(resourcesDir)
     doLast {
         versionFile.writeText(version)

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -4,6 +4,7 @@
  */
 
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import java.io.ByteArrayOutputStream
 
 plugins {
     kotlin("jvm")
@@ -39,6 +40,18 @@ tasks.compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+fun gitCommitHash() =
+    try {
+        val output = ByteArrayOutputStream()
+        exec {
+            commandLine = listOf("git", "rev-parse", "HEAD")
+            standardOutput = output
+        }
+        output.toString().trim()
+    } catch (ex: Exception) {
+        "unknown"
+    }
+
 val generateSmithyRuntimeCrateVersion by tasks.registering {
     // generate the version of the runtime to use as a resource.
     // this keeps us from having to manually change version numbers in multiple places
@@ -47,9 +60,11 @@ val generateSmithyRuntimeCrateVersion by tasks.registering {
     outputs.file(versionFile)
     val crateVersion = project.properties["smithy.rs.runtime.crate.version"].toString()
     inputs.property("crateVersion", crateVersion)
+    // version format must be in sync with `software.amazon.smithy.rust.codegen.smithy.Version`
+    val version = "$crateVersion-${gitCommitHash()}"
     sourceSets.main.get().output.dir(resourcesDir)
     doLast {
-        versionFile.writeText(crateVersion)
+        versionFile.writeText(version)
     }
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -46,12 +46,10 @@ fun RuntimeCrateLocation.crateLocation(): DependencyLocation = when (this.path) 
 }
 
 fun defaultRuntimeCrateVersion(): String {
-    // generated as part of the build, see codegen/build.gradle.kts
     try {
-        return object {}.javaClass.getResource("runtime-crate-version.txt")?.readText()
-            ?: throw CodegenException("sdk-version.txt does not exist")
+        return Version.crateVersion()
     } catch (ex: Exception) {
-        throw CodegenException("failed to load sdk-version.txt which sets the default client-runtime version", ex)
+        throw CodegenException("failed to get crate version which sets the default client-runtime version", ex)
     }
 }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
@@ -7,22 +7,17 @@ package software.amazon.smithy.rust.codegen.smithy
 
 import software.amazon.smithy.codegen.core.CodegenException
 
-class Version(private val content: String) {
-    fun fullVersion(): String = content
+// generated as part of the build in the "{smithy_rs_version}\n{git_commit_hash}" format,
+// see codegen/build.gradle.kts
+private const val VERSION_FILENAME = "runtime-crate-version.txt"
 
-    fun crateVersion(): String {
-        val parts = content.split("-")
-        if (parts.size < 2) {
-            return ""
-        }
-        return parts.first()
-    }
+class Version(private val content: String) {
+    // Returns full version in the "{smithy_rs_version}-{git_commit_hash}" format
+    fun fullVersion(): String = content.lines().joinToString("-")
+
+    fun crateVersion(): String = content.lines().first()
 
     companion object {
-        // generated as part of the build in the "{smithy_rs_version}-{git_commit_hash}" format,
-        // see codegen/build.gradle.kts
-        private const val VERSION_FILENAME = "runtime-crate-version.txt"
-
         fun fullVersion(): String =
             fromDefaultResource().fullVersion()
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
@@ -11,7 +11,7 @@ class Version {
     companion object {
         // generated as part of the build in the "{smithy_rs_version}-{git_commit_hash}" format,
         // see codegen/build.gradle.kts
-        private const val VERSION_FILENAME = "smithy-version.txt"
+        private const val VERSION_FILENAME = "runtime-crate-version.txt"
 
         fun version(): String {
             return object {}.javaClass.getResource(VERSION_FILENAME)?.readText()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy
+
+import software.amazon.smithy.codegen.core.CodegenException
+
+class Version {
+    companion object {
+        // generated as part of the build, see codegen/build.gradle.kts
+        private const val CRATE_VERSION_FILENAME = "runtime-crate-version.txt"
+
+        fun crateVersion(): String {
+            return object {}.javaClass.getResource(CRATE_VERSION_FILENAME)?.readText()
+                ?: throw CodegenException("$CRATE_VERSION_FILENAME does not exist")
+        }
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
@@ -7,25 +7,29 @@ package software.amazon.smithy.rust.codegen.smithy
 
 import software.amazon.smithy.codegen.core.CodegenException
 
-// generated as part of the build in the "{smithy_rs_version}\n{git_commit_hash}" format,
-// see codegen/build.gradle.kts
+// generated as part of the build, see codegen/build.gradle.kts
 private const val VERSION_FILENAME = "runtime-crate-version.txt"
 
-class Version(private val content: String) {
-    // Returns full version in the "{smithy_rs_version}-{git_commit_hash}" format
-    fun fullVersion(): String = content.lines().joinToString("-")
-
-    fun crateVersion(): String = content.lines().first()
-
+data class Version(val fullVersion: String, val crateVersion: String) {
     companion object {
+        // Version must be in the "{smithy_rs_version}\n{git_commit_hash}" format
+        fun parse(content: String): Version {
+            val lines = content.lines()
+            if (lines.size != 2) {
+                throw IllegalArgumentException("Invalid version format, it should contain `2` lines but contains `${lines.size}` line(s)")
+            }
+            return Version(lines.joinToString("-"), lines.first())
+        }
+
+        // Returns full version in the "{smithy_rs_version}-{git_commit_hash}" format
         fun fullVersion(): String =
-            fromDefaultResource().fullVersion()
+            fromDefaultResource().fullVersion
 
         fun crateVersion(): String =
-            fromDefaultResource().crateVersion()
+            fromDefaultResource().crateVersion
 
         private fun fromDefaultResource(): Version =
-            Version(
+            parse(
                 object {}.javaClass.getResource(VERSION_FILENAME)?.readText()
                     ?: throw CodegenException("$VERSION_FILENAME does not exist"),
             )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
@@ -9,12 +9,16 @@ import software.amazon.smithy.codegen.core.CodegenException
 
 class Version {
     companion object {
-        // generated as part of the build, see codegen/build.gradle.kts
-        private const val CRATE_VERSION_FILENAME = "runtime-crate-version.txt"
+        // generated as part of the build in the "{smithy_rs_version}-{git_commit_hash}" format,
+        // see codegen/build.gradle.kts
+        private const val VERSION_FILENAME = "smithy-version.txt"
 
-        fun crateVersion(): String {
-            return object {}.javaClass.getResource(CRATE_VERSION_FILENAME)?.readText()
-                ?: throw CodegenException("$CRATE_VERSION_FILENAME does not exist")
+        fun version(): String {
+            return object {}.javaClass.getResource(VERSION_FILENAME)?.readText()
+                ?: throw CodegenException("$VERSION_FILENAME does not exist")
         }
+
+        fun crateVersion(): String =
+            version().split("-").first()
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/Version.kt
@@ -7,18 +7,32 @@ package software.amazon.smithy.rust.codegen.smithy
 
 import software.amazon.smithy.codegen.core.CodegenException
 
-class Version {
+class Version(private val content: String) {
+    fun fullVersion(): String = content
+
+    fun crateVersion(): String {
+        val parts = content.split("-")
+        if (parts.size < 2) {
+            return ""
+        }
+        return parts.first()
+    }
+
     companion object {
         // generated as part of the build in the "{smithy_rs_version}-{git_commit_hash}" format,
         // see codegen/build.gradle.kts
         private const val VERSION_FILENAME = "runtime-crate-version.txt"
 
-        fun version(): String {
-            return object {}.javaClass.getResource(VERSION_FILENAME)?.readText()
-                ?: throw CodegenException("$VERSION_FILENAME does not exist")
-        }
+        fun fullVersion(): String =
+            fromDefaultResource().fullVersion()
 
         fun crateVersion(): String =
-            version().split("-").first()
+            fromDefaultResource().crateVersion()
+
+        private fun fromDefaultResource(): Version =
+            Version(
+                object {}.javaClass.getResource(VERSION_FILENAME)?.readText()
+                    ?: throw CodegenException("$VERSION_FILENAME does not exist"),
+            )
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
@@ -81,4 +81,4 @@ class CargoTomlGenerator(
     }
 }
 
-fun smithyCodegenVersion(): String = Version.crateVersion()
+fun smithyCodegenVersion(): String = Version.version()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
@@ -81,4 +81,4 @@ class CargoTomlGenerator(
     }
 }
 
-fun smithyCodegenVersion(): String = Version.version()
+fun smithyCodegenVersion(): String = Version.fullVersion()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.rust.codegen.rustlang.DependencyScope
 import software.amazon.smithy.rust.codegen.rustlang.Feature
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.smithy.CoreRustSettings
+import software.amazon.smithy.rust.codegen.smithy.Version
 import software.amazon.smithy.rust.codegen.util.deepMergeWith
 
 /**
@@ -63,6 +64,11 @@ class CargoTomlGenerator(
                 "edition" to "2021",
                 "license" to settings.license,
                 "repository" to settings.moduleRepository,
+                "metadata" to listOfNotNull(
+                    "smithy" to listOfNotNull(
+                        "codegen-version" to smithyCodegenVersion(),
+                    ).toMap(),
+                ).toMap(),
             ).toMap(),
             "dependencies" to dependencies.filter { it.scope == DependencyScope.Compile }
                 .associate { it.name to it.toMap() },
@@ -74,3 +80,6 @@ class CargoTomlGenerator(
         writer.writeWithNoFormatting(TomlWriter().write(cargoToml))
     }
 }
+
+fun smithyCodegenVersion(): String =
+    try { Version.crateVersion() } catch (ex: Exception) { "unknown" }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
@@ -66,7 +66,7 @@ class CargoTomlGenerator(
                 "repository" to settings.moduleRepository,
                 "metadata" to listOfNotNull(
                     "smithy" to listOfNotNull(
-                        "codegen-version" to smithyCodegenVersion(),
+                        "codegen-version" to Version.fullVersion(),
                     ).toMap(),
                 ).toMap(),
             ).toMap(),
@@ -80,5 +80,3 @@ class CargoTomlGenerator(
         writer.writeWithNoFormatting(TomlWriter().write(cargoToml))
     }
 }
-
-fun smithyCodegenVersion(): String = Version.fullVersion()

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGenerator.kt
@@ -81,5 +81,4 @@ class CargoTomlGenerator(
     }
 }
 
-fun smithyCodegenVersion(): String =
-    try { Version.crateVersion() } catch (ex: Exception) { "unknown" }
+fun smithyCodegenVersion(): String = Version.crateVersion()

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/VersionTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/VersionTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class VersionTest {
+    @ParameterizedTest()
+    @CsvSource(
+        "'0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e','0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e','0.47.0'",
+        "'0.0.0','0.0.0',''",
+        "'','',''",
+    )
+    fun `parses version`(
+        content: String,
+        fullVersion: String,
+        crateVersion: String,
+    ) {
+        Assertions.assertEquals(fullVersion, Version(content).fullVersion())
+        Assertions.assertEquals(crateVersion, Version(content).crateVersion())
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/VersionTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/VersionTest.kt
@@ -5,23 +5,61 @@
 
 package software.amazon.smithy.rust.codegen.smithy
 
-import org.junit.jupiter.api.Assertions
+import io.kotest.matchers.shouldBe
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 
 class VersionTest {
     @ParameterizedTest()
-    @CsvSource(
-        "'0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e','0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e','0.47.0'",
-        "'0.0.0','0.0.0',''",
-        "'','',''",
-    )
+    @MethodSource("versionProvider")
     fun `parses version`(
         content: String,
         fullVersion: String,
         crateVersion: String,
     ) {
-        Assertions.assertEquals(fullVersion, Version(content).fullVersion())
-        Assertions.assertEquals(crateVersion, Version(content).crateVersion())
+        Version(content).fullVersion() shouldBe fullVersion
+        Version(content).crateVersion() shouldBe crateVersion
+    }
+
+    companion object {
+        @JvmStatic
+        fun versionProvider() = listOf(
+            Arguments.of(
+                "0.47.0\n0198d26096eb1af510ce24766c921ffc5e4c191e",
+                "0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e",
+                "0.47.0",
+            ),
+            Arguments.of(
+                "release-2022-08-04\ndb48039065bec890ef387385773b37154b555b14",
+                "release-2022-08-04-db48039065bec890ef387385773b37154b555b14",
+                "release-2022-08-04",
+            ),
+            Arguments.of(
+                "0.30.0-alpha\na1dbbe2947de3c8bbbef9446eb442e298f83f200",
+                "0.30.0-alpha-a1dbbe2947de3c8bbbef9446eb442e298f83f200",
+                "0.30.0-alpha",
+            ),
+            Arguments.of(
+                "0.6-rc1.cargo\nc281800a185b34600b05f8b501a0322074184123",
+                "0.6-rc1.cargo-c281800a185b34600b05f8b501a0322074184123",
+                "0.6-rc1.cargo",
+            ),
+            Arguments.of(
+                "0.27.0-alpha.1\n643f2ee",
+                "0.27.0-alpha.1-643f2ee",
+                "0.27.0-alpha.1",
+            ),
+            Arguments.of(
+                "0.0.0",
+                "0.0.0",
+                "0.0.0",
+            ),
+            Arguments.of(
+                "",
+                "",
+                "",
+            ),
+        )
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/VersionTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/VersionTest.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.smithy
 
+import io.kotest.assertions.throwables.shouldThrowAny
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -18,8 +19,17 @@ class VersionTest {
         fullVersion: String,
         crateVersion: String,
     ) {
-        Version(content).fullVersion() shouldBe fullVersion
-        Version(content).crateVersion() shouldBe crateVersion
+        val version = Version.parse(content)
+        version.fullVersion shouldBe fullVersion
+        version.crateVersion shouldBe crateVersion
+    }
+
+    @ParameterizedTest()
+    @MethodSource("invalidVersionProvider")
+    fun `fails to parse version`(
+        content: String,
+    ) {
+        shouldThrowAny { Version.parse(content) }
     }
 
     companion object {
@@ -50,16 +60,9 @@ class VersionTest {
                 "0.27.0-alpha.1-643f2ee",
                 "0.27.0-alpha.1",
             ),
-            Arguments.of(
-                "0.0.0",
-                "0.0.0",
-                "0.0.0",
-            ),
-            Arguments.of(
-                "",
-                "",
-                "",
-            ),
         )
+
+        @JvmStatic
+        fun invalidVersionProvider() = listOf("0.0.0", "")
     }
 }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGeneratorTest.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.smithy.generators
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.CratesIo
+import software.amazon.smithy.rust.codegen.smithy.Version
 import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.testutil.unitTest
@@ -35,7 +36,7 @@ class CargoTomlGeneratorTest {
                     .expect("missing `smithy.codegen-version` field")
                     .as_str()
                     .expect("`smithy.codegen-version` is not str");
-                assert_eq!(codegen_version, "${smithyCodegenVersion()}");
+                assert_eq!(codegen_version, "${Version.fullVersion()}");
                 """,
             )
         }

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/CargoTomlGeneratorTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.rustlang.CratesIo
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+
+class CargoTomlGeneratorTest {
+    private val CargoMetadata: CargoDependency = CargoDependency("cargo_metadata", CratesIo("0.15.0"))
+
+    @Test
+    fun `adds codegen version to package metadata`() {
+        val project = TestWorkspace.testProject()
+        project.lib { writer ->
+            writer.addDependency(CargoMetadata)
+            writer.unitTest(
+                "smithy_codegen_version_in_package_metadata",
+                """
+                let metadata = cargo_metadata::MetadataCommand::new()
+                    .exec()
+                    .expect("could not run `cargo metadata`");
+
+                let pgk_metadata = &metadata.root_package().expect("missing root package").metadata;
+
+                let codegen_version = pgk_metadata
+                    .get("smithy")
+                    .and_then(|s| s.get("codegen-version"))
+                    .expect("missing `smithy.codegen-version` field")
+                    .as_str()
+                    .expect("`smithy.codegen-version` is not str");
+                assert_eq!(codegen_version, "${smithyCodegenVersion()}");
+                """,
+            )
+        }
+        project.compileAndTest()
+    }
+}


### PR DESCRIPTION
## Motivation and Context
> Looking at the code that was generated by the "SmithyRs Code Generator" one cannot tell the version of the generator that was used.
> Knowing the versions can help in post-deployment to track version specific bugs, and to potentially inform customers to regenerate in case of some vulnerability.

Closes https://github.com/awslabs/smithy-rs/issues/1612

## Description

This PR adds smithy-rs's version to generated `Cargo.toml`s. This information later can be fetched via `cargo metadata` (or [cargo_metadata](https://crates.io/crates/cargo_metadata) crate).

## Testing
It can be tested by generating any package, for example:
```bash
$ cd rust-runtime/aws-smithy-http-server/examples
$ make # generates both client and server for Pokemon service

$ rg -B1 -u codegen-version # version can be found in generated `Cargo.toml`s
pokemon-service-client/Cargo.toml
9-[package.metadata.smithy]
10:codegen-version = "0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e"

pokemon-service-server-sdk/Cargo.toml
9-[package.metadata.smithy]
10:codegen-version = "0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e"

# it can also be fetched via `cargo metadata`
$ cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "pokemon-service-server-sdk") | .metadata.smithy."codegen-version"'
0.47.0-0198d26096eb1af510ce24766c921ffc5e4c191e
```

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
