### PR TITLE
Fix double semicolons in logging generated code

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGenerator.kt
@@ -30,7 +30,6 @@ import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.rustlang.withBlock
-import software.amazon.smithy.rust.codegen.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
 import software.amazon.smithy.rust.codegen.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.util.dq
@@ -355,62 +354,62 @@ class ServerHttpSensitivityGenerator(
     }
 
     fun renderRequestFmt(writer: RustWriter) {
-        writer.withBlockTemplate("#{SmithyHttpServer}::logging::sensitivity::RequestFmt::new()", ";", *codegenScope) {
-            // Sensitivity only applies when http trait is applied to the operation
-            val httpTrait = operation.getTrait<HttpTrait>() ?: return@withBlockTemplate
-            val inputShape = input() ?: return@withBlockTemplate
+        writer.rustTemplate("#{SmithyHttpServer}::logging::sensitivity::RequestFmt::new()", *codegenScope)
 
-            // httpHeader/httpPrefixHeaders bindings
-            val headerSensitivity = findHeaderSensitivity(inputShape)
-            if (headerSensitivity.hasRedactions()) {
-                withBlock(".header(", ")") {
-                    renderHeaderClosure(writer, headerSensitivity)
-                }
+        // Sensitivity only applies when http trait is applied to the operation
+        val httpTrait = operation.getTrait<HttpTrait>() ?: return
+        val inputShape = input() ?: return
+
+        // httpHeader/httpPrefixHeaders bindings
+        val headerSensitivity = findHeaderSensitivity(inputShape)
+        if (headerSensitivity.hasRedactions()) {
+            writer.withBlock(".header(", ")") {
+                renderHeaderClosure(writer, headerSensitivity)
             }
+        }
 
-            // httpLabel bindings
-            when (val label = findLabel(httpTrait.uri, inputShape)) {
-                is LabelSensitivity.Normal -> {
-                    if (label.indexes.isNotEmpty()) {
-                        withBlock(".label(", ")") {
-                            renderLabelClosure(writer, label.indexes)
-                        }
+        // httpLabel bindings
+        when (val label = findLabel(httpTrait.uri, inputShape)) {
+            is LabelSensitivity.Normal -> {
+                if (label.indexes.isNotEmpty()) {
+                    writer.withBlock(".label(", ")") {
+                        renderLabelClosure(writer, label.indexes)
                     }
                 }
-                is LabelSensitivity.Greedy -> {
-                    rust(".greedy_label(${label.suffixPosition})")
-                }
             }
+            is LabelSensitivity.Greedy -> {
+                writer.rust(".greedy_label(${label.suffixPosition})")
+            }
+        }
 
-            // httpQuery/httpQueryParams bindings
-            val querySensitivity = findQuerySensitivity(inputShape)
-            if (querySensitivity.hasRedactions()) {
-                withBlock(".query(", ")") {
-                    renderQueryClosure(writer, querySensitivity)
-                }
+        // httpQuery/httpQueryParams bindings
+        val querySensitivity = findQuerySensitivity(inputShape)
+        if (querySensitivity.hasRedactions()) {
+            writer.withBlock(".query(", ")") {
+                renderQueryClosure(writer, querySensitivity)
             }
         }
     }
 
     fun renderResponseFmt(writer: RustWriter) {
-        writer.withBlockTemplate("#{SmithyHttpServer}::logging::sensitivity::ResponseFmt::new()", ";", *codegenScope) {
-            // Sensitivity only applies when HTTP trait is applied to the operation
-            operation.getTrait<HttpTrait>() ?: return@withBlockTemplate
-            val outputShape = output() ?: return@withBlockTemplate
+        writer.rustTemplate("#{SmithyHttpServer}::logging::sensitivity::ResponseFmt::new()", *codegenScope)
 
-            // httpHeader/httpPrefixHeaders bindings
-            val headerSensitivity = findHeaderSensitivity(outputShape)
-            if (headerSensitivity.hasRedactions()) {
-                withBlock(".header(", ")") {
-                    renderHeaderClosure(writer, headerSensitivity)
-                }
-            }
+        // Sensitivity only applies when HTTP trait is applied to the operation
+        operation.getTrait<HttpTrait>() ?: return
+        val outputShape = output() ?: return
 
-            // Status code bindings
-            val hasResponseStatusCode = findSensitiveBoundTrait<HttpResponseCodeTrait>(outputShape).isNotEmpty()
-            if (hasResponseStatusCode) {
-                rust(".status_code()")
+        // httpHeader/httpPrefixHeaders bindings
+        val headerSensitivity = findHeaderSensitivity(outputShape)
+        if (headerSensitivity.hasRedactions()) {
+            writer.withBlock(".header(", ")") {
+                renderHeaderClosure(writer, headerSensitivity)
             }
+        }
+
+        // Status code bindings
+        val hasResponseStatusCode = findSensitiveBoundTrait<HttpResponseCodeTrait>(outputShape).isNotEmpty()
+        if (hasResponseStatusCode) {
+            writer.rust(".status_code()")
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context

Double semicolons are generated in `operation_registry.rs`

```rust
        let request_fmt =
            aws_smithy_http_server::logging::sensitivity::RequestFmt::new()
            ;
        ;
        let response_fmt =
            aws_smithy_http_server::logging::sensitivity::ResponseFmt::new()
            ;
        ;
```
which causes `cargo clippy` lints to trigger.

## Description

Avoid generating two sequential semicolons by making `renderResponseFmt` and `renderRequestFmt` correctly write an expression without a trailing `;`.

## Testing

Generate a service and note that 

```rust
                let request_fmt = aws_smithy_http_server::logging::sensitivity::RequestFmt::new();
                let response_fmt = aws_smithy_http_server::logging::sensitivity::ResponseFmt::new();
```
is generated instead and in the case where there is HTTP bound sensitive data the code continues to compile.

The `rust-runtime/aws-smithy-http-server/examples` with `make` satisfies these testing criteria.