### PR TITLE
Make the PR Bot manually invokable

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -46,6 +46,10 @@ jobs:
     # Only run this job on pull requests (not directly on main)
     if: ${{ github.head_ref }}
     uses: ./.github/workflows/pull-request-bot.yml
+    with:
+      issue_number: ${{ github.event.number }}
+      base_revision: ${{ github.event.pull_request.base.sha }}
+      head_revision: ${{ github.event.pull_request.head.sha }}
     secrets:
       SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME }}
       SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}

--- a/.github/workflows/manual-pull-request-bot.yml
+++ b/.github/workflows/manual-pull-request-bot.yml
@@ -1,0 +1,69 @@
+# This workflow allows maintainers to manually run the PR bot on a pull request to work around permissions
+# issues that prevent it from working for non-maintainers.
+name: Invoke PR Bot as Maintainer
+on:
+  workflow_dispatch:
+    inputs:
+      pull_number:
+        description: The PR number to invoke the PR bot on.
+        required: true
+        type: string
+
+jobs:
+  get-pr-info:
+    name: Get PR info
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get PR info
+      id: get-pr-info
+      uses: actions/github-script@v5
+      with:
+        script: |
+          const response = await github.rest.pulls.get({
+            pull_number: ${{ inputs.pull_number }},
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          });
+          const data = {
+            base_revision: response.data.base.sha,
+            head_revision: response.data.head.sha,
+          };
+          console.log("data:", data);
+          return data;
+    outputs:
+      pull_data: ${{ steps.get-pr-info.outputs.result }}
+
+  # This job detects if the PR made changes to build tools. If it did, then it builds a new
+  # build Docker image. Otherwise, it downloads a build image from Public ECR. In both cases,
+  # it uploads the image as a build artifact for other jobs to download and use.
+  acquire-base-image:
+    name: Acquire Base Image
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        path: smithy-rs
+        fetch-depth: 0
+    - name: Acquire base image
+      id: acquire
+      run: ./smithy-rs/tools/ci-build/acquire-build-image
+    - name: Upload base image
+      uses: actions/upload-artifact@v3
+      with:
+        name: smithy-rs-base-image
+        path: smithy-rs-base-image
+        retention-days: 1
+
+  invoke-pr-bot:
+    name: PR Bot
+    needs:
+    - acquire-base-image
+    - get-pr-info
+    uses: ./.github/workflows/pull-request-bot.yml
+    with:
+      issue_number: ${{ inputs.pull_number }}
+      base_revision: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).base_revision }}
+      head_revision: ${{ fromJSON(needs.get-pr-info.outputs.pull_data).head_revision }}
+    secrets:
+      SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME }}
+      SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_ROLE_ARN }}

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -2,6 +2,19 @@
 name: PR Bot
 on:
   workflow_call:
+    inputs:
+      issue_number:
+        description: The issue number to post the diff comment to.
+        required: true
+        type: number
+      base_revision:
+        description: Base git revision.
+        required: true
+        type: string
+      head_revision:
+        description: Head git revision.
+        required: true
+        type: string
     secrets:
       SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME:
         required: true
@@ -10,7 +23,7 @@ on:
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:
-  group: pull-request-bot-yml-${{ github.ref }}
+  group: pull-request-bot-yml-${{ inputs.issue_number }}
   cancel-in-progress: true
 
 env:
@@ -40,7 +53,7 @@ jobs:
       uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: generate-codegen-diff
-        action-arguments: ${{ github.event.pull_request.base.sha }}
+        action-arguments: ${{ inputs.base_revision }}
     - uses: aws-actions/configure-aws-credentials@v1
       name: Acquire credentials for uploading to S3
       with:
@@ -49,9 +62,9 @@ jobs:
         aws-region: us-west-2
     - name: Upload diff to S3
       run: |
-        if [[ -d artifacts/codegen-diff/${{ github.event.pull_request.base.sha }} ]]; then
-            aws s3 cp artifacts/codegen-diff/${{ github.event.pull_request.base.sha }} \
-                "s3://${S3_BUCKET_NAME}/codegen-diff/${{ github.event.pull_request.base.sha }}" --recursive
+        if [[ -d artifacts/codegen-diff/${{ inputs.base_revision }} ]]; then
+            aws s3 cp artifacts/codegen-diff/${{ inputs.base_revision }} \
+                "s3://${S3_BUCKET_NAME}/codegen-diff/${{ inputs.base_revision }}" --recursive
         fi
 
   generate-doc-preview:
@@ -107,9 +120,9 @@ jobs:
 
         cargo doc --no-deps --all-features
         popd
-        ./tools/generate-doc-preview-index.sh ${{ github.event.pull_request.base.sha }}
+        ./tools/generate-doc-preview-index.sh ${{ inputs.base_revision }}
 
-        echo '::set-output name=bot-message::A [new doc preview](https://d2luzm2xt3nokh.cloudfront.net/docs/'${{ github.event.pull_request.head.sha }}'/index.html) is ready to view.'
+        echo '::set-output name=bot-message::A [new doc preview](https://d2luzm2xt3nokh.cloudfront.net/docs/'${{ inputs.head_revision }}'/index.html) is ready to view.'
     - uses: aws-actions/configure-aws-credentials@v1
       name: Acquire credentials for uploading to S3
       with:
@@ -118,7 +131,7 @@ jobs:
         aws-region: us-west-2
     - name: Upload doc preview to S3
       run: |
-        aws s3 cp target/doc "s3://${S3_BUCKET_NAME}/docs/${{ github.event.pull_request.head.sha }}" --recursive
+        aws s3 cp target/doc "s3://${S3_BUCKET_NAME}/docs/${{ inputs.head_revision }}" --recursive
 
   post-bot-comment:
     needs:
@@ -143,11 +156,10 @@ jobs:
         echo ::set-output name=codegen-diff::"$(cat ./bot-message-codegen-diff)"
     - name: Post bot comment
       uses: actions/github-script@v5
-      if: ${{ github.head_ref != null }}
       with:
         script: |
           await github.rest.issues.createComment({
-            issue_number: context.issue.number,
+            issue_number: ${{ inputs.issue_number }},
             owner: context.repo.owner,
             repo: context.repo.repo,
             body: '${{ steps.bot-messages.outputs.codegen-diff }}\n\n' +

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -6,7 +6,7 @@ on:
       issue_number:
         description: The issue number to post the diff comment to.
         required: true
-        type: number
+        type: string
       base_revision:
         description: Base git revision.
         required: true


### PR DESCRIPTION
## Motivation and Context
When people outside the rust-sdk-owners or smithy-rs-server groups try to contribute to smithy-rs, the PR bot fails due to lack of permissions. This PR makes the PR bot manually invokable by maintainers so that on PRs where a codegen diff would be helpful, it should be possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
