### PR TITLE
Env vars and profile to configure IMDS retry and timeouts

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -137,3 +137,24 @@ message = "Fix regression where `connect_timeout` and `read_timeout` fields are 
 references = ["smithy-rs#1822"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "kevinpark1217"
+
+[[aws-sdk-rust]]
+message = """
+It is now possible to configure IMDS retry and timeout with environment variables and profile keys.
+See [Amazon EC2 instance metadata](https://docs.aws.amazon.com/sdkref/latest/guide/feature-ec2-instance-metadata.html) doc for more information.
+
+New environment variables:
+```
+AWS_METADATA_SERVICE_NUM_ATTEMPTS
+AWS_METADATA_SERVICE_TIMEOUT
+```
+
+New profile keys:
+```
+metadata_service_num_attempts
+metadata_service_timeout
+```
+"""
+references = ["aws-sdk-rust#625"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "kevinpark1217"


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This is a PR for the [issue #625](https://github.com/awslabs/aws-sdk-rust/issues/625) in `aws-sdk-rust` repo.

## Description
<!--- Describe your changes in detail -->

Adds the ability to configure retry logic using profile and environment variables.
https://docs.aws.amazon.com/sdkref/latest/guide/feature-ec2-instance-metadata.html

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
