### PR TITLE
Do not generate public empty modules

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.GenericTypeArg
 import software.amazon.smithy.rust.codegen.core.rustlang.RustGenerics
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.core.rustlang.asType
 import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
@@ -34,7 +35,7 @@ class CustomizableOperationGenerator(
     private val smithyTypes = CargoDependency.SmithyTypes(runtimeConfig).asType()
 
     fun render(crate: RustCrate) {
-        crate.withModule(RustModule.Operation) { writer ->
+        crate.withModule(RustModule.operationModule(Visibility.PUBLIC)) { writer ->
             writer.docs("Operation customization and supporting types")
             writer.rust("pub mod customize;")
         }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustModule.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustModule.kt
@@ -25,6 +25,12 @@ data class RustModule(val name: String, val rustMetadata: RustMetadata, val docu
 
         val Config = public("config", documentation = "Configuration for the service.")
         val Error = public("error", documentation = "All error types that operations can return.")
-        val Operation = public("operation", documentation = "All operations that this crate can perform.")
+
+        /**
+         * Helper method to generate the `operation` Rust module.
+         * Its visibility depends on the generation context (client or server).
+         */
+        fun operationModule(visibility: Visibility): RustModule =
+            default("operation", visibility = visibility, documentation = "All operations that this crate can perform.")
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CodegenDelegator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/CodegenDelegator.kt
@@ -175,7 +175,6 @@ open class RustCrate(
  */
 val DefaultPublicModules = setOf(
     RustModule.Error,
-    RustModule.Operation,
     RustModule.public("model", documentation = "Data structures used by operation inputs/outputs."),
     RustModule.public("input", documentation = "Input structures for operations."),
     RustModule.public("output", documentation = "Output structures for operations."),

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -13,7 +13,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
-import software.amazon.smithy.rust.codegen.core.smithy.DefaultPublicModules
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocol
@@ -41,7 +40,7 @@ open class ServerServiceGenerator(
      * which assigns a symbol location to each shape.
      */
     fun render() {
-        rustCrate.withModule(DefaultPublicModules["operation"]!!) { writer ->
+        rustCrate.withModule(RustModule.operationModule(Visibility.PRIVATE)) { writer ->
             ServerProtocolTestGenerator(codegenContext, protocolSupport, protocolGenerator).render(writer)
         }
 
@@ -52,7 +51,7 @@ open class ServerServiceGenerator(
                 }
             }
         }
-        rustCrate.withModule(RustModule.public("operation_handler", "Operation handlers definition and implementation.")) { writer ->
+        rustCrate.withModule(RustModule.private("operation_handler", "Operation handlers definition and implementation.")) { writer ->
             renderOperationHandler(writer, operations)
         }
         rustCrate.withModule(


### PR DESCRIPTION
## Motivation and Context
When experimenting with `smithy-rs` I noticed that the generated server crate exposes two public empty modules - `operation` and `operation_handler`. 

## Description
Make sure that `operation` and `operational_handler` are private modules in the generated server crate, while keeping `operation` public for the generated client crate.

## Testing
I verified the generated server and client code via `./gradlew codegen-client-test:test` and `./gradlew codegen-server-test:test`.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
