### PR TITLE
missing `RuntimeConfig` node should behave the same as `{}`

### DIFF
--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -75,21 +75,18 @@ data class RuntimeConfig(
         /**
          * Load a `RuntimeConfig` from an [ObjectNode] (JSON)
          */
-        fun fromNode(node: Optional<ObjectNode>): RuntimeConfig {
-            return if (node.isPresent) {
-                val crateVersionMap = node.get().getObjectMember("versions").orElse(Node.objectNode()).members.entries.let { members ->
-                    val map = members.associate { it.key.toString() to it.value.expectStringNode().value }
-                    CrateVersionMap(map)
-                }
-                val path = node.get().getStringMember("relativePath").orNull()?.value
-                val runtimeCrateLocation = RuntimeCrateLocation(path = path, versions = crateVersionMap)
-                RuntimeConfig(
-                    node.get().getStringMemberOrDefault("cratePrefix", "aws-smithy"),
-                    runtimeCrateLocation = runtimeCrateLocation,
-                )
-            } else {
-                RuntimeConfig()
+        fun fromNode(node_: Optional<ObjectNode>): RuntimeConfig {
+            val node = node_.orElse(Node.objectNode())
+            val crateVersionMap = node.getObjectMember("versions").orElse(Node.objectNode()).members.entries.let { members ->
+                val map = members.associate { it.key.toString() to it.value.expectStringNode().value }
+                CrateVersionMap(map)
             }
+            val path = node.getStringMember("relativePath").orNull()?.value
+            val runtimeCrateLocation = RuntimeCrateLocation(path = path, versions = crateVersionMap)
+            return RuntimeConfig(
+                node.getStringMemberOrDefault("cratePrefix", "aws-smithy"),
+                runtimeCrateLocation = runtimeCrateLocation,
+            )
         }
     }
 

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypes.kt
@@ -75,8 +75,8 @@ data class RuntimeConfig(
         /**
          * Load a `RuntimeConfig` from an [ObjectNode] (JSON)
          */
-        fun fromNode(node_: Optional<ObjectNode>): RuntimeConfig {
-            val node = node_.orElse(Node.objectNode())
+        fun fromNode(maybeNode: Optional<ObjectNode>): RuntimeConfig {
+            val node = maybeNode.orElse(Node.objectNode())
             val crateVersionMap = node.getObjectMember("versions").orElse(Node.objectNode()).members.entries.let { members ->
                 val map = members.associate { it.key.toString() to it.value.expectStringNode().value }
                 CrateVersionMap(map)

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypesTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/RuntimeTypesTest.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rust.codegen.smithy
 
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -13,6 +14,7 @@ import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.rust.codegen.rustlang.CratesIo
 import software.amazon.smithy.rust.codegen.rustlang.DependencyLocation
 import software.amazon.smithy.rust.codegen.rustlang.Local
+import java.util.Optional
 
 class RuntimeTypesTest {
     @ParameterizedTest
@@ -24,6 +26,13 @@ class RuntimeTypesTest {
         val node = Node.parse(runtimeConfig)
         val cfg = RuntimeConfig.fromNode(node.asObjectNode())
         cfg.runtimeCrateLocation shouldBe expectedCrateLocation
+    }
+
+    @Test
+    fun `succeeded to provide a default runtime config if missing`() {
+        // This default config should share the same behaviour with `{}` empty object.
+        val cfg = RuntimeConfig.fromNode(Optional.empty())
+        cfg.runtimeCrateLocation shouldBe RuntimeCrateLocation(null, CrateVersionMap(mapOf()))
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Motivation and Context

Address #1676. #1635 forgot to handle a case that the whole `RuntimeConfig` is missing.

## Description

If seeing a empty node for where `RuntimeConfig` should be, we just treat it as `{}` empty object. They now share the same behaviour that by default using runtime crates with the versions from crates.io.

## Testing

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
