### PR TITLE
Use . delimiter in OperationExtension

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -115,7 +115,7 @@ open class ServerOperationHandlerGenerator(
                         $callImpl
                         let output_wrapper: $outputWrapperName = output_inner.into();
                         let mut response = output_wrapper.into_response();
-                        let operation_ext = #{SmithyHttpServer}::extension::OperationExtension::new("${operation.id.namespace}##$operationName").expect("malformed absolute shape ID");
+                        let operation_ext = #{SmithyHttpServer}::extension::OperationExtension::new("${operation.id.namespace}.$operationName").expect("malformed absolute shape ID");
                         response.extensions_mut().insert(operation_ext);
                         response.map(#{SmithyHttpServer}::body::boxed)
                     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -533,7 +533,7 @@ class ServerProtocolTestGenerator(
         )
         rustWriter.writeWithNoFormatting(
             """
-            assert_eq!(operation_extension.operation(), format!("{}#{}", "${operationShape.id.namespace}", "${operationSymbol.name}"));
+            assert_eq!(operation_extension.absolute(), format!("{}.{}", "${operationShape.id.namespace}", "${operationSymbol.name}"));
             """.trimIndent(),
         )
     }

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -69,7 +69,7 @@ pub struct OperationExtension {
 }
 
 /// An error occurred when parsing an absolute operation shape ID.
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ParseError {
     #[error(". was not found - missing namespace")]
@@ -208,6 +208,9 @@ mod tests {
     #[test]
     fn ext_reject() {
         let value = "CompleteSnapshot";
-        assert!(OperationExtension::new(value).is_err())
+        assert_eq!(
+            OperationExtension::new(value).unwrap_err(),
+            ParseError::MissingNamespace
+        )
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -58,6 +58,8 @@ use crate::request::RequestParts;
 /// This extension type is set when it has been correctly determined that the request should be
 /// routed to a particular operation. The operation handler might not even get invoked because the
 /// request fails to deserialize into the modeled operation input.
+///
+/// The format given must be the absolute shape ID with `#` replaced with a `.`.
 #[derive(Debug, Clone)]
 pub struct OperationExtension {
     absolute: &'static str,
@@ -70,15 +72,15 @@ pub struct OperationExtension {
 #[derive(Debug, Clone, Error)]
 #[non_exhaustive]
 pub enum ParseError {
-    #[error("# was not found - missing namespace")]
+    #[error(". was not found - missing namespace")]
     MissingNamespace,
 }
 
 impl OperationExtension {
-    /// Creates a new [`OperationExtension`] from the absolute shape ID of the operation.
+    /// Creates a new [`OperationExtension`] from the absolute shape ID of the operation with `#` symbol replaced with a `.`.
     pub fn new(absolute_operation_id: &'static str) -> Result<Self, ParseError> {
         let (namespace, name) = absolute_operation_id
-            .split_once('#')
+            .rsplit_once('.')
             .ok_or(ParseError::MissingNamespace)?;
         Ok(Self {
             absolute: absolute_operation_id,
@@ -187,4 +189,25 @@ where
         .map(|x| x.clone())?;
 
     Ok(Extension(value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ext_accept() {
+        let value = "com.amazonaws.ebs.CompleteSnapshot";
+        let ext = OperationExtension::new(value).unwrap();
+
+        assert_eq!(ext.absolute(), value);
+        assert_eq!(ext.namespace(), "com.amazonaws.ebs");
+        assert_eq!(ext.name(), "CompleteSnapshot");
+    }
+
+    #[test]
+    fn ext_reject() {
+        let value = "CompleteSnapshot";
+        assert!(OperationExtension::new(value).is_err())
+    }
 }


### PR DESCRIPTION
## Motivation and Context

`#` is a special character which is rejected in many protocols.


## Description

- Change `#` in `OperationExtension` to `.`
- Add basic unit tests.
