### PR TITLE
Add wiring to generate parameters in operations

### DIFF
--- a/aws/rust-runtime/aws-endpoint/src/lib.rs
+++ b/aws/rust-runtime/aws-endpoint/src/lib.rs
@@ -35,6 +35,12 @@ pub struct Params {
     region: Option<Region>,
 }
 
+impl From<Option<String>> for Params {
+    fn from(region: Option<String>) -> Self {
+        Params::new(region.map(Region::new))
+    }
+}
+
 impl Params {
     pub fn new(region: Option<Region>) -> Self {
         Self { region }

--- a/aws/sdk-codegen/build.gradle.kts
+++ b/aws/sdk-codegen/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.jsoup:jsoup:1.14.3")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
 }

--- a/codegen-test/build.gradle.kts
+++ b/codegen-test/build.gradle.kts
@@ -43,6 +43,7 @@ val allCodegenTests = listOf(
     CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
     CodegenTest("aws.protocoltests.restjson#RestJsonExtras", "rest_json_extras"),
     CodegenTest("aws.protocoltests.misc#MiscService", "misc"),
+    CodegenTest("aws.protocoltests.json#TestService", "endpoint-rules"),
     CodegenTest(
         "aws.protocoltests.restxml#RestXml", "rest_xml",
         extraConfig = """, "codegen": { "addMessageToErrors": false } """,

--- a/codegen-test/model/endpoint-rules.smithy
+++ b/codegen-test/model/endpoint-rules.smithy
@@ -1,0 +1,33 @@
+$version: "1.0"
+
+namespace aws.protocoltests.json
+
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+use smithy.rules#clientContextParams
+use smithy.rules#staticContextParams
+use smithy.rules#contextParam
+use aws.protocols#awsJson1_1
+
+@awsJson1_1
+@endpointRuleSet({
+    "version": "1.0",
+    "rules": [],
+    "parameters": {
+        "Bucket": { "required": false, "type": "String" },
+        "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+    }
+})
+service TestService {
+    operations: [TestOperation]
+}
+
+operation TestOperation {
+    input: TestOperationInput
+}
+
+structure TestOperationInput {
+    @contextParam(name: "Bucket")
+    bucket: String
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/ClientCodegenContext.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/ClientCodegenContext.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.smithy
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
 import software.amazon.smithy.rust.codegen.smithy.generators.CodegenTarget
 
 /**
@@ -22,6 +23,7 @@ data class ClientCodegenContext(
     override val serviceShape: ServiceShape,
     override val protocol: ShapeId,
     override val settings: ClientRustSettings,
+    val rootDecorator: RustCodegenDecorator<ClientCodegenContext>,
 ) : CoreCodegenContext(
     model, symbolProvider, serviceShape, protocol, settings, CodegenTarget.CLIENT,
 )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/CodegenVisitor.kt
@@ -72,7 +72,7 @@ class CodegenVisitor(context: PluginContext, private val codegenDecorator: RustC
         model = codegenDecorator.transformModel(service, baseModel)
         symbolProvider = RustCodegenPlugin.baseSymbolProvider(model, service, symbolVisitorConfig)
 
-        codegenContext = ClientCodegenContext(model, symbolProvider, service, protocol, settings)
+        codegenContext = ClientCodegenContext(model, symbolProvider, service, protocol, settings, codegenDecorator)
         rustCrate = RustCrate(
             context.fileManifest,
             symbolProvider,

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustCodegenPlugin.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/RustCodegenPlugin.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.smithy.customizations.ClientCustomiza
 import software.amazon.smithy.rust.codegen.smithy.customize.CombinedCodegenDecorator
 import software.amazon.smithy.rust.codegen.smithy.customize.NoOpEventStreamSigningDecorator
 import software.amazon.smithy.rust.codegen.smithy.customize.RequiredCustomizations
+import software.amazon.smithy.rust.codegen.smithy.endpoints.EndpointsDecorator
 import software.amazon.smithy.rust.codegen.smithy.generators.CodegenTarget
 import software.amazon.smithy.rust.codegen.smithy.generators.client.FluentClientDecorator
 import java.util.logging.Level
@@ -44,6 +45,7 @@ class RustCodegenPlugin : SmithyBuildPlugin {
                 context,
                 ClientCustomizations(),
                 RequiredCustomizations(),
+                EndpointsDecorator(),
                 FluentClientDecorator(),
                 NoOpEventStreamSigningDecorator(),
             )

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customize/RustCodegenDecorator.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/customize/RustCodegenDecorator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.smithy.endpoints.RulesEngineBuiltInResolver
 import software.amazon.smithy.rust.codegen.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.smithy.generators.ManifestCustomizations
 import software.amazon.smithy.rust.codegen.smithy.generators.config.ConfigCustomization
@@ -70,6 +71,8 @@ interface RustCodegenDecorator<C : CoreCodegenContext> {
     fun transformModel(service: ServiceShape, model: Model): Model = model
 
     fun supportsCodegenContext(clazz: Class<out CoreCodegenContext>): Boolean
+
+    fun builtInResolvers(codegenContext: C): List<RulesEngineBuiltInResolver> = listOf()
 }
 
 /**
@@ -143,6 +146,10 @@ open class CombinedCodegenDecorator<C : CoreCodegenContext>(decorators: List<Rus
     override fun supportsCodegenContext(clazz: Class<out CoreCodegenContext>): Boolean =
         // `CombinedCodegenDecorator` can work with all types of codegen context.
         CoreCodegenContext::class.java.isAssignableFrom(clazz)
+
+    override fun builtInResolvers(codegenContext: C): List<RulesEngineBuiltInResolver> {
+        return orderedDecorators.flatMap { it.builtInResolvers(codegenContext) }
+    }
 
     companion object {
         inline fun <reified T : CoreCodegenContext> fromClasspath(

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointCustomization.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointCustomization.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.endpoints
+
+import software.amazon.smithy.model.node.BooleanNode
+import software.amazon.smithy.model.node.StringNode
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ShapeType
+import software.amazon.smithy.rulesengine.language.lang.parameters.Builtins
+import software.amazon.smithy.rulesengine.language.lang.parameters.Parameter
+import software.amazon.smithy.rulesengine.language.lang.parameters.Parameters
+import software.amazon.smithy.rulesengine.traits.ContextIndex
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.smithy.CoreCodegenContext
+import software.amazon.smithy.rust.codegen.smithy.customize.OperationCustomization
+import software.amazon.smithy.rust.codegen.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.smithy.generators.operationBuildError
+import software.amazon.smithy.rust.codegen.util.orNull
+
+/**
+ * BuiltInResolver enables potentially external codegen stages to provide sources for `builtIn` parameters.
+ * For example, allows AWS to provide the value for the region builtIn in separate codegen.
+ *
+ * If this resolver does not recognize the value, it MUST return `null`.
+ */
+interface RulesEngineBuiltInResolver {
+    fun defaultFor(parameter: Parameter, configRef: String): Writable?
+}
+
+class EndpointsDecorator : RustCodegenDecorator<ClientCodegenContext> {
+    override val name: String = "Endpoints"
+    override val order: Byte = 0
+
+    override fun supportsCodegenContext(clazz: Class<out CoreCodegenContext>): Boolean =
+        clazz.isAssignableFrom(ClientCodegenContext::class.java)
+
+    override fun operationCustomizations(
+        codegenContext: ClientCodegenContext,
+        operation: OperationShape,
+        baseCustomizations: List<OperationCustomization>,
+    ): List<OperationCustomization> {
+        return baseCustomizations + CreateEndpointParams(
+            codegenContext,
+            operation,
+            codegenContext.rootDecorator.builtInResolvers(codegenContext),
+        )
+    }
+}
+
+/**
+ * Creates an `<crate>::endpoint_resolver::Params` structure in make operation generator. This combines state from the
+ * client, the operation, and the model to create parameters.
+ *
+ * Example generated code:
+ * ```rust
+ * let _endpoint_params = crate::endpoint_resolver::Params::builder()
+ *     .set_region(Some("test-region"))
+ *     .set_disable_everything(Some(true))
+ *     .set_bucket(input.bucket.as_ref())
+ *     .build();
+ * ```
+ */
+class CreateEndpointParams(
+    private val ctx: CoreCodegenContext,
+    private val operationShape: OperationShape,
+    private val rulesEngineBuiltInResolvers: List<RulesEngineBuiltInResolver>,
+) :
+    OperationCustomization() {
+
+    private val runtimeConfig = ctx.runtimeConfig
+    private val params =
+        EndpointRulesetIndex.of(ctx.model).endpointRulesForService(ctx.serviceShape)?.parameters
+            ?: Parameters.builder().addParameter(Builtins.REGION).build()
+    private val idx = ContextIndex.of(ctx.model)
+
+    private val codegenScope = arrayOf(
+        "Params" to EndpointParamsGenerator(params).paramsStruct(),
+        "BuildError" to runtimeConfig.operationBuildError(),
+    )
+
+    override fun section(section: OperationSection): Writable {
+        return when (section) {
+            is OperationSection.MutateInput -> writable {
+                // insert the endpoint resolution _result_ into the bag (note that this won't bail if endpoint
+                // resolution failed)
+                // generate with a leading `_` because we aren't generating rules that will use this for all services
+                // yet.
+                rustTemplate(
+                    """
+                    let _endpoint_params = #{Params}::builder()#{builderFields:W}.build();
+                    """,
+                    "builderFields" to builderFields(section),
+                    *codegenScope,
+                )
+            }
+
+            else -> emptySection
+        }
+    }
+
+    private fun builderFields(section: OperationSection.MutateInput) = writable {
+        val memberParams = idx.getContextParams(operationShape)
+        val builtInParams = params.toList().filter { it.isBuiltIn }
+        // first load builtins and their defaults
+        builtInParams.forEach { param ->
+            val defaultProviders = rulesEngineBuiltInResolvers.mapNotNull { it.defaultFor(param, section.config) }
+            if (defaultProviders.size > 1) {
+                error("Multiple providers provided a value for the builtin $param")
+            }
+            defaultProviders.firstOrNull()?.also { defaultValue ->
+                rust(".set_${param.name.rustName()}(#W)", defaultValue)
+            }
+        }
+        // NOTE(rcoh): we are not currently generating client context params onto the service shape yet
+        // these can be overridden with client context params
+        idx.getClientContextParams(ctx.serviceShape).orNull()?.parameters?.forEach { (name, param) ->
+            val paramName = EndpointParamsGenerator.memberName(name)
+            val setterName = EndpointParamsGenerator.setterName(name)
+            if (param.type == ShapeType.BOOLEAN) {
+                rust(".$setterName(${section.config}.$paramName)")
+            } else {
+                rust(".$setterName(${section.config}.$paramName.as_ref())")
+            }
+        }
+
+        idx.getStaticContextParams(operationShape).orNull()?.parameters?.forEach { (name, param) ->
+            val setterName = EndpointParamsGenerator.setterName(name)
+            val value = writable {
+                when (val v = param.value) {
+                    is BooleanNode -> rust("Some(${v.value})")
+                    is StringNode -> rust("Some(${v.value})")
+                    else -> TODO("Unexpected static value type: $v")
+                }
+            }
+            rust(".$setterName(#W)", value)
+        }
+
+        // lastly, allow these to be overridden by members
+        memberParams.forEach { (memberShape, param) ->
+            rust(
+                ".${EndpointParamsGenerator.setterName(param.name)}(${section.input}.${
+                ctx.symbolProvider.toMemberName(
+                    memberShape,
+                )
+                }.as_ref())",
+            )
+        }
+    }
+}

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/Util.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/Util.kt
@@ -6,22 +6,46 @@
 package software.amazon.smithy.rust.codegen.smithy.endpoints
 
 import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.KnowledgeIndex
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.rulesengine.language.EndpointRuleset
 import software.amazon.smithy.rulesengine.language.lang.Identifier
 import software.amazon.smithy.rulesengine.language.lang.parameters.Parameter
 import software.amazon.smithy.rulesengine.language.lang.parameters.ParameterType
+import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 import software.amazon.smithy.rust.codegen.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.rustlang.RustType
 import software.amazon.smithy.rust.codegen.smithy.letIf
 import software.amazon.smithy.rust.codegen.smithy.makeOptional
 import software.amazon.smithy.rust.codegen.smithy.rustType
+import software.amazon.smithy.rust.codegen.util.getTrait
 import software.amazon.smithy.rust.codegen.util.toSnakeCase
+
+class EndpointRulesetIndex(model: Model) : KnowledgeIndex {
+
+    private val rulesets: HashMap<ServiceShape, EndpointRuleset?> = HashMap()
+
+    fun endpointRulesForService(serviceShape: ServiceShape) = rulesets.computeIfAbsent(
+        serviceShape,
+    ) { serviceShape.getTrait<EndpointRuleSetTrait>()?.ruleSet?.let { EndpointRuleset.fromNode(it) } }
+
+    companion object {
+        fun of(model: Model): EndpointRulesetIndex {
+            return model.getKnowledge(EndpointRulesetIndex::class.java) { EndpointRulesetIndex(it) }
+        }
+    }
+}
 
 /**
  * Utility function to convert an [Identifier] into a valid Rust identifier (snake case)
  */
 fun Identifier.rustName(): String {
-    return RustReservedWords.escapeIfNeeded(this.toString().toSnakeCase())
+    return this.toString().stringToRustName()
 }
+
+fun String.stringToRustName(): String = RustReservedWords.escapeIfNeeded(this.toSnakeCase())
 
 /**
  * Returns the memberName() for a given [Parameter]
@@ -29,6 +53,8 @@ fun Identifier.rustName(): String {
 fun Parameter.memberName(): String {
     return name.rustName()
 }
+
+fun ContextParamTrait.memberName(): String = this.name.stringToRustName()
 
 /**
  * Returns the symbol for a given parameter. This enables [RustWriter] to generate the correct [RustType].

--- a/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/Rust.kt
+++ b/codegen/src/main/kotlin/software/amazon/smithy/rust/codegen/testutil/Rust.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.model.traits.EnumDefinition
 import software.amazon.smithy.rust.codegen.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustDependency
 import software.amazon.smithy.rust.codegen.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.rustlang.Writable
 import software.amazon.smithy.rust.codegen.rustlang.raw
 import software.amazon.smithy.rust.codegen.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.smithy.CoreCodegenConfig
@@ -91,7 +92,7 @@ object TestWorkspace {
     }
 
     @Suppress("NAME_SHADOWING")
-    fun testProject(symbolProvider: RustSymbolProvider? = null, debugMode: Boolean = false): TestWriterDelegator {
+    fun testProject(symbolProvider: RustSymbolProvider? = null, debugMode: Boolean = true): TestWriterDelegator {
         val subprojectDir = subproject()
         val symbolProvider = symbolProvider ?: object : RustSymbolProvider {
             override fun config(): SymbolVisitorConfig {
@@ -124,7 +125,13 @@ object TestWorkspace {
  * "cargo test".runCommand(path)
  * ```
  */
-fun generatePluginContext(model: Model, additionalSettings: ObjectNode = ObjectNode.builder().build(), addModuleToEventStreamAllowList: Boolean = false, service: String? = null, runtimeConfig: RuntimeConfig? = null): Pair<PluginContext, Path> {
+fun generatePluginContext(
+    model: Model,
+    additionalSettings: ObjectNode = ObjectNode.builder().build(),
+    addModuleToEventStreamAllowList: Boolean = false,
+    service: String? = null,
+    runtimeConfig: RuntimeConfig? = null,
+): Pair<PluginContext, Path> {
     val testDir = TestWorkspace.subproject()
     val moduleName = "test_${testDir.nameWithoutExtension}"
     val testPath = testDir.toPath()
@@ -201,6 +208,15 @@ class TestWriterDelegator(
             println("file:///$path")
         }
     }
+}
+
+fun TestWriterDelegator.unitTest(test: Writable): TestWriterDelegator {
+    lib { writer ->
+        writer.unitTest(writer.safeName("test")) {
+            test(this)
+        }
+    }
+    return this
 }
 
 /**

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/CreateEndpointParamsTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/CreateEndpointParamsTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.smithy.endpoints
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rulesengine.language.lang.parameters.Parameter
+import software.amazon.smithy.rust.codegen.rustlang.Writable
+import software.amazon.smithy.rust.codegen.rustlang.rust
+import software.amazon.smithy.rust.codegen.rustlang.writable
+import software.amazon.smithy.rust.codegen.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.testutil.unitTest
+
+internal class CreateEndpointParamsTest {
+    val model = """
+        namespace com.example
+        use smithy.rules#endpointRuleSet
+        use smithy.rules#contextParam
+        use smithy.rules#staticContextParams
+
+        @endpointRuleSet({
+            "version": "1.0",
+            "rules": [],
+            "parameters": {
+                "Bucket": { "required": false, "type": "String" },
+                "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
+                "DisableEverything": { "required": false, "type": "Boolean" }
+            }
+        })
+        service MyService {
+            operations: [TestOperation]
+        }
+
+        @staticContextParams({ "disableEverything": { value: true } })
+        operation TestOperation {
+            input: TestOperationInput
+        }
+
+        structure TestOperationInput {
+            @contextParam(name: "Bucket")
+            bucket: String
+        }
+    """.asSmithyModel()
+
+    @Test
+    fun `generate an operation with parameters wired properly`() {
+        val ctx = testCodegenContext(model)
+        val injector = CreateEndpointParams(
+            ctx,
+            model.expectShape(ShapeId.from("com.example#TestOperation"), OperationShape::class.java),
+            listOf(object : RulesEngineBuiltInResolver {
+                override fun defaultFor(parameter: Parameter, configRef: String): Writable? {
+                    if (parameter.builtIn.get() == "AWS::Region") {
+                        return writable { rust("""Some("test-region")""") }
+                    }
+                    return null
+                }
+            },
+            ),
+        )
+        val project = TestWorkspace.testProject()
+        project.unitTest {
+            rust(
+                """
+                struct Input { bucket: Option<String> }
+                let input = Input{ bucket: Some("my-bucket".to_string()) };
+                """,
+            )
+            injector.section(OperationSection.MutateInput(listOf(), "input", "config"))(this)
+            rust(
+                """
+                let endpoint_params = _endpoint_params.expect("endpoint params should be valid");
+                assert_eq!(endpoint_params.bucket(), Some("my-bucket"));
+                assert_eq!(endpoint_params.region(), Some("test-region"));
+                assert_eq!(endpoint_params.disable_everything(), Some(true));
+                """,
+            )
+        }.compileAndTest()
+    }
+}

--- a/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointParamsGeneratorTest.kt
+++ b/codegen/src/test/kotlin/software/amazon/smithy/rust/codegen/smithy/endpoints/EndpointParamsGeneratorTest.kt
@@ -31,7 +31,7 @@ internal class EndpointParamsGeneratorTest {
                     // this might fail if there are required fields
                     let _ = #{Params}::builder().build();
                     """,
-                    "Params" to EndpointParamsGenerator(testSuite.ruleset()).paramsStruct(),
+                    "Params" to EndpointParamsGenerator(testSuite.ruleset().parameters).paramsStruct(),
                 )
             }
         }


### PR DESCRIPTION
## Motivation and Context

- #1637 
- Wire up the `params` in `operation` generator

## Description
Code generate params into `make_operation` generator. As a stop gap, we currently extract the region from this parameter and use it to drive the custom AWS resolver. The AWS resolver will be removed once we have endpoint rules for all services.

As a TLDR, this adds the following code to the body of make_operation:
```rust
        let _endpoint_params = crate::endpoint_resolver::Params::builder()
            /* region is a builtIn, other parameters will be injected here in the future */
            .set_region(_config.region.as_ref().map(|r| r.as_ref()))
            .build();

```
## Testing
- [x] codegen integration tests
- [x] added new codegen integration test
## Checklist


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
