### PR TITLE
Add a join method for `Iterable<Writable>`, `Sequence<Writable>`, and `Array<Writable>`

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
@@ -27,9 +27,13 @@ fun Writable.isEmpty(): Boolean {
 }
 
 /**
- * Helper allowing a `Iterable<Writable>` to be joined together using a separator.
+ * Helper allowing a `Iterable<Writable>` to be joined together using a `String` separator.
  */
 fun Iterable<Writable>.join(separator: String = ", ") = join(writable(separator))
+
+/**
+ * Helper allowing a `Iterable<Writable>` to be joined together using a `Writable` separator.
+ */
 fun Iterable<Writable>.join(separator: Writable = writable { }): Writable {
     val iter = this.iterator()
     return writable {
@@ -41,9 +45,25 @@ fun Iterable<Writable>.join(separator: Writable = writable { }): Writable {
         }
     }
 }
+
+/**
+ * Helper allowing a `Sequence<Writable>` to be joined together using a `String` separator.
+ */
 fun Sequence<Writable>.join(separator: String = ", ") = asIterable().join(separator)
+
+/**
+ * Helper allowing a `Sequence<Writable>` to be joined together using a `Writable` separator.
+ */
 fun Sequence<Writable>.join(separator: Writable = writable { }) = asIterable().join(separator)
+
+/**
+ * Helper allowing a `Array<Writable>` to be joined together using a `String` separator.
+ */
 fun Array<Writable>.join(separator: String = ", ") = asIterable().join(separator)
+
+/**
+ * Helper allowing a `Array<Writable>` to be joined together using a `Writable` separator.
+ */
 fun Array<Writable>.join(separator: Writable = writable { }) = asIterable().join(separator)
 
 /**

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
@@ -18,7 +18,7 @@ typealias Writable = RustWriter.() -> Unit
  */
 fun writable(w: Writable): Writable = w
 
-fun writable(w: String): Writable = writable { rust(w) }
+fun writable(w: String): Writable = writable { writeInline(w) }
 
 fun Writable.isEmpty(): Boolean {
     val writer = RustWriter.root()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
@@ -27,6 +27,26 @@ fun Writable.isEmpty(): Boolean {
 }
 
 /**
+ * Helper allowing a `Iterable<Writable>` to be joined together using a separator.
+ */
+fun Iterable<Writable>.join(separator: String = ", ") = join(writable(separator))
+fun Iterable<Writable>.join(separator: Writable = writable { }): Writable {
+    val iter = this.iterator()
+    return writable {
+        iter.forEach { value ->
+            value()
+            if (iter.hasNext()) {
+                separator()
+            }
+        }
+    }
+}
+fun Sequence<Writable>.join(separator: String = ", ") = asIterable().join(separator)
+fun Sequence<Writable>.join(separator: Writable = writable { }) = asIterable().join(separator)
+fun Array<Writable>.join(separator: String = ", ") = asIterable().join(separator)
+fun Array<Writable>.join(separator: Writable = writable { }) = asIterable().join(separator)
+
+/**
  * Combine multiple writable types into a Rust generic type parameter list
  *
  * e.g.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/rustlang/Writable.kt
@@ -29,12 +29,12 @@ fun Writable.isEmpty(): Boolean {
 /**
  * Helper allowing a `Iterable<Writable>` to be joined together using a `String` separator.
  */
-fun Iterable<Writable>.join(separator: String = ", ") = join(writable(separator))
+fun Iterable<Writable>.join(separator: String) = join(writable(separator))
 
 /**
  * Helper allowing a `Iterable<Writable>` to be joined together using a `Writable` separator.
  */
-fun Iterable<Writable>.join(separator: Writable = writable { }): Writable {
+fun Iterable<Writable>.join(separator: Writable): Writable {
     val iter = this.iterator()
     return writable {
         iter.forEach { value ->
@@ -49,22 +49,22 @@ fun Iterable<Writable>.join(separator: Writable = writable { }): Writable {
 /**
  * Helper allowing a `Sequence<Writable>` to be joined together using a `String` separator.
  */
-fun Sequence<Writable>.join(separator: String = ", ") = asIterable().join(separator)
+fun Sequence<Writable>.join(separator: String) = asIterable().join(separator)
 
 /**
  * Helper allowing a `Sequence<Writable>` to be joined together using a `Writable` separator.
  */
-fun Sequence<Writable>.join(separator: Writable = writable { }) = asIterable().join(separator)
+fun Sequence<Writable>.join(separator: Writable) = asIterable().join(separator)
 
 /**
  * Helper allowing a `Array<Writable>` to be joined together using a `String` separator.
  */
-fun Array<Writable>.join(separator: String = ", ") = asIterable().join(separator)
+fun Array<Writable>.join(separator: String) = asIterable().join(separator)
 
 /**
  * Helper allowing a `Array<Writable>` to be joined together using a `Writable` separator.
  */
-fun Array<Writable>.join(separator: Writable = writable { }) = asIterable().join(separator)
+fun Array<Writable>.join(separator: Writable) = asIterable().join(separator)
 
 /**
  * Combine multiple writable types into a Rust generic type parameter list

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/rustlang/WritableTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/rustlang/WritableTest.kt
@@ -75,4 +75,36 @@ internal class RustTypeParametersTest {
 
         writer.toString() shouldContain "'<()>'"
     }
+
+    @Test
+    fun `join iterable`() {
+        val writer = RustWriter.forModule("model")
+        listOf(writable("A"), writable("B"), writable("C")).join("-")(writer)
+        listOf(writable("D"), writable("E"), writable("F")).join(writable("+"))(writer)
+        writer.toString() shouldContain "A-B-CD+E+F"
+    }
+
+    @Test
+    fun `join array`() {
+        val writer = RustWriter.forModule("model")
+        arrayOf(writable("A"), writable("B"), writable("C")).join("-")(writer)
+        arrayOf(writable("D"), writable("E"), writable("F")).join(writable("+"))(writer)
+        writer.toString() shouldContain "A-B-CD+E+F"
+    }
+
+    @Test
+    fun `join sequence`() {
+        val writer = RustWriter.forModule("model")
+        sequence {
+            yield(writable("A"))
+            yield(writable("B"))
+            yield(writable("C"))
+        }.join("-")(writer)
+        sequence {
+            yield(writable("D"))
+            yield(writable("E"))
+            yield(writable("F"))
+        }.join(writable("+"))(writer)
+        writer.toString() shouldContain "A-B-CD+E+F"
+    }
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/rustlang/WritableTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/rustlang/WritableTest.kt
@@ -79,9 +79,10 @@ internal class RustTypeParametersTest {
     @Test
     fun `join iterable`() {
         val writer = RustWriter.forModule("model")
-        listOf(writable("A"), writable("B"), writable("C")).join("-")(writer)
-        listOf(writable("D"), writable("E"), writable("F")).join(writable("+"))(writer)
-        writer.toString() shouldContain "A-B-CD+E+F"
+        val itemsA = listOf(writable("a"), writable("b"), writable("c")).join(", ")
+        val itemsB = listOf(writable("d"), writable("e"), writable("f")).join(writable(", "))
+        writer.rustTemplate("vec![#{ItemsA:W}, #{ItemsB:W}]", "ItemsA" to itemsA, "ItemsB" to itemsB)
+        writer.toString() shouldContain "vec![a, b, c, d, e, f]"
     }
 
     @Test


### PR DESCRIPTION
## Motivation and Context

For `Iterable<String>`, `Sequence<String>`, and `Array<String>` Kotlin provides a [joinToString](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/join-to-string.html) function which takes a separator and returns the concatenated `String` - it'd be nice if such an API existed for `Writable` too.

## Description

- Add `join` method for `Iterable<Writable>`, `Sequence<Writable>`, and `Array<Writable>`.
- Change `writable` definition to `writeInline` to prevent excess newlines from being introduced.

## Notes

We may want to add prefix/postfix arguments in a similar fashion to `joinToString`.
