### PR TITLE
Revamp errors in `aws-config` and `aws-types`

### DIFF
--- a/aws/rust-runtime/aws-config/external-types.toml
+++ b/aws/rust-runtime/aws-config/external-types.toml
@@ -21,9 +21,6 @@ allowed_external_types = [
    "http::uri::Uri",
    "tower_service::Service",
 
-   # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Decide if `InvalidUri` should be exposed
-   "http::uri::InvalidUri",
-
    # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Decide if the following should be exposed
    "hyper::client::connect::Connection",
    "tokio::io::async_read::AsyncRead",

--- a/aws/rust-runtime/aws-config/src/credential_process.rs
+++ b/aws/rust-runtime/aws-config/src/credential_process.rs
@@ -7,6 +7,7 @@
 
 use crate::json_credentials::{json_parse_loop, InvalidJsonCredentials, RefreshableCredentials};
 use aws_smithy_json::deserialize::Token;
+use aws_smithy_types::error::opaque::OpaqueError;
 use aws_types::credentials::{future, CredentialsError, ProvideCredentials};
 use aws_types::{credentials, Credentials};
 use std::fmt;
@@ -197,7 +198,7 @@ pub(crate) fn parse_credential_process_json_credentials(
                 version = Some(i32::try_from(*value).map_err(|err| {
                     InvalidJsonCredentials::InvalidField {
                         field: "Version",
-                        err: err.into(),
+                        source: OpaqueError::new(err),
                     }
                 })?);
             }
@@ -227,7 +228,7 @@ pub(crate) fn parse_credential_process_json_credentials(
         Some(version) => {
             return Err(InvalidJsonCredentials::InvalidField {
                 field: "version",
-                err: format!("unknown version number: {}", version).into(),
+                source: format!("unknown version number: {}", version).into(),
             })
         }
     }
@@ -241,7 +242,7 @@ pub(crate) fn parse_credential_process_json_credentials(
         SystemTime::try_from(OffsetDateTime::parse(&expiration, &Rfc3339).map_err(|err| {
             InvalidJsonCredentials::InvalidField {
                 field: "Expiration",
-                err: err.into(),
+                source: OpaqueError::new(err),
             }
         })?)
         .map_err(|_| {

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -150,7 +150,7 @@ impl TokenMiddleware {
             .client
             .call(operation)
             .await
-            .map_err(ImdsError::FailedToLoadToken)?;
+            .map_err(ImdsError::failed_to_load_token)?;
         let expiry = response.expiry;
         Ok((response, expiry))
     }

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -137,9 +137,12 @@ impl ImdsCredentialsProvider {
                 );
                 Err(CredentialsError::not_loaded("received 404 from IMDS"))
             }
-            Err(ImdsError::FailedToLoadToken(SdkError::DispatchFailure(err))) => Err(
-                CredentialsError::not_loaded(format!("could not communicate with imds: {}", err)),
-            ),
+            Err(ImdsError::FailedToLoadToken {
+                source: SdkError::DispatchFailure(err),
+            }) => Err(CredentialsError::not_loaded(format!(
+                "could not communicate with IMDS: {}",
+                err
+            ))),
             Err(other) => Err(CredentialsError::provider_error(other)),
         }
     }

--- a/aws/rust-runtime/aws-config/src/imds/region.rs
+++ b/aws/rust-runtime/aws-config/src/imds/region.rs
@@ -12,10 +12,9 @@ use crate::imds;
 use crate::imds::client::LazyClient;
 use crate::meta::region::{future, ProvideRegion};
 use crate::provider_config::ProviderConfig;
-
+use aws_smithy_types::error::display_context::DisplayErrorContext;
 use aws_types::os_shim_internal::Env;
 use aws_types::region::Region;
-
 use tracing::Instrument;
 
 /// IMDSv2 Region Provider
@@ -57,7 +56,7 @@ impl ImdsRegionProvider {
                 Some(Region::new(region))
             }
             Err(err) => {
-                tracing::warn!(err = % err, "failed to load region from IMDS");
+                tracing::warn!(err = %DisplayErrorContext(&err), "failed to load region from IMDS");
                 None
             }
         }

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::borrow::Cow;
-
+use aws_smithy_types::error::display_context::DisplayErrorContext;
 use aws_types::credentials::{self, future, CredentialsError, ProvideCredentials};
+use std::borrow::Cow;
 use tracing::Instrument;
 
 /// Credentials provider that checks a series of inner providers
@@ -82,12 +82,11 @@ impl CredentialsProviderChain {
                     tracing::debug!(provider = %name, "loaded credentials");
                     return Ok(credentials);
                 }
-                Err(CredentialsError::CredentialsNotLoaded { context, .. }) => {
-                    tracing::debug!(provider = %name, context = %context, "provider in chain did not provide credentials");
+                Err(CredentialsError::CredentialsNotLoaded { source, .. }) => {
+                    tracing::debug!(provider = %name, context = %DisplayErrorContext(&source), "provider in chain did not provide credentials");
                 }
-                Err(e) => {
-                    tracing::warn!(provider = %name, error = %e, "provider failed to provide credentials");
-                    return Err(e);
+                Err(err) => {
+                    return Err(err);
                 }
             }
         }

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -129,7 +129,7 @@ async fn load_config_file(
                     return Err(ProfileFileError::CouldNotReadProfileFile(
                         CouldNotReadProfileFile {
                             path: path.clone(),
-                            cause: e,
+                            source: e,
                         },
                     ))
                 }

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -3,17 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::connector::default_connector;
 use crate::provider_config::ProviderConfig;
-
 use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep, TokioSleep};
 use aws_smithy_client::dvr::{NetworkTraffic, RecordingConnection, ReplayingConnection};
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::error::display_context::DisplayErrorContext;
 use aws_types::credentials::{self, ProvideCredentials};
 use aws_types::os_shim_internal::{Env, Fs};
-
 use serde::Deserialize;
-
-use crate::connector::default_connector;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Debug;
@@ -101,7 +99,7 @@ where
             }
             (Err(err), GenericTestResult::ErrorContains(substr)) => {
                 assert!(
-                    format!("{}", err).contains(substr),
+                    format!("{}", DisplayErrorContext(&err)).contains(substr),
                     "`{}` did not contain `{}`",
                     err,
                     substr

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -266,6 +266,7 @@ mod test {
     };
     use aws_sdk_sts::Region;
     use aws_smithy_async::rt::sleep::TokioSleep;
+    use aws_smithy_types::error::display_context::DisplayErrorContext;
     use aws_types::credentials::CredentialsError;
     use aws_types::os_shim_internal::{Env, Fs};
     use std::collections::HashMap;
@@ -308,7 +309,7 @@ mod test {
             .await
             .expect_err("should fail, provider not loaded");
         assert!(
-            format!("{}", err).contains("AWS_ROLE_ARN"),
+            format!("{}", DisplayErrorContext(&err)).contains("AWS_ROLE_ARN"),
             "`{}` did not contain expected string",
             err
         );

--- a/rust-runtime/aws-smithy-types/src/error.rs
+++ b/rust-runtime/aws-smithy-types/src/error.rs
@@ -1,0 +1,148 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Generic errors for Smithy codegen
+
+use crate::retry::{ErrorKind, ProvideErrorKind};
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
+pub mod display_context;
+pub mod opaque;
+
+/// Generic Error type
+///
+/// For many services, Errors are modeled. However, many services only partially model errors or don't
+/// model errors at all. In these cases, the SDK will return this generic error type to expose the
+/// `code`, `message` and `request_id`.
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+pub struct Error {
+    code: Option<String>,
+    message: Option<String>,
+    request_id: Option<String>,
+    extras: HashMap<&'static str, String>,
+}
+
+/// Builder for [`Error`].
+#[derive(Debug, Default)]
+pub struct Builder {
+    inner: Error,
+}
+
+impl Builder {
+    /// Sets the error message.
+    pub fn message(&mut self, message: impl Into<String>) -> &mut Self {
+        self.inner.message = Some(message.into());
+        self
+    }
+
+    /// Sets the error code.
+    pub fn code(&mut self, code: impl Into<String>) -> &mut Self {
+        self.inner.code = Some(code.into());
+        self
+    }
+
+    /// Sets the request ID the error happened for.
+    pub fn request_id(&mut self, request_id: impl Into<String>) -> &mut Self {
+        self.inner.request_id = Some(request_id.into());
+        self
+    }
+
+    /// Set a custom field on the error metadata
+    ///
+    /// Typically, these will be accessed with an extension trait:
+    /// ```rust
+    /// use aws_smithy_types::Error;
+    /// const HOST_ID: &str = "host_id";
+    /// trait S3ErrorExt {
+    ///     fn extended_request_id(&self) -> Option<&str>;
+    /// }
+    ///
+    /// impl S3ErrorExt for Error {
+    ///     fn extended_request_id(&self) -> Option<&str> {
+    ///         self.extra(HOST_ID)
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     // Extension trait must be brought into scope
+    ///     use S3ErrorExt;
+    ///     let sdk_response: Result<(), Error> = Err(Error::builder().custom(HOST_ID, "x-1234").build());
+    ///     if let Err(err) = sdk_response {
+    ///         println!("request id: {:?}, extended request id: {:?}", err.request_id(), err.extended_request_id());
+    ///     }
+    /// }
+    /// ```
+    pub fn custom(&mut self, key: &'static str, value: impl Into<String>) -> &mut Self {
+        self.inner.extras.insert(key, value.into());
+        self
+    }
+
+    /// Creates the error.
+    pub fn build(&mut self) -> Error {
+        std::mem::take(&mut self.inner)
+    }
+}
+
+impl Error {
+    /// Returns the error code.
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+    /// Returns the error message.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+    /// Returns the request ID the error occurred for, if it's available.
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+    /// Returns additional information about the error if it's present.
+    pub fn extra(&self, key: &'static str) -> Option<&str> {
+        self.extras.get(key).map(|k| k.as_str())
+    }
+
+    /// Creates an `Error` builder.
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    /// Converts an `Error` into a builder.
+    pub fn into_builder(self) -> Builder {
+        Builder { inner: self }
+    }
+}
+
+impl ProvideErrorKind for Error {
+    fn retryable_error_kind(&self) -> Option<ErrorKind> {
+        None
+    }
+
+    fn code(&self) -> Option<&str> {
+        Error::code(self)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut fmt = f.debug_struct("Error");
+        if let Some(code) = &self.code {
+            fmt.field("code", code);
+        }
+        if let Some(message) = &self.message {
+            fmt.field("message", message);
+        }
+        if let Some(req_id) = &self.request_id {
+            fmt.field("request_id", req_id);
+        }
+        for (k, v) in &self.extras {
+            fmt.field(k, &v);
+        }
+        fmt.finish()
+    }
+}
+
+impl std::error::Error for Error {}

--- a/rust-runtime/aws-smithy-types/src/error/display_context.rs
+++ b/rust-runtime/aws-smithy-types/src/error/display_context.rs
@@ -1,0 +1,90 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Error wrapper that displays error context
+
+use std::error::Error;
+use std::fmt;
+
+/// Provides a `Display` impl for an `Error` that outputs the full error context
+///
+/// This is useful for emitting errors with `tracing` in cases where the error
+/// is not returned back to the customer.
+#[derive(Debug)]
+pub struct DisplayErrorContext<E: Error>(pub E);
+
+impl<E: Error> fmt::Display for DisplayErrorContext<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err(f, &self.0)
+    }
+}
+
+fn write_err(f: &mut fmt::Formatter<'_>, err: &dyn Error) -> fmt::Result {
+    write!(f, "{}", err)?;
+    if let Some(source) = err.source() {
+        write!(f, ": ")?;
+        write_err(f, source)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct TestError {
+        what: &'static str,
+        source: Option<Box<dyn Error>>,
+    }
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.what)
+        }
+    }
+
+    impl Error for TestError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source.as_deref()
+        }
+    }
+
+    #[test]
+    fn no_sources() {
+        assert_eq!(
+            "test",
+            format!(
+                "{}",
+                DisplayErrorContext(TestError {
+                    what: "test",
+                    source: None
+                })
+            )
+        );
+    }
+
+    #[test]
+    fn sources() {
+        assert_eq!(
+            "foo: bar: baz",
+            format!(
+                "{}",
+                DisplayErrorContext(TestError {
+                    what: "foo",
+                    source: Some(Box::new(TestError {
+                        what: "bar",
+                        source: Some(Box::new(TestError {
+                            what: "baz",
+                            source: None
+                        }))
+                    }) as Box<_>)
+                })
+            )
+        );
+    }
+}

--- a/rust-runtime/aws-smithy-types/src/error/opaque.rs
+++ b/rust-runtime/aws-smithy-types/src/error/opaque.rs
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Opaque error type used by generated code and runtime crates
+
+use crate::error::display_context::DisplayErrorContext;
+use std::error::Error;
+use std::fmt;
+
+/// Opaque error type
+///
+/// Provides a `Display` implementation to show the formatted contents of the inner error type,
+/// but does not allow downcasting of the inner error type.
+#[derive(Debug)]
+pub struct OpaqueError(Box<dyn Error + Send + Sync + 'static>);
+
+impl OpaqueError {
+    /// Creates a new `OpaqueError` around the given `inner` error
+    pub fn new(inner: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+        Self(inner.into())
+    }
+}
+
+impl fmt::Display for OpaqueError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        DisplayErrorContext(self.0.as_ref()).fmt(f)
+    }
+}
+
+impl Error for OpaqueError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        // Intentionally don't reveal the source since this is an opaque error type
+        None
+    }
+}
+
+impl From<String> for OpaqueError {
+    fn from(string: String) -> Self {
+        Self::new(string)
+    }
+}
+
+impl From<&str> for OpaqueError {
+    fn from(string: &str) -> Self {
+        Self::new(string)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error as IOError, ErrorKind as IOErrorKind};
+
+    #[test]
+    fn send_sync() {
+        fn verify_send_sync<T: Send + Sync>(_thing: Option<T>) {}
+        verify_send_sync::<Option<OpaqueError>>(None);
+    }
+
+    #[test]
+    fn source() {
+        use std::error::Error as _;
+        let err = OpaqueError::new(IOError::new(IOErrorKind::Other, "test"));
+        assert!(err.source().is_none());
+        assert_eq!("test", format!("{}", err));
+    }
+}

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -18,11 +18,13 @@ use std::collections::HashMap;
 pub mod base64;
 pub mod date_time;
 pub mod endpoint;
+pub mod error;
 pub mod primitive;
 pub mod retry;
 pub mod timeout;
 
 pub use crate::date_time::DateTime;
+pub use error::Error;
 
 /// Binary Blob Type
 ///
@@ -552,148 +554,4 @@ mod number {
             1452089100f32
         );
     }
-}
-
-pub use error::Error;
-
-/// Generic errors for Smithy codegen
-pub mod error {
-    use crate::retry::{ErrorKind, ProvideErrorKind};
-    use std::collections::HashMap;
-    use std::fmt;
-    use std::fmt::{Display, Formatter};
-
-    /// Generic Error type
-    ///
-    /// For many services, Errors are modeled. However, many services only partially model errors or don't
-    /// model errors at all. In these cases, the SDK will return this generic error type to expose the
-    /// `code`, `message` and `request_id`.
-    #[derive(Debug, Eq, PartialEq, Default, Clone)]
-    pub struct Error {
-        code: Option<String>,
-        message: Option<String>,
-        request_id: Option<String>,
-        extras: HashMap<&'static str, String>,
-    }
-
-    /// Builder for [`Error`].
-    #[derive(Debug, Default)]
-    pub struct Builder {
-        inner: Error,
-    }
-
-    impl Builder {
-        /// Sets the error message.
-        pub fn message(&mut self, message: impl Into<String>) -> &mut Self {
-            self.inner.message = Some(message.into());
-            self
-        }
-
-        /// Sets the error code.
-        pub fn code(&mut self, code: impl Into<String>) -> &mut Self {
-            self.inner.code = Some(code.into());
-            self
-        }
-
-        /// Sets the request ID the error happened for.
-        pub fn request_id(&mut self, request_id: impl Into<String>) -> &mut Self {
-            self.inner.request_id = Some(request_id.into());
-            self
-        }
-
-        /// Set a custom field on the error metadata
-        ///
-        /// Typically, these will be accessed with an extension trait:
-        /// ```rust
-        /// use aws_smithy_types::Error;
-        /// const HOST_ID: &str = "host_id";
-        /// trait S3ErrorExt {
-        ///     fn extended_request_id(&self) -> Option<&str>;
-        /// }
-        ///
-        /// impl S3ErrorExt for Error {
-        ///     fn extended_request_id(&self) -> Option<&str> {
-        ///         self.extra(HOST_ID)
-        ///     }
-        /// }
-        ///
-        /// fn main() {
-        ///     // Extension trait must be brought into scope
-        ///     use S3ErrorExt;
-        ///     let sdk_response: Result<(), Error> = Err(Error::builder().custom(HOST_ID, "x-1234").build());
-        ///     if let Err(err) = sdk_response {
-        ///         println!("request id: {:?}, extended request id: {:?}", err.request_id(), err.extended_request_id());
-        ///     }
-        /// }
-        /// ```
-        pub fn custom(&mut self, key: &'static str, value: impl Into<String>) -> &mut Self {
-            self.inner.extras.insert(key, value.into());
-            self
-        }
-
-        /// Creates the error.
-        pub fn build(&mut self) -> Error {
-            std::mem::take(&mut self.inner)
-        }
-    }
-
-    impl Error {
-        /// Returns the error code.
-        pub fn code(&self) -> Option<&str> {
-            self.code.as_deref()
-        }
-        /// Returns the error message.
-        pub fn message(&self) -> Option<&str> {
-            self.message.as_deref()
-        }
-        /// Returns the request ID the error occurred for, if it's available.
-        pub fn request_id(&self) -> Option<&str> {
-            self.request_id.as_deref()
-        }
-        /// Returns additional information about the error if it's present.
-        pub fn extra(&self, key: &'static str) -> Option<&str> {
-            self.extras.get(key).map(|k| k.as_str())
-        }
-
-        /// Creates an `Error` builder.
-        pub fn builder() -> Builder {
-            Builder::default()
-        }
-
-        /// Converts an `Error` into a builder.
-        pub fn into_builder(self) -> Builder {
-            Builder { inner: self }
-        }
-    }
-
-    impl ProvideErrorKind for Error {
-        fn retryable_error_kind(&self) -> Option<ErrorKind> {
-            None
-        }
-
-        fn code(&self) -> Option<&str> {
-            Error::code(self)
-        }
-    }
-
-    impl Display for Error {
-        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-            let mut fmt = f.debug_struct("Error");
-            if let Some(code) = &self.code {
-                fmt.field("code", code);
-            }
-            if let Some(message) = &self.message {
-                fmt.field("message", message);
-            }
-            if let Some(req_id) = &self.request_id {
-                fmt.field("request_id", req_id);
-            }
-            for (k, v) in &self.extras {
-                fmt.field(k, &v);
-            }
-            fmt.finish()
-        }
-    }
-
-    impl std::error::Error for Error {}
 }


### PR DESCRIPTION
## Motivation and Context
This PR addresses #1345 for the `aws-config` and `aws-types` crates.

## Checklist
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
