### PR TITLE
Check external types in `aws-endpoint`

### DIFF
--- a/aws/rust-runtime/aws-endpoint/external-types.toml
+++ b/aws/rust-runtime/aws-endpoint/external-types.toml
@@ -1,0 +1,5 @@
+allowed_external_types = [
+    "aws_types::*",
+    "aws_smithy_http::property_bag::PropertyBag",
+    "aws_smithy_http::middleware::MapRequest",
+]


### PR DESCRIPTION
## Motivation and Context
This PR adds the `cargo-check-external-types` check to `aws-endpoints`, which previously didn't have it due to the bug fixed in #1654. CI on this PR won't pass until #1654 is merged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
