### PR TITLE
Fix HttpSensitivityGenerator string length calculation

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGenerator.kt
@@ -36,7 +36,7 @@ import java.util.Optional
  *
  * See https://doc.rust-lang.org/std/string/struct.String.html#method.len for more information.
  * */
-private fun String.toRustLen(): Int = this.encodeToByteArray(throwOnInvalidSequence = true).size
+internal fun String.toRustLen(): Int = this.encodeToByteArray(throwOnInvalidSequence = true).size
 
 /** Models the ways status codes can be bound and sensitive. */
 class StatusCodeSensitivity(private val sensitive: Boolean, runtimeConfig: RuntimeConfig) {

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGeneratorTest.kt
@@ -28,6 +28,27 @@ class ServerHttpSensitivityGeneratorTest {
     )
 
     @Test
+    fun `rust string length`() {
+        val strings = arrayOf(
+            "",
+            "hello world",
+            "\uD83D\uDE0A",
+            "ᄿԼӔӰ㌕",
+            "פארוואס קוקסטו דאס?",
+        )
+
+        val testProject = TestWorkspace.testProject()
+        testProject.lib { writer ->
+            writer.unitTest("rust_length") {
+                for (str in strings) {
+                    rustTemplate("""assert_eq!("$str".len(), ${str.toRustLen()});""")
+                }
+            }
+        }
+        testProject.compileAndTest()
+    }
+
+    @Test
     fun `query closure`() {
         val model = """
             namespace test


### PR DESCRIPTION
## Motivation and Context

There is no guarantee that Kotlins `String::length` is equivalent to Rusts `String::length`.

## Description

Add and use `toRustLen()` in `HttpSensitivityGenerator.kt`.
