### PR TITLE
Add new service builder machinery

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -50,9 +50,14 @@
 
 use std::ops::Deref;
 
+use http::StatusCode;
 use thiserror::Error;
 
-use crate::request::RequestParts;
+use crate::{
+    body::{empty, BoxBody},
+    request::{FromParts, RequestParts},
+    response::IntoResponse,
+};
 
 /// Extension type used to store information about Smithy operations in HTTP responses.
 /// This extension type is set when it has been correctly determined that the request should be
@@ -162,6 +167,31 @@ impl<T> Deref for Extension<T> {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+/// The extension has not been added to the [`Request`](http::Request) or has been previously removed.
+#[derive(Debug, Error)]
+#[error("the `Extension` is not present in the `http::Request`")]
+pub struct MissingExtension;
+
+impl<Protocol> IntoResponse<Protocol> for MissingExtension {
+    fn into_response(self) -> http::Response<BoxBody> {
+        http::Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(empty())
+            .expect("invalid HTTP response for missing extensions; please file a bug report under https://github.com/awslabs/smithy-rs/issues")
+    }
+}
+
+impl<Protocol, T> FromParts<Protocol> for Extension<T>
+where
+    T: Clone + Send + Sync + 'static,
+{
+    type Rejection = MissingExtension;
+
+    fn from_parts(parts: &mut http::request::Parts) -> Result<Self, Self::Rejection> {
+        parts.extensions.remove::<T>().map(Extension).ok_or(MissingExtension)
     }
 }
 

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -16,6 +16,10 @@ pub mod extension;
 #[doc(hidden)]
 pub mod logging;
 #[doc(hidden)]
+pub mod make_service;
+#[doc(hidden)]
+pub mod operation;
+#[doc(hidden)]
 pub mod protocols;
 #[doc(hidden)]
 pub mod rejection;

--- a/rust-runtime/aws-smithy-http-server/src/make_service.rs
+++ b/rust-runtime/aws-smithy-http-server/src/make_service.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::{
+    convert::Infallible,
+    future::{ready, Ready},
+    task::{Context, Poll},
+};
+
+use tower::Service;
+
+/// A basic [`MakeService`](tower::MakeService) which [`Clone`]s the inner service.
+pub struct IntoMakeService<S> {
+    svc: S,
+}
+
+impl<S> IntoMakeService<S> {
+    /// Constructs a new [`IntoMakeService`].
+    pub fn new(svc: S) -> Self {
+        Self { svc }
+    }
+}
+
+impl<S, T> Service<T> for IntoMakeService<S>
+where
+    S: Clone,
+{
+    type Response = S;
+    type Error = Infallible;
+    type Future = Ready<Result<S, Infallible>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _target: T) -> Self::Future {
+        ready(Ok(self.svc.clone()))
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/operation/handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/handler.rs
@@ -1,0 +1,153 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::{
+    convert::Infallible,
+    future::Future,
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use futures_util::{
+    future::{Map, MapErr},
+    FutureExt, TryFutureExt,
+};
+use tower::Service;
+
+use super::{OperationError, OperationShape};
+
+/// A utility trait used to provide an even interface for all handlers.
+pub trait Handler<Op, Exts>
+where
+    Op: OperationShape,
+{
+    type Future: Future<Output = Result<Op::Output, Op::Error>>;
+
+    fn call(&mut self, input: Op::Input, exts: Exts) -> Self::Future;
+}
+
+/// A utility trait used to provide an even interface over return types `Result<Ok, Error>`/`Ok`.
+trait ToResult<Ok, Error> {
+    fn into_result(self) -> Result<Ok, Error>;
+}
+
+// We can convert from `Result<Ok, Error>` to `Result<Ok, Error>`.
+impl<Ok, Error> ToResult<Ok, Error> for Result<Ok, Error> {
+    fn into_result(self) -> Result<Ok, Error> {
+        self
+    }
+}
+
+// We can convert from `Ok` to `Result<Ok, Error>`.
+impl<Ok> ToResult<Ok, Infallible> for Ok {
+    fn into_result(self) -> Result<Ok, Infallible> {
+        Ok(self)
+    }
+}
+
+// fn(Input) -> Output
+impl<Op, F, Fut> Handler<Op, ()> for F
+where
+    Op: OperationShape,
+    F: Fn(Op::Input) -> Fut,
+    Fut: Future,
+    Fut::Output: ToResult<Op::Output, Op::Error>,
+{
+    type Future = Map<Fut, fn(Fut::Output) -> Result<Op::Output, Op::Error>>;
+
+    fn call(&mut self, input: Op::Input, _exts: ()) -> Self::Future {
+        (self)(input).map(ToResult::into_result)
+    }
+}
+
+// fn(Input, Ext0) -> Output
+impl<Op, F, Fut, Ext0> Handler<Op, (Ext0,)> for F
+where
+    Op: OperationShape,
+    F: Fn(Op::Input, Ext0) -> Fut,
+    Fut: Future,
+    Fut::Output: ToResult<Op::Output, Op::Error>,
+{
+    type Future = Map<Fut, fn(Fut::Output) -> Result<Op::Output, Op::Error>>;
+
+    fn call(&mut self, input: Op::Input, exts: (Ext0,)) -> Self::Future {
+        (self)(input, exts.0).map(ToResult::into_result)
+    }
+}
+
+// fn(Input, Ext0, Ext1) -> Output
+impl<Op, F, Fut, Ext0, Ext1> Handler<Op, (Ext0, Ext1)> for F
+where
+    Op: OperationShape,
+    F: Fn(Op::Input, Ext0, Ext1) -> Fut,
+    Fut: Future,
+    Fut::Output: ToResult<Op::Output, Op::Error>,
+{
+    type Future = Map<Fut, fn(Fut::Output) -> Result<Op::Output, Op::Error>>;
+
+    fn call(&mut self, input: Op::Input, exts: (Ext0, Ext1)) -> Self::Future {
+        (self)(input, exts.0, exts.1).map(ToResult::into_result)
+    }
+}
+
+/// An extension trait for [`Handler`].
+pub trait HandlerExt<Op, Exts>: Handler<Op, Exts>
+where
+    Op: OperationShape,
+{
+    /// Convert the [`Handler`] into a [`Service`].
+    fn into_service(self) -> IntoService<Op, Self>
+    where
+        Self: Sized,
+    {
+        IntoService {
+            handler: self,
+            _operation: PhantomData,
+        }
+    }
+}
+
+impl<Op, Exts, H> HandlerExt<Op, Exts> for H
+where
+    Op: OperationShape,
+    H: Handler<Op, Exts>,
+{
+}
+
+/// A [`Service`] provided for every [`Handler`].
+pub struct IntoService<Op, H> {
+    handler: H,
+    _operation: PhantomData<Op>,
+}
+
+impl<Op, H> Clone for IntoService<Op, H>
+where
+    H: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+            _operation: PhantomData,
+        }
+    }
+}
+
+impl<Op, Exts, H> Service<(Op::Input, Exts)> for IntoService<Op, H>
+where
+    Op: OperationShape,
+    H: Handler<Op, Exts>,
+{
+    type Response = Op::Output;
+    type Error = OperationError<Op::Error, Infallible>;
+    type Future = MapErr<H::Future, fn(Op::Error) -> Self::Error>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, (input, exts): (Op::Input, Exts)) -> Self::Future {
+        self.handler.call(input, exts).map_err(OperationError::Model)
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/operation/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/mod.rs
@@ -1,0 +1,268 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! # Operations
+//!
+//! The shape of a [Smithy operation] is modelled by the [`OperationShape`] trait, it's associated types
+//! [`OperationShape::Input`], [`OperationShape::Output`], and [`OperationShape::Error`] map to the structures
+//! representing the Smithy inputs, outputs, and errors respectively. When an operation error is not specified
+//! [`OperationShape::Error`] is [`Infallible`](std::convert::Infallible).
+//!
+//! A ZST for each Smithy operation is generated and [`OperationShape`] should be implemented on it, this will be used
+//! as a helper which provides static methods and parameterizes other traits.
+//!
+//! The model
+//!
+//! ```smithy
+//! operation GetShopping {
+//!    input: CartIdentifier,
+//!    output: ShoppingCart,
+//!    errors: [...]
+//! }
+//! ```
+//!
+//! is identified with the implementation
+//!
+//! ```rust
+//! # use aws_smithy_http_server::operation::OperationShape;
+//! # pub struct CartIdentifier;
+//! # pub struct ShoppingCart;
+//! # pub enum GetShoppingError {}
+//! pub struct GetShopping;
+//!
+//! impl OperationShape for GetShopping {
+//!     const NAME: &'static str = "GetShopping";
+//!
+//!     type Input = CartIdentifier;
+//!     type Output = ShoppingCart;
+//!     type Error = GetShoppingError;
+//! }
+//! ```
+//!
+//! The behavior of a Smithy operation is encoded by an [`Operation`]. The [`OperationShape`] ZSTs can be used to
+//! construct specific operations using [`OperationShapeExt::from_handler`] and [`OperationShapeExt::from_service`].
+//! The [from_handler](OperationShapeExt::from_handler) constructor takes a [`Handler`] whereas the
+//! [from_service](OperationShapeExt::from_service) takes a [`OperationService`]. Both traits serve a similar purpose -
+//! they provide a common interface over a class of structures.
+//!
+//! ## [`Handler`]
+//!
+//! The [`Handler`] trait is implemented by all closures which accept [`OperationShape::Input`] as their first
+//! argument, the remaining arguments implement [`FromParts`](crate::request::FromParts), and return either
+//! [`OperationShape::Output`] when [`OperationShape::Error`] is [`Infallible`](std::convert::Infallible) or
+//! [`Result`]<[`OperationShape::Output`],[`OperationShape::Error`]>. The following are examples of closures which
+//! implement [`Handler`]:
+//!
+//! ```rust
+//! # use aws_smithy_http_server::Extension;
+//! # pub struct CartIdentifier;
+//! # pub struct ShoppingCart;
+//! # pub enum GetShoppingError {}
+//! # pub struct Context;
+//! # pub struct ExtraContext;
+//! // Simple handler where no error is given.
+//! async fn handler_a(input: CartIdentifier) -> ShoppingCart {
+//!     todo!()
+//! }
+//!
+//! // Handler with an extension where no error is given.
+//! async fn handler_b(input: CartIdentifier, ext: Extension<Context>) -> ShoppingCart {
+//!     todo!()
+//! }
+//!
+//! // More than one extension can be provided.
+//! async fn handler_c(input: CartIdentifier, ext_1: Extension<Context>, ext_2: Extension<ExtraContext>) -> ShoppingCart {
+//!     todo!()
+//! }
+//!
+//! // When an error is given we must return a `Result`.
+//! async fn handler_d(input: CartIdentifier, ext: Extension<Context>) -> Result<ShoppingCart, GetShoppingError> {
+//!     todo!()
+//! }
+//! ```
+//!
+//! ## [`OperationService`]
+//!
+//! Similarly, the [`OperationService`] trait is implemented by all `Service<(Op::Input, ...)>` with
+//! `Response = Op::Output`, and `Error = OperationError<Op::Output, PollError>`.
+//!
+//! We use [`OperationError`], with a `PollError` not constrained by the model, to allow the user to provide a custom
+//! [`Service::poll_ready`](tower::Service::poll_ready) implementation.
+//!
+//! The following are examples of [`Service`](tower::Service)s which implement [`OperationService`]:
+//!
+//! - `Service<CartIdentifier, Response = ShoppingCart, Error = Infallible>`.
+//! - `Service<(CartIdentifier, Extension<Context>), Response = ShoppingCart, Error = GetShoppingCartError>`.
+//! - `Service<(CartIdentifier, Extension<Context>, Extension<ExtraContext>), Response = ShoppingCart, Error = GetShoppingCartError)`.
+//!
+//! Notice the parallels between [`OperationService`] and [`Handler`].
+//!
+//! ## Constructing an [`Operation`]
+//!
+//! The following is an example of using both construction approaches:
+//!
+//! ```rust
+//! # use std::task::{Poll, Context};
+//! # use aws_smithy_http_server::operation::*;
+//! # use tower::Service;
+//! # pub struct CartIdentifier;
+//! # pub struct ShoppingCart;
+//! # pub enum GetShoppingError {}
+//! # pub struct GetShopping;
+//! # impl OperationShape for GetShopping {
+//! #    const NAME: &'static str = "GetShopping";
+//! #
+//! #    type Input = CartIdentifier;
+//! #    type Output = ShoppingCart;
+//! #    type Error = GetShoppingError;
+//! # }
+//! # type OpFuture = std::future::Ready<Result<ShoppingCart, OperationError<GetShoppingError, PollError>>>;
+//! // Construction of an `Operation` from a `Handler`.
+//!
+//! async fn op_handler(input: CartIdentifier) -> Result<ShoppingCart, GetShoppingError> {
+//!     todo!()
+//! }
+//!
+//! let operation = GetShopping::from_handler(op_handler);
+//!
+//! // Construction of an `Operation` from a `Service`.
+//!
+//! pub struct PollError;
+//!
+//! pub struct OpService;
+//!
+//! impl Service<(CartIdentifier, ())> for OpService {
+//!     type Response = ShoppingCart;
+//!     type Error = OperationError<GetShoppingError, PollError>;
+//!     type Future = OpFuture;
+//!
+//!     fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+//!         // NOTE: This MUST NOT return `Err(OperationError::Model(_))`.
+//!         todo!()
+//!     }
+//!
+//!     fn call(&mut self, request: (CartIdentifier, ())) -> Self::Future {
+//!         // NOTE: This MUST NOT return `Err(OperationError::Poll(_))`.
+//!         todo!()
+//!     }
+//! }
+//!
+//! let operation = GetShopping::from_service(OpService);
+//!
+//! ```
+//!
+//! ## Upgrading Smithy services to HTTP services
+//!
+//! Both [`Handler`] and [`OperationService`] accept and return Smithy model structures. After an [`Operation`] is
+//! constructed they are converted to a normal form
+//! `Service<(Op::Input, Exts), Response = Op::Output, Error = OperationError<Op::Error, PollError>>`. The
+//! [`UpgradeLayer`] acts upon such services by converting them to
+//! `Service<http::Request, Response = http::Response, Error = PollError>`.
+//!
+//! Note that the `PollError` is still exposed, for two reasons:
+//!
+//! - Smithy is agnostic to `PollError` and therefore we have no prescribed way to serialize it to a [`http::Response`]
+//! , unlike the operation errors.
+//! - The intention of `PollError` is to signal that the underlying service is no longer able to take requests, so
+//! should be discarded. See [`Service::poll_ready`](tower::Service::poll_ready).
+//!
+//! The [`UpgradeLayer`] and it's [`Layer::Service`] [`Upgrade`] are both parameterized by a protocol. This allows
+//! for upgrading to `Service<http::Request, Response = http::Response, Error = PollError>` to be protocol dependent.
+//!
+//! The [`Operation::upgrade`] will apply [`UpgradeLayer`] to `S` then apply the [`Layer`] `L`. The service builder
+//! provided to the user will perform this composition on `build`.
+//!
+//! [Smithy operation]: https://awslabs.github.io/smithy/2.0/spec/service-types.html#operation
+
+mod handler;
+mod operation_service;
+mod shape;
+mod upgrade;
+
+use tower::{
+    layer::util::{Identity, Stack},
+    Layer,
+};
+
+pub use handler::*;
+pub use operation_service::*;
+pub use shape::*;
+pub use upgrade::*;
+
+/// A Smithy operation, represented by a [`Service`](tower::Service) `S` and a [`Layer`] `L`.
+///
+/// The `L` is held and applied lazily during [`Operation::upgrade`].
+pub struct Operation<S, L = Identity> {
+    inner: S,
+    layer: L,
+}
+
+type StackedUpgradeService<P, Op, E, B, L, S> = <Stack<UpgradeLayer<P, Op, E, B>, L> as Layer<S>>::Service;
+
+impl<S, L> Operation<S, L> {
+    /// Takes the [`Operation`], containing the inner [`Service`](tower::Service) `S`, the HTTP [`Layer`] `L` and
+    /// composes them together using [`UpgradeLayer`] for a specific protocol and [`OperationShape`].
+    ///
+    /// The composition is made explicit in the method constraints and return type.
+    pub fn upgrade<P, Op, E, B>(self) -> StackedUpgradeService<P, Op, E, B, L, S>
+    where
+        UpgradeLayer<P, Op, E, B>: Layer<S>,
+        L: Layer<<UpgradeLayer<P, Op, E, B> as Layer<S>>::Service>,
+    {
+        let Self { inner, layer } = self;
+        let layer = Stack::new(UpgradeLayer::new(), layer);
+        layer.layer(inner)
+    }
+}
+
+impl<Op, S, PollError> Operation<Normalize<Op, S, PollError>> {
+    /// Creates an [`Operation`] from a [`Service`](tower::Service).
+    pub fn from_service<Exts>(inner: S) -> Self
+    where
+        Op: OperationShape,
+        S: OperationService<Op, Exts, PollError>,
+    {
+        Self {
+            inner: inner.into_unflatten(),
+            layer: Identity::new(),
+        }
+    }
+}
+
+impl<Op, H> Operation<IntoService<Op, H>> {
+    /// Creates an [`Operation`] from a [`Handler`].
+    pub fn from_handler<Exts>(handler: H) -> Self
+    where
+        Op: OperationShape,
+        H: Handler<Op, Exts>,
+    {
+        Self {
+            inner: handler.into_service(),
+            layer: Identity::new(),
+        }
+    }
+}
+
+impl<S, L> Operation<S, L> {
+    /// Applies a [`Layer`] to the operation _after_ it has been upgraded via [`Operation::upgrade`].
+    pub fn layer<NewL>(self, layer: NewL) -> Operation<S, Stack<L, NewL>> {
+        Operation {
+            inner: self.inner,
+            layer: Stack::new(self.layer, layer),
+        }
+    }
+}
+
+/// A marker struct indicating an [`Operation`] has not been set in a builder.
+pub struct OperationNotSet;
+
+/// The operation [`Service`](tower::Service) has two classes of failure modes - the failure models specified by
+/// the Smithy model and failures to [`Service::poll_ready`](tower::Service::poll_ready).
+pub enum OperationError<ModelError, PollError> {
+    /// An error modelled by the Smithy model occurred.
+    Model(ModelError),
+    /// A [`Service::poll_ready`](tower::Service::poll_ready) failure occurred.
+    Poll(PollError),
+}

--- a/rust-runtime/aws-smithy-http-server/src/operation/operation_service.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/operation_service.rs
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::{
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+use tower::Service;
+
+use super::{OperationError, OperationShape};
+
+/// A utility trait used to provide an even interface for all operation services.
+///
+/// This serves to take [`Service`]s of the form `Service<(Op::Input, Ext0, Ext1, ...)>` to the canonical
+/// representation of `Service<(Input, (Ext0, Ext1, ...))>` inline with
+/// [`IntoService`](super::IntoService).
+pub trait OperationService<Op, Exts, PollError>:
+    Service<Self::Normalized, Response = Op::Output, Error = OperationError<Op::Error, PollError>>
+where
+    Op: OperationShape,
+{
+    type Normalized;
+
+    // Normalize the request type.
+    fn normalize(input: Op::Input, exts: Exts) -> Self::Normalized;
+}
+
+// `Service<Op::Input>`
+impl<Op, S, PollError> OperationService<Op, (), PollError> for S
+where
+    Op: OperationShape,
+    S: Service<Op::Input, Response = Op::Output, Error = OperationError<Op::Error, PollError>>,
+{
+    type Normalized = Op::Input;
+
+    fn normalize(input: Op::Input, _exts: ()) -> Self::Normalized {
+        input
+    }
+}
+
+// `Service<(Op::Input, Ext0)>`
+impl<Op, Ext0, S, PollError> OperationService<Op, (Ext0,), PollError> for S
+where
+    Op: OperationShape,
+    S: Service<(Op::Input, Ext0), Response = Op::Output, Error = OperationError<Op::Error, PollError>>,
+{
+    type Normalized = (Op::Input, Ext0);
+
+    fn normalize(input: Op::Input, exts: (Ext0,)) -> Self::Normalized {
+        (input, exts.0)
+    }
+}
+
+// `Service<(Op::Input, Ext0, Ext1)>`
+impl<Op, Ext0, Ext1, S, PollError> OperationService<Op, (Ext0, Ext1), PollError> for S
+where
+    Op: OperationShape,
+    S: Service<(Op::Input, Ext0, Ext1), Response = Op::Output, Error = OperationError<Op::Error, PollError>>,
+{
+    type Normalized = (Op::Input, Ext0, Ext1);
+
+    fn normalize(input: Op::Input, exts: (Ext0, Ext1)) -> Self::Normalized {
+        (input, exts.0, exts.1)
+    }
+}
+
+/// An extension trait of [`OperationService`].
+pub trait OperationServiceExt<Op, Exts, PollError>: OperationService<Op, Exts, PollError>
+where
+    Op: OperationShape,
+{
+    /// Convert the [`OperationService`] into a canonicalized [`Service`].
+    fn into_unflatten(self) -> Normalize<Op, Self, PollError>
+    where
+        Self: Sized,
+    {
+        Normalize {
+            inner: self,
+            _operation: PhantomData,
+            _poll_error: PhantomData,
+        }
+    }
+}
+
+impl<F, Op, Exts, PollError> OperationServiceExt<Op, Exts, PollError> for F
+where
+    Op: OperationShape,
+    F: OperationService<Op, Exts, PollError>,
+{
+}
+
+/// A [`Service`] normalizing the request type of a [`OperationService`].
+#[derive(Debug)]
+pub struct Normalize<Op, S, PollError> {
+    inner: S,
+    _operation: PhantomData<Op>,
+    _poll_error: PhantomData<PollError>,
+}
+
+impl<Op, S, PollError> Clone for Normalize<Op, S, PollError>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _operation: PhantomData,
+            _poll_error: PhantomData,
+        }
+    }
+}
+
+impl<Op, S, Exts, PollError> Service<(Op::Input, Exts)> for Normalize<Op, S, PollError>
+where
+    Op: OperationShape,
+    S: OperationService<Op, Exts, PollError>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = <S as Service<S::Normalized>>::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, (input, exts): (Op::Input, Exts)) -> Self::Future {
+        let req = S::normalize(input, exts);
+        self.inner.call(req)
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/operation/shape.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/shape.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use super::{Handler, IntoService, Normalize, Operation, OperationService};
+
+/// Models the [Smithy Operation shape].
+///
+/// [Smithy Operation shape]: https://awslabs.github.io/smithy/1.0/spec/core/model.html#operation
+pub trait OperationShape {
+    /// The name of the operation.
+    const NAME: &'static str;
+
+    /// The operation input.
+    type Input;
+    /// The operation output.
+    type Output;
+    /// The operation error. [`Infallible`](std::convert::Infallible) in the case where no error
+    /// exists.
+    type Error;
+}
+
+/// An extension trait over [`OperationShape`].
+pub trait OperationShapeExt: OperationShape {
+    /// Creates a new [`Operation`] for well-formed [`Handler`]s.
+    fn from_handler<H, Exts>(handler: H) -> Operation<IntoService<Self, H>>
+    where
+        H: Handler<Self, Exts>,
+        Self: Sized,
+    {
+        Operation::from_handler(handler)
+    }
+
+    /// Creates a new [`Operation`] for well-formed [`Service`](tower::Service)s.
+    fn from_service<S, Exts, PollError>(svc: S) -> Operation<Normalize<Self, S, PollError>>
+    where
+        S: OperationService<Self, Exts, PollError>,
+        Self: Sized,
+    {
+        Operation::from_service(svc)
+    }
+}
+
+impl<S> OperationShapeExt for S where S: OperationShape {}

--- a/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
@@ -1,0 +1,213 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#![allow(clippy::type_complexity)]
+
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures_util::ready;
+use pin_project_lite::pin_project;
+use tower::{Layer, Service};
+
+use crate::{
+    request::{FromParts, FromRequest},
+    response::IntoResponse,
+};
+
+use super::{OperationError, OperationShape};
+
+/// A [`Layer`] responsible for taking an operation [`Service`], accepting and returning Smithy
+/// types and converting it into a [`Service`] taking and returning [`http`] types.
+///
+/// See [`Upgrade`].
+#[derive(Debug, Clone)]
+pub struct UpgradeLayer<Protocol, Operation, Exts, B> {
+    _protocol: PhantomData<Protocol>,
+    _operation: PhantomData<Operation>,
+    _exts: PhantomData<Exts>,
+    _body: PhantomData<B>,
+}
+
+impl<P, Op, E, B> Default for UpgradeLayer<P, Op, E, B> {
+    fn default() -> Self {
+        Self {
+            _protocol: PhantomData,
+            _operation: PhantomData,
+            _exts: PhantomData,
+            _body: PhantomData,
+        }
+    }
+}
+
+impl<Protocol, Operation, Exts, B> UpgradeLayer<Protocol, Operation, Exts, B> {
+    /// Creates a new [`UpgradeLayer`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<S, P, Op, E, B> Layer<S> for UpgradeLayer<P, Op, E, B> {
+    type Service = Upgrade<P, Op, E, B, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Upgrade {
+            _protocol: PhantomData,
+            _operation: PhantomData,
+            _body: PhantomData,
+            _exts: PhantomData,
+            inner,
+        }
+    }
+}
+
+/// An alias allowing for quick access to [`UpgradeLayer`]s target [`Service`].
+pub type UpgradedService<P, Op, E, B, S> = <UpgradeLayer<P, Op, E, B> as Layer<S>>::Service;
+
+/// A [`Service`] responsible for wrapping an operation [`Service`] accepting and returning Smithy
+/// types, and converting it into a [`Service`] accepting and returning [`http`] types.
+pub struct Upgrade<Protocol, Operation, Exts, B, S> {
+    _protocol: PhantomData<Protocol>,
+    _operation: PhantomData<Operation>,
+    _exts: PhantomData<Exts>,
+    _body: PhantomData<B>,
+    inner: S,
+}
+
+impl<P, Op, E, B, S> Clone for Upgrade<P, Op, E, B, S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            _protocol: PhantomData,
+            _operation: PhantomData,
+            _body: PhantomData,
+            _exts: PhantomData,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+pin_project! {
+    /// The [`Service::Future`] of [`Upgrade`].
+    pub struct UpgradeFuture<Protocol, Operation, Exts, B, S>
+    where
+        Operation: OperationShape,
+        (Operation::Input, Exts): FromRequest<Protocol, B>,
+        S: Service<(Operation::Input, Exts)>,
+    {
+        service: S,
+        #[pin]
+        inner: Inner<<(Operation::Input, Exts) as FromRequest<Protocol, B>>::Future, S::Future>
+    }
+}
+
+pin_project! {
+    #[project = InnerProj]
+    #[project_replace = InnerProjReplace]
+    enum Inner<FromFut, HandlerFut> {
+        FromRequest {
+            #[pin]
+            inner: FromFut
+        },
+        Inner {
+            #[pin]
+            call: HandlerFut
+        }
+    }
+}
+
+impl<P, Op, E, B, S, PollError, OpError> Future for UpgradeFuture<P, Op, E, B, S>
+where
+    // `Op` is used to specify the operation shape
+    Op: OperationShape,
+    // Smithy input must convert from a HTTP request
+    Op::Input: FromRequest<P, B>,
+    // Smithy output must convert into a HTTP response
+    Op::Output: IntoResponse<P>,
+    // Smithy error must convert into a HTTP response
+    OpError: IntoResponse<P>,
+
+    // Must be able to convert extensions
+    E: FromParts<P>,
+
+    // The signature of the inner service is correct
+    S: Service<(Op::Input, E), Response = Op::Output, Error = OperationError<OpError, PollError>>,
+{
+    type Output = Result<http::Response<crate::body::BoxBody>, PollError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        loop {
+            let mut this = self.as_mut().project();
+            let this2 = this.inner.as_mut().project();
+
+            let call = match this2 {
+                InnerProj::FromRequest { inner } => {
+                    let result = ready!(inner.poll(cx));
+                    match result {
+                        Ok(ok) => this.service.call(ok),
+                        Err(err) => return Poll::Ready(Ok(err.into_response())),
+                    }
+                }
+                InnerProj::Inner { call } => {
+                    let result = ready!(call.poll(cx));
+                    let output = match result {
+                        Ok(ok) => ok.into_response(),
+                        Err(OperationError::Model(err)) => err.into_response(),
+                        Err(OperationError::Poll(_)) => {
+                            unreachable!("poll error should not be raised")
+                        }
+                    };
+                    return Poll::Ready(Ok(output));
+                }
+            };
+
+            this.inner.as_mut().project_replace(Inner::Inner { call });
+        }
+    }
+}
+
+impl<P, Op, E, B, S, PollError, OpError> Service<http::Request<B>> for Upgrade<P, Op, E, B, S>
+where
+    // `Op` is used to specify the operation shape
+    Op: OperationShape,
+    // Smithy input must convert from a HTTP request
+    Op::Input: FromRequest<P, B>,
+    // Smithy output must convert into a HTTP response
+    Op::Output: IntoResponse<P>,
+    // Smithy error must convert into a HTTP response
+    OpError: IntoResponse<P>,
+
+    // Must be able to convert extensions
+    E: FromParts<P>,
+
+    // The signature of the inner service is correct
+    S: Service<(Op::Input, E), Response = Op::Output, Error = OperationError<OpError, PollError>> + Clone,
+{
+    type Response = http::Response<crate::body::BoxBody>;
+    type Error = PollError;
+    type Future = UpgradeFuture<P, Op, E, B, S>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(|err| match err {
+            OperationError::Poll(err) => err,
+            OperationError::Model(_) => unreachable!("operation error should not be raised"),
+        })
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        UpgradeFuture {
+            service: self.inner.clone(),
+            inner: Inner::FromRequest {
+                inner: <(Op::Input, E) as FromRequest<P, B>>::from_request(req),
+            },
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -32,7 +32,15 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-use http::{Extensions, HeaderMap, Request, Uri};
+use std::future::{ready, Future, Ready};
+
+use futures_util::{
+    future::{try_join, MapErr, MapOk, TryJoin},
+    TryFutureExt,
+};
+use http::{request::Parts, Extensions, HeaderMap, Request, Uri};
+
+use crate::{rejection::EitherRejection, response::IntoResponse};
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -54,7 +62,7 @@ impl<B> RequestParts<B> {
     #[doc(hidden)]
     pub fn new(req: Request<B>) -> Self {
         let (
-            http::request::Parts {
+            Parts {
                 uri,
                 headers,
                 extensions,
@@ -97,5 +105,68 @@ impl<B> RequestParts<B> {
     #[doc(hidden)]
     pub fn extensions(&self) -> Option<&Extensions> {
         self.extensions.as_ref()
+    }
+}
+
+/// Provides a protocol aware extraction from a [`Request`]. This borrows the
+/// [`Parts`], in contrast to [`FromRequest`].
+pub trait FromParts<Protocol>: Sized {
+    type Rejection: IntoResponse<Protocol>;
+
+    /// Extracts `self` from a [`Parts`] synchronously.
+    fn from_parts(parts: &mut Parts) -> Result<Self, Self::Rejection>;
+}
+
+impl<P, T1, T2> FromParts<P> for (T1, T2)
+where
+    T1: FromParts<P>,
+    T2: FromParts<P>,
+{
+    type Rejection = EitherRejection<T1::Rejection, T2::Rejection>;
+
+    fn from_parts(parts: &mut Parts) -> Result<Self, Self::Rejection> {
+        let t1 = T1::from_parts(parts).map_err(EitherRejection::Left)?;
+        let t2 = T2::from_parts(parts).map_err(EitherRejection::Right)?;
+        Ok((t1, t2))
+    }
+}
+
+/// Provides a protocol aware extraction from a [`Request`]. This consumes the
+/// [`Request`], in contrast to [`FromParts`].
+pub trait FromRequest<Protocol, B>: Sized {
+    type Rejection: IntoResponse<Protocol>;
+    type Future: Future<Output = Result<Self, Self::Rejection>>;
+
+    /// Extracts `self` from a [`Request`] asynchronously.
+    fn from_request(request: Request<B>) -> Self::Future;
+}
+
+impl<'a, P, B, T1> FromRequest<P, B> for (T1,)
+where
+    T1: FromRequest<P, B>,
+{
+    type Rejection = T1::Rejection;
+    type Future = MapOk<T1::Future, fn(T1) -> (T1,)>;
+
+    fn from_request(request: Request<B>) -> Self::Future {
+        T1::from_request(request).map_ok(|t1| (t1,))
+    }
+}
+
+impl<P, B, T1, T2> FromRequest<P, B> for (T1, T2)
+where
+    T1: FromRequest<P, B>,
+    T2: FromParts<P>,
+{
+    type Rejection = EitherRejection<T1::Rejection, T2::Rejection>;
+    type Future = TryJoin<MapErr<T1::Future, fn(T1::Rejection) -> Self::Rejection>, Ready<Result<T2, Self::Rejection>>>;
+
+    fn from_request(request: Request<B>) -> Self::Future {
+        let (mut parts, body) = request.into_parts();
+        let t2_result = T2::from_parts(&mut parts).map_err(EitherRejection::Right);
+        try_join(
+            T1::from_request(Request::from_parts(parts, body)).map_err(EitherRejection::Left),
+            ready(t2_result),
+        )
     }
 }


### PR DESCRIPTION
## Motivation and Context

https://github.com/awslabs/smithy-rs/pull/1620

## Description

- Add protocol specific `FromRequest` and `FromParts`.
- Add `OperationShape` trait to model Smithy operations.
- Add `Handler` and `OperationService` traits.
- Add `Upgrade` `Service` and `UpgradeLayer` `Layer`.

