### PR TITLE
Fix crash for certain re-exports in `cargo-check-external-types`

### DIFF
--- a/tools/cargo-check-external-types/Cargo.lock
+++ b/tools/cargo-check-external-types/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "atty"
@@ -42,16 +42,16 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "camino"
-version = "1.0.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
+checksum = "88ad0e1e3e88dd237a156ab9f571021b8a158caa0ae44b1968a241efb5144c1e"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-check-external-types"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -204,9 +204,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "log"
@@ -228,15 +228,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "output_vt100"
@@ -249,18 +249,18 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "decf7381921fea4dcb2549c5667eda59b3ec297ab7e2b5fc33eac69d2e7da87b"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 dependencies = [
  "supports-color",
 ]
 
 [[package]]
 name = "pest"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -376,18 +376,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",

--- a/tools/cargo-check-external-types/Cargo.toml
+++ b/tools/cargo-check-external-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-check-external-types"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>", "John DiSanti <jdisanti@amazon.com>"]
 description = "Static analysis tool to detect external types exposed in a library's public API."
 edition = "2021"

--- a/tools/cargo-check-external-types/test-workspace/Cargo.toml
+++ b/tools/cargo-check-external-types/test-workspace/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["external-lib", "test-crate"]
+members = ["external-lib", "test-crate", "test-reexports-crate"]

--- a/tools/cargo-check-external-types/test-workspace/test-reexports-crate/Cargo.toml
+++ b/tools/cargo-check-external-types/test-workspace/test-reexports-crate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test-crate"
+name = "test-reexports-crate"
 version = "0.1.0"
 edition = "2021"
 publish = false

--- a/tools/cargo-check-external-types/test-workspace/test-reexports-crate/src/lib.rs
+++ b/tools/cargo-check-external-types/test-workspace/test-reexports-crate/src/lib.rs
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+pub use external_lib::AssociatedGenericTrait;
+pub use external_lib::ReprCType;
+pub use external_lib::SimpleTrait;
+
+pub mod Something {
+    pub use external_lib::SimpleGenericTrait;
+    pub use external_lib::SimpleNewType;
+}
+
+pub use external_lib::SomeOtherStruct;
+pub use external_lib::SomeStruct;

--- a/tools/cargo-check-external-types/tests/integration_test.rs
+++ b/tools/cargo-check-external-types/tests/integration_test.rs
@@ -63,3 +63,15 @@ fn with_output_format_markdown_table() {
     );
     assert_str_eq!(expected_output, actual_output);
 }
+
+// Make sure that the visitor doesn't attempt to visit the inner items of re-exported external types.
+// Rustdoc doesn't include these inner items in its JSON output, which leads to obtuse crashes if they're
+// referenced. It's also just the wrong behavior to look into the type being re-exported, since if it's
+// approved, then it doesn't matter what it referenced. If it's not approved, then the re-export itself
+// is the violation.
+#[test]
+fn test_reexports() {
+    let expected_output = fs::read_to_string("tests/test-reexports-expected-output.md").unwrap();
+    let actual_output = run_with_args("test-workspace/test-reexports-crate", &[]);
+    assert_str_eq!(expected_output, actual_output);
+}

--- a/tools/cargo-check-external-types/tests/test-reexports-expected-output.md
+++ b/tools/cargo-check-external-types/tests/test-reexports-expected-output.md
@@ -1,0 +1,57 @@
+error: Unapproved external type `external_lib::AssociatedGenericTrait` referenced in public API
+ --> test-reexports-crate/src/lib.rs:6:1
+  |
+6 | pub use external_lib::AssociatedGenericTrait;
+  | ^-------------------------------------------^
+  |
+  = in re-export named `test_reexports_crate::AssociatedGenericTrait`
+
+error: Unapproved external type `external_lib::ReprCType` referenced in public API
+ --> test-reexports-crate/src/lib.rs:7:1
+  |
+7 | pub use external_lib::ReprCType;
+  | ^------------------------------^
+  |
+  = in re-export named `test_reexports_crate::ReprCType`
+
+error: Unapproved external type `external_lib::SimpleTrait` referenced in public API
+ --> test-reexports-crate/src/lib.rs:8:1
+  |
+8 | pub use external_lib::SimpleTrait;
+  | ^--------------------------------^
+  |
+  = in re-export named `test_reexports_crate::SimpleTrait`
+
+error: Unapproved external type `external_lib::SimpleGenericTrait` referenced in public API
+  --> test-reexports-crate/src/lib.rs:11:5
+   |
+11 |     pub use external_lib::SimpleGenericTrait;
+   |     ^---------------------------------------^
+   |
+   = in re-export named `test_reexports_crate::Something::SimpleGenericTrait`
+
+error: Unapproved external type `external_lib::SimpleNewType` referenced in public API
+  --> test-reexports-crate/src/lib.rs:12:5
+   |
+12 |     pub use external_lib::SimpleNewType;
+   |     ^----------------------------------^
+   |
+   = in re-export named `test_reexports_crate::Something::SimpleNewType`
+
+error: Unapproved external type `external_lib::SomeOtherStruct` referenced in public API
+  --> test-reexports-crate/src/lib.rs:15:1
+   |
+15 | pub use external_lib::SomeOtherStruct;
+   | ^------------------------------------^
+   |
+   = in re-export named `test_reexports_crate::SomeOtherStruct`
+
+error: Unapproved external type `external_lib::SomeStruct` referenced in public API
+  --> test-reexports-crate/src/lib.rs:16:1
+   |
+16 | pub use external_lib::SomeStruct;
+   | ^-------------------------------^
+   |
+   = in re-export named `test_reexports_crate::SomeStruct`
+
+7 errors emitted


### PR DESCRIPTION
## Motivation and Context
The visitor was examining the inner contents of the entire re-exported type, which, for a type that is re-exported within the same crate, is the correct behavior. Its the wrong behavior when exporting types from other crates, however, since it doesn't matter what is inside that external type, and rustdoc doesn't include information about inner pieces of the external type in the JSON output.

To give a concrete example, let's say we're running `cargo-check-external-types` against `aws-sdk-s3`, and this crate has a `pub use aws_smithy_async::AsyncSleep` statement to re-export the `AsyncSleep` type from `aws-smithy-async`. Before these changes, `cargo-check-external-types` would try to visit each function inside of `AsyncSleep` to see if any of those functions referenced external types. However, it doesn't make any sense to do that since the entire trait is external, and rustdoc's JSON doesn't even bother to include these details. After these changes, it just stops after hitting that external type.

## Testing
- [x] Verified the tool now works against the changes in https://github.com/awslabs/smithy-rs/pull/1603, where it was failing in CI
- [x] Added a test case that reproduced the issue to the `cargo-check-external-types` test suite

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
