### PR TITLE
Allow review of codegen to server members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,5 @@
 *                                               @awslabs/rust-sdk-owners
+/codegen/                                       @awslabs/rust-sdk-owners @crisidev @david-perez
 /codegen-server/                                @awslabs/smithy-rs-server
 /codegen-server-test/                           @awslabs/smithy-rs-server
 /rust-runtime/aws-smithy-http-server/           @awslabs/smithy-rs-server


### PR DESCRIPTION
Signed-off-by: Daniele Ahmed <ahmeddan@amazon.de>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
We have agreed to:
* allow members of the server team to approve simple PRs that touch the codegen
* request reviews from the sdk team with the needs-sdk-review label

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
