### PR TITLE
Make OperationExtension hold a &'static str for the absolute shape ID

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -115,9 +115,8 @@ open class ServerOperationHandlerGenerator(
                         $callImpl
                         let output_wrapper: $outputWrapperName = output_inner.into();
                         let mut response = output_wrapper.into_response();
-                        response.extensions_mut().insert(
-                            #{SmithyHttpServer}::extension::OperationExtension::new("${operation.id.namespace}", "$operationName")
-                        );
+                        let operation_ext = #{SmithyHttpServer}::extension::OperationExtension::new("${operation.id.namespace}##$operationName").expect("malformed absolute shape ID");
+                        response.extensions_mut().insert(operation_ext);
                         response.map(#{SmithyHttpServer}::body::boxed)
                     }
                     """,

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -97,7 +97,7 @@ impl OperationExtension {
         self.name
     }
 
-    /// Returns the absolute operation shape I.
+    /// Returns the absolute operation shape ID.
     pub fn absolute(&self) -> &'static str {
         self.absolute
     }

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -50,6 +50,8 @@
 
 use std::ops::Deref;
 
+use thiserror::Error;
+
 use crate::request::RequestParts;
 
 /// Extension type used to store information about Smithy operations in HTTP responses.
@@ -58,19 +60,31 @@ use crate::request::RequestParts;
 /// request fails to deserialize into the modeled operation input.
 #[derive(Debug, Clone)]
 pub struct OperationExtension {
-    /// Smithy model namespace.
+    absolute: &'static str,
+
     namespace: &'static str,
-    /// Smithy operation name.
-    operation_name: &'static str,
+    name: &'static str,
+}
+
+/// An error occurred when parsing an absolute operation shape ID.
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
+pub enum ParseError {
+    #[error("# was not found - missing namespace")]
+    MissingNamespace,
 }
 
 impl OperationExtension {
-    /// Creates a new `OperationExtension`.
-    pub fn new(namespace: &'static str, operation_name: &'static str) -> Self {
-        Self {
+    /// Creates a new [`OperationExtension`] from the absolute shape ID of the operation.
+    pub fn new(absolute_operation_id: &'static str) -> Result<Self, ParseError> {
+        let (namespace, name) = absolute_operation_id
+            .split_once('#')
+            .ok_or(ParseError::MissingNamespace)?;
+        Ok(Self {
+            absolute: absolute_operation_id,
             namespace,
-            operation_name,
-        }
+            name,
+        })
     }
 
     /// Returns the Smithy model namespace.
@@ -79,13 +93,13 @@ impl OperationExtension {
     }
 
     /// Returns the Smithy operation name.
-    pub fn operation_name(&self) -> &'static str {
-        self.operation_name
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 
-    /// Returns the current operation formatted as `<namespace>#<operation_name>`.
-    pub fn operation(&self) -> String {
-        format!("{}#{}", self.namespace, self.operation_name)
+    /// Returns the absolute operation shape I.
+    pub fn absolute(&self) -> &'static str {
+        self.absolute
     }
 }
 


### PR DESCRIPTION
## Motivation and Context

The absolute operation ID is always known statically, if the customer provides it we can parse it at construction and provide an API which can provide it later as `&'static str` rather than concatenating it at runtime.

## Description

- Change the `OperationExtension::new` to take the absolute operation ID.
- Change the `OperationExtension::operation` to `OperationExtension::absolute` and make it return `&'static str`.
- Rename `OperationExtension::operation_name` to `OperationExtension::name`.
