### PR TITLE
Fix regression: Use `connect_timeout` and `read_timeout` again (#1822)

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -125,3 +125,9 @@ message = "The client Config now has getters for every value that it holds."
 references = ["smithy-rs#1747"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "kastolars"
+
+[[aws-sdk-rust]]
+message = "Fix regression where `connect_timeout` and `read_timeout` fields are unused in the IMDS client"
+references = ["smithy-rs#1822"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "kevinpark1217"

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -556,8 +556,8 @@ impl Builder {
     pub async fn build(self) -> Result<Client, BuildError> {
         let config = self.config.unwrap_or_default();
         let timeout_config = TimeoutConfig::builder()
-            .connect_timeout(DEFAULT_CONNECT_TIMEOUT)
-            .read_timeout(DEFAULT_READ_TIMEOUT)
+            .connect_timeout(self.connect_timeout.unwrap_or(DEFAULT_CONNECT_TIMEOUT))
+            .read_timeout(self.read_timeout.unwrap_or(DEFAULT_READ_TIMEOUT))
             .build();
         let connector_settings = ConnectorSettings::from_timeout_config(&timeout_config);
         let connector = expect_connector(config.connector(&connector_settings));


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

For #1822 
@jdisanti 

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
