### PR TITLE
Create initial `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# .git-blame-ignore-revs
+#
+# To make use of this file when running `git blame`, add `--ignore-revs-file .git-blame-ignore-revs` to the arguments.
+# To always make use of this file, run the following:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+
+# Add `client` to `codegen-client` package namespace (#1711)
+1a0f81ae33816c10c9d305f33ea03da23c6265ef


### PR DESCRIPTION
## Motivation and Context
This PR creates a `.git-blame-ignore-revs` file following the [GitHub documentation](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view), as suggested in #1711.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
