### PR TITLE
aws-smithy-http-tower: Lower log level of two info logs.

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,6 +11,12 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
+[[smithy-rs]]
+message = "Lower log level of two info-level log messages."
+references = ["smithy-rs#1735"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+author = "vojtechkral"
+
 [[aws-sdk-rust]]
 message = "`aws_config::RetryConfig` no longer implements `Default`, and its `new` function has been replaced with `standard`."
 references = ["smithy-rs#1603", "aws-sdk-rust#586"]

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -355,7 +355,7 @@ impl RetryHandler {
             sleep_future.await;
             next
         }
-        .instrument(tracing::info_span!("retry", kind = &debug(retry_kind)));
+        .instrument(tracing::debug_span!("retry", kind = &debug(retry_kind)));
         Some(check_send(Box::pin(fut)))
     }
 }

--- a/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
+++ b/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
@@ -15,7 +15,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tower::{Layer, Service};
 use tracing::field::display;
-use tracing::{debug_span, field, info_span, Instrument};
+use tracing::{debug_span, field, Instrument};
 
 /// `ParseResponseService` dispatches [`Operation`](aws_smithy_http::operation::Operation)s and parses them.
 ///
@@ -92,7 +92,7 @@ where
         let handler = parts.response_handler;
         // send_operation records the full request-response lifecycle.
         // NOTE: For operations that stream output, only the setup is captured in this span.
-        let span = info_span!(
+        let span = debug_span!(
             "send_operation",
             operation = field::Empty,
             service = field::Empty,


### PR DESCRIPTION
## Motivation and Context
`aws-smithy-http-tower` polutes our logs with info-level messages.

## Description
Changed two info-level messages to debug level, it felt appropriate...

## Testing
I wanted to run `./gradlew rust-runtime:cargoTest` but I got the following error:

    Task 'cargoTest' not found in project ':rust-runtime'.


## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
