### PR TITLE
Lambda support for Python servers

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonApplicationGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonApplicationGenerator.kt
@@ -268,7 +268,7 @@ class PythonApplicationGenerator(
                     py: #{pyo3}::Python,
                 ) -> #{pyo3}::PyResult<()> {
                     use #{SmithyPython}::PyApp;
-                    self.run_lambda_server(py)
+                    self.run_lambda_handler(py)
                 }
                 /// Build the router and start a single worker.
                 ##[pyo3(text_signature = "(${'$'}self, socket, worker_number)")]

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonApplicationGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonApplicationGenerator.kt
@@ -29,6 +29,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.Ser
  * Generates a Python compatible application and server that can be configured from Python.
  *
  * Example:
+ * ```
  *     from pool import DatabasePool
  *     from my_library import App, OperationInput, OperationOutput
  *     @dataclass
@@ -44,47 +45,48 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.Ser
  *        return OperationOutput(description)
  *
  *     app.run()
- *
- * The application holds a mapping between operation names (lowercase, snakecase),
- * the context as defined in Python and some task local with the Python event loop
- * for the current process.
+ * ```
+ * The application holds a mapping between operation names (lowercase, snakecase), the context as
+ * defined in Python and some task local with the Python event loop for the current process.
  *
  * The application exposes several methods to Python:
  * * `App()`: constructor to create an instance of `App`.
  * * `run()`: run the application on a number of workers.
  * * `context()`: register the context object that is passed to the Python handlers.
- * * One register method per operation that can be used as decorator. For example if
- *   the model has one operation called `RegisterServer`, it will codegenerate a method
- *   of `App` called `register_service()` that can be used to decorate the Python implementation
- *   of this operation.
+ * * One register method per operation that can be used as decorator. For example if the model has
+ * one operation called `RegisterServer`, it will codegenerate a method of `App` called
+ * `register_service()` that can be used to decorate the Python implementation of this operation.
  *
  * This class also renders the implementation of the `aws_smity_http_server_python::PyServer` trait,
  * that abstracts the processes / event loops / workers lifecycles.
  */
 class PythonApplicationGenerator(
-    codegenContext: CodegenContext,
-    private val protocol: ServerProtocol,
-    private val operations: List<OperationShape>,
+        codegenContext: CodegenContext,
+        private val protocol: ServerProtocol,
+        private val operations: List<OperationShape>,
 ) {
     private val symbolProvider = codegenContext.symbolProvider
     private val libName = "lib${codegenContext.settings.moduleName.toSnakeCase()}"
     private val runtimeConfig = codegenContext.runtimeConfig
     private val model = codegenContext.model
     private val codegenScope =
-        arrayOf(
-            "SmithyPython" to PythonServerCargoDependency.SmithyHttpServerPython(runtimeConfig).asType(),
-            "SmithyServer" to ServerCargoDependency.SmithyHttpServer(runtimeConfig).asType(),
-            "pyo3" to PythonServerCargoDependency.PyO3.asType(),
-            "pyo3_asyncio" to PythonServerCargoDependency.PyO3Asyncio.asType(),
-            "tokio" to PythonServerCargoDependency.Tokio.asType(),
-            "tracing" to PythonServerCargoDependency.Tracing.asType(),
-            "tower" to PythonServerCargoDependency.Tower.asType(),
-            "tower_http" to PythonServerCargoDependency.TowerHttp.asType(),
-            "num_cpus" to PythonServerCargoDependency.NumCpus.asType(),
-            "hyper" to PythonServerCargoDependency.Hyper.asType(),
-            "HashMap" to RustType.HashMap.RuntimeType,
-            "parking_lot" to PythonServerCargoDependency.ParkingLot.asType(),
-        )
+            arrayOf(
+                    "SmithyPython" to
+                            PythonServerCargoDependency.SmithyHttpServerPython(runtimeConfig)
+                                    .asType(),
+                    "SmithyServer" to
+                            ServerCargoDependency.SmithyHttpServer(runtimeConfig).asType(),
+                    "pyo3" to PythonServerCargoDependency.PyO3.asType(),
+                    "pyo3_asyncio" to PythonServerCargoDependency.PyO3Asyncio.asType(),
+                    "tokio" to PythonServerCargoDependency.Tokio.asType(),
+                    "tracing" to PythonServerCargoDependency.Tracing.asType(),
+                    "tower" to PythonServerCargoDependency.Tower.asType(),
+                    "tower_http" to PythonServerCargoDependency.TowerHttp.asType(),
+                    "num_cpus" to PythonServerCargoDependency.NumCpus.asType(),
+                    "hyper" to PythonServerCargoDependency.Hyper.asType(),
+                    "HashMap" to RustType.HashMap.RuntimeType,
+                    "parking_lot" to PythonServerCargoDependency.ParkingLot.asType(),
+            )
 
     fun render(writer: RustWriter) {
         renderPyApplicationRustDocs(writer)
@@ -92,13 +94,12 @@ class PythonApplicationGenerator(
         renderAppDefault(writer)
         renderAppClone(writer)
         renderPyAppTrait(writer)
-        renderAppImpl(writer)
         renderPyMethods(writer)
     }
 
     fun renderAppStruct(writer: RustWriter) {
         writer.rustTemplate(
-            """
+                """
             ##[#{pyo3}::pyclass]
             ##[derive(Debug)]
             pub struct App {
@@ -108,13 +109,13 @@ class PythonApplicationGenerator(
                 workers: #{parking_lot}::Mutex<Vec<#{pyo3}::PyObject>>,
             }
             """,
-            *codegenScope,
+                *codegenScope,
         )
     }
 
     private fun renderAppClone(writer: RustWriter) {
         writer.rustTemplate(
-            """
+                """
             impl Clone for App {
                 fn clone(&self) -> Self {
                     Self {
@@ -126,13 +127,13 @@ class PythonApplicationGenerator(
                 }
             }
             """,
-            *codegenScope,
+                *codegenScope,
         )
     }
 
     private fun renderAppDefault(writer: RustWriter) {
         writer.rustTemplate(
-            """
+                """
             impl Default for App {
                 fn default() -> Self {
                     Self {
@@ -144,69 +145,20 @@ class PythonApplicationGenerator(
                 }
             }
             """,
-            "Protocol" to protocol.markerStruct(),
-            *codegenScope,
+                "Protocol" to protocol.markerStruct(),
+                *codegenScope,
         )
     }
 
-    private fun renderAppImpl(writer: RustWriter) {
-        writer.rustBlockTemplate(
-            """
-            impl App
-            """,
-            *codegenScope,
-        ) {
-            rustBlockTemplate(
-                """
-                /// Dynamically codegenerate the routes, allowing to build the Smithy [#{SmithyServer}::routing::Router].
-                pub fn build_router(&mut self, event_loop: &#{pyo3}::PyAny) -> #{pyo3}::PyResult<#{SmithyServer}::routing::Router>
-                """,
-                *codegenScope,
-            ) {
-                rustTemplate(
-                    """
-                    let router = crate::operation_registry::OperationRegistryBuilder::default();
-                    """,
-                    *codegenScope,
-                )
-                for (operation in operations) {
-                    val operationName = symbolProvider.toSymbol(operation).name
-                    val name = operationName.toSnakeCase()
-                    rustTemplate(
-                        """
-                        let ${name}_locals = #{pyo3_asyncio}::TaskLocals::new(event_loop);
-                        let handler = self.handlers.get("$name").expect("Python handler for operation `$name` not found").clone();
-                        let router = router.$name(move |input, state| {
-                            #{pyo3_asyncio}::tokio::scope(${name}_locals, crate::operation_handler::$name(input, state, handler))
-                        });
-                        """,
-                        *codegenScope,
-                    )
-                }
-                rustTemplate(
-                    """
-                    let middleware_locals = pyo3_asyncio::TaskLocals::new(event_loop);
-                    let service = #{tower}::ServiceBuilder::new()
-                        .layer(
-                            #{SmithyPython}::PyMiddlewareLayer::<#{Protocol}>::new(self.middlewares.clone(), middleware_locals),
-                        );
-                    let router: #{SmithyServer}::routing::Router = router
-                        .build()
-                        .expect("Unable to build operation registry")
-                        .into();
-                    Ok(router.layer(service))
-                    """,
-                    "Protocol" to protocol.markerStruct(),
-                    *codegenScope,
-                )
-            }
-        }
-    }
-
     private fun renderPyAppTrait(writer: RustWriter) {
-        writer.rustTemplate(
-            """
-            impl #{SmithyPython}::PyApp for App {
+        writer.rustBlockTemplate(
+                """
+            impl #{SmithyPython}::PyApp for App
+            """,
+                *codegenScope,
+        ) {
+            rustTemplate(
+                    """
                 fn workers(&self) -> &#{parking_lot}::Mutex<Vec<#{pyo3}::PyObject>> {
                     &self.workers
                 }
@@ -219,22 +171,67 @@ class PythonApplicationGenerator(
                 fn middlewares(&mut self) -> &mut #{SmithyPython}::PyMiddlewares {
                     &mut self.middlewares
                 }
+                """,
+                    *codegenScope,
+            )
+
+            rustBlockTemplate(
+                    """
+                // Dynamically codegenerate the routes, allowing to build the Smithy [#{SmithyServer}::routing::Router].
+                fn build_router(&mut self, event_loop: &#{pyo3}::PyAny) -> #{pyo3}::PyResult<#{SmithyServer}::routing::Router>
+                """,
+                    *codegenScope,
+            ) {
+                rustTemplate(
+                        """
+                    let router = crate::operation_registry::OperationRegistryBuilder::default();
+                    """,
+                        *codegenScope,
+                )
+                for (operation in operations) {
+                    val operationName = symbolProvider.toSymbol(operation).name
+                    val name = operationName.toSnakeCase()
+                    rustTemplate(
+                            """
+                        let ${name}_locals = #{pyo3_asyncio}::TaskLocals::new(event_loop);
+                        let handler = self.handlers.get("$name").expect("Python handler for operation `$name` not found").clone();
+                        let router = router.$name(move |input, state| {
+                            #{pyo3_asyncio}::tokio::scope(${name}_locals, crate::operation_handler::$name(input, state, handler))
+                        });
+                        """,
+                            *codegenScope,
+                    )
+                }
+                rustTemplate(
+                        """
+                    let middleware_locals = pyo3_asyncio::TaskLocals::new(event_loop);
+                    let service = #{tower}::ServiceBuilder::new()
+                        .layer(
+                            #{SmithyPython}::PyMiddlewareLayer::<#{Protocol}>::new(self.middlewares.clone(), middleware_locals),
+                        );
+                    let router: #{SmithyServer}::routing::Router = router
+                        .build()
+                        .expect("Unable to build operation registry")
+                        .into();
+                    Ok(router.layer(service))
+                    """,
+                        "Protocol" to protocol.markerStruct(),
+                        *codegenScope,
+                )
             }
-            """,
-            *codegenScope,
-        )
+        }
     }
 
     private fun renderPyMethods(writer: RustWriter) {
         writer.rustBlockTemplate(
-            """
+                """
             ##[#{pyo3}::pymethods]
             impl App
             """,
-            *codegenScope,
+                *codegenScope,
         ) {
             rustTemplate(
-                """
+                    """
                 /// Create a new [App].
                 ##[new]
                 pub fn new() -> Self {
@@ -264,6 +261,15 @@ class PythonApplicationGenerator(
                     use #{SmithyPython}::PyApp;
                     self.run_server(py, address, port, backlog, workers)
                 }
+                /// Lambda entrypoint: start the server on Lambda.
+                ##[pyo3(text_signature = "(${'$'}self)")]
+                pub fn run_lambda(
+                    &mut self,
+                    py: #{pyo3}::Python,
+                ) -> #{pyo3}::PyResult<()> {
+                    use #{SmithyPython}::PyApp;
+                    self.run_lambda_server(py)
+                }
                 /// Build the router and start a single worker.
                 ##[pyo3(text_signature = "(${'$'}self, socket, worker_number)")]
                 pub fn start_worker(
@@ -274,17 +280,17 @@ class PythonApplicationGenerator(
                 ) -> pyo3::PyResult<()> {
                     use #{SmithyPython}::PyApp;
                     let event_loop = self.configure_python_event_loop(py)?;
-                    let router = self.build_router(event_loop)?;
+                    let router = self.build_and_configure_router(py, event_loop)?;
                     self.start_hyper_worker(py, socket, event_loop, router, worker_number)
                 }
                 """,
-                *codegenScope,
+                    *codegenScope,
             )
             operations.map { operation ->
                 val operationName = symbolProvider.toSymbol(operation).name
                 val name = operationName.toSnakeCase()
                 rustTemplate(
-                    """
+                        """
                     /// Method to register `$name` Python implementation inside the handlers map.
                     /// It can be used as a function decorator in Python.
                     ##[pyo3(text_signature = "(${'$'}self, func)")]
@@ -293,7 +299,7 @@ class PythonApplicationGenerator(
                         self.register_operation(py, "$name", func)
                     }
                     """,
-                    *codegenScope,
+                        *codegenScope,
                 )
             }
         }
@@ -301,7 +307,7 @@ class PythonApplicationGenerator(
 
     private fun renderPyApplicationRustDocs(writer: RustWriter) {
         writer.rust(
-            """
+                """
             ##[allow(clippy::tabs_in_doc_comments)]
             /// Main Python application, used to register operations and context and start multiple
             /// workers on the same shared socket.
@@ -314,7 +320,7 @@ class PythonApplicationGenerator(
             """.trimIndent(),
         )
         writer.rust(
-            """
+                """
             /// from $libName import ${Inputs.namespace}
             /// from $libName import ${Outputs.namespace}
             """.trimIndent(),
@@ -323,7 +329,7 @@ class PythonApplicationGenerator(
             writer.rust("""/// from $libName import ${Errors.namespace}""".trimIndent())
         }
         writer.rust(
-            """
+                """
             /// from $libName import middleware
             /// from $libName import App
             ///
@@ -343,7 +349,7 @@ class PythonApplicationGenerator(
         )
         writer.operationImplementationStubs(operations)
         writer.rust(
-            """
+                """
             ///
             /// app.run()
             /// ```
@@ -354,22 +360,27 @@ class PythonApplicationGenerator(
         )
     }
 
-    private fun RustWriter.operationImplementationStubs(operations: List<OperationShape>) = rust(
-        operations.joinToString("\n///\n") {
-            val operationDocumentation = it.getTrait<DocumentationTrait>()?.value
-            val ret = if (!operationDocumentation.isNullOrBlank()) {
-                operationDocumentation.replace("#", "##").prependIndent("/// ## ") + "\n"
-            } else ""
-            ret +
-                """
+    private fun RustWriter.operationImplementationStubs(operations: List<OperationShape>) =
+            rust(
+                    operations.joinToString("\n///\n") {
+                        val operationDocumentation = it.getTrait<DocumentationTrait>()?.value
+                        val ret =
+                                if (!operationDocumentation.isNullOrBlank()) {
+                                    operationDocumentation
+                                            .replace("#", "##")
+                                            .prependIndent("/// ## ") + "\n"
+                                } else ""
+                        ret +
+                                """
                 /// ${it.signature()}:
                 ///     raise NotImplementedError
                 """.trimIndent()
-        },
-    )
+                    },
+            )
 
     /**
-     * Returns the function signature for an operation handler implementation. Used in the documentation.
+     * Returns the function signature for an operation handler implementation. Used in the
+     * documentation.
      */
     private fun OperationShape.signature(): String {
         val inputSymbol = symbolProvider.toSymbol(inputShape(model))

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -22,6 +22,7 @@ bytes = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14.20", features = ["server", "http1", "http2", "tcp", "stream"] }
+lambda_http = "0.6.0"
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server-python/README.md
+++ b/rust-runtime/aws-smithy-http-server-python/README.md
@@ -47,8 +47,19 @@ COPY app.py ${LAMBDA_TASK_ROOT}
 # When you build your Server SDK for your service you get a shared library
 # that is importable in Python. You need to copy that shared library to same folder
 # with your application code, so it can be imported by your application.
+# Note that you need to build your library for Linux,
+# if you are on a different platform you can consult to
+# https://pyo3.rs/latest/building_and_distribution.html#cross-compiling
+# for cross compiling.
 COPY lib_pokemon_service_server_sdk.so ${LAMBDA_TASK_ROOT}
 
+# You can install your application's dependencies using file `requirements.txt`
+# from your project folder, if you have any.
+# COPY requirements.txt  .
+# RUN  pip3 install -r requirements.txt --target "${LAMBDA_TASK_ROOT}"
+
+# Create a symlink for your application's entrypoint,
+# so we can use `/app.py` to refer it
 RUN ln -s ${LAMBDA_TASK_ROOT}/app.py /app.py
 
 # By default `public.ecr.aws/lambda/python` images comes with Python runtime,

--- a/rust-runtime/aws-smithy-http-server-python/README.md
+++ b/rust-runtime/aws-smithy-http-server-python/README.md
@@ -59,7 +59,5 @@ CMD [ "/app.py" ]
 ```
 
 <!-- anchor_start:footer -->
-
 This crate is part of the [AWS SDK for Rust](https://awslabs.github.io/aws-sdk-rust/) and the [smithy-rs](https://github.com/awslabs/smithy-rs) code generator. In most cases, it should not be used directly.
-
 <!-- anchor_end:footer -->

--- a/rust-runtime/aws-smithy-http-server-python/README.md
+++ b/rust-runtime/aws-smithy-http-server-python/README.md
@@ -2,6 +2,64 @@
 
 Server libraries for smithy-rs generated servers, targeting pure Python business logic.
 
+## Running servers on AWS Lambda
+
+`aws-smithy-http-server-python` supports running your services on [AWS Lambda](https://aws.amazon.com/lambda/).
+
+You need to use `run_lambda` method instead of `run` method to start
+the [custom runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html)
+instead of the [Hyper](https://hyper.rs/) HTTP server.
+
+In your `app.py`:
+
+```diff
+from libpokemon_service_server_sdk import App
+from libpokemon_service_server_sdk.error import ResourceNotFoundException
+
+# ...
+
+# Get the number of requests served by this server.
+@app.get_server_statistics
+def get_server_statistics(
+    _: GetServerStatisticsInput, context: Context
+) -> GetServerStatisticsOutput:
+    calls_count = context.get_calls_count()
+    logging.debug("The service handled %d requests", calls_count)
+    return GetServerStatisticsOutput(calls_count=calls_count)
+
+# ...
+
+-app.run()
++app.run_lambda()
+```
+
+`aws-smithy-http-server-python` comes with a
+[custom runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtimes-custom.html)
+so you should run your service without any provided runtimes.
+You can achieve that with a `Dockerfile` similar to this:
+
+```dockerfile
+# You can use any image that has your desired Python version
+FROM public.ecr.aws/lambda/python:3.8-x86_64
+
+# Copy your application code to `LAMBDA_TASK_ROOT`
+COPY app.py ${LAMBDA_TASK_ROOT}
+# When you build your Server SDK for your service you get a shared library
+# that is importable in Python. You need to copy that shared library to same folder
+# with your application code, so it can be imported by your application.
+COPY lib_pokemon_service_server_sdk.so ${LAMBDA_TASK_ROOT}
+
+RUN ln -s ${LAMBDA_TASK_ROOT}/app.py /app.py
+
+# By default `public.ecr.aws/lambda/python` images comes with Python runtime,
+# we need to override `ENTRYPOINT` and `CMD` to not call that runtime and
+# instead run directly your service and it will start our custom runtime.
+ENTRYPOINT [ "/var/lang/bin/python3.8" ]
+CMD [ "/app.py" ]
+```
+
 <!-- anchor_start:footer -->
+
 This crate is part of the [AWS SDK for Rust](https://awslabs.github.io/aws-sdk-rust/) and the [smithy-rs](https://github.com/awslabs/smithy-rs) code generator. In most cases, it should not be used directly.
+
 <!-- anchor_end:footer -->

--- a/rust-runtime/aws-smithy-http-server-python/src/server.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/server.rs
@@ -453,11 +453,11 @@ event_loop.add_signal_handler(signal.SIGINT,
         Ok(())
     }
 
-    /// Lambda main entrypoint: start the server on Lambda.
+    /// Lambda main entrypoint: start the handler on Lambda.
     ///
-    /// Unlike the `run_server`, `run_lambda_server` does not spawns other processes,
-    /// it starts the Lambda server on the current process.
-    fn run_lambda_server(&mut self, py: Python) -> PyResult<()> {
+    /// Unlike the `run_server`, `run_lambda_handler` does not spawns other processes,
+    /// it starts the Lambda handler on the current process.
+    fn run_lambda_handler(&mut self, py: Python) -> PyResult<()> {
         let event_loop = self.configure_python_event_loop(py)?;
         let app = self.build_and_configure_router(py, event_loop)?;
         let rt = runtime::Builder::new_multi_thread()
@@ -467,9 +467,9 @@ event_loop.add_signal_handler(signal.SIGINT,
         rt.block_on(async move {
             let handler = LambdaHandler::new(app);
             let lambda = lambda_http::run(handler);
-            tracing::debug!("Starting Lambda server");
+            tracing::debug!("Starting Lambda handler");
             if let Err(err) = lambda.await {
-                tracing::error!("server error: {}", err);
+                tracing::error!("Lambda handler error: {}", err);
             }
         });
         Ok(())

--- a/rust-runtime/aws-smithy-http-server-python/src/server.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/server.rs
@@ -372,15 +372,12 @@ event_loop.add_signal_handler(signal.SIGINT,
     ///     #[derive(Debug, Clone)]
     ///     pub struct App {};
     ///
-    ///     impl App {
-    ///         pub fn build_router(&mut self, event_loop: &PyAny) -> PyResult<aws_smithy_http_server::routing::Router> { todo!() }
-    ///     }
-    ///
     ///     impl PyApp for App {
     ///         fn workers(&self) -> &Mutex<Vec<PyObject>> { todo!() }
     ///         fn context(&self) -> &Option<PyObject> { todo!() }
     ///         fn handlers(&mut self) -> &mut HashMap<String, PyHandler> { todo!() }
     ///         fn middlewares(&mut self) -> &mut PyMiddlewares { todo!() }
+    ///         fn build_router(&mut self, event_loop: &PyAny) -> PyResult<aws_smithy_http_server::routing::Router> { todo!() }
     ///     }
     ///
     ///     #[pymethods]

--- a/rust-runtime/aws-smithy-http-server-python/src/server.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/server.rs
@@ -463,13 +463,13 @@ event_loop.add_signal_handler(signal.SIGINT,
         let rt = runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
-            .expect("Unable to start a new Tokio runtime for this process");
+            .expect("unable to start a new tokio runtime for this process");
         rt.block_on(async move {
             let handler = LambdaHandler::new(app);
             let lambda = lambda_http::run(handler);
-            tracing::debug!("Starting Lambda handler");
+            tracing::debug!("starting lambda handler");
             if let Err(err) = lambda.await {
-                tracing::error!("Lambda handler error: {}", err);
+                tracing::error!(error = %err, "unable to start lambda handler");
             }
         });
         Ok(())
@@ -484,7 +484,7 @@ event_loop.add_signal_handler(signal.SIGINT,
         let app = self.build_router(event_loop)?;
         // Create the `PyState` object from the Python context object.
         let context = self.context().clone().unwrap_or_else(|| py.None());
-        tracing::debug!("Add middlewares to Rust Python router");
+        tracing::debug!("add middlewares to rust python router");
         let app = app.layer(ServiceBuilder::new().layer(AddExtensionLayer::new(context)));
         Ok(app)
     }


### PR DESCRIPTION
This PR exposes `app.run_lambda()` function to allow Python servers to run on Lambda. Closes https://github.com/awslabs/smithy-rs/issues/1750.

## Why we use custom Rust runtime
We could also use builtin Python runtime, I decided to use custom Rust runtime because there was some performance overheads.

If you use Python runtime: 
- Receive requests with Python (Python)
- Pass requests to Rust (Rust)
- You basically receive a JSON object in API Gateway schema and you need to convert it to Hyper Request, this is handled by `lambda_http` crate but it is not designed to be reusable and requires some modification/copying (Rust)
- Call Python handler to get result (Python)
- Convert that result to Http response (Rust)
- Pass that result to Python  (Python)
- Finally return response to Lambda runtime to complete (Python)

If you use Rust runtime:
- Receive Hyper Request with Rust (Conversion from JSON object to Hyper Request is already handled by `lambda_http` crate) (Rust)
- Call Python handler to get result (Python)
- Convert that result to Http response (Rust)
- Finally return response to Lambda runtime to complete (Rust)

## Testing

It can be tested with a `Dockerfile` similar to this:
```Dockerfile
FROM public.ecr.aws/lambda/python:3.8-x86_64

COPY app.py ${LAMBDA_TASK_ROOT}
# Shared library should be on the same folder with application code, so it can be imported
COPY lib_pokemon_service_server_sdk.so ${LAMBDA_TASK_ROOT}

RUN ln -s ${LAMBDA_TASK_ROOT}/app.py /app.py

# override `ENTRYPOINT` to not call Python runtime, so we can use Rust runtime
ENTRYPOINT [ "/var/lang/bin/python3.8" ] 
CMD [ "/app.py" ]
```