### PR TITLE
Upgrade to Rust 1.62.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_call:
 
 env:
-  rust_version: 1.61.0
+  rust_version: 1.62.0
   rust_toolchain_components: clippy,rustfmt
 
 jobs:

--- a/.github/workflows/pull-request-bot.yml
+++ b/.github/workflows/pull-request-bot.yml
@@ -28,7 +28,7 @@ concurrency:
 
 env:
   java_version: 11
-  rust_version: 1.61.0
+  rust_version: 1.62.0
   rust_toolchain_components: clippy,rustfmt
   apt_dependencies: libssl-dev gnuplot jq
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  rust_version: 1.61.0
+  rust_version: 1.62.0
 
 name: Release smithy-rs
 on:

--- a/aws/rust-runtime/aws-endpoint/src/lib.rs
+++ b/aws/rust-runtime/aws-endpoint/src/lib.rs
@@ -283,8 +283,7 @@ mod test {
             props.insert(region.clone());
             props.insert(SigningService::from_static("qldb"));
             props.insert(
-                EndpointShim::from_arc(provider)
-                    .resolve_endpoint(&Params::new(Some(region.clone()))),
+                EndpointShim::from_arc(provider).resolve_endpoint(&Params::new(Some(region))),
             );
         };
         let req = AwsEndpointStage.apply(req).expect("should succeed");
@@ -314,8 +313,7 @@ mod test {
             props.insert(region.clone());
             props.insert(SigningService::from_static("qldb"));
             props.insert(
-                EndpointShim::from_arc(provider)
-                    .resolve_endpoint(&Params::new(Some(region.clone()))),
+                EndpointShim::from_arc(provider).resolve_endpoint(&Params::new(Some(region))),
             );
         };
         let req = AwsEndpointStage.apply(req).expect("should succeed");

--- a/aws/rust-runtime/aws-http/src/content_encoding.rs
+++ b/aws/rust-runtime/aws-http/src/content_encoding.rs
@@ -376,7 +376,7 @@ mod tests {
 
     impl SputteringBody {
         fn len(&self) -> usize {
-            self.parts.iter().flat_map(|b| b).map(|b| b.len()).sum()
+            self.parts.iter().flatten().map(|b| b.len()).sum()
         }
     }
 
@@ -462,7 +462,7 @@ mod tests {
         };
 
         let timeout_duration = Duration::from_secs(3);
-        if let Err(_) = tokio::time::timeout(timeout_duration, test_fut).await {
+        if (tokio::time::timeout(timeout_duration, test_fut).await).is_err() {
             panic!("test_aws_chunked_encoding timed out after {timeout_duration:?}");
         }
     }
@@ -513,7 +513,7 @@ mod tests {
         };
 
         let timeout_duration = Duration::from_secs(3);
-        if let Err(_) = tokio::time::timeout(timeout_duration, test_fut).await {
+        if (tokio::time::timeout(timeout_duration, test_fut).await).is_err() {
             panic!(
                 "test_aws_chunked_encoding_sputtering_body timed out after {timeout_duration:?}"
             );

--- a/aws/rust-runtime/aws-http/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-http/src/recursion_detection.rs
@@ -160,7 +160,7 @@ mod test {
             )
         }
         assert_ok(validate_headers(
-            &augmented_req.http().headers(),
+            augmented_req.http().headers(),
             test_case.request_headers_after(),
         ))
     }

--- a/aws/rust-runtime/aws-http/src/retry.rs
+++ b/aws/rust-runtime/aws-http/src/retry.rs
@@ -143,7 +143,7 @@ mod test {
     ) -> Result<SdkSuccess<()>, SdkError<E>> {
         Err(SdkError::ServiceError {
             err,
-            raw: operation::Response::new(raw.map(|b| SdkBody::from(b))),
+            raw: operation::Response::new(raw.map(SdkBody::from)),
         })
     }
 
@@ -265,9 +265,7 @@ mod test {
             policy.classify_retry(
                 Result::<SdkSuccess<()>, SdkError<UnmodeledError>>::Err(SdkError::ResponseError {
                     err: Box::new(UnmodeledError),
-                    raw: operation::Response::new(
-                        http::Response::new("OK").map(|b| SdkBody::from(b))
-                    ),
+                    raw: operation::Response::new(http::Response::new("OK").map(SdkBody::from)),
                 })
                 .as_ref()
             ),

--- a/aws/rust-runtime/aws-inlineable/src/http_body_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_body_checksum.rs
@@ -265,7 +265,7 @@ mod tests {
         for i in 0..10000 {
             let line = format!("This is a large file created for testing purposes {}", i);
             file.as_file_mut().write(line.as_bytes()).unwrap();
-            crc32c_checksum.update(&line.as_bytes());
+            crc32c_checksum.update(line.as_bytes());
         }
 
         let body = ByteStream::read_from()

--- a/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
+++ b/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
@@ -93,7 +93,7 @@ fn test_operation() -> Operation<TestOperationParser, AwsResponseRetryClassifier
             .resolve_endpoint(&Params::new(Some(Region::new("test-region")))),
         );
         aws_http::auth::set_provider(
-            &mut conf,
+            conf,
             SharedCredentialsProvider::new(Credentials::new(
                 "access_key",
                 "secret_key",

--- a/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
+++ b/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
@@ -82,7 +82,7 @@ fn test_operation() -> Operation<TestOperationParser, AwsResponseRetryClassifier
             .body(SdkBody::from("request body"))
             .unwrap(),
     )
-    .augment(|req, mut conf| {
+    .augment(|req, conf| {
         conf.insert(
             EndpointShim::from_resolver(aws_endpoint::partition::endpoint::Metadata {
                 uri_template: "test-service.{region}.amazonaws.com",

--- a/aws/rust-runtime/aws-sigv4/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sigv4/src/event_stream.rs
@@ -159,7 +159,7 @@ mod tests {
             security_token: None,
             region: "us-east-1",
             service_name: "testservice",
-            time: (UNIX_EPOCH + Duration::new(123_456_789_u64, 1234u32)).into(),
+            time: (UNIX_EPOCH + Duration::new(123_456_789_u64, 1234u32)),
             settings: (),
         };
 
@@ -197,7 +197,7 @@ mod tests {
             security_token: None,
             region: "us-east-1",
             service_name: "testservice",
-            time: (UNIX_EPOCH + Duration::new(123_456_789_u64, 1234u32)).into(),
+            time: (UNIX_EPOCH + Duration::new(123_456_789_u64, 1234u32)),
             settings: (),
         };
 

--- a/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/canonical_request.rs
@@ -597,7 +597,7 @@ mod tests {
             region: "us-east-1",
             service: "iam",
         };
-        assert_eq!(format!("{}\n", scope.to_string()), expected);
+        assert_eq!(format!("{}\n", scope), expected);
     }
 
     #[test]

--- a/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 pub type SigningParams<'a> = crate::SigningParams<'a, SigningSettings>;
 
 /// HTTP-specific signing settings
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct SigningSettings {
     /// Specifies how to encode the request URL when signing. Some services do not decode

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 #
 
 # Rust MSRV (entered into the generated README)
-rust.msrv=1.61.0
+rust.msrv=1.62.0
 
 org.gradle.jvmargs=-Xmx1024M
 

--- a/rust-runtime/aws-smithy-async/src/future/fn_stream.rs
+++ b/rust-runtime/aws-smithy-async/src/future/fn_stream.rs
@@ -200,7 +200,7 @@ mod test {
             Box::pin(async move {
                 for i in 0..5 {
                     if i != 2 {
-                        if let Err(_) = tx.send(Ok(i)).await {
+                        if (tx.send(Ok(i)).await).is_err() {
                             return;
                         }
                     } else {

--- a/rust-runtime/aws-smithy-checksums/src/lib.rs
+++ b/rust-runtime/aws-smithy-checksums/src/lib.rs
@@ -82,7 +82,7 @@ impl ChecksumAlgorithm {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Error {
     UnknownChecksumAlgorithm(String),
 }

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -300,7 +300,7 @@ pub use value::HeaderValue;
 
 /// Event Stream header.
 #[non_exhaustive]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Header {
     name: StrBytes,
@@ -368,7 +368,7 @@ pub fn write_headers_to<B: BufMut>(headers: &[Header], mut buffer: B) -> Result<
 
 /// Event Stream message.
 #[non_exhaustive]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Message {
     headers: Vec<Header>,
     payload: Bytes,

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -96,7 +96,7 @@ mod value {
 
     /// Event Stream frame header value.
     #[non_exhaustive]
-    #[derive(Clone, Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Eq)]
     pub enum HeaderValue {
         Bool(bool),
         Byte(i8),

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -601,7 +601,7 @@ mod message_tests {
             0x36,
         ];
 
-        let result = Message::read_from(&mut Bytes::from_static(&data)).unwrap();
+        let result = Message::read_from(&mut Bytes::from_static(data)).unwrap();
         assert_eq!(result.headers(), Vec::new());
 
         let expected_payload = b"{'foo':'bar'}";
@@ -620,7 +620,7 @@ mod message_tests {
             0x7d, 0x8D, 0x9C, 0x08, 0xB1,
         ];
 
-        let result = Message::read_from(&mut Bytes::from_static(&data)).unwrap();
+        let result = Message::read_from(&mut Bytes::from_static(data)).unwrap();
         assert_eq!(
             result.headers(),
             vec![Header::new(

--- a/rust-runtime/aws-smithy-eventstream/src/str_bytes.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/str_bytes.rs
@@ -151,7 +151,7 @@ mod tests {
         let str_bytes: StrBytes = valid_utf8.into();
         assert_eq!(valid_utf8.as_bytes(), str_bytes.as_bytes());
         assert_eq!(valid_utf8, str_bytes.as_str());
-        assert_eq!(valid_utf8, str_bytes.clone().as_str());
+        assert_eq!(valid_utf8, str_bytes.as_str());
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -25,8 +25,8 @@ hyper = { version = "0.14.20", features = ["server", "http1", "http2", "tcp", "s
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2"
-pyo3 = "0.16.5"
-pyo3-asyncio = { version = "0.16.0", features = ["tokio-runtime"] }
+pyo3 = "0.17.0"
+pyo3-asyncio = { version = "0.17.0", features = ["tokio-runtime"] }
 signal-hook = { version = "0.3.14", features = ["extended-siginfo"] }
 socket2 = { version = "0.4.4", features = ["all"] }
 thiserror = "1.0.32"

--- a/rust-runtime/aws-smithy-http-server-python/src/types.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/types.rs
@@ -26,7 +26,7 @@ use crate::PyError;
 
 /// Python Wrapper for [aws_smithy_types::Blob].
 #[pyclass]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Blob(aws_smithy_types::Blob);
 
 impl Blob {
@@ -88,7 +88,7 @@ impl<'blob> From<&'blob Blob> for &'blob aws_smithy_types::Blob {
 
 /// Python Wrapper for [aws_smithy_types::date_time::DateTime].
 #[pyclass]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DateTime(aws_smithy_types::date_time::DateTime);
 
 #[pyclass]

--- a/rust-runtime/aws-smithy-http-server/src/instrumentation/sensitivity/sensitive.rs
+++ b/rust-runtime/aws-smithy-http-server/src/instrumentation/sensitivity/sensitive.rs
@@ -93,9 +93,9 @@ mod tests {
         let sensitive = Sensitive(inner);
         let actual = format!("{}", sensitive);
         let expected = if cfg!(feature = "unredacted-logging") {
-            format!("{}", inner)
+            inner.to_string()
         } else {
-            format!("{}", REDACTED)
+            REDACTED.to_string()
         };
         assert_eq!(actual, expected)
     }

--- a/rust-runtime/aws-smithy-http-server/src/instrumentation/sensitivity/uri/label.rs
+++ b/rust-runtime/aws-smithy-http-server/src/instrumentation/sensitivity/uri/label.rs
@@ -186,7 +186,7 @@ mod tests {
         let originals = EXAMPLES.into_iter().map(Uri::from_static);
         for original in originals {
             let expected = original.path().to_string();
-            let output = Label::new(&original.path(), |_| false, None).to_string();
+            let output = Label::new(original.path(), |_| false, None).to_string();
             assert_eq!(output, expected, "original = {original}");
         }
     }
@@ -222,7 +222,7 @@ mod tests {
         let originals = EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = ALL_EXAMPLES.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Label::new(&original.path(), |_| true, None).to_string();
+            let output = Label::new(original.path(), |_| true, None).to_string();
             assert_eq!(output, expected.path(), "original = {original}");
         }
     }
@@ -258,7 +258,7 @@ mod tests {
         let originals = EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = GREEDY_EXAMPLES.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Label::new(&original.path(), |_| false, Some(GreedyLabel::new(1, 0))).to_string();
+            let output = Label::new(original.path(), |_| false, Some(GreedyLabel::new(1, 0))).to_string();
             assert_eq!(output, expected.path(), "original = {original}");
         }
     }
@@ -294,7 +294,7 @@ mod tests {
         let originals = EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = GREEDY_EXAMPLES_OFFSET.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Label::new(&original.path(), |_| false, Some(GreedyLabel::new(1, 1))).to_string();
+            let output = Label::new(original.path(), |_| false, Some(GreedyLabel::new(1, 1))).to_string();
             assert_eq!(output, expected.path(), "original = {original}");
         }
     }
@@ -321,7 +321,7 @@ mod tests {
         let originals = EXTRA_EXAMPLES_UNREDACTED.into_iter().map(Uri::from_static);
         let expecteds = EXTRA_EXAMPLES_REDACTED.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Label::new(&original.path(), |_| false, Some(GreedyLabel::new(2, 5))).to_string();
+            let output = Label::new(original.path(), |_| false, Some(GreedyLabel::new(2, 5))).to_string();
             assert_eq!(output, expected.path(), "original = {original}");
         }
     }

--- a/rust-runtime/aws-smithy-http-server/src/instrumentation/sensitivity/uri/query.rs
+++ b/rust-runtime/aws-smithy-http-server/src/instrumentation/sensitivity/uri/query.rs
@@ -131,7 +131,7 @@ mod tests {
         let originals = EXAMPLES.into_iter().chain(QUERY_STRING_EXAMPLES).map(Uri::from_static);
         for original in originals {
             if let Some(query) = original.query() {
-                let output = Query::new(&query, |_| QueryMarker::default()).to_string();
+                let output = Query::new(query, |_| QueryMarker::default()).to_string();
                 assert_eq!(output, query, "original = {original}");
             }
         }
@@ -142,7 +142,7 @@ mod tests {
         let originals = QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = ALL_KEYS_QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Query::new(&original.query().unwrap(), |_| QueryMarker {
+            let output = Query::new(original.query().unwrap(), |_| QueryMarker {
                 key: true,
                 value: false,
             })
@@ -156,7 +156,7 @@ mod tests {
         let originals = QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = ALL_VALUES_QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Query::new(&original.query().unwrap(), |_| QueryMarker {
+            let output = Query::new(original.query().unwrap(), |_| QueryMarker {
                 key: false,
                 value: true,
             })
@@ -170,7 +170,7 @@ mod tests {
         let originals = QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = ALL_PAIRS_QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Query::new(&original.query().unwrap(), |_| QueryMarker { key: true, value: true }).to_string();
+            let output = Query::new(original.query().unwrap(), |_| QueryMarker { key: true, value: true }).to_string();
             assert_eq!(output, expected.query().unwrap(), "original = {original}");
         }
     }
@@ -180,7 +180,7 @@ mod tests {
         let originals = QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         let expecteds = X_QUERY_STRING_EXAMPLES.into_iter().map(Uri::from_static);
         for (original, expected) in originals.zip(expecteds) {
-            let output = Query::new(&original.query().unwrap(), |key| QueryMarker {
+            let output = Query::new(original.query().unwrap(), |key| QueryMarker {
                 key: false,
                 value: key == "x",
             })

--- a/rust-runtime/aws-smithy-http-server/src/protocols.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocols.rs
@@ -190,7 +190,7 @@ mod tests {
                         );
                         assert_eq!(found_mime, invalid_mime.parse::<mime::Mime>().ok());
                     }
-                    _ => panic!("Unexpected `MissingContentTypeReason`: {}", e.to_string()),
+                    _ => panic!("Unexpected `MissingContentTypeReason`: {}", e),
                 },
             }
         }

--- a/rust-runtime/aws-smithy-http-server/src/protocols.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocols.rs
@@ -8,7 +8,7 @@ use crate::rejection::MissingContentTypeReason;
 use crate::request::RequestParts;
 
 /// Supported protocols.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Protocol {
     RestJson1,
     RestXml,

--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -323,7 +323,7 @@ mod rest_tests {
 
         #[inline]
         fn call(&mut self, req: Request<B>) -> Self::Future {
-            let body = boxed(Body::from(format!("{} :: {}", self.0, req.uri().to_string())));
+            let body = boxed(Body::from(format!("{} :: {}", self.0, req.uri())));
             let fut = async { Ok(Response::builder().status(&http::StatusCode::OK).body(body).unwrap()) };
             Box::pin(fut)
         }

--- a/rust-runtime/aws-smithy-http-server/src/routing/tiny_map.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/tiny_map.rs
@@ -122,9 +122,9 @@ mod tests {
 
     const CUTOFF: usize = 5;
 
-    const SMALL_VALUES: [(&'static str, usize); 3] = [("a", 0), ("b", 1), ("c", 2)];
-    const MEDIUM_VALUES: [(&'static str, usize); 5] = [("a", 0), ("b", 1), ("c", 2), ("d", 3), ("e", 4)];
-    const LARGE_VALUES: [(&'static str, usize); 10] = [
+    const SMALL_VALUES: [(&str, usize); 3] = [("a", 0), ("b", 1), ("c", 2)];
+    const MEDIUM_VALUES: [(&str, usize); 5] = [("a", 0), ("b", 1), ("c", 2), ("d", 3), ("e", 4)];
+    const LARGE_VALUES: [(&str, usize); 10] = [
         ("a", 0),
         ("b", 1),
         ("c", 2),

--- a/rust-runtime/aws-smithy-http/src/header.rs
+++ b/rust-runtime/aws-smithy-http/src/header.rs
@@ -604,10 +604,8 @@ mod test {
 
         let merged_header_map =
             append_merge_header_maps(left_hand_side_headers, right_hand_side_headers);
-        let actual_merged_values: Vec<_> = merged_header_map
-            .get_all(header_name.clone())
-            .into_iter()
-            .collect();
+        let actual_merged_values: Vec<_> =
+            merged_header_map.get_all(header_name).into_iter().collect();
 
         let expected_merged_values = vec![left_header_value, right_header_value];
 
@@ -630,10 +628,8 @@ mod test {
 
         let merged_header_map =
             append_merge_header_maps(left_hand_side_headers, right_hand_side_headers);
-        let actual_merged_values: Vec<_> = merged_header_map
-            .get_all(header_name.clone())
-            .into_iter()
-            .collect();
+        let actual_merged_values: Vec<_> =
+            merged_header_map.get_all(header_name).into_iter().collect();
 
         let expected_merged_values =
             vec![left_header_value_1, left_header_value_2, right_header_value];
@@ -655,10 +651,8 @@ mod test {
 
         let merged_header_map =
             append_merge_header_maps(left_hand_side_headers, right_hand_side_headers);
-        let actual_merged_values: Vec<_> = merged_header_map
-            .get_all(header_name.clone())
-            .into_iter()
-            .collect();
+        let actual_merged_values: Vec<_> =
+            merged_header_map.get_all(header_name).into_iter().collect();
 
         let expected_merged_values = vec![right_header_value_1, right_header_value_2];
 

--- a/rust-runtime/aws-smithy-http/src/retry.rs
+++ b/rust-runtime/aws-smithy-http/src/retry.rs
@@ -124,7 +124,7 @@ mod test {
     ) -> Result<SdkSuccess<()>, SdkError<E>> {
         Err(SdkError::ServiceError {
             err,
-            raw: operation::Response::new(raw.map(|b| SdkBody::from(b))),
+            raw: operation::Response::new(raw.map(SdkBody::from)),
         })
     }
 
@@ -194,9 +194,7 @@ mod test {
             policy.classify_retry(
                 Result::<SdkSuccess<()>, SdkError<UnmodeledError>>::Err(SdkError::ResponseError {
                     err: Box::new(UnmodeledError),
-                    raw: operation::Response::new(
-                        http::Response::new("OK").map(|b| SdkBody::from(b))
-                    ),
+                    raw: operation::Response::new(http::Response::new("OK").map(SdkBody::from)),
                 })
                 .as_ref()
             ),

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -600,7 +600,7 @@ pub mod test {
                 Err(Error::new(
                     ErrorReason::Custom(Cow::Owned(format!(
                         "{} is not a valid epoch",
-                        invalid.replace("-", "")
+                        invalid.replace('-', "")
                     ))),
                     None,
                 )),

--- a/rust-runtime/aws-smithy-protocol-test/src/lib.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/lib.rs
@@ -386,9 +386,7 @@ mod tests {
     fn test_validate_empty_query_string() {
         let request = Request::builder().uri("/foo").body(()).unwrap();
         validate_query_string(&request, &[]).expect("no required params should pass");
-        validate_query_string(&request, &["a"])
-            .err()
-            .expect("no params provided");
+        validate_query_string(&request, &["a"]).expect_err("no params provided");
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-query/src/lib.rs
+++ b/rust-runtime/aws-smithy-query/src/lib.rs
@@ -9,6 +9,7 @@ use aws_smithy_types::date_time::{DateTimeFormatError, Format};
 use aws_smithy_types::primitive::Encoder;
 use aws_smithy_types::{DateTime, Number};
 use std::borrow::Cow;
+use std::fmt::Write;
 use urlencoding::encode;
 
 pub struct QueryWriter<'a> {
@@ -62,14 +63,18 @@ impl<'a> QueryMapWriter<'a> {
 
     pub fn entry(&mut self, key: &str) -> QueryValueWriter {
         let entry = if self.flatten { "" } else { ".entry" };
-        self.output.push_str(&format!(
+        write!(
+            &mut self.output,
             "&{}{}.{}.{}={}",
             self.prefix,
             entry,
             self.next_index,
             self.key_name,
             encode(key)
-        ));
+        )
+        // The `Write` implementation for `String` is infallible,
+        // see https://doc.rust-lang.org/src/alloc/string.rs.html#2815
+        .unwrap();
         let value_name = format!(
             "{}{}.{}.{}",
             self.prefix, entry, self.next_index, self.value_name

--- a/rust-runtime/aws-smithy-types/src/date_time/format.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/format.rs
@@ -532,7 +532,7 @@ mod tests {
                 .smithy_format_value
                 .as_ref()
                 .expect("parse test cases should always have a formatted value");
-            let actual = parse(&to_parse);
+            let actual = parse(to_parse);
 
             assert!(
                 actual.is_ok(),

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -46,7 +46,7 @@ const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 /// The [`aws-smithy-types-convert`](https://crates.io/crates/aws-smithy-types-convert) crate
 /// can be used for conversions to/from other libraries, such as
 /// [`time`](https://crates.io/crates/time) or [`chrono`](https://crates.io/crates/chrono).
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct DateTime {
     seconds: i64,
     subsecond_nanos: u32,

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -27,7 +27,7 @@ pub use crate::date_time::DateTime;
 /// Binary Blob Type
 ///
 /// Blobs represent protocol-agnostic binary content.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Blob {
     inner: Vec<u8>,
 }

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -291,7 +291,7 @@ impl TryFrom<Number> for f64 {
                 }
             }
             Number::NegInt(v) => {
-                if -(1 << 53) <= v && v <= (1 << 53) {
+                if (-(1 << 53)..=(1 << 53)).contains(&v) {
                     Ok(v as Self)
                 } else {
                     Err(Self::Error::I64ToFloatLossyConversion(v))
@@ -316,7 +316,7 @@ impl TryFrom<Number> for f32 {
                 }
             }
             Number::NegInt(v) => {
-                if -(1 << 24) <= v && v <= (1 << 24) {
+                if (-(1 << 24)..=(1 << 24)).contains(&v) {
                     Ok(v as Self)
                 } else {
                     Err(Self::Error::I64ToFloatLossyConversion(v))

--- a/rust-runtime/aws-smithy-types/src/retry.rs
+++ b/rust-runtime/aws-smithy-types/src/retry.rs
@@ -130,7 +130,7 @@ impl FromStr for RetryMode {
 
 /// Builder for [`RetryConfig`].
 #[non_exhaustive]
-#[derive(Debug, Default, Clone, PartialEq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct RetryConfigBuilder {
     mode: Option<RetryMode>,
     max_attempts: Option<u32>,
@@ -217,7 +217,7 @@ impl RetryConfigBuilder {
 
 /// Retry configuration for requests.
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RetryConfig {
     mode: RetryMode,
     max_attempts: u32,

--- a/rust-runtime/aws-smithy-types/src/timeout/config.rs
+++ b/rust-runtime/aws-smithy-types/src/timeout/config.rs
@@ -197,7 +197,7 @@ impl From<TimeoutConfig> for TimeoutConfigBuilder {
 /// # }
 /// ```
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TimeoutConfig {
     connect_timeout: Option<Duration>,
     read_timeout: Option<Duration>,
@@ -274,7 +274,7 @@ impl TimeoutConfig {
 
 /// Configuration subset of [`TimeoutConfig`] for operation timeouts
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct OperationTimeoutConfig {
     operation_timeout: Option<Duration>,
     operation_attempt_timeout: Option<Duration>,

--- a/rust-runtime/aws-smithy-xml/src/decode.rs
+++ b/rust-runtime/aws-smithy-xml/src/decode.rs
@@ -463,7 +463,7 @@ mod test {
         let xml = r#"<Response/>"#;
         let mut doc = Document::new(xml);
         let mut scoped = doc.root_element().expect("valid doc");
-        assert_eq!(scoped.start_el.closed, true);
+        assert!(scoped.start_el.closed);
         assert!(scoped.next_tag().is_none())
     }
 

--- a/rust-runtime/aws-smithy-xml/src/decode.rs
+++ b/rust-runtime/aws-smithy-xml/src/decode.rs
@@ -531,8 +531,8 @@ mod test {
             root.start_el().attributes,
             vec![Attr {
                 name: Name {
-                    prefix: "xsi".into(),
-                    local: "type".into()
+                    prefix: "xsi",
+                    local: "type"
                 },
                 value: "CanonicalUser".into()
             }]

--- a/rust-runtime/aws-smithy-xml/src/decode.rs
+++ b/rust-runtime/aws-smithy-xml/src/decode.rs
@@ -51,7 +51,7 @@ impl XmlError {
     }
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Name<'a> {
     pub prefix: &'a str,
     pub local: &'a str,
@@ -72,14 +72,14 @@ impl Name<'_> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Attr<'a> {
     name: Name<'a>,
     // attribute values can be escaped (e.g. with double quotes, so we need a Cow)
     value: Cow<'a, str>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct StartEl<'a> {
     name: Name<'a>,
     attributes: Vec<Attr<'a>>,

--- a/rust-runtime/aws-smithy-xml/src/unescape.rs
+++ b/rust-runtime/aws-smithy-xml/src/unescape.rs
@@ -150,7 +150,7 @@ mod test {
         fn no_panics(s: String) {
             let unescaped = unescape(&s);
             // if the string needed to be escaped, we
-            if s.contains("&") {
+            if s.contains('&') {
                 assert!(
                     matches!(unescaped, Ok(Cow::Owned(_)) | Err(_))
                 );

--- a/rust-runtime/aws-smithy-xml/tests/handwritten_parsers.rs
+++ b/rust-runtime/aws-smithy-xml/tests/handwritten_parsers.rs
@@ -44,6 +44,7 @@ fn deserialize_xml_attribute(inp: &str) -> Result<XmlAttribute, XmlError> {
     let mut doc = Document::new(inp);
     let mut root = doc.root_element()?;
     #[allow(unused_assignments)]
+    #[allow(clippy::blacklisted_name)]
     let mut foo: Option<String> = None;
     let mut bar: Option<String> = None;
     foo = root.start_el().attr("foo").map(|attr| attr.to_string());

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -45,7 +45,7 @@ RUN set -eux; \
 # Rust & Tools Installation Stage
 #
 FROM bare_base_image AS install_rust
-ARG rust_stable_version=1.61.0
+ARG rust_stable_version=1.62.0
 ARG rust_nightly_version=nightly-2022-07-25
 ARG cargo_deny_version=0.12.2
 ARG cargo_udeps_version=0.1.29
@@ -116,7 +116,7 @@ RUN set -eux; \
 # Final image
 #
 FROM bare_base_image AS final_image
-ARG rust_stable_version=1.61.0
+ARG rust_stable_version=1.62.0
 ARG rust_nightly_version=nightly-2022-07-25
 RUN set -eux; \
     yum -y updateinfo; \


### PR DESCRIPTION
## Motivation and Context
Upgrade MSRV to Rust 1.62.0

## Description
We are upgrading the Rust version in our various configs and fixing all relevant Clippy lints.

## Checklist
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
