### PR TITLE
Endpoint params

### DIFF
--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
+
     runtimeOnly(project(":rust-runtime"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")

--- a/codegen/build.gradle.kts
+++ b/codegen/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     runtimeOnly(project(":rust-runtime"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointParamsGenerator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointParamsGenerator.kt
@@ -1,0 +1,282 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.endpoints
+
+import software.amazon.smithy.rulesengine.language.EndpointRuleset
+import software.amazon.smithy.rulesengine.language.eval.Value
+import software.amazon.smithy.rust.codegen.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.asDeref
+import software.amazon.smithy.rust.codegen.rustlang.docs
+import software.amazon.smithy.rust.codegen.rustlang.isCopy
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.stripOuter
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.Clone
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.Debug
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.Default
+import software.amazon.smithy.rust.codegen.smithy.RuntimeType.Companion.PartialEq
+import software.amazon.smithy.rust.codegen.smithy.isOptional
+import software.amazon.smithy.rust.codegen.smithy.makeOptional
+import software.amazon.smithy.rust.codegen.smithy.mapRustType
+import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.util.dq
+import software.amazon.smithy.rust.codegen.util.orNull
+
+val EndpointsModule = RustModule.public("endpoint_resolver", "Endpoint resolution functionality")
+
+/** Endpoint Parameters generator.
+ *
+ * This class generates the `Params` struct for an [EndpointRuleset]. The struct will have `pub(crate)` fields, a `Builder`,
+ * and an error type that is created to handle when construction fails.
+ *
+ * The builder of this struct generates a fallible `build()` method because endpoint params MAY have required fields. However,
+ * the external parts of this struct (the public accessors) will _always_ be optional to ensure a public interface is maintained.
+ *
+ * The following snippet contains an example of what is generated (eliding the error):
+ *  ```rust
+ *  #[non_exhaustive]
+ *  #[derive(std::clone::Clone, std::cmp::PartialEq, std::fmt::Debug)]
+ *  /// Configuration parameters for resolving the correct endpoint
+ *  pub struct Params {
+ *      pub(crate) region: std::option::Option<std::string::String>,
+ *  }
+ *  impl Params {
+ *      /// Create a builder for [`Params`]
+ *      pub fn builder() -> crate::endpoint_resolver::Builder {
+ *          crate::endpoint_resolver::Builder::default()
+ *      }
+ *      /// Gets the value for region
+ *      pub fn region(&self) -> std::option::Option<&str> {
+ *          self.region.as_deref()
+ *      }
+ *  }
+ *
+ *  /// Builder for [`Params`]
+ *  #[derive(std::default::Default, std::clone::Clone, std::cmp::PartialEq, std::fmt::Debug)]
+ *  pub struct Builder {
+ *      region: std::option::Option<std::string::String>,
+ *  }
+ *  impl Builder {
+ *      /// Consume this builder, creating [`Params`].
+ *      pub fn build(
+ *          self,
+ *      ) -> Result<crate::endpoint_resolver::Params, crate::endpoint_resolver::Error> {
+ *          Ok(crate::endpoint_resolver::Params {
+ *                  region: self.region,
+ *          })
+ *      }
+ *
+ *      /// Sets the value for region
+ *      pub fn region(mut self, value: std::string::String) -> Self {
+ *          self.region = Some(value);
+ *          self
+ *      }
+ *
+ *      /// Sets the value for region
+ *      pub fn set_region(mut self, param: Option<impl Into<std::string::String>>) -> Self {
+ *          self.region = param.map(|t| t.into());
+ *          self
+ *      }
+ *  }
+ *  ```
+ */
+
+class EndpointParamsGenerator(private val endpointRules: EndpointRuleset) {
+
+    fun paramsStruct(): RuntimeType = RuntimeType.forInlineFun("Params", EndpointsModule) { writer ->
+        generateEndpointsStruct(writer)
+    }
+
+    private fun endpointsBuilder(): RuntimeType = RuntimeType.forInlineFun("Builder", EndpointsModule) { writer ->
+        generateEndpointParamsBuilder(writer)
+    }
+
+    private fun paramsError(): RuntimeType = RuntimeType.forInlineFun("Error", EndpointsModule) { writer ->
+        writer.rust(
+            """
+            /// An error that occurred during endpoint resolution
+            ##[derive(Debug)]
+            ##[non_exhaustive]
+            pub enum Error {
+                ##[non_exhaustive]
+                /// A required field was missing
+                MissingRequiredField {
+                    /// Name of the missing field
+                    field: std::borrow::Cow<'static, str>
+                },
+
+                ##[non_exhaustive]
+                /// A valid endpoint could not be resolved
+                EndpointResolutionError {
+                    /// The error message
+                    message: std::borrow::Cow<'static, str>
+                }
+            }
+
+            impl Error {
+                fn missing(field: &'static str) -> Self {
+                    Self::MissingRequiredField { field: field.into() }
+                }
+            }
+
+            impl std::fmt::Display for Error {
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    match self {
+                        Error::MissingRequiredField { field } => write!(f, "A required field was missing: `{}`", field),
+                        Error::EndpointResolutionError { message } => write!(f, "A valid endpoint could not be resolved: {}.", message)
+                    }
+                }
+            }
+
+            impl std::error::Error for Error { }
+            """,
+        )
+    }
+
+    /**
+     * Generates an endpoints struct based on the provided endpoint rules. The struct fields are `pub(crate)`
+     * with optionality as indicated by the required status of the parameter.
+     */
+    private fun generateEndpointsStruct(writer: RustWriter) {
+        // Ensure that fields can be added in the future
+        Attribute.NonExhaustive.render(writer)
+        // Automatically implement standard Rust functionality
+        Attribute.Derives(setOf(Debug, PartialEq, Clone)).render(writer)
+        // Generate the struct block:
+        /*
+            pub struct Params {
+                ... members: pub(crate) field
+            }
+         */
+        writer.docs("Configuration parameters for resolving the correct endpoint")
+        writer.rustBlock("pub struct Params") {
+            endpointRules.parameters.toList().forEach { parameter ->
+                // Render documentation for each parameter
+                parameter.documentation.orNull()?.also { docs(it) }
+                rust("pub(crate) ${parameter.memberName()}: #T,", parameter.symbol())
+            }
+        }
+
+        // Generate the impl block for the struct
+        writer.rustBlock("impl Params") {
+            rustTemplate(
+                """
+                /// Create a builder for [`Params`]
+                pub fn builder() -> #{Builder} {
+                    #{Builder}::default()
+                }
+                """,
+                "Builder" to endpointsBuilder(),
+            )
+            endpointRules.parameters.toList().forEach { parameter ->
+                val name = parameter.memberName()
+                val type = parameter.symbol()
+
+                parameter.documentation.orNull() ?: "Gets the value for $name".also { docs(it) }
+                rustTemplate(
+                    """
+                    pub fn ${parameter.memberName()}(&self) -> #{paramType} {
+                        #{param:W}
+                    }
+
+                    """,
+                    "paramType" to type.makeOptional().mapRustType { t -> t.asDeref() },
+                    "param" to writable {
+                        when {
+                            type.isOptional() && type.rustType().isCopy() -> rust("self.$name")
+                            type.isOptional() -> rust("self.$name.as_deref()")
+                            type.rustType().isCopy() -> rust("Some(self.$name)")
+                            else -> rust("Some(&self.$name)")
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    private fun value(value: Value): String {
+        return when (value) {
+            is Value.Str -> value.value().dq() + ".to_string()"
+            is Value.Bool -> value.expectBool().toString()
+            else -> TODO("unexpected type: $value")
+        }
+    }
+
+    private fun generateEndpointParamsBuilder(rustWriter: RustWriter) {
+        rustWriter.docs("Builder for [`Params`]")
+        Attribute.Derives(setOf(Debug, Default, PartialEq, Clone)).render(rustWriter)
+        rustWriter.rustBlock("pub struct Builder") {
+            endpointRules.parameters.toList().forEach { parameter ->
+                val name = parameter.memberName()
+                val type = parameter.symbol().makeOptional()
+                rust("$name: #T,", type)
+            }
+        }
+
+        rustWriter.rustBlock("impl Builder") {
+            docs("Consume this builder, creating [`Params`].")
+            rustBlockTemplate(
+                "pub fn build(self) -> Result<#{Params}, #{ParamsError}>",
+                "Params" to paramsStruct(),
+                "ParamsError" to paramsError(),
+            ) {
+                val params = writable {
+                    rustBlockTemplate("#{Params}", "Params" to paramsStruct()) {
+                        endpointRules.parameters.toList().forEach { parameter ->
+                            rust("${parameter.memberName()}: self.${parameter.memberName()}")
+                            parameter.default.orNull()?.also { default -> rust(".or(Some(${value(default)}))") }
+                            if (parameter.isRequired) {
+                                rustTemplate(
+                                    ".ok_or_else(||#{Error}::missing(${parameter.memberName().dq()}))?",
+                                    "Error" to paramsError(),
+                                )
+                            }
+                            rust(",")
+                        }
+                    }
+                }
+                rust("Ok(#W)", params)
+            }
+            endpointRules.parameters.toList().forEach { parameter ->
+                val name = parameter.memberName()
+                val type = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
+                rustTemplate(
+                    """
+                    /// Sets the value for $name #{extraDocs:W}
+                    pub fn $name(mut self, value: #{type}) -> Self {
+                        self.$name = Some(value);
+                        self
+                    }
+
+                    /// Sets the value for $name #{extraDocs:W}
+                    pub fn set_$name(mut self, param: Option<impl Into<#{nonOptionalType}>>) -> Self {
+                        self.$name = param.map(|t|t.into());
+                        self
+                    }
+                    """,
+                    "nonOptionalType" to parameter.symbol().mapRustType { it.stripOuter<RustType.Option>() },
+                    "type" to type,
+                    "extraDocs" to writable {
+                        if (parameter.default.isPresent || parameter.documentation.isPresent) {
+                            rust("\n///")
+                        }
+                        parameter.default.orNull()?.also {
+                            docs("When unset, this parameter has a default value of `$it`.")
+                        }
+                        parameter.documentation.orNull()?.also { docs(it) }
+                    },
+                )
+            }
+        }
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/Util.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/Util.kt
@@ -1,0 +1,39 @@
+package software.amazon.smithy.rust.codegen.smithy.endpoints
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.rulesengine.language.lang.Identifier
+import software.amazon.smithy.rulesengine.language.lang.parameters.Parameter
+import software.amazon.smithy.rulesengine.language.lang.parameters.ParameterType
+import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
+import software.amazon.smithy.rust.codegen.rustlang.RustType
+import software.amazon.smithy.rust.codegen.smithy.letIf
+import software.amazon.smithy.rust.codegen.smithy.makeOptional
+import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.util.toSnakeCase
+
+/**
+ * Utility function to convert an [Identifier] into a valid Rust identifier (snake case)
+ */
+fun Identifier.rustName(): String {
+    return RustReservedWords.escapeIfNeeded(this.toString().toSnakeCase())
+}
+
+/**
+ * Returns the memberName() for a given [Parameter]
+ */
+fun Parameter.memberName(): String {
+    return name.rustName()
+}
+
+/**
+ * Returns the symbol for a given parameter. This enables [RustWriter] to generate the correct [RustType].
+ */
+fun Parameter.symbol(): Symbol {
+    val rustType = when (this.type) {
+        ParameterType.STRING -> RustType.String
+        ParameterType.BOOLEAN -> RustType.Bool
+        else -> TODO("unexpected type: ${this.type}")
+    }
+    // Parameter return types are always optional
+    return Symbol.builder().rustType(rustType).build().letIf(!this.isRequired) { it.makeOptional() }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/Util.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/Util.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.rust.codegen.smithy.endpoints
 
 import software.amazon.smithy.codegen.core.Symbol

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointParamsGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointParamsGeneratorTest.kt
@@ -1,0 +1,40 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.endpoints
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import software.amazon.smithy.rulesengine.testutil.TestDiscovery
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+import java.util.stream.Stream
+
+internal class EndpointParamsGeneratorTest {
+    companion object {
+        @JvmStatic
+        fun testSuites(): Stream<TestDiscovery.RulesTestSuite> = TestDiscovery().testSuites()
+    }
+
+    @ParameterizedTest()
+    @MethodSource("testSuites")
+    fun `generate endpoint params for provided test suites`(testSuite: TestDiscovery.RulesTestSuite) {
+        val project = TestWorkspace.testProject()
+        project.lib { writer ->
+            writer.unitTest("params_work") {
+                rustTemplate(
+                    """
+                    // this might fail if there are required fields
+                    let _ = #{Params}::builder().build();
+                    """,
+                    "Params" to EndpointParamsGenerator(testSuite.ruleset()).paramsStruct(),
+                )
+            }
+        }
+        project.compileAndTest()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+sourceControl {
+    gitRepository(uri("https://github.com/skmcgrail/smithy.git")) {
+        producesModule("software.amazon.smithy:smithy-rules-engine")
+    }
+}
+
 rootProject.name = "software.amazon.smithy.rust.codegen.smithy-rs"
 
 include(":codegen")


### PR DESCRIPTION
## Motivation and Context
This adds generation of the `EndpointParams` struct from endpoint rules. This is the first of a series of PRs to the `feature/endpoints` branch. This uses a `source` dependency to avoid the need to manually publishToMavenLocal. Prior to merging to mainline, we will need to finalize the Ruleset changes in a smithy release and remove the source override.

## Description
- add endpoint params generator
- add tests that uses the test cases provided by endpoints 2.0

## Testing
- standard compile-and-test unit tests
## Checklist

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
