### PR TITLE
Remove `RemoveEventStreamOperations` model transformer from `ServerCodegenVisitor`

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.Optional
 
 /**
@@ -76,24 +77,28 @@ data class ClientRustSettings(
 data class ClientCodegenConfig(
     override val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
     override val debugMode: Boolean = defaultDebugMode,
-    override val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
     val renameExceptions: Boolean = defaultRenameExceptions,
     val includeFluentClient: Boolean = defaultIncludeFluentClient,
     val addMessageToErrors: Boolean = defaultAddMessageToErrors,
+    // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
+    val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
 ) : CoreCodegenConfig(
-    formatTimeoutSeconds, debugMode, eventStreamAllowList,
+    formatTimeoutSeconds, debugMode,
 ) {
     companion object {
         private const val defaultRenameExceptions = true
         private const val defaultIncludeFluentClient = true
         private const val defaultAddMessageToErrors = true
+        private val defaultEventStreamAllowList: Set<String> = emptySet()
 
         fun fromCodegenConfigAndNode(coreCodegenConfig: CoreCodegenConfig, node: Optional<ObjectNode>) =
             if (node.isPresent) {
                 ClientCodegenConfig(
                     formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                     debugMode = coreCodegenConfig.debugMode,
-                    eventStreamAllowList = coreCodegenConfig.eventStreamAllowList,
+                    eventStreamAllowList = node.get().getArrayMember("eventStreamAllowList")
+                        .map { array -> array.toList().mapNotNull { node -> node.asStringNode().orNull()?.value } }
+                        .orNull()?.toSet() ?: defaultEventStreamAllowList,
                     renameExceptions = node.get().getBooleanMemberOrDefault("renameErrors", defaultRenameExceptions),
                     includeFluentClient = node.get().getBooleanMemberOrDefault("includeFluentClient", defaultIncludeFluentClient),
                     addMessageToErrors = node.get().getBooleanMemberOrDefault("addMessageToErrors", defaultAddMessageToErrors),
@@ -102,7 +107,7 @@ data class ClientCodegenConfig(
                 ClientCodegenConfig(
                     formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                     debugMode = coreCodegenConfig.debugMode,
-                    eventStreamAllowList = coreCodegenConfig.eventStreamAllowList,
+                    eventStreamAllowList = defaultEventStreamAllowList,
                 )
             }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CoreRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/CoreRustSettings.kt
@@ -41,28 +41,21 @@ const val CODEGEN_SETTINGS = "codegen"
 open class CoreCodegenConfig(
     open val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
     open val debugMode: Boolean = defaultDebugMode,
-    // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
-    open val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
 ) {
     companion object {
         const val defaultFormatTimeoutSeconds = 20
         const val defaultDebugMode = false
-        val defaultEventStreamAllowList: Set<String> = emptySet()
 
         fun fromNode(node: Optional<ObjectNode>): CoreCodegenConfig =
             if (node.isPresent) {
                 CoreCodegenConfig(
                     node.get().getNumberMemberOrDefault("formatTimeoutSeconds", defaultFormatTimeoutSeconds).toInt(),
                     node.get().getBooleanMemberOrDefault("debugMode", defaultDebugMode),
-                    node.get().getArrayMember("eventStreamAllowList")
-                        .map { array -> array.toList().mapNotNull { node -> node.asStringNode().orNull()?.value } }
-                        .orNull()?.toSet() ?: defaultEventStreamAllowList,
                 )
             } else {
                 CoreCodegenConfig(
                     formatTimeoutSeconds = defaultFormatTimeoutSeconds,
                     debugMode = defaultDebugMode,
-                    eventStreamAllowList = defaultEventStreamAllowList,
                 )
             }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ServerRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ServerRustSettings.kt
@@ -74,7 +74,7 @@ data class ServerCodegenConfig(
     override val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
     override val debugMode: Boolean = defaultDebugMode,
 ) : CoreCodegenConfig(
-    formatTimeoutSeconds, debugMode
+    formatTimeoutSeconds, debugMode,
 ) {
     companion object {
         // Note `node` is unused, because at the moment `ServerCodegenConfig` has the same properties as

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ServerRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ServerRustSettings.kt
@@ -73,9 +73,8 @@ data class ServerRustSettings(
 data class ServerCodegenConfig(
     override val formatTimeoutSeconds: Int = defaultFormatTimeoutSeconds,
     override val debugMode: Boolean = defaultDebugMode,
-    override val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
 ) : CoreCodegenConfig(
-    formatTimeoutSeconds, debugMode, eventStreamAllowList,
+    formatTimeoutSeconds, debugMode
 ) {
     companion object {
         // Note `node` is unused, because at the moment `ServerCodegenConfig` has the same properties as
@@ -85,7 +84,6 @@ data class ServerCodegenConfig(
             ServerCodegenConfig(
                 formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                 debugMode = coreCodegenConfig.debugMode,
-                eventStreamAllowList = coreCodegenConfig.eventStreamAllowList,
             )
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperations.kt
@@ -9,7 +9,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.transform.ModelTransformer
-import software.amazon.smithy.rust.codegen.client.smithy.CoreRustSettings
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
 import software.amazon.smithy.rust.codegen.core.util.findStreamingMember
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.logging.Logger
@@ -19,7 +19,7 @@ import java.util.logging.Logger
 object RemoveEventStreamOperations {
     private val logger = Logger.getLogger(javaClass.name)
 
-    fun transform(model: Model, settings: CoreRustSettings): Model {
+    fun transform(model: Model, settings: ClientRustSettings): Model {
         // If Event Stream is allowed in build config, then don't remove the operations
         val allowList = settings.codegenConfig.eventStreamAllowList
         if (allowList.isEmpty() || allowList.contains(settings.moduleName)) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
@@ -7,6 +7,7 @@ package software.amazon.smithy.rust.codegen.client.testutil
 
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.NullableIndex
+import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
@@ -16,6 +17,8 @@ import software.amazon.smithy.rust.codegen.client.rustlang.CratesIo
 import software.amazon.smithy.rust.codegen.client.rustlang.DependencyScope
 import software.amazon.smithy.rust.codegen.client.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.client.rustlang.asType
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenConfig
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
 import software.amazon.smithy.rust.codegen.client.smithy.CoreCodegenConfig
 import software.amazon.smithy.rust.codegen.client.smithy.CoreCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.CoreRustSettings
@@ -39,6 +42,32 @@ val TestSymbolVisitorConfig = SymbolVisitorConfig(
     renameExceptions = true,
     handleRustBoxing = true,
     nullabilityCheckMode = NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1,
+)
+
+fun clientTestRustSettings(
+    service: ShapeId = ShapeId.from("notrelevant#notrelevant"),
+    moduleName: String = "test-module",
+    moduleVersion: String = "0.0.1",
+    moduleAuthors: List<String> = listOf("notrelevant"),
+    moduleDescription: String = "not relevant",
+    moduleRepository: String? = null,
+    runtimeConfig: RuntimeConfig = TestRuntimeConfig,
+    codegenConfig: ClientCodegenConfig = ClientCodegenConfig(),
+    license: String? = null,
+    examplesUri: String? = null,
+    customizationConfig: ObjectNode? = null,
+) = ClientRustSettings(
+    service,
+    moduleName,
+    moduleVersion,
+    moduleAuthors,
+    moduleDescription,
+    moduleRepository,
+    runtimeConfig,
+    codegenConfig,
+    license,
+    examplesUri,
+    customizationConfig,
 )
 
 fun testRustSettings(

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperationsTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperationsTest.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenConfig
 import software.amazon.smithy.rust.codegen.client.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.client.testutil.clientTestRustSettings
-import software.amazon.smithy.rust.codegen.client.testutil.testRustSettings
 import java.util.Optional
 
 internal class RemoveEventStreamOperationsTest {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperationsTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperationsTest.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenConfig
 import software.amazon.smithy.rust.codegen.client.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.client.testutil.clientTestRustSettings
 import software.amazon.smithy.rust.codegen.client.testutil.testRustSettings
 import java.util.Optional
 
@@ -49,7 +50,7 @@ internal class RemoveEventStreamOperationsTest {
     fun `remove event stream ops from services that are not in the allow list`() {
         val transformed = RemoveEventStreamOperations.transform(
             model,
-            testRustSettings(
+            clientTestRustSettings(
                 codegenConfig = ClientCodegenConfig(eventStreamAllowList = setOf("not-test-module")),
             ),
         )
@@ -61,7 +62,7 @@ internal class RemoveEventStreamOperationsTest {
     fun `keep event stream ops from services that are in the allow list`() {
         val transformed = RemoveEventStreamOperations.transform(
             model,
-            testRustSettings(
+            clientTestRustSettings(
                 codegenConfig = ClientCodegenConfig(eventStreamAllowList = setOf("test-module")),
             ),
         )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -113,8 +113,6 @@ open class ServerCodegenVisitor(
             .let(RecursiveShapeBoxer::transform)
             // Normalize operations by adding synthetic input and output shapes to every operation
             .let(OperationNormalizer::transform)
-            // Drop unsupported event stream operations from the model
-            .let { RemoveEventStreamOperations.transform(it, settings) }
             // Normalize event stream operations
             .let(EventStreamNormalizer::transform)
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -35,7 +35,6 @@ import software.amazon.smithy.rust.codegen.client.smithy.protocols.ProtocolGener
 import software.amazon.smithy.rust.codegen.client.smithy.transformers.EventStreamNormalizer
 import software.amazon.smithy.rust.codegen.client.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.client.smithy.transformers.RecursiveShapeBoxer
-import software.amazon.smithy.rust.codegen.client.smithy.transformers.RemoveEventStreamOperations
 import software.amazon.smithy.rust.codegen.core.util.CommandFailed
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.runCommand


### PR DESCRIPTION
This is a holdover from when the server subproject was started. We've
never utilized this model transformer, nor will we have any use for it
now, since event stream operations are supported in the server since #1479.

The `eventStreamAllowList` codegen config setting has been moved from
`CoreCodegenConfig` into `ClientCodegenConfig`.

See https://github.com/awslabs/smithy-rs/pull/1762#discussion_r978151466.

## Testing

No diff should be observed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
