### PR TITLE
Override codegen version commit hash in PR diffs

### DIFF
--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -39,6 +39,8 @@ jobs:
     env:
       AWS_REGION: us-west-2
       S3_BUCKET_NAME: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME }}
+      # Override version commit hash to prevent unnecessary diffs
+      SMITHY_RS_VERSION_COMMIT_HASH_OVERRIDE: ci
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -39,8 +39,6 @@ jobs:
     env:
       AWS_REGION: us-west-2
       S3_BUCKET_NAME: ${{ secrets.SMITHY_RS_PULL_REQUEST_CDN_S3_BUCKET_NAME }}
-      # Override version commit hash to prevent unnecessary diffs
-      SMITHY_RS_VERSION_COMMIT_HASH_OVERRIDE: ci
     permissions:
       id-token: write
       contents: read

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -40,8 +40,16 @@ tasks.compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
-fun gitCommitHash() =
-    try {
+fun gitCommitHash(): String {
+    // Use commit hash from env if provided, it is helpful to override commit hash in some contexts.
+    // For example: while generating diff for generated SDKs we don't want to see version diff,
+    // so we are overriding commit hash to something fixed
+    val commitHashFromEnv = System.getenv("SMITHY_RS_VERSION_COMMIT_HASH_OVERRIDE")
+    if (commitHashFromEnv != null) {
+        return commitHashFromEnv
+    }
+
+    return try {
         val output = ByteArrayOutputStream()
         exec {
             commandLine = listOf("git", "rev-parse", "HEAD")
@@ -51,6 +59,7 @@ fun gitCommitHash() =
     } catch (ex: Exception) {
         "unknown"
     }
+}
 
 val generateSmithyRuntimeCrateVersion by tasks.registering {
     // generate the version of the runtime to use as a resource.

--- a/tools/ci-build/scripts/generate-codegen-diff
+++ b/tools/ci-build/scripts/generate-codegen-diff
@@ -12,6 +12,8 @@ if [[ $# -ne 1 ]]; then
     exit 1
 fi
 
+# Override version commit hash to prevent unnecessary diffs
+export SMITHY_RS_VERSION_COMMIT_HASH_OVERRIDE=ci
 base_revision="$1"
 ./tools/codegen-diff-revisions.py . "${base_revision}"
 


### PR DESCRIPTION
## Motivation and Context
After https://github.com/awslabs/smithy-rs/pull/1621 we started inserting codegen versions to generated packages. Those versions also include git commit hash and that causes PR Bot to generate diffs for every PR even when there are no changes in generated packages ([example](https://d2luzm2xt3nokh.cloudfront.net/codegen-diff/fd98756160ebbbc2f964c804a80587d0a81f99c3/84a8d19621dfebd98e4aaa5fb9840146c20f6f1b/diff-aws-sdk.html)). In order to prevent that we want to have a fixed commit hash while generating diffs for generated packages.

## Description
This PR allows overriding commit hash used in codegen versions via `SMITHY_RS_VERSION_COMMIT_HASH_OVERRIDE` env variable. We provide that value in PR Bot to fix commit hash used in PR Bot diffs.

## Testing
You can provide that env variable while generating packages to see whether codegen version is changed.
```bash
$ cd rust-runtime/aws-smithy-http-server/examples
$ SMITHY_RS_VERSION_COMMIT_HASH_OVERRIDE=test make
$ rg -B1 -u codegen-version
pokemon-service-client/Cargo.toml
9-[package.metadata.smithy]
10:codegen-version = "0.47.0-test"

pokemon-service-server-sdk/Cargo.toml
9-[package.metadata.smithy]
10:codegen-version = "0.47.0-test"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
