### PR TITLE
Fix git root check for submodules

### DIFF
--- a/tools/cargo-check-external-types/Cargo.lock
+++ b/tools/cargo-check-external-types/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-check-external-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/tools/smithy-rs-tool-common/Cargo.toml
+++ b/tools/smithy-rs-tool-common/Cargo.toml
@@ -27,3 +27,6 @@ serde_json = "1"
 tokio = { version = "1", features = ["rt", "macros"], optional = true }
 toml = { version = "0.5.8", features = ["preserve_order"] }
 tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3.3.0"


### PR DESCRIPTION
## Motivation and Context
It looks like the original fix to support git submodules in the build tooling was lost at some point for #1162. This PR adds it back and adds some tests for it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
