### PR TITLE
Don't compile crates a second time during `cargo publish`

### DIFF
--- a/tools/publisher/src/cargo/publish.rs
+++ b/tools/publisher/src/cargo/publish.rs
@@ -33,10 +33,10 @@ impl ShellOperation for Publish {
         let mut command = Command::new(self.program);
         command
             .current_dir(&self.package_path)
-            .env("CARGO_INCREMENTAL", "0") // Disable incremental compilation to reduce disk space used
             .arg("publish")
             .arg("--jobs")
-            .arg("1");
+            .arg("1")
+            .arg("--no-verify"); // The crates have already been built in previous CI steps
         let output = command.output()?;
         if !output.status.success() {
             let (stdout, stderr) = output_text(&output);


### PR DESCRIPTION
## Motivation and Context
By the time the publisher tool runs, the crates have been thoroughly tested by our CI, so the additional verification in `cargo publish` is redundant and slows the whole release process down.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
