### PR TITLE
Add partition function

### DIFF
--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -23,11 +23,11 @@ repository = "https://github.com/awslabs/smithy-rs"
 "pin-project-lite" = "0.2"
 "tower" = { version = "0.4.11", default_features = false }
 "async-trait" = "0.1"
+regex = "1"
 "url" = "2.2.2"
 
 [dev-dependencies]
 proptest = "1"
-regex = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/inlineable/src/endpoint_lib.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib.rs
@@ -7,4 +7,5 @@ mod arn;
 mod diagnostic;
 mod host;
 mod parse_url;
+mod partition;
 mod substring;

--- a/rust-runtime/inlineable/src/endpoint_lib/partition.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/partition.rs
@@ -1,0 +1,573 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Partition function to determine a partition for a given region
+//!
+//! This function supports adding regions dynamically, parsing a JSON file, and builder construction.
+//!
+//! If, at a future point, this interface stabilizes it is a good candidate for extraction into a
+//! shared crate.
+use crate::endpoint_lib::diagnostic::DiagnosticCollector;
+use aws_smithy_json::deserialize::Error;
+use regex::Regex;
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+/// Determine the AWS partition metadata for a given region
+pub(crate) struct PartitionResolver {
+    partitions: Vec<PartitionMetadata>,
+}
+
+impl PartitionResolver {
+    pub(crate) fn from_partitions(partitions: Vec<PartitionMetadata>) -> Self {
+        Self { partitions }
+    }
+}
+
+/// Partition result returned from partition resolver
+pub(crate) struct Partition<'a> {
+    name: &'a str,
+    dns_suffix: &'a str,
+    dualstack_dns_suffix: &'a str,
+    supports_fips: bool,
+    supports_dualstack: bool,
+}
+
+static DEFAULT_OVERRIDE: &PartitionOutputOverride = &PartitionOutputOverride {
+    name: None,
+    dns_suffix: None,
+    dualstack_dns_suffix: None,
+    supports_fips: None,
+    supports_dualstack: None,
+};
+
+/// Merge the base output and the override output, dealing with `Cow`s
+macro_rules! merge {
+    ($base: expr, $output: expr, $field: ident) => {
+        $output
+            .$field
+            .as_ref()
+            .map(|s| s.as_ref())
+            .unwrap_or($base.outputs.$field.as_ref())
+    };
+}
+
+impl PartitionResolver {
+    pub(crate) fn new() -> PartitionResolver {
+        PartitionResolver { partitions: vec![] }
+    }
+    pub(crate) fn add_partition(&mut self, partition: PartitionMetadata) {
+        self.partitions.push(partition);
+    }
+
+    /// Resolve a partition for a given region
+    ///
+    /// 1. Enumerate each partition in the `partitions` array, and determine if the identifier to be
+    ///    resolved matches an explicit region listed in the `regions` array for a given partition.
+    ///    If identifier matches, proceed to step 4, otherwise continue to step 2.
+    /// 2. Enumerate each partition in the `partitions` array, use the regular expression
+    ///    `regionRegex` to determine if the identifier matches the regular expression. If the
+    ///    identifier matches, proceed to step 4, otherwise continue to step 3.
+    /// 3. If no partition is matched after exhausting step 1 and step 2, then fallback to matching
+    ///    the identifier to the partition where `id == "aws"`, and proceed to step 4. If no `aws`
+    ///    partition is present, return `None`.
+    /// 4. After matching the identifier to a partition using one of the previous steps, the partition function should return a
+    ///    typed data structure containing the fields in `outputs` in the matched partition. **Important:** If a specific region
+    ///    was matched, the properties associated with that region **MUST** be merged with the `outputs` field.
+    pub(crate) fn resolve_partition(
+        &self,
+        region: &str,
+        e: &mut DiagnosticCollector,
+    ) -> Option<Partition> {
+        let mut explicit_match_partition = self
+            .partitions
+            .iter()
+            .flat_map(|part| part.explicit_match(region));
+        let mut regex_match_partition = self
+            .partitions
+            .iter()
+            .flat_map(|part| part.regex_match(region));
+
+        let (base, region_override) = explicit_match_partition
+            .next()
+            .or_else(|| regex_match_partition.next())
+            .or_else(|| match self.partitions.iter().find(|p| p.id == "aws") {
+                Some(partition) => Some((partition, None)),
+                None => {
+                    e.report_error("no AWS partition!");
+                    None
+                }
+            })?;
+        let region_override = region_override.as_ref().unwrap_or(&DEFAULT_OVERRIDE);
+        Some(Partition {
+            name: merge!(base, region_override, name),
+            dns_suffix: merge!(base, region_override, dns_suffix),
+            dualstack_dns_suffix: merge!(base, region_override, dualstack_dns_suffix),
+            supports_fips: region_override
+                .supports_fips
+                .unwrap_or(base.outputs.supports_fips),
+            supports_dualstack: region_override
+                .supports_dualstack
+                .unwrap_or(base.outputs.supports_dualstack),
+        })
+    }
+}
+
+type Str = Cow<'static, str>;
+
+pub(crate) struct PartitionMetadata {
+    id: Str,
+    region_regex: Regex,
+    regions: HashMap<Str, PartitionOutputOverride>,
+    outputs: PartitionOutput,
+}
+
+#[derive(Default)]
+pub(crate) struct PartitionMetadataBuilder {
+    pub(crate) id: Option<Str>,
+    pub(crate) region_regex: Option<Regex>,
+    pub(crate) regions: HashMap<Str, PartitionOutputOverride>,
+    pub(crate) outputs: Option<PartitionOutputOverride>,
+}
+
+impl PartitionMetadataBuilder {
+    pub(crate) fn build(self) -> PartitionMetadata {
+        PartitionMetadata {
+            id: self.id.expect("id must be defined"),
+            region_regex: self.region_regex.expect("region regex must be defined"),
+            regions: self.regions,
+            outputs: self
+                .outputs
+                .expect("outputs must be defined")
+                .into_partition_output()
+                .expect("missing fields on outputs"),
+        }
+    }
+}
+
+impl PartitionMetadata {
+    fn explicit_match(
+        &self,
+        region: &str,
+    ) -> Option<(&PartitionMetadata, Option<&PartitionOutputOverride>)> {
+        self.regions
+            .get(region)
+            .map(|output_override| (self, Some(output_override)))
+    }
+
+    fn regex_match(
+        &self,
+        region: &str,
+    ) -> Option<(&PartitionMetadata, Option<&PartitionOutputOverride>)> {
+        if self.region_regex.is_match(region) {
+            Some((self, None))
+        } else {
+            None
+        }
+    }
+}
+
+pub(crate) struct PartitionOutput {
+    name: Str,
+    dns_suffix: Str,
+    dualstack_dns_suffix: Str,
+    supports_fips: bool,
+    supports_dualstack: bool,
+}
+
+#[derive(Default)]
+pub(crate) struct PartitionOutputOverride {
+    name: Option<Str>,
+    dns_suffix: Option<Str>,
+    dualstack_dns_suffix: Option<Str>,
+    supports_fips: Option<bool>,
+    supports_dualstack: Option<bool>,
+}
+
+impl PartitionOutputOverride {
+    pub(crate) fn into_partition_output(
+        self,
+    ) -> Result<PartitionOutput, Box<dyn std::error::Error>> {
+        Ok(PartitionOutput {
+            name: self.name.ok_or("missing name")?,
+            dns_suffix: self.dns_suffix.ok_or("missing dnsSuffix")?,
+            dualstack_dns_suffix: self
+                .dualstack_dns_suffix
+                .ok_or("missing dualstackDnsSuffix")?,
+            supports_fips: self.supports_fips.ok_or("missing supports fips")?,
+            supports_dualstack: self.supports_dualstack.ok_or("missing supportsDualstack")?,
+        })
+    }
+}
+
+/// JSON deserializers for partition metadata
+///
+/// This code was generated by smithy-rs and then hand edited for clarity
+mod deser {
+    use crate::endpoint_lib::partition::{
+        PartitionMetadata, PartitionMetadataBuilder, PartitionOutputOverride, PartitionResolver,
+    };
+    use aws_smithy_json::deserialize::token::{
+        expect_bool_or_null, expect_start_object, expect_string_or_null, skip_value,
+    };
+    use aws_smithy_json::deserialize::{json_token_iter, Error, Token};
+    use regex::Regex;
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+
+    pub(crate) fn deserialize_partitions(value: &[u8]) -> Result<PartitionResolver, Error> {
+        let mut tokens_owned = json_token_iter(value).peekable();
+        let tokens = &mut tokens_owned;
+        expect_start_object(tokens.next())?;
+        let mut resolver = None;
+        loop {
+            match tokens.next().transpose()? {
+                Some(Token::EndObject { .. }) => break,
+                Some(Token::ObjectKey { key, .. }) => match key.to_unescaped()?.as_ref() {
+                    "partitions" => {
+                        resolver = Some(PartitionResolver::from_partitions(deser_partitions(
+                            tokens,
+                        )?));
+                    }
+                    _ => skip_value(tokens)?,
+                },
+                other => {
+                    return Err(Error::custom(format!(
+                        "expected object key or end object, found: {:?}",
+                        other
+                    )))
+                }
+            }
+        }
+        if tokens.next().is_some() {
+            return Err(Error::custom(
+                "found more JSON tokens after completing parsing",
+            ));
+        }
+        resolver.ok_or_else(|| Error::custom("did not find partitions array"))
+    }
+
+    fn deser_partitions<'a, I>(
+        tokens: &mut std::iter::Peekable<I>,
+    ) -> Result<Vec<PartitionMetadata>, Error>
+    where
+        I: Iterator<Item = Result<Token<'a>, Error>>,
+    {
+        match tokens.next().transpose()? {
+            Some(Token::StartArray { .. }) => {
+                let mut items = Vec::new();
+                loop {
+                    match tokens.peek() {
+                        Some(Ok(Token::EndArray { .. })) => {
+                            tokens.next().transpose().unwrap();
+                            break;
+                        }
+                        _ => {
+                            items.push(deser_partition(tokens)?);
+                        }
+                    }
+                }
+                Ok(items)
+            }
+            _ => Err(Error::custom("expected start array")),
+        }
+    }
+
+    pub(crate) fn deser_partition<'a, I>(
+        tokens: &mut std::iter::Peekable<I>,
+    ) -> Result<PartitionMetadata, Error>
+    where
+        I: Iterator<Item = Result<Token<'a>, Error>>,
+    {
+        match tokens.next().transpose()? {
+            Some(Token::StartObject { .. }) => {
+                let mut builder = PartitionMetadataBuilder::default();
+                loop {
+                    match tokens.next().transpose()? {
+                        Some(Token::EndObject { .. }) => break,
+                        Some(Token::ObjectKey { key, .. }) => match key.to_unescaped()?.as_ref() {
+                            "id" => {
+                                builder.id = token_to_str(tokens.next())?;
+                            }
+                            "regionRegex" => {
+                                builder.region_regex = token_to_str(tokens.next())?
+                                    .map(|region_regex| Regex::new(&region_regex))
+                                    .transpose()
+                                    .map_err(|e| Error::custom("invalid regex"))?;
+                            }
+                            "regions" => {
+                                builder.regions = deser_explicit_regions(tokens)?;
+                            }
+                            "outputs" => {
+                                builder.outputs = deser_outputs(tokens)?;
+                            }
+                            _ => skip_value(tokens)?,
+                        },
+                        other => {
+                            return Err(Error::custom(format!(
+                                "expected object key or end object, found: {:?}",
+                                other
+                            )))
+                        }
+                    }
+                }
+                Ok(builder.build())
+            }
+            _ => Err(Error::custom("expected start object")),
+        }
+    }
+
+    #[allow(clippy::type_complexity, non_snake_case)]
+    pub(crate) fn deser_explicit_regions<'a, I>(
+        tokens: &mut std::iter::Peekable<I>,
+    ) -> Result<HashMap<super::Str, PartitionOutputOverride>, Error>
+    where
+        I: Iterator<Item = Result<Token<'a>, Error>>,
+    {
+        match tokens.next().transpose()? {
+            Some(Token::StartObject { .. }) => {
+                let mut map = HashMap::new();
+                loop {
+                    match tokens.next().transpose()? {
+                        Some(Token::EndObject { .. }) => break,
+                        Some(Token::ObjectKey { key, .. }) => {
+                            let key = key.to_unescaped().map(|u| u.into_owned())?;
+                            let value = deser_outputs(tokens)?;
+                            if let Some(value) = value {
+                                map.insert(key.into(), value);
+                            }
+                        }
+                        other => {
+                            return Err(Error::custom(format!(
+                                "expected object key or end object, found: {:?}",
+                                other
+                            )))
+                        }
+                    }
+                }
+                Ok(map)
+            }
+            _ => Err(Error::custom("expected start object")),
+        }
+    }
+
+    /// Convert a token to `Str` (a potentially static String)
+    fn token_to_str(token: Option<Result<Token, Error>>) -> Result<Option<super::Str>, Error> {
+        Ok(expect_string_or_null(token)?
+            .map(|s| s.to_unescaped().map(|u| u.into_owned()))
+            .transpose()?
+            .map(Cow::Owned))
+    }
+
+    fn deser_outputs<'a, I>(
+        tokens: &mut std::iter::Peekable<I>,
+    ) -> Result<Option<PartitionOutputOverride>, Error>
+    where
+        I: Iterator<Item = Result<Token<'a>, Error>>,
+    {
+        match tokens.next().transpose()? {
+            Some(Token::StartObject { .. }) => {
+                #[allow(unused_mut)]
+                let mut builder = PartitionOutputOverride::default();
+                loop {
+                    match tokens.next().transpose()? {
+                        Some(Token::EndObject { .. }) => break,
+                        Some(Token::ObjectKey { key, .. }) => match key.to_unescaped()?.as_ref() {
+                            "name" => {
+                                builder.name = token_to_str(tokens.next())?;
+                            }
+                            "dnsSuffix" => {
+                                builder.dns_suffix = token_to_str(tokens.next())?;
+                            }
+                            "dualStackDnsSuffix" => {
+                                builder.dualstack_dns_suffix = token_to_str(tokens.next())?;
+                            }
+                            "supportsFIPS" => {
+                                builder.supports_fips = expect_bool_or_null(tokens.next())?;
+                            }
+                            "supportsDualStack" => {
+                                builder.supports_dualstack = expect_bool_or_null(tokens.next())?;
+                            }
+                            _ => skip_value(tokens)?,
+                        },
+                        other => {
+                            return Err(Error::custom(format!(
+                                "expected object key or end object, found: {:?}",
+                                other
+                            )))
+                        }
+                    }
+                }
+                Ok(Some(builder))
+            }
+            _ => Err(Error::custom("expected start object")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::endpoint_lib::diagnostic::DiagnosticCollector;
+    use crate::endpoint_lib::partition::{
+        Partition, PartitionMetadata, PartitionOutput, PartitionOutputOverride, PartitionResolver,
+    };
+    use regex::Regex;
+    use std::collections::HashMap;
+
+    fn resolve<'a, 'b>(resolver: &'a PartitionResolver, region: &'b str) -> Partition<'a> {
+        resolver
+            .resolve_partition(region, &mut DiagnosticCollector::new())
+            .expect("could not resolve partition")
+    }
+
+    #[test]
+    fn deserialize_partitions() {
+        let partitions = r#"{
+  "version": "1.1",
+  "partitions": [
+    {
+      "id": "aws",
+      "regionRegex": "^(us|eu|ap|sa|ca|me|af)-\\w+-\\d+$",
+      "regions": {
+        "af-south-1": {},
+        "af-east-1": {},
+        "ap-northeast-1": {},
+        "ap-northeast-2": {},
+        "ap-northeast-3": {},
+        "ap-south-1": {},
+        "ap-southeast-1": {},
+        "ap-southeast-2": {},
+        "ap-southeast-3": {},
+        "ca-central-1": {},
+        "eu-central-1": {},
+        "eu-north-1": {},
+        "eu-south-1": {},
+        "eu-west-1": {},
+        "eu-west-2": {},
+        "eu-west-3": {},
+        "me-south-1": {},
+        "sa-east-1": {},
+        "us-east-1": {},
+        "us-east-2": {},
+        "us-west-1": {},
+        "us-west-2": {},
+        "aws-global": {}
+      },
+      "outputs": {
+        "name": "aws",
+        "dnsSuffix": "amazonaws.com",
+        "dualStackDnsSuffix": "api.aws",
+        "supportsFIPS": true,
+        "supportsDualStack": true
+      }
+    },
+    {
+      "id": "aws-us-gov",
+      "regionRegex": "^us\\-gov\\-\\w+\\-\\d+$",
+      "regions": {
+        "us-gov-west-1": {},
+        "us-gov-east-1": {},
+        "aws-us-gov-global": {}
+      },
+      "outputs": {
+        "name": "aws-us-gov",
+        "dnsSuffix": "amazonaws.com",
+        "dualStackDnsSuffix": "api.aws",
+        "supportsFIPS": true,
+        "supportsDualStack": true
+      }
+    },
+    {
+      "id": "aws-cn",
+      "regionRegex": "^cn\\-\\w+\\-\\d+$",
+      "regions": {
+        "cn-north-1": {},
+        "cn-northwest-1": {},
+        "aws-cn-global": {}
+      },
+      "outputs": {
+        "name": "aws-cn",
+        "dnsSuffix": "amazonaws.com.cn",
+        "dualStackDnsSuffix": "api.amazonwebservices.com.cn",
+        "supportsFIPS": true,
+        "supportsDualStack": true
+      }
+    },
+    {
+      "id": "aws-iso",
+      "regionRegex": "^us\\-iso\\-\\w+\\-\\d+$",
+      "outputs": {
+        "name": "aws-iso",
+        "dnsSuffix": "c2s.ic.gov",
+        "supportsFIPS": true,
+        "supportsDualStack": false,
+        "dualStackDnsSuffix": "c2s.ic.gov"
+      },
+      "regions": {}
+    },
+    {
+      "id": "aws-iso-b",
+      "regionRegex": "^us\\-isob\\-\\w+\\-\\d+$",
+      "outputs": {
+        "name": "aws-iso-b",
+        "dnsSuffix": "sc2s.sgov.gov",
+        "supportsFIPS": true,
+        "supportsDualStack": false,
+        "dualStackDnsSuffix": "sc2s.sgov.gov"
+      },
+      "regions": {}
+    }
+  ]
+}"#;
+        let resolver =
+            super::deser::deserialize_partitions(partitions.as_bytes()).expect("valid resolver");
+        assert_eq!(resolve(&resolver, "cn-north-1").name, "aws-cn");
+        assert_eq!(
+            resolve(&resolver, "cn-north-1").dns_suffix,
+            "amazonaws.com.cn"
+        );
+        assert_eq!(resolver.partitions.len(), 5);
+    }
+
+    #[test]
+    fn resolve_partitions() {
+        let mut resolver = PartitionResolver::new();
+        let mut new_suffix = PartitionOutputOverride::default();
+        new_suffix.dns_suffix = Some("mars.aws".into());
+        resolver.add_partition(PartitionMetadata {
+            id: "aws".into(),
+            region_regex: Regex::new("^(us|eu|ap|sa|ca|me|af)-\\w+-\\d+$").unwrap(),
+            regions: HashMap::from([("mars-east-2".into(), new_suffix)]),
+            outputs: PartitionOutput {
+                name: "aws".into(),
+                dns_suffix: "amazonaws.com".into(),
+                dualstack_dns_suffix: "api.aws".into(),
+                supports_fips: true,
+                supports_dualstack: true,
+            },
+        });
+        resolver.add_partition(PartitionMetadata {
+            id: "other".into(),
+            region_regex: Regex::new("^(other)-\\w+-\\d+$").unwrap(),
+            regions: Default::default(),
+            outputs: PartitionOutput {
+                name: "other".into(),
+                dns_suffix: "other.amazonaws.com".into(),
+                dualstack_dns_suffix: "other.aws".into(),
+                supports_fips: false,
+                supports_dualstack: true,
+            },
+        });
+        assert_eq!(resolve(&resolver, "us-east-1").name, "aws");
+        assert_eq!(resolve(&resolver, "other-west-2").name, "other");
+        // mars-east-1 hits aws through the default fallback
+        assert_eq!(
+            resolve(&resolver, "mars-east-1").dns_suffix,
+            "amazonaws.com"
+        );
+        // mars-east-2 hits aws through the region override
+        assert_eq!(resolve(&resolver, "mars-east-2").dns_suffix, "mars.aws");
+    }
+}


### PR DESCRIPTION
## Motivation and Context
Adds the `aws.partition` function for endpoints 2.0

## Description
Adds support for the partition function

## Testing
- [x] basic testing. More thorough testing will come from generated endpoint tests

## Checklist


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
