### PR TITLE
Allow for unchecked service builders

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
@@ -292,6 +292,23 @@ class ServerServiceGeneratorV2(
         }
     }
 
+    // Returns a `Writable` comma delimited sequence of `DummyOperation`.
+    private fun dummyGenerics(): Writable = writable {
+        for (index in 1..allOperationShapes.size) {
+            rustTemplate("#{SmithyHttpServer}::operation::DummyOperation,", *codegenScope)
+        }
+    }
+
+    // Returns a `Writable` comma delimited sequence of `builder_field: DummyOperation`.
+    private fun dummyFields(): Writable = writable {
+        for (fieldName in builderFieldNames()) {
+            rustTemplate(
+                "$fieldName: #{SmithyHttpServer}::operation::DummyOperation,",
+                *codegenScope,
+            )
+        }
+    }
+
     // Returns a `Writable` containing the service struct definition and its implementations.
     private fun struct(): Writable = writable {
         // Generate struct documentation.
@@ -312,6 +329,17 @@ class ServerServiceGeneratorV2(
                 pub fn builder() -> $builderName<#{NotSetGenerics:W}> {
                     $builderName {
                         #{NotSetFields:W}
+                        modifier: #{SmithyHttpServer}::build_modifier::Identity,
+                        _exts: std::marker::PhantomData
+                    }
+                }
+
+                /// Constructs a unchecked builder for [`$serviceName`].
+                ///
+                /// This will not enforce that all operations are set, however if an unset operation is used at runtime it will cause a panic.
+                pub fn unchecked_builder() -> $builderName<#{DummyGenerics:W}> {
+                    $builderName {
+                        #{DummyFields:W}
                         modifier: #{SmithyHttpServer}::build_modifier::Identity,
                         _exts: std::marker::PhantomData
                     }
@@ -354,6 +382,8 @@ class ServerServiceGeneratorV2(
                 }
             }
             """,
+            "DummyGenerics" to dummyGenerics(),
+            "DummyFields" to dummyFields(),
             "NotSetGenerics" to notSetGenerics(),
             "NotSetFields" to notSetFields(),
             "Router" to protocol.routerType(),

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
@@ -336,7 +336,8 @@ class ServerServiceGeneratorV2(
 
                 /// Constructs a unchecked builder for [`$serviceName`].
                 ///
-                /// This will not enforce that all operations are set, however if an unset operation is used at runtime it will cause a panic.
+                /// This will not enforce that all operations are set, however if an unset operation is used at runtime
+                /// it will cause a panic.
                 pub fn unchecked_builder() -> $builderName<#{DummyGenerics:W}> {
                     $builderName {
                         #{DummyFields:W}

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
@@ -63,6 +63,9 @@ pub async fn main() {
         .health_check_operation(health_check_operation)
         .build();
 
+    // Unchecked build does not type check whether or not an operation is set but will panic at runtime.
+    let _ = PokemonService::unchecked_builder().build::<hyper::Body>();
+
     // Setup shared state and middlewares.
     let shared_state = Arc::new(State::default());
     let app = app.layer(

--- a/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
@@ -266,14 +266,21 @@ where
 }
 
 /// A marker struct indicating an [`Operation`] has not been set in a builder.
+///
+/// This does _not_ implement [`Upgradable`] purposely.
 pub struct MissingOperation;
 
+/// A marker struct indicating an [`Operation`] has not been set in a builder.
+///
+/// This does implement [`Upgradable`] but the output [`Service`] of the upgrade is a [`PanicService`], which will
+/// [`panic`] on [`Service::call`].
 pub struct DummyOperation;
 
+/// A [`Service`] which panics on [`Service::call`].
 #[derive(Clone)]
-pub struct UnreachableService;
+pub struct PanicService;
 
-impl<B> Service<http::Request<B>> for UnreachableService {
+impl<B> Service<http::Request<B>> for PanicService {
     type Response = http::Response<BoxBody>;
     type Error = Infallible;
     type Future = Ready<Result<Self::Response, Self::Error>>;
@@ -283,14 +290,14 @@ impl<B> Service<http::Request<B>> for UnreachableService {
     }
 
     fn call(&mut self, _req: Request<B>) -> Self::Future {
-        unreachable!("this operation was not set")
+        panic!("this operation was not set")
     }
 }
 
 impl<P, Op, Exts, B, Modify> Upgradable<P, Op, Exts, B, Modify> for DummyOperation {
-    type Service = UnreachableService;
+    type Service = PanicService;
 
     fn upgrade(self, _modify: &Modify) -> Self::Service {
-        UnreachableService
+        PanicService
     }
 }


### PR DESCRIPTION
## Motivation and Context

Closes https://github.com/awslabs/smithy-rs/issues/1705

## Description

- Add a `PanicService` which implements `Service` and does nothing but panic.
- Add `DummyOperation` which implements `Upgradable`, yielding `UnreachableService`.
- Add `unchecked_builder` which sets all builder generics to `DummyOperation`.

## Notes

Depends on https://github.com/awslabs/smithy-rs/pull/1693