### PR TITLE
Add "invalid xml body root" check exemption for S3's `GetObjectAttributes`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -214,3 +214,18 @@ fn f1(n: aws_smithy_types::Number) {
 references = ["smithy-rs#1274"]
 meta = { "breaking" = true, "tada" = false, "bug" = true }
 author = "david-perez"
+
+[[aws-sdk-rust]]
+message = "The AWS S3 `GetObjectAttributes` operation will no longer fail with an XML error."
+references = ["aws-sdk-rust#609"]
+meta = { "breaking" = false, "tada" = true, "bug" = true }
+author = "Velfi"
+
+[[smithy-rs]]
+message = """
+It is now possible to exempt specific operations from XML body root checking. To do this, add the `AllowInvalidXmlRoot`
+trait to the output struct of the operation you want to exempt.
+"""
+references = ["aws-sdk-rust#609"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+author = "Velfi"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/route53/TrimResourceId.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/route53/TrimResourceId.kt
@@ -12,7 +12,7 @@ import software.amazon.smithy.model.traits.AnnotationTrait
 /**
  * Indicates that a member should have their resource ID prefix stripped
  */
-class TrimResourceId() : AnnotationTrait(ID, Node.objectNode()) {
+class TrimResourceId : AnnotationTrait(ID, Node.objectNode()) {
     companion object {
         val ID: ShapeId = ShapeId.from("aws.api.internal#trimResourceId")
     }

--- a/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
+++ b/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
@@ -14,10 +14,6 @@ use std::time::{Duration, UNIX_EPOCH};
 
 pub type Client<C> = CoreClient<C, DefaultMiddleware>;
 
-// ---- ignore_invalid_xml_body_root stdout ----
-// thread 'ignore_invalid_xml_body_root' panicked at 'called `Result::unwrap()` on an `Err` value: ServiceError { err: GetObjectAttributesError { kind: Unhandled(Custom("invalid root, expected GetObjectAttributesOutput got StartEl { name: Name { prefix: \"\", local: \"GetObjectAttributesResponse\" }, attributes: [Attr { name: Name { prefix: \"\", local: \"xmlns\" }, value: \"http://s3.amazonaws.com/doc/2006-03-01/\" }], closed: false, depth: 0 }")), meta: Error { code: None, message: None, request_id: None, extras: {} } }, raw: Response { inner: Response { status: 200, version: HTTP/1.1, headers: {"x-amz-id-2": "sOlLnhHVXvis03pbAizg5SuUEgGN9GpTqztFLDKcTjzMcGjLahc+xGmK81RfU+YIo28DjHS967c=", "x-amz-request-id": "KH5W7YV84JEXWAKT", "date": "Tue, 23 Aug 2022 18:16:28 GMT", "last-modified": "Tue, 21 Jun 2022 16:30:01 GMT", "server": "AmazonS3", "content-length": "224"}, body: SdkBody { inner: Once(Some(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<GetObjectAttributesResponse xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Checksum><ChecksumSHA1>e1AsOh9IyGCa4hLN+2Od7jlnP14=</ChecksumSHA1></Checksum></GetObjectAttributesResponse>")), retryable: true } }, properties: SharedPropertyBag(Mutex { data: PropertyBag, poisoned: false, .. }) } }', s3/tests/ignore-invalid-xml-body-root.rs:39:10
-// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
-
 const RESPONSE_BODY_XML: &[u8] = b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<GetObjectAttributesResponse xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Checksum><ChecksumSHA1>e1AsOh9IyGCa4hLN+2Od7jlnP14=</ChecksumSHA1></Checksum></GetObjectAttributesResponse>";
 
 #[tokio::test]

--- a/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
+++ b/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_http::user_agent::AwsUserAgent;
+use aws_sdk_s3::{
+    middleware::DefaultMiddleware, model::ObjectAttributes, operation::GetObjectAttributes,
+    Credentials, Region,
+};
+use aws_smithy_client::{test_connection::TestConnection, Client as CoreClient};
+use aws_smithy_http::body::SdkBody;
+use std::time::{Duration, UNIX_EPOCH};
+
+pub type Client<C> = CoreClient<C, DefaultMiddleware>;
+
+// ---- ignore_invalid_xml_body_root stdout ----
+// thread 'ignore_invalid_xml_body_root' panicked at 'called `Result::unwrap()` on an `Err` value: ServiceError { err: GetObjectAttributesError { kind: Unhandled(Custom("invalid root, expected GetObjectAttributesOutput got StartEl { name: Name { prefix: \"\", local: \"GetObjectAttributesResponse\" }, attributes: [Attr { name: Name { prefix: \"\", local: \"xmlns\" }, value: \"http://s3.amazonaws.com/doc/2006-03-01/\" }], closed: false, depth: 0 }")), meta: Error { code: None, message: None, request_id: None, extras: {} } }, raw: Response { inner: Response { status: 200, version: HTTP/1.1, headers: {"x-amz-id-2": "sOlLnhHVXvis03pbAizg5SuUEgGN9GpTqztFLDKcTjzMcGjLahc+xGmK81RfU+YIo28DjHS967c=", "x-amz-request-id": "KH5W7YV84JEXWAKT", "date": "Tue, 23 Aug 2022 18:16:28 GMT", "last-modified": "Tue, 21 Jun 2022 16:30:01 GMT", "server": "AmazonS3", "content-length": "224"}, body: SdkBody { inner: Once(Some(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<GetObjectAttributesResponse xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Checksum><ChecksumSHA1>e1AsOh9IyGCa4hLN+2Od7jlnP14=</ChecksumSHA1></Checksum></GetObjectAttributesResponse>")), retryable: true } }, properties: SharedPropertyBag(Mutex { data: PropertyBag, poisoned: false, .. }) } }', s3/tests/ignore-invalid-xml-body-root.rs:39:10
+// note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+const RESPONSE_BODY_XML: &[u8] = b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<GetObjectAttributesResponse xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"><Checksum><ChecksumSHA1>e1AsOh9IyGCa4hLN+2Od7jlnP14=</ChecksumSHA1></Checksum></GetObjectAttributesResponse>";
+
+#[tokio::test]
+async fn ignore_invalid_xml_body_root() {
+    tracing_subscriber::fmt::init();
+
+    let conn = TestConnection::new(vec![
+        (http::Request::builder()
+             .header("x-amz-object-attributes", "Checksum")
+             .header("x-amz-user-agent", "aws-sdk-rust/0.123.test api/test-service/0.123 os/windows/XPSP3 lang/rust/1.50.0")
+             .header("x-amz-date", "20210618T170728Z")
+             .header("authorization", "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210618/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-object-attributes;x-amz-security-token;x-amz-user-agent, Signature=0e6ec749db5a0af07890a83f553319eda95be0e498d058c64880471a474c5378")
+             .header("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+             .header("x-amz-security-token", "notarealsessiontoken")
+             .uri(http::Uri::from_static("https://s3.us-east-1.amazonaws.com/some-test-bucket/test.txt?attributes"))
+             .body(SdkBody::empty())
+             .unwrap(),
+         http::Response::builder()
+             .header(
+                 "x-amz-id-2",
+                 "rbipIUyF3YKPIcqpz6hrP9x9mzYMSqkHzDEp6TEN/STcKvylDIE/LLN6x9t6EKJRrgctNsdNHWk=",
+             )
+             .header("x-amz-request-id", "K8036R3D4NZNMMVC")
+             .header("date", "Tue, 23 Aug 2022 18:17:23 GMT")
+             .header("last-modified", "Tue, 21 Jun 2022 16:30:01 GMT")
+             .header("server", "AmazonS3")
+             .header("content-length", "224")
+             .status(200)
+             .body(RESPONSE_BODY_XML)
+             .unwrap())
+    ]);
+    let creds = Credentials::new(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+        None,
+        "test",
+    );
+    let conf = aws_sdk_s3::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let client = Client::new(conn.clone());
+
+    let mut op = GetObjectAttributes::builder()
+        .bucket("some-test-bucket")
+        .key("test.txt")
+        .object_attributes(ObjectAttributes::Checksum)
+        .build()
+        .unwrap()
+        .make_operation(&conf)
+        .await
+        .unwrap();
+    op.properties_mut()
+        .insert(UNIX_EPOCH + Duration::from_secs(1624036048));
+    op.properties_mut().insert(AwsUserAgent::for_tests());
+
+    let res = client.call(op).await.unwrap();
+
+    conn.assert_requests_match(&[]);
+
+    println!("res: {:#?}", res)
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -119,6 +119,6 @@ open class RestXml(private val coreCodegenContext: CoreCodegenContext) : Protoco
  */
 class AllowInvalidXmlRoot : AnnotationTrait(ID, Node.objectNode()) {
     companion object {
-        val ID: ShapeId = ShapeId.from("aws.api.internal#allowInvalidXmlRoot")
+        val ID: ShapeId = ShapeId.from("smithy.api.internal#allowInvalidXmlRoot")
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/RestXml.kt
@@ -6,7 +6,10 @@
 package software.amazon.smithy.rust.codegen.smithy.protocols
 
 import software.amazon.smithy.aws.traits.protocols.RestXmlTrait
+import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.AnnotationTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustModule
@@ -109,4 +112,13 @@ open class RestXml(private val coreCodegenContext: CoreCodegenContext) : Protoco
     ): Writable = RestRequestSpecGenerator(httpBindingResolver, requestSpecModule).generate(operationShape)
 
     override fun serverRouterRuntimeConstructor() = "new_rest_xml_router"
+}
+
+/**
+ * Indicates that a service is expected to send XML where the root element name does not match the modeled member name.
+ */
+class AllowInvalidXmlRoot : AnnotationTrait(ID, Node.objectNode()) {
+    companion object {
+        val ID: ShapeId = ShapeId.from("aws.api.internal#allowInvalidXmlRoot")
+    }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/RestXmlParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/RestXmlParserGenerator.kt
@@ -49,7 +49,9 @@ class RestXmlParserGenerator(
                         """
                         // Zelda B
                         return Err(
-                            #{XmlError}::custom(format!("invalid root, expected $shapeName got {:?}", start_el))
+                            #{XmlError}::custom(format!("encountered invalid XML root: \
+                                expected $shapeName but got {:?}. \
+                                This is likely a bug in the SDK.", start_el))
                         )""",
                         "XmlError" to context.xmlErrorType,
                     )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/RestXmlParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/RestXmlParserGenerator.kt
@@ -5,10 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.smithy.protocols.parse
 
-import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
-import software.amazon.smithy.rust.codegen.rustlang.asType
 import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.rustlang.writable
 import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.smithy.protocols.AllowInvalidXmlRoot

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/RestXmlParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/RestXmlParserGenerator.kt
@@ -37,11 +37,11 @@ class RestXmlParserGenerator(
             if (!allowInvalidRoot) {
                 rustTemplate(
                     """
-                    if !(${XmlBindingTraitParserGenerator.XmlName(shapeName).matchExpression("start_el")}) {
+                    if !${XmlBindingTraitParserGenerator.XmlName(shapeName).matchExpression("start_el")} {
                         return Err(
-                            #{XmlError}::custom(format!("encountered invalid XML root: \
-                                expected $shapeName but got {:?}. \
-                                This is likely a bug in the SDK.", start_el)
+                            #{XmlError}::custom(
+                                format!("encountered invalid XML root: expected $shapeName but got {:?}. This is likely a bug in the SDK.", start_el)
+                            )
                         )
                     }
                     """,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -196,6 +196,7 @@ class XmlBindingTraitParserGenerator(
 
                     ##[allow(unused_mut)]
                     let mut decoder = doc.root_element()?;
+                    ##[allow(unused_variables)]
                     let start_el = decoder.start_el();
                     """,
                     *codegenScope,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/protocols/parse/XmlBindingTraitParserGenerator.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.knowledge.HttpBindingIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.BooleanShape
 import software.amazon.smithy.model.shapes.CollectionShape
-import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.NumberShape
@@ -22,6 +21,7 @@ import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.TimestampShape
 import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.model.traits.XmlFlattenedTrait
 import software.amazon.smithy.rust.codegen.rustlang.Attribute
@@ -657,7 +657,7 @@ class XmlBindingTraitParserGenerator(
 
     private fun RustWriter.parseStringInner(shape: StringShape, provider: RustWriter.() -> Unit) {
         withBlock("Result::<#T, #T>::Ok(", ")", symbolProvider.toSymbol(shape), xmlError) {
-            if (shape is EnumShape) {
+            if (shape.hasTrait<EnumTrait>()) {
                 val enumSymbol = symbolProvider.toSymbol(shape)
                 if (convertsToEnumInServer(shape)) {
                     withBlock("#T::try_from(", ")", enumSymbol) {
@@ -677,7 +677,7 @@ class XmlBindingTraitParserGenerator(
         }
     }
 
-    private fun convertsToEnumInServer(shape: StringShape) = target == CodegenTarget.SERVER && shape is EnumShape
+    private fun convertsToEnumInServer(shape: StringShape) = target == CodegenTarget.SERVER && shape.hasTrait<EnumTrait>()
 
     private fun MemberShape.xmlName(): XmlName {
         return XmlName(xmlIndex.memberName(this))

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticInputTrait.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticInputTrait.kt
@@ -12,14 +12,14 @@ import software.amazon.smithy.model.traits.AnnotationTrait
 /**
  * Indicates that a shape is a synthetic input (see `OperationNormalizer.kt`)
  *
- * All operations are normalized to have an input, even when they are defined without on. This is done for backwards compatibility
- * and to produce a consistent API.
+ * All operations are normalized to have an input, even when they are defined without on. This is done for backwards
+ * compatibility and to produce a consistent API.
  */
 class SyntheticInputTrait(
     val operation: ShapeId,
     val originalId: ShapeId?,
 ) : AnnotationTrait(ID, Node.objectNode()) {
     companion object {
-        val ID = ShapeId.from("smithy.api.internal#syntheticInput")
+        val ID: ShapeId = ShapeId.from("smithy.api.internal#syntheticInput")
     }
 }

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticOutputTrait.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/traits/SyntheticOutputTrait.kt
@@ -10,14 +10,14 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.AnnotationTrait
 
 /**
- * Indicates that a shape is a synthetic input (see `OperationNormalizer.kt`)
+ * Indicates that a shape is a synthetic output (see `OperationNormalizer.kt`)
  *
- * All operations are normalized to have an input, even when they are defined without on. This is done for backwards compatibility
- * and to produce a consistent API.
+ * All operations are normalized to have an output, even when they are defined without on. This is done for backwards
+ * compatibility and to produce a consistent API.
  */
 class SyntheticOutputTrait constructor(val operation: ShapeId, val originalId: ShapeId?) :
     AnnotationTrait(ID, Node.objectNode()) {
     companion object {
-        val ID = ShapeId.from("smithy.api.internal#syntheticOutput")
+        val ID: ShapeId = ShapeId.from("smithy.api.internal#syntheticOutput")
     }
 }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-rust#609

## Description
<!--- Describe your changes in detail -->
It is now possible to exempt specific operations from XML body root checking. To do this, add the `AllowInvalidXmlRoot`
trait to the output struct of the operation you want to exempt. Previously, S3's `GetObjectAttributes` would always fail because they return an XML object with a root named `GetObjectAttributesResponse` instead of `GetObjectAttributesOutput` as specified by their model.

_They'll still be returning the incorrect XML, we just won't hold them to their model once this is merged._

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I have included an integration test

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
