### PR TITLE
Avoid info-level log about unimportant event

### DIFF
--- a/aws/rust-runtime/aws-config/src/imds/region.rs
+++ b/aws/rust-runtime/aws-config/src/imds/region.rs
@@ -53,7 +53,7 @@ impl ImdsRegionProvider {
         let client = self.client.client().await.ok()?;
         match client.get(REGION_PATH).await {
             Ok(region) => {
-                tracing::info!(region = % region, "loaded region from IMDS");
+                tracing::debug!(region = % region, "loaded region from IMDS");
                 Some(Region::new(region))
             }
             Err(err) => {


### PR DESCRIPTION
Loading regions happens fairly frequently, and isn't an exceptional event, so logging it at info level seems excessive.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
