### PR TITLE
Use Rust 2021 edition with `rustfmt` in CI

### DIFF
--- a/tools/ci-build/scripts/check-style-and-lints
+++ b/tools/ci-build/scripts/check-style-and-lints
@@ -11,7 +11,7 @@ sdk-lints check --all
 sdk-lints fix --all
 
 # shellcheck disable=SC2046
-rustfmt --check --edition 2018 $(find . -name '*.rs' -print | grep -v /target/)
+rustfmt --check --edition 2021 $(find . -name '*.rs' -print | grep -v /target/)
 
 ./gradlew -p buildSrc test
 ./gradlew ktlint


### PR DESCRIPTION
We've long migrated to the 2021 edition everywhere. See PRs #1388, #1328,
and #1268.

See issue #1332 too.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
