### PR TITLE
Fix CI by pinning version of `arbitrary`

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -52,7 +52,7 @@ async-trait = "0.1.51"
 env_logger = "0.9.0"
 
 # used for fuzzing profile parsing
-arbitrary = "1.0.2"
+arbitrary = "=1.1.3" # 1.1.4 requires Rust 1.63 to compile
 
 # used for test case deserialization
 serde = { version = "1", features = ["derive"] }

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 derive-arbitrary = ["arbitrary"]
 
 [dependencies]
-arbitrary = { version = "1", optional = true, features = ["derive"] }
+arbitrary = { version = "=1.1.3", optional = true, features = ["derive"] } # 1.1.4 requires Rust 1.63 to compile
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 crc32fast = "1.3"

--- a/rust-runtime/aws-smithy-eventstream/fuzz/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/fuzz/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "1", features = ["derive"] }
+arbitrary = { version = "=1.1.3", optional = true, features = ["derive"] } # 1.1.4 requires Rust 1.63 to compile
 aws-smithy-types = { path = "../../aws-smithy-types" }
 bytes = "1"
 crc32fast = "1"


### PR DESCRIPTION
## Motivation and Context
The `arbitrary` crate that we use in some of our fuzz tests started using `array::from_fn`, which is only stable as of Rust 1.63. The `arbitrary` crate [has no intention of supporting any Rust version other than the latest stable](https://github.com/rust-fuzz/arbitrary/issues/99). Since our MSRV is 1.61, this causes our Rust runtime tests to fail to compile. This PR resolves the issue by pinning the `arbitrary` crate to the last version that successfully compiles against Rust 1.61. This should be fine since it's only needed for tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
