### PR TITLE
Escape routing regex in path segment literals

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::borrow::Cow;
+
 use http::Request;
 use regex::Regex;
 
@@ -104,13 +106,13 @@ impl From<&PathSpec> for Regex {
                 .0
                 .iter()
                 .map(|segment_spec| match segment_spec {
-                    PathSegment::Literal(literal) => literal,
+                    PathSegment::Literal(literal) => Cow::Owned(regex::escape(literal)),
                     // TODO(https://github.com/awslabs/smithy/issues/975) URL spec says it should be ASCII but this regex accepts UTF-8:
                     // `*` instead of `+` because the empty string `""` can be bound to a label.
-                    PathSegment::Label => "[^/]*",
-                    PathSegment::Greedy => ".*",
+                    PathSegment::Label => Cow::Borrowed("[^/]*"),
+                    PathSegment::Greedy => Cow::Borrowed(".*"),
                 })
-                .fold(String::new(), |a, b| a + sep + b)
+                .fold(String::new(), |a, b| a + sep + &b)
         };
 
         Regex::new(&format!("^{}$", re)).expect("invalid `Regex` from `PathSpec`; please file a bug report under https://github.com/awslabs/smithy-rs/issues")

--- a/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/request_spec.rs
@@ -469,4 +469,22 @@ mod tests {
             assert_eq!(Match::Yes, label_spec.matches(&req(method, uri, None)));
         }
     }
+
+    #[test]
+    fn unsanitary_path() {
+        let spec = RequestSpec::from_parts(
+            Method::GET,
+            vec![
+                PathSegment::Literal(String::from("ReDosLiteral")),
+                PathSegment::Label,
+                PathSegment::Literal(String::from("(a+)+")),
+            ],
+            Vec::new(),
+        );
+
+        assert_eq!(
+            Match::Yes,
+            spec.matches(&req(&Method::GET, "/ReDosLiteral/abc/(a+)+", None))
+        );
+    }
 }


### PR DESCRIPTION
## Motivation and Context

When constructing the regex to match routes we should escape path segments deemed as literals.

This is covered by the  [HttpRequestWithRegexLiteral protocol test](https://github.com/awslabs/smithy/blob/f598b87c51af5943686e38706847a5091fe718da/smithy-aws-protocol-tests/model/restJson1/http-labels.smithy#L254-L266)

This has caused problems [here](https://github.com/awslabs/smithy-rs/pull/1708#discussion_r965846689).

## Description

Escape `PathSegment::Literal`s so that they don't contribute to the routing regex.

