### PR TITLE
[WIP] Support union generator for Python

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerEnumGenerator
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerServiceGenerator
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerStructureGenerator
+import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerUnionGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenVisitor
 import software.amazon.smithy.rust.codegen.server.smithy.protocols.ServerProtocolLoader
 import software.amazon.smithy.rust.codegen.smithy.DefaultPublicModules
@@ -122,7 +123,10 @@ class PythonServerCodegenVisitor(
      * Note: this does not generate serializers
      */
     override fun unionShape(shape: UnionShape) {
-        throw CodegenException("Union shapes are not supported in Python yet")
+        logger.info("[rust-server-codegen] Generating an union $shape")
+        rustCrate.useShapeWriter(shape) { writer ->
+            PythonServerUnionGenerator(model, symbolProvider, writer, shape).render()
+        }
     }
 
     /**

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGenerator.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.python.smithy.generators
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.rust.codegen.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asType
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.server.python.smithy.PythonServerCargoDependency
+import software.amazon.smithy.rust.codegen.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.smithy.expectRustMetadata
+import software.amazon.smithy.rust.codegen.smithy.generators.UnionGenerator
+import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.orNull
+import software.amazon.smithy.rust.codegen.util.toSnakeCase
+
+/**
+ * To share unions defined in Rust with Python, `pyo3` provides the `PyClass` trait.
+ * This class generates unions definitions with one wrapper type, implements the
+ * `PyClass` trait and adds some utility functions like `__str__()` and * `__repr__()`.
+ */
+class PythonServerUnionGenerator(
+    model: Model,
+    symbolProvider: RustSymbolProvider,
+    private val writer: RustWriter,
+    private val shape: UnionShape,
+    private val renderUnknownVariant: Boolean = true,
+) : UnionGenerator(model, symbolProvider, writer, shape, renderUnknownVariant) {
+
+    private val pyo3Symbol = PythonServerCargoDependency.PyO3.asType()
+    private val unionSymbol = symbolProvider.toSymbol(shape)
+
+    private val wrapperSuffix = "WrapperPrivate__"
+
+    private val codegenScope =
+        arrayOf(
+            "pyo3" to PythonServerCargoDependency.PyO3.asType(),
+            "union" to symbolProvider.toSymbol(shape),
+        )
+
+    override fun render() {
+        super.render()
+        renderPyClass()
+        renderWrapper()
+        renderWrapperImpl()
+    }
+
+    private fun renderPyClass() {
+        Attribute.Custom("pyo3::pyclass(name = ${unionSymbol.name.dq()})", symbols = listOf(pyo3Symbol)).render(writer)
+    }
+
+    private fun renderWrapper() {
+        val containerMeta = unionSymbol.expectRustMetadata()
+        containerMeta.render(writer)
+        writer.rust("struct ${unionSymbol.name}$wrapperSuffix(${unionSymbol.name});")
+    }
+
+    private fun renderWrapperImpl() {
+        Attribute.Custom("pyo3::pymethods", symbols = listOf(pyo3Symbol)).render(writer)
+        writer.rustBlock("impl ${unionSymbol.name}$wrapperSuffix") {
+            rust("/// Constructs an instance of union ${unionSymbol.name}")
+            Attribute.Custom("new").render(writer)
+            rustBlockTemplate("fn constructor(ty: &#{pyo3}::PyAny) -> #{pyo3}::PyResult<Self>", *codegenScope) {
+                rustTemplate("#{pyo3}::Python::with_gil(|py|", *codegenScope)
+                withBlock("{ ", "})") {
+                    sortedMembers.forEach { member ->
+                        val variantName = symbolProvider.toMemberName(member)
+                        val memberSymbol = symbolProvider.toSymbol(member)
+                        var suffix = ""
+                        model.getShape(member.target).orNull().let {
+                            if (it != null && it.isUnionShape()) {
+                                suffix = wrapperSuffix
+                            }
+                        }
+                        rustBlock("if let Ok(val) = ty.extract::<#T$suffix>()", memberSymbol) {
+                            rustTemplate("return Ok(Self(#{union}::$variantName(val)))", *codegenScope)
+                        }
+                    }
+                    val message = "not a valid member value to construct ${unionSymbol.name}"
+                    rustTemplate("Err(#{pyo3}::exceptions::PyTypeError::new_err(${message.dq()}))", *codegenScope)
+                }
+            }
+
+            sortedMembers.forEach { member ->
+                val memberSymbol = symbolProvider.toSymbol(member)
+                val funcNamePart = member.memberName.toSnakeCase()
+                val variantName = symbolProvider.toMemberName(member)
+
+                rustTemplate(
+                    "/// Tries to convert the enum instance into [`$variantName`](pyo3::$variantName), extracting the inner member.",
+                    *codegenScope,
+                    "member" to memberSymbol,
+                )
+                rust("/// Returns `Err(&Self)` if it can't be converted.")
+                rustBlockTemplate("pub fn as_$funcNamePart(&self) -> #{pyo3}::PyResult<#{member}>", *codegenScope, "member" to memberSymbol) {
+                    val message = "cannot access $variantName"
+                    rustTemplate(
+                        "self.0.as_$funcNamePart().map(|x| x.to_owned()).or(Err(#{pyo3}::exceptions::PyAttributeError::new_err(${message.dq()})))",
+                        *codegenScope,
+                    )
+                }
+                rustTemplate("/// Returns true if this is a [`$variantName`](#{union}::$variantName).", *codegenScope)
+
+                rustBlock("pub fn is_$funcNamePart(&self) -> bool") {
+                    rust("self.0.as_$funcNamePart().is_ok()")
+                }
+            }
+
+            rust(
+                """
+                fn __repr__(&self) -> String  {
+                    format!("{:?}", self.0)
+                }
+                fn __str__(&self) -> String {
+                    format!("{:?}", self.0)
+                }
+                """,
+            )
+        }
+    }
+}

--- a/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGeneratorTest.kt
+++ b/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerUnionGeneratorTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.python.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.util.lookup
+
+internal class PythonServerUnionGeneratorTest {
+
+    @Test
+    fun `python union generator works`() {
+        val model = """
+            namespace test
+
+            union MyUnion {
+                int: PrimitiveInteger,
+                union: YourUnion
+            }
+
+            union YourUnion {
+                str: String,
+                struct: Struct,
+            }
+
+            structure Struct {
+                str: String,
+            }
+        """.asSmithyModel()
+        val provider = testSymbolProvider(model)
+        val writer = RustWriter.forModule("model")
+        PythonServerStructureGenerator(model, provider, writer, model.lookup("test#Struct")).render()
+        PythonServerUnionGenerator(model, provider, writer, model.lookup("test#YourUnion")).render()
+        PythonServerUnionGenerator(model, provider, writer, model.lookup("test#MyUnion")).render()
+
+        println(writer.toString())
+
+        writer.compileAndTest()
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/generators/UnionGenerator.kt
@@ -38,16 +38,16 @@ fun CodegenTarget.renderUnknownVariant() = when (this) {
  * Finally, if `[renderUnknownVariant]` is true (the default), it will render an `Unknown` variant. This is used by
  * clients to allow response parsing to succeed, even if the server has added a new variant since the client was generated.
  */
-class UnionGenerator(
+open class UnionGenerator(
     val model: Model,
-    private val symbolProvider: SymbolProvider,
+    protected val symbolProvider: SymbolProvider,
     private val writer: RustWriter,
     private val shape: UnionShape,
     private val renderUnknownVariant: Boolean = true,
 ) {
-    private val sortedMembers: List<MemberShape> = shape.allMembers.values.sortedBy { symbolProvider.toMemberName(it) }
+    protected val sortedMembers: List<MemberShape> = shape.allMembers.values.sortedBy { symbolProvider.toMemberName(it) }
 
-    fun render() {
+    open fun render() {
         renderUnion()
     }
 


### PR DESCRIPTION
> ### ❌ Blocked. See https://github.com/awslabs/smithy-rs/pull/1626#issuecomment-1212913774

## Motivation and Context

Support union generator for Python

## TODO

- [ ] constructor
- [ ] more tests
- [ ] (optional) avoid calling `to_owned`

## Description

TODO

## Testing

TODO

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
