### PR TITLE
Fix changelog template

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -8,7 +8,7 @@
 # [[smithy-rs]]
 # message = "Fix typos in module documentation for generated crates"
 # references = ["smithy-rs#920"]
-# meta = { "breaking" = false, "tada" = false, "bug" = false, "sdk" = "client | server | all"}
+# meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
 [[smithy-rs]]

--- a/tools/changelogger/src/render.rs
+++ b/tools/changelogger/src/render.rs
@@ -28,7 +28,7 @@ pub const EXAMPLE_ENTRY: &str = r#"
 # [[smithy-rs]]
 # message = "Fix typos in module documentation for generated crates"
 # references = ["smithy-rs#920"]
-# meta = { "breaking" = false, "tada" = false, "bug" = false, "sdk" = "client | server | all"}
+# meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 "#;
 

--- a/tools/ci-build/scripts/generate-smithy-rs-release
+++ b/tools/ci-build/scripts/generate-smithy-rs-release
@@ -42,6 +42,6 @@ mv "${SMITHY_RS_DIR}/rust-runtime/build/smithy-rs/rust-runtime" \
 # the `smithy-rs-release` artifact for push to GitHub
 pushd "${ARTIFACTS_DIR}"
 git clone "${SMITHY_RS_DIR}"
-# Copy over the original remotes so that it's possibel to push to `origin`
+# Copy over the original remotes so that it's possible to push to `origin`
 cp "${SMITHY_RS_DIR}/.git/config" smithy-rs/.git/config
 popd


### PR DESCRIPTION
## Motivation and Context
The `changelogger` uses `target` instead of `sdk` in the `meta` struct, but the template example says `sdk`. This PR fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
