### PR TITLE
Cleanup pokemon.smithy

### DIFF
--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -88,7 +88,7 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
             """.trimIndent(),
             imports = listOf("$commonModels/naming-obstacle-course-structs.smithy"),
         ),
-        CodegenTest("com.aws.example#PokemonService", "pokemon-service-client", imports = listOf("$commonModels/pokemon.smithy")),
+        CodegenTest("com.aws.example.rust#PokemonService", "pokemon-service-client", imports = listOf("$commonModels/pokemon.smithy", "$commonModels/pokemon-common.smithy")),
     )
 }
 

--- a/codegen-core/common-test-models/pokemon-common.smithy
+++ b/codegen-core/common-test-models/pokemon-common.smithy
@@ -1,0 +1,136 @@
+$version: "1.0"
+
+namespace com.aws.example
+
+/// A Pokémon species forms the basis for at least one Pokémon.
+@title("Pokémon Species")
+resource PokemonSpecies {
+    identifiers: {
+        name: String
+    },
+    read: GetPokemonSpecies,
+}
+
+@error("client")
+structure InvalidPokeballError {
+    @required
+    pokeball: String,
+}
+@error("server")
+structure MasterBallUnsuccessful {
+    @required
+    message: String,
+}
+
+
+/// Retrieve information about a Pokémon species.
+@readonly
+@http(uri: "/pokemon-species/{name}", method: "GET")
+operation GetPokemonSpecies {
+    input: GetPokemonSpeciesInput,
+    output: GetPokemonSpeciesOutput,
+    errors: [ResourceNotFoundException],
+}
+
+@input
+structure GetPokemonSpeciesInput {
+    @required
+    @httpLabel
+    name: String
+}
+
+@output
+structure GetPokemonSpeciesOutput {
+    /// The name for this resource.
+    @required
+    name: String,
+
+    /// A list of flavor text entries for this Pokémon species.
+    @required
+    flavorTextEntries: FlavorTextEntries
+}
+
+/// Retrieve HTTP server statistiscs, such as calls count.
+@readonly
+@http(uri: "/stats", method: "GET")
+operation GetServerStatistics {
+    input: GetServerStatisticsInput,
+    output: GetServerStatisticsOutput,
+}
+
+@input
+structure GetServerStatisticsInput { }
+
+@output
+structure GetServerStatisticsOutput {
+    /// The number of calls executed by the server.
+    @required
+    calls_count: Long,
+}
+
+list FlavorTextEntries {
+    member: FlavorText
+}
+
+structure FlavorText {
+    /// The localized flavor text for an API resource in a specific language.
+    @required
+    flavorText: String,
+
+    /// The language this name is in.
+    @required
+    language: Language,
+}
+
+/// Supported languages for FlavorText entries.
+@enum([
+    {
+        name: "ENGLISH",
+        value: "en",
+        documentation: "American English.",
+    },
+    {
+        name: "SPANISH",
+        value: "es",
+        documentation: "Español.",
+    },
+    {
+        name: "ITALIAN",
+        value: "it",
+        documentation: "Italiano.",
+    },
+    {
+        name: "JAPANESE",
+        value: "jp",
+        documentation: "日本語。",
+    },
+])
+string Language
+
+/// DoNothing operation, used to stress test the framework.
+@readonly
+@http(uri: "/do-nothing", method: "GET")
+operation DoNothing {
+    input: DoNothingInput,
+    output: DoNothingOutput,
+}
+
+@input
+structure DoNothingInput { }
+
+@output
+structure DoNothingOutput { }
+
+/// Health check operation, to check the service is up
+/// Not yet a deep check
+@readonly
+@http(uri: "/ping", method: "GET")
+operation CheckHealth {
+}
+
+@error("client")
+@httpError(404)
+structure ResourceNotFoundException {
+    @required
+    message: String,
+}

--- a/codegen-core/common-test-models/pokemon-common.smithy
+++ b/codegen-core/common-test-models/pokemon-common.smithy
@@ -11,18 +11,6 @@ resource PokemonSpecies {
     read: GetPokemonSpecies,
 }
 
-@error("client")
-structure InvalidPokeballError {
-    @required
-    pokeball: String,
-}
-@error("server")
-structure MasterBallUnsuccessful {
-    @required
-    message: String,
-}
-
-
 /// Retrieve information about a Pokémon species.
 @readonly
 @http(uri: "/pokemon-species/{name}", method: "GET")

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -7,6 +7,7 @@ use com.aws.example#PokemonSpecies
 use com.aws.example#GetServerStatistics
 use com.aws.example#DoNothing
 use com.aws.example#CheckHealth
+use com.aws.example#ResourceNotFoundException
 
 /// The Pokémon Service allows you to retrieve information about Pokémon species.
 @title("Pokémon Service")
@@ -130,6 +131,17 @@ structure CaptureEvent {
 structure UnsupportedRegionError {
     @required
     region: String,
+}
+
+@error("client")
+structure InvalidPokeballError {
+    @required
+    pokeball: String,
+}
+@error("server")
+structure MasterBallUnsuccessful {
+    @required
+    message: String,
 }
 
 @error("client")

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -30,7 +30,7 @@ resource Storage {
     read: GetStorage,
 }
 
-/// Capture Pokémons via event streams
+/// Capture Pokémons via event streams.
 @http(uri: "/capture-pokemon-event/{region}", method: "POST")
 operation CapturePokemon {
     input: CapturePokemonEventsInput,

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -10,7 +10,7 @@ use aws.protocols#restJson1
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies, Storage],
-    operations: [GetServerStatistics, Empty, CapturePokemon, HealthCheck],
+    operations: [GetServerStatistics, DoNothing, CapturePokemon, CheckHealth],
 }
 
 /// A Pokémon species forms the basis for at least one Pokémon.
@@ -228,25 +228,25 @@ structure FlavorText {
 ])
 string Language
 
-/// Empty operation, used to stress test the framework.
+/// DoNothing operation, used to stress test the framework.
 @readonly
-@http(uri: "/empty-operation", method: "GET")
-operation Empty {
-    input: EmptyInput,
-    output: EmptyOutput,
+@http(uri: "/do-nothing", method: "GET")
+operation DoNothing {
+    input: DoNothingInput,
+    output: DoNothingOutput,
 }
 
 @input
-structure EmptyInput { }
+structure DoNothingInput { }
 
 @output
-structure EmptyOutput { }
+structure DoNothingOutput { }
 
 /// Health check operation, to check the service is up
 /// Not yet a deep check
 @readonly
 @http(uri: "/ping", method: "GET")
-operation HealthCheck {
+operation CheckHealth {
 }
 
 @error("client")

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -1,8 +1,13 @@
 $version: "1.0"
 
-namespace com.aws.example
+namespace com.aws.example.rust
 
 use aws.protocols#restJson1
+use com.aws.example#PokemonSpecies
+use com.aws.example#GetServerStatistics
+use com.aws.example#DoNothing
+use com.aws.example#CheckHealth
+use com.aws.example#CapturePokemon
 
 /// The Pokémon Service allows you to retrieve information about Pokémon species.
 @title("Pokémon Service")
@@ -13,21 +18,50 @@ service PokemonService {
     operations: [GetServerStatistics, DoNothing, CapturePokemon, CheckHealth],
 }
 
-/// A Pokémon species forms the basis for at least one Pokémon.
-@title("Pokémon Species")
-resource PokemonSpecies {
-    identifiers: {
-        name: String
-    },
-    read: GetPokemonSpecies,
-}
-
 /// A users current Pokémon storage.
 resource Storage {
     identifiers: {
         user: String
     },
     read: GetStorage,
+}
+
+/// Retrieve information about your Pokedex.
+@readonly
+@http(uri: "/pokedex/{user}", method: "GET")
+operation GetStorage {
+    input: GetStorageInput,
+    output: GetStorageOutput,
+    errors: [ResourceNotFoundException, NotAuthorized],
+}
+
+/// Not authorized to access Pokémon storage.
+@error("client")
+@httpError(401)
+structure NotAuthorized {}
+
+/// A request to access Pokémon storage.
+@input
+@sensitive
+structure GetStorageInput {
+    @required
+    @httpLabel
+    user: String,
+    @required
+    @httpHeader("passcode")
+    passcode: String,
+}
+
+/// A list of Pokémon species.
+list SpeciesCollection {
+    member: String
+}
+
+/// Contents of the Pokémon storage.
+@output
+structure GetStorageOutput {
+    @required
+    collection: SpeciesCollection
 }
 
 /// Capture Pokémons via event streams.
@@ -93,165 +127,6 @@ structure UnsupportedRegionError {
     @required
     region: String,
 }
-@error("client")
-structure InvalidPokeballError {
-    @required
-    pokeball: String,
-}
-@error("server")
-structure MasterBallUnsuccessful {
-    @required
-    message: String,
-}
+
 @error("client")
 structure ThrottlingError {}
-
-/// Retrieve information about a Pokémon species.
-@readonly
-@http(uri: "/pokemon-species/{name}", method: "GET")
-operation GetPokemonSpecies {
-    input: GetPokemonSpeciesInput,
-    output: GetPokemonSpeciesOutput,
-    errors: [ResourceNotFoundException],
-}
-
-@input
-structure GetPokemonSpeciesInput {
-    @required
-    @httpLabel
-    name: String
-}
-
-@output
-structure GetPokemonSpeciesOutput {
-    /// The name for this resource.
-    @required
-    name: String,
-
-    /// A list of flavor text entries for this Pokémon species.
-    @required
-    flavorTextEntries: FlavorTextEntries
-}
-
-/// Retrieve information about your Pokedex.
-@readonly
-@http(uri: "/pokedex/{user}", method: "GET")
-operation GetStorage {
-    input: GetStorageInput,
-    output: GetStorageOutput,
-    errors: [ResourceNotFoundException, NotAuthorized],
-}
-
-/// Not authorized to access Pokémon storage.
-@error("client")
-@httpError(401)
-structure NotAuthorized {}
-
-/// A request to access Pokémon storage.
-@input
-@sensitive
-structure GetStorageInput {
-    @required
-    @httpLabel
-    user: String,
-    @required
-    @httpHeader("passcode")
-    passcode: String,
-}
-
-/// A list of Pokémon species.
-list SpeciesCollection {
-    member: String
-}
-
-/// Contents of the Pokémon storage.
-@output
-structure GetStorageOutput {
-    @required
-    collection: SpeciesCollection
-}
-
-/// Retrieve HTTP server statistiscs, such as calls count.
-@readonly
-@http(uri: "/stats", method: "GET")
-operation GetServerStatistics {
-    input: GetServerStatisticsInput,
-    output: GetServerStatisticsOutput,
-}
-
-@input
-structure GetServerStatisticsInput { }
-
-@output
-structure GetServerStatisticsOutput {
-    /// The number of calls executed by the server.
-    @required
-    calls_count: Long,
-}
-
-list FlavorTextEntries {
-    member: FlavorText
-}
-
-structure FlavorText {
-    /// The localized flavor text for an API resource in a specific language.
-    @required
-    flavorText: String,
-
-    /// The language this name is in.
-    @required
-    language: Language,
-}
-
-/// Supported languages for FlavorText entries.
-@enum([
-    {
-        name: "ENGLISH",
-        value: "en",
-        documentation: "American English.",
-    },
-    {
-        name: "SPANISH",
-        value: "es",
-        documentation: "Español.",
-    },
-    {
-        name: "ITALIAN",
-        value: "it",
-        documentation: "Italiano.",
-    },
-    {
-        name: "JAPANESE",
-        value: "jp",
-        documentation: "日本語。",
-    },
-])
-string Language
-
-/// DoNothing operation, used to stress test the framework.
-@readonly
-@http(uri: "/do-nothing", method: "GET")
-operation DoNothing {
-    input: DoNothingInput,
-    output: DoNothingOutput,
-}
-
-@input
-structure DoNothingInput { }
-
-@output
-structure DoNothingOutput { }
-
-/// Health check operation, to check the service is up
-/// Not yet a deep check
-@readonly
-@http(uri: "/ping", method: "GET")
-operation CheckHealth {
-}
-
-@error("client")
-@httpError(404)
-structure ResourceNotFoundException {
-    @required
-    message: String,
-}

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -10,7 +10,7 @@ use aws.protocols#restJson1
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies, Storage],
-    operations: [GetServerStatistics, EmptyOperation, CapturePokemonOperation, HealthCheckOperation],
+    operations: [GetServerStatistics, Empty, CapturePokemon, HealthCheck],
 }
 
 /// A Pokémon species forms the basis for at least one Pokémon.
@@ -32,14 +32,14 @@ resource Storage {
 
 /// Capture Pokémons via event streams
 @http(uri: "/capture-pokemon-event/{region}", method: "POST")
-operation CapturePokemonOperation {
-    input: CapturePokemonOperationEventsInput,
-    output: CapturePokemonOperationEventsOutput,
+operation CapturePokemon {
+    input: CapturePokemonEventsInput,
+    output: CapturePokemonEventsOutput,
     errors: [UnsupportedRegionError, ThrottlingError]
 }
 
 @input
-structure CapturePokemonOperationEventsInput {
+structure CapturePokemonEventsInput {
     @httpPayload
     events: AttemptCapturingPokemonEvent,
 
@@ -49,7 +49,7 @@ structure CapturePokemonOperationEventsInput {
 }
 
 @output
-structure CapturePokemonOperationEventsOutput {
+structure CapturePokemonEventsOutput {
     @httpPayload
     events: CapturePokemonEvents,
 }
@@ -230,22 +230,22 @@ string Language
 /// Empty operation, used to stress test the framework.
 @readonly
 @http(uri: "/empty-operation", method: "GET")
-operation EmptyOperation {
-    input: EmptyOperationInput,
-    output: EmptyOperationOutput,
+operation Empty {
+    input: EmptyInput,
+    output: EmptyOutput,
 }
 
 @input
-structure EmptyOperationInput { }
+structure EmptyInput { }
 
 @output
-structure EmptyOperationOutput { }
+structure EmptyOutput { }
 
 /// Health check operation, to check the service is up
 /// Not yet a deep check
 @readonly
 @http(uri: "/ping", method: "GET")
-operation HealthCheckOperation {
+operation HealthCheck {
 }
 
 @error("client")

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -7,7 +7,6 @@ use com.aws.example#PokemonSpecies
 use com.aws.example#GetServerStatistics
 use com.aws.example#DoNothing
 use com.aws.example#CheckHealth
-use com.aws.example#CapturePokemon
 
 /// The Pokémon Service allows you to retrieve information about Pokémon species.
 @title("Pokémon Service")
@@ -15,7 +14,12 @@ use com.aws.example#CapturePokemon
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies, Storage],
-    operations: [GetServerStatistics, DoNothing, CapturePokemon, CheckHealth],
+    operations: [
+        GetServerStatistics,
+        DoNothing,
+        CapturePokemon,
+        CheckHealth
+    ],
 }
 
 /// A users current Pokémon storage.

--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -122,6 +122,7 @@ structure GetPokemonSpeciesInput {
     name: String
 }
 
+@output
 structure GetPokemonSpeciesOutput {
     /// The name for this resource.
     @required
@@ -160,7 +161,7 @@ structure GetStorageInput {
 
 /// A list of Pokémon species.
 list SpeciesCollection {
-    member: GetPokemonSpeciesOutput
+    member: String
 }
 
 /// Contents of the Pokémon storage.

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -48,7 +48,7 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
         CodegenTest("aws.protocoltests.misc#MiscService", "misc", imports = listOf("$commonModels/misc.smithy")),
         CodegenTest("com.amazonaws.ebs#Ebs", "ebs", imports = listOf("$commonModels/ebs.json")),
         CodegenTest("com.amazonaws.s3#AmazonS3", "s3"),
-        CodegenTest("com.aws.example#PokemonService", "pokemon-service-server-sdk", imports = listOf("$commonModels/pokemon.smithy")),
+        CodegenTest("com.aws.example.rust#PokemonService", "pokemon-service-server-sdk", imports = listOf("$commonModels/pokemon.smithy", "$commonModels/pokemon-common.smithy")),
     )
 }
 

--- a/codegen-server-test/python/build.gradle.kts
+++ b/codegen-server-test/python/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
 val allCodegenTests = "../../codegen-core/common-test-models".let { commonModels ->
     listOf(
         CodegenTest("com.amazonaws.simple#SimpleService", "simple", imports = listOf("$commonModels/simple.smithy")),
-        CodegenTest("com.aws.example#PokemonService", "pokemon-service-server-sdk"),
+        CodegenTest("com.aws.example.python#PokemonService", "pokemon-service-server-sdk"),
     )
 }
 

--- a/codegen-server-test/python/model/pokemon-common.smithy
+++ b/codegen-server-test/python/model/pokemon-common.smithy
@@ -1,0 +1,1 @@
+../../../codegen-core/common-test-models/pokemon-common.smithy

--- a/codegen-server-test/python/model/pokemon.smithy
+++ b/codegen-server-test/python/model/pokemon.smithy
@@ -3,9 +3,14 @@
 /// once the Python implementation supports Streaming and Union shapes.
 $version: "1.0"
 
-namespace com.aws.example
+namespace com.aws.example.python
 
 use aws.protocols#restJson1
+use com.aws.example#PokemonSpecies
+use com.aws.example#Storage
+use com.aws.example#GetServerStatistics
+use com.aws.example#DoNothing
+use com.aws.example#CheckHealth
 
 /// The Pokémon Service allows you to retrieve information about Pokémon species.
 @title("Pokémon Service")
@@ -13,67 +18,18 @@ use aws.protocols#restJson1
 service PokemonService {
     version: "2021-12-01",
     resources: [PokemonSpecies],
-    operations: [GetServerStatistics, EmptyOperation, HealthCheckOperation, StreamPokemonRadioOperation],
-}
-
-/// A Pokémon species forms the basis for at least one Pokémon.
-@title("Pokémon Species")
-resource PokemonSpecies {
-    identifiers: {
-        name: String
-    },
-    read: GetPokemonSpecies,
-}
-
-/// Retrieve information about a Pokémon species.
-@readonly
-@http(uri: "/pokemon-species/{name}", method: "GET")
-operation GetPokemonSpecies {
-    input: GetPokemonSpeciesInput,
-    output: GetPokemonSpeciesOutput,
-    errors: [ResourceNotFoundException],
-}
-
-@input
-structure GetPokemonSpeciesInput {
-    @required
-    @httpLabel
-    name: String
-}
-
-@output
-structure GetPokemonSpeciesOutput {
-    /// The name for this resource.
-    @required
-    name: String,
-
-    /// A list of flavor text entries for this Pokémon species.
-    @required
-    flavorTextEntries: FlavorTextEntries
-}
-
-/// Retrieve HTTP server statistiscs, such as calls count.
-@readonly
-@http(uri: "/stats", method: "GET")
-operation GetServerStatistics {
-    input: GetServerStatisticsInput,
-    output: GetServerStatisticsOutput,
-}
-
-@input
-structure GetServerStatisticsInput { }
-
-@output
-structure GetServerStatisticsOutput {
-    /// The number of calls executed by the server.
-    @required
-    calls_count: Long,
+    operations: [
+        GetServerStatistics,
+        DoNothing,
+        CheckHealth,
+        StreamPokemonRadio
+    ],
 }
 
 /// Fetch the radio song from the database and stream it back as a playable audio.
 @readonly
 @http(uri: "/radio", method: "GET")
-operation StreamPokemonRadioOperation {
+operation StreamPokemonRadio {
     output: StreamPokemonRadioOutput,
 }
 
@@ -85,69 +41,3 @@ structure StreamPokemonRadioOutput {
 
 @streaming
 blob StreamingBlob
-
-list FlavorTextEntries {
-    member: FlavorText
-}
-
-structure FlavorText {
-    /// The localized flavor text for an API resource in a specific language.
-    @required
-    flavorText: String,
-
-    /// The language this name is in.
-    @required
-    language: Language,
-}
-
-/// Supported languages for FlavorText entries.
-@enum([
-    {
-        name: "ENGLISH",
-        value: "en",
-        documentation: "American English.",
-    },
-    {
-        name: "SPANISH",
-        value: "es",
-        documentation: "Español.",
-    },
-    {
-        name: "ITALIAN",
-        value: "it",
-        documentation: "Italiano.",
-    },
-    {
-        name: "JAPANESE",
-        value: "jp",
-        documentation: "日本語。",
-    },
-])
-string Language
-
-/// Empty operation, used to stress test the framework.
-@readonly
-@http(uri: "/empty-operation", method: "GET")
-operation EmptyOperation {
-    input: EmptyOperationInput,
-    output: EmptyOperationOutput,
-}
-
-@input
-structure EmptyOperationInput { }
-
-@output
-structure EmptyOperationOutput { }
-
-/// Health check operation, to check the service is up
-/// Not yet a deep check
-@readonly
-@http(uri: "/ping", method: "GET")
-operation HealthCheckOperation { }
-
-@error("client")
-@httpError(404)
-structure ResourceNotFoundException {
-    @required
-    message: String,
-}

--- a/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/tests/simple_integration_test.rs
@@ -48,5 +48,5 @@ async fn simple_integration_test() {
     let service_statistics_out = client().get_server_statistics().send().await.unwrap();
     assert_eq!(2, service_statistics_out.calls_count.unwrap());
 
-    let _health_check = client().health_check_operation().send().await.unwrap();
+    let _health_check = client().check_health().send().await.unwrap();
 }

--- a/rust-runtime/aws-smithy-http-server-python/examples/pokemon_service.py
+++ b/rust-runtime/aws-smithy-http-server-python/examples/pokemon_service.py
@@ -15,15 +15,15 @@ import aiohttp
 from libpokemon_service_server_sdk import App
 from libpokemon_service_server_sdk.error import ResourceNotFoundException
 from libpokemon_service_server_sdk.input import (
-    EmptyOperationInput, GetPokemonSpeciesInput, GetServerStatisticsInput,
-    HealthCheckOperationInput, StreamPokemonRadioOperationInput)
+    DoNothingInput, GetPokemonSpeciesInput, GetServerStatisticsInput,
+    CheckHealthInput, StreamPokemonRadioInput)
 from libpokemon_service_server_sdk.logging import TracingHandler
 from libpokemon_service_server_sdk.middleware import (MiddlewareException,
                                                       Request)
 from libpokemon_service_server_sdk.model import FlavorText, Language
 from libpokemon_service_server_sdk.output import (
-    EmptyOperationOutput, GetPokemonSpeciesOutput, GetServerStatisticsOutput,
-    HealthCheckOperationOutput, StreamPokemonRadioOperationOutput)
+    DoNothingOutput, GetPokemonSpeciesOutput, GetServerStatisticsOutput,
+    CheckHealthOutput, StreamPokemonRadioOutput)
 from libpokemon_service_server_sdk.types import ByteStream
 
 # Logging can bee setup using standard Python tooling. We provide
@@ -171,11 +171,11 @@ async def check_x_amzn_answer_header(request: Request):
 ###########################################################
 # App handlers definition
 ###########################################################
-# Empty operation used for raw benchmarking.
-@app.empty_operation
-def empty_operation(_: EmptyOperationInput) -> EmptyOperationOutput:
-    # logging.debug("Running the empty operation")
-    return EmptyOperationOutput()
+# DoNothing operation used for raw benchmarking.
+@app.do_nothing
+def do_nothing(_: DoNothingInput) -> DoNothingOutput:
+    # logging.debug("Running the DoNothing operation")
+    return DoNothingOutput()
 
 
 # Get the translation of a Pokémon specie or an error.
@@ -207,22 +207,22 @@ def get_server_statistics(
     return GetServerStatisticsOutput(calls_count=calls_count)
 
 
-# Run a shallow healthcheck of the service.
-@app.health_check_operation
-def health_check_operation(_: HealthCheckOperationInput) -> HealthCheckOperationOutput:
-    return HealthCheckOperationOutput()
+# Run a shallow health check of the service.
+@app.check_health
+def check_health(_: CheckHealthInput) -> CheckHealthOutput:
+    return CheckHealthOutput()
 
 
 # Stream a random Pokémon song.
-@app.stream_pokemon_radio_operation
-async def stream_pokemon_radio(_: StreamPokemonRadioOperationInput, context: Context):
+@app.stream_pokemon_radio
+async def stream_pokemon_radio(_: StreamPokemonRadioInput, context: Context):
     radio_url = context.get_random_radio_stream()
     logging.info("Random radio URL for this stream is %s", radio_url)
     async with aiohttp.ClientSession() as session:
         async with session.get(radio_url) as response:
             data = ByteStream(await response.read())
         logging.debug("Successfully fetched radio url %s", radio_url)
-    return StreamPokemonRadioOperationOutput(data=data)
+    return StreamPokemonRadioOutput(data=data)
 
 
 ###########################################################

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
@@ -32,8 +32,7 @@ use aws_smithy_http_server::{routing::Router, AddExtensionLayer};
 use clap::Parser;
 use futures_util::stream::StreamExt;
 use pokemon_service::{
-    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, get_storage, health_check_operation,
-    setup_tracing, State,
+    capture_pokemon, empty, get_pokemon_species, get_server_statistics, get_storage, health_check, setup_tracing, State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tokio_rustls::{
@@ -71,9 +70,9 @@ pub async fn main() {
         .get_pokemon_species(get_pokemon_species)
         .get_storage(get_storage)
         .get_server_statistics(get_server_statistics)
-        .capture_pokemon_operation(capture_pokemon)
-        .empty_operation(empty_operation)
-        .health_check_operation(health_check_operation)
+        .capture_pokemon(capture_pokemon)
+        .empty(empty)
+        .health_check(health_check)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
@@ -32,7 +32,8 @@ use aws_smithy_http_server::{routing::Router, AddExtensionLayer};
 use clap::Parser;
 use futures_util::stream::StreamExt;
 use pokemon_service::{
-    capture_pokemon, empty, get_pokemon_species, get_server_statistics, get_storage, health_check, setup_tracing, State,
+    capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics, get_storage, setup_tracing,
+    State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tokio_rustls::{
@@ -71,8 +72,8 @@ pub async fn main() {
         .get_storage(get_storage)
         .get_server_statistics(get_server_statistics)
         .capture_pokemon(capture_pokemon)
-        .empty(empty)
-        .health_check(health_check)
+        .do_nothing(do_nothing)
+        .check_health(check_health)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lambda.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 
 use aws_smithy_http_server::{routing::LambdaHandler, routing::Router, AddExtensionLayer};
 use pokemon_service::{
-    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, get_storage, health_check_operation,
-    setup_tracing, State,
+    capture_pokemon, empty, get_pokemon_species, get_server_statistics, get_storage, health_check, setup_tracing, State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
@@ -26,9 +25,9 @@ pub async fn main() {
         .get_pokemon_species(get_pokemon_species)
         .get_storage(get_storage)
         .get_server_statistics(get_server_statistics)
-        .capture_pokemon_operation(capture_pokemon)
-        .empty_operation(empty_operation)
-        .health_check_operation(health_check_operation)
+        .capture_pokemon(capture_pokemon)
+        .empty(empty)
+        .health_check(health_check)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lambda.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 
 use aws_smithy_http_server::{routing::LambdaHandler, routing::Router, AddExtensionLayer};
 use pokemon_service::{
-    capture_pokemon, empty, get_pokemon_species, get_server_statistics, get_storage, health_check, setup_tracing, State,
+    capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics, get_storage, setup_tracing,
+    State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
@@ -26,8 +27,8 @@ pub async fn main() {
         .get_storage(get_storage)
         .get_server_statistics(get_server_statistics)
         .capture_pokemon(capture_pokemon)
-        .empty(empty)
-        .health_check(health_check)
+        .do_nothing(do_nothing)
+        .check_health(check_health)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
@@ -276,13 +276,13 @@ pub async fn capture_pokemon(
 }
 
 /// Empty operation used to benchmark the service.
-pub async fn empty(_input: input::EmptyInput) -> output::EmptyOutput {
-    output::EmptyOutput {}
+pub async fn do_nothing(_input: input::DoNothingInput) -> output::DoNothingOutput {
+    output::DoNothingOutput {}
 }
 
 /// Operation used to show the service is running.
-pub async fn health_check(_input: input::HealthCheckInput) -> output::HealthCheckOutput {
-    output::HealthCheckOutput {}
+pub async fn check_health(_input: input::CheckHealthInput) -> output::CheckHealthOutput {
+    output::CheckHealthOutput {}
 }
 
 #[cfg(test)]

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
@@ -210,10 +210,10 @@ pub async fn get_server_statistics(
 
 /// Attempts to capture a Pokémon
 pub async fn capture_pokemon(
-    mut input: input::CapturePokemonOperationInput,
-) -> Result<output::CapturePokemonOperationOutput, error::CapturePokemonOperationError> {
+    mut input: input::CapturePokemonInput,
+) -> Result<output::CapturePokemonOutput, error::CapturePokemonError> {
     if input.region != "Kanto" {
-        return Err(error::CapturePokemonOperationError::UnsupportedRegionError(
+        return Err(error::CapturePokemonError::UnsupportedRegionError(
             error::UnsupportedRegionError::builder().build(),
         ));
     }
@@ -269,20 +269,20 @@ pub async fn capture_pokemon(
             }
         }
     };
-    Ok(output::CapturePokemonOperationOutput::builder()
+    Ok(output::CapturePokemonOutput::builder()
         .events(output_stream.into())
         .build()
         .unwrap())
 }
 
 /// Empty operation used to benchmark the service.
-pub async fn empty_operation(_input: input::EmptyOperationInput) -> output::EmptyOperationOutput {
-    output::EmptyOperationOutput {}
+pub async fn empty(_input: input::EmptyInput) -> output::EmptyOutput {
+    output::EmptyOutput {}
 }
 
 /// Operation used to show the service is running.
-pub async fn health_check_operation(_input: input::HealthCheckOperationInput) -> output::HealthCheckOperationOutput {
-    output::HealthCheckOperationOutput {}
+pub async fn health_check(_input: input::HealthCheckInput) -> output::HealthCheckOutput {
+    output::HealthCheckOutput {}
 }
 
 #[cfg(test)]

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
@@ -179,7 +179,7 @@ pub async fn get_pokemon_species(
     }
 }
 
-/// Retrieves the users storage
+/// Retrieves the users storage.
 pub async fn get_storage(
     input: input::GetStorageInput,
     _state: Extension<Arc<State>>,
@@ -208,7 +208,7 @@ pub async fn get_server_statistics(
     output::GetServerStatisticsOutput { calls_count }
 }
 
-/// Attempts to capture a Pokémon
+/// Attempts to capture a Pokémon.
 pub async fn capture_pokemon(
     mut input: input::CapturePokemonInput,
 ) -> Result<output::CapturePokemonOutput, error::CapturePokemonError> {

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
@@ -9,7 +9,8 @@ use std::{net::SocketAddr, sync::Arc};
 use aws_smithy_http_server::{routing::Router, AddExtensionLayer};
 use clap::Parser;
 use pokemon_service::{
-    capture_pokemon, empty, get_pokemon_species, get_server_statistics, get_storage, health_check, setup_tracing, State,
+    capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics, get_storage, setup_tracing,
+    State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
@@ -38,8 +39,8 @@ pub async fn main() {
         .get_storage(get_storage)
         .get_server_statistics(get_server_statistics)
         .capture_pokemon(capture_pokemon)
-        .empty(empty)
-        .health_check(health_check)
+        .do_nothing(do_nothing)
+        .check_health(check_health)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/main.rs
@@ -9,8 +9,7 @@ use std::{net::SocketAddr, sync::Arc};
 use aws_smithy_http_server::{routing::Router, AddExtensionLayer};
 use clap::Parser;
 use pokemon_service::{
-    capture_pokemon, empty_operation, get_pokemon_species, get_server_statistics, get_storage, health_check_operation,
-    setup_tracing, State,
+    capture_pokemon, empty, get_pokemon_species, get_server_statistics, get_storage, health_check, setup_tracing, State,
 };
 use pokemon_service_server_sdk::operation_registry::OperationRegistryBuilder;
 use tower::ServiceBuilder;
@@ -38,9 +37,9 @@ pub async fn main() {
         .get_pokemon_species(get_pokemon_species)
         .get_storage(get_storage)
         .get_server_statistics(get_server_statistics)
-        .capture_pokemon_operation(capture_pokemon)
-        .empty_operation(empty_operation)
-        .health_check_operation(health_check_operation)
+        .capture_pokemon(capture_pokemon)
+        .empty(empty)
+        .health_check(health_check)
         .build()
         .expect("Unable to build operation registry")
         // Convert it into a router that will route requests to the matching operation

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
@@ -44,18 +44,18 @@ fn get_pokemon_to_capture() -> String {
 
 #[tokio::test]
 #[serial]
-async fn test_health_check_operation() {
+async fn test_health_check() {
     let _program = PokemonService::run().await;
 
-    let _health_check = client().health_check_operation().send().await.unwrap();
+    let _health_check = client().health_check().send().await.unwrap();
 }
 
 #[tokio::test]
 #[serial]
-async fn test_health_check_operation_http2() {
+async fn test_health_check_http2() {
     // Make sure our server can serve http2
     let _program = PokemonService::run_https().await;
-    let _health_check = client_http2_only().health_check_operation().send().await.unwrap();
+    let _health_check = client_http2_only().health_check().send().await.unwrap();
 }
 
 #[tokio::test]
@@ -151,7 +151,7 @@ async fn event_stream_test() {
 
     // Throw many!
     let mut output = client()
-        .capture_pokemon_operation()
+        .capture_pokemon()
         .region("Kanto")
         .events(input_stream.into())
         .send()
@@ -196,7 +196,7 @@ async fn event_stream_test() {
             ))
         };
         let mut output = client()
-            .capture_pokemon_operation()
+            .capture_pokemon()
             .region("Kanto")
             .events(input_stream.into())
             .send()

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
@@ -44,18 +44,18 @@ fn get_pokemon_to_capture() -> String {
 
 #[tokio::test]
 #[serial]
-async fn test_health_check() {
+async fn test_check_health() {
     let _program = PokemonService::run().await;
 
-    let _health_check = client().health_check().send().await.unwrap();
+    let _check_health = client().check_health().send().await.unwrap();
 }
 
 #[tokio::test]
 #[serial]
-async fn test_health_check_http2() {
+async fn test_check_health_http2() {
     // Make sure our server can serve http2
     let _program = PokemonService::run_https().await;
-    let _health_check = client_http2_only().health_check().send().await.unwrap();
+    let _check_health = client_http2_only().check_health().send().await.unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation and Context

* The `pokemon.smithy` is used as an example for customers and should encode best practices.
* Having `Operation` suffix on operation names collides with the `_operation` suffix of https://github.com/awslabs/smithy-rs/blob/e5c8cf3061a21f4d33423fd7df642d9c5fb70729/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt#L132

## Description

- Add missing full-stops.
- Remove `Operation` suffix from operations.
- Don't re-use an `@output` struct.
