### PR TITLE
Remove Protocol enum

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -137,3 +137,15 @@ message = "Fix regression where `connect_timeout` and `read_timeout` fields are 
 references = ["smithy-rs#1822"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "kevinpark1217"
+
+[[smithy-rs]]
+message = "Remove `Protocol` enum, removing an obstruction to extending smithy to third-party protocols."
+references = ["smithy-rs#1829"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
+author = "hlbarber"
+
+[[smithy-rs]]
+message = "Convert the `protocol` argument on `PyMiddlewares::new` constructor to a type parameter."
+references = ["smithy-rs#1829"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
+author = "hlbarber"

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerOperationHandlerGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerOperationHandlerGenerator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import software.amazon.smithy.rust.codegen.server.python.smithy.PythonServerCargoDependency
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
 import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerOperationHandlerGenerator
+import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocol
 
 /**
  * The Rust code responsible to run the Python business logic on the Python interpreter
@@ -33,8 +34,9 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerOperat
  */
 class PythonServerOperationHandlerGenerator(
     codegenContext: CodegenContext,
+    protocol: ServerProtocol,
     private val operations: List<OperationShape>,
-) : ServerOperationHandlerGenerator(codegenContext, operations) {
+) : ServerOperationHandlerGenerator(codegenContext, protocol, operations) {
     private val symbolProvider = codegenContext.symbolProvider
     private val runtimeConfig = codegenContext.runtimeConfig
     private val codegenScope =

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerServiceGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerServiceGenerator.kt
@@ -34,12 +34,12 @@ class PythonServerServiceGenerator(
     }
 
     override fun renderOperationHandler(writer: RustWriter, operations: List<OperationShape>) {
-        PythonServerOperationHandlerGenerator(context, operations).render(writer)
+        PythonServerOperationHandlerGenerator(context, protocol, operations).render(writer)
     }
 
     override fun renderExtras(operations: List<OperationShape>) {
         rustCrate.withModule(RustModule.public("python_server_application", "Python server and application implementation.")) { writer ->
-            PythonApplicationGenerator(context, operations)
+            PythonApplicationGenerator(context, protocol, operations)
                 .render(writer)
         }
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -82,7 +82,7 @@ open class ServerOperationHandlerGenerator(
                         Ok(v) => v,
                         Err(extension_not_found_rejection) => {
                             let extension = $serverCrate::extension::RuntimeErrorExtension::new(extension_not_found_rejection.to_string());
-                            let runtime_error = $serverCrate::runtime_error::RuntimeError { kind: extension_not_found_rejection.into() };
+                            let runtime_error = $serverCrate::runtime_error::RuntimeError::from(extension_not_found_rejection);
                             let mut response = #{SmithyHttpServer}::response::IntoResponse::<#{Protocol}>::into_response(runtime_error);
                             response.extensions_mut().insert(extension);
                             return response.map($serverCrate::body::boxed);

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationHandlerGenerator.kt
@@ -29,7 +29,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.protocols.ServerHttpBou
  */
 open class ServerOperationHandlerGenerator(
     codegenContext: CodegenContext,
-    private val protocol: ServerProtocol,
+    val protocol: ServerProtocol,
     private val operations: List<OperationShape>,
 ) {
     private val serverCrate = "aws_smithy_http_server"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -29,7 +29,7 @@ open class ServerServiceGenerator(
     private val rustCrate: RustCrate,
     private val protocolGenerator: ServerProtocolGenerator,
     private val protocolSupport: ProtocolSupport,
-    private val protocol: ServerProtocol,
+    val protocol: ServerProtocol,
     private val codegenContext: CodegenContext,
 ) {
     private val index = TopDownIndex.of(codegenContext.model)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -107,7 +107,7 @@ open class ServerServiceGenerator(
 
     // Render operations handler.
     open fun renderOperationHandler(writer: RustWriter, operations: List<OperationShape>) {
-        ServerOperationHandlerGenerator(codegenContext, operations).render(writer)
+        ServerOperationHandlerGenerator(codegenContext, protocol, operations).render(writer)
     }
 
     // Render operations registry.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolGenerator.kt
@@ -11,11 +11,10 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.MakeOperationGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolTraitImplGenerator
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 
 open class ServerProtocolGenerator(
     codegenContext: CodegenContext,
-    protocol: Protocol,
+    val protocol: ServerProtocol,
     makeOperationGenerator: MakeOperationGenerator,
     private val traitGenerator: ProtocolTraitImplGenerator,
 ) : ProtocolGenerator(codegenContext, protocol, makeOperationGenerator, traitGenerator) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -452,8 +452,9 @@ class ServerProtocolTestGenerator(
             """
             let mut http_request = #{SmithyHttpServer}::request::RequestParts::new(http_request);
             let rejection = super::$operationName::from_request(&mut http_request).await.expect_err("request was accepted but we expected it to be rejected");
-            let http_response = rejection.into_response();
+            let http_response = #{SmithyHttpServer}::response::IntoResponse::<#{Protocol}>::into_response(rejection);
             """,
+            "Protocol" to protocolGenerator.protocol.markerStruct(),
             *codegenScope,
         )
         checkResponse(this, testCase.response)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -176,9 +176,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                 rustTemplate(
                     """
                     if ! #{SmithyHttpServer}::protocols::accept_header_classifier(req, ${contentType.dq()}) {
-                        return Err(#{RuntimeError} {
-                            kind: #{SmithyHttpServer}::runtime_error::RuntimeErrorKind::NotAcceptable,
-                        })
+                        return Err(#{RuntimeError}::NotAcceptable)
                     }
                     """,
                     *codegenScope,
@@ -198,9 +196,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                         rustTemplate(
                             """
                             if #{SmithyHttpServer}::protocols::content_type_header_classifier(req, $expectedRequestContentType).is_err() {
-                                return Err(#{RuntimeError} {
-                                    kind: #{SmithyHttpServer}::runtime_error::RuntimeErrorKind::UnsupportedMediaType,
-                                })
+                                return Err(#{RuntimeError}::UnsupportedMediaType)
                             }
                             """,
                             *codegenScope,
@@ -227,11 +223,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                     #{parse_request}(req)
                         .await
                         .map($inputName)
-                        .map_err(
-                            |err| #{RuntimeError} {
-                                kind: err.into()
-                            }
-                        )
+                        .map_err(Into::into)
                 }
             }
 
@@ -278,7 +270,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                     Self::Output(o) => {
                         match #{serialize_response}(o) {
                             Ok(response) => response,
-                            Err(e) => #{SmithyHttpServer}::response::IntoResponse::<#{Marker}>::into_response(#{RuntimeError} { kind: e.into() })
+                            Err(e) => #{SmithyHttpServer}::response::IntoResponse::<#{Marker}>::into_response(#{RuntimeError}::from(e))
                         }
                     },
                     Self::Error(err) => {
@@ -287,7 +279,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                                 response.extensions_mut().insert(#{SmithyHttpServer}::extension::ModeledErrorExtension::new(err.name()));
                                 response
                             },
-                            Err(e) => #{SmithyHttpServer}::response::IntoResponse::<#{Marker}>::into_response(#{RuntimeError} { kind: e.into() })
+                            Err(e) => #{SmithyHttpServer}::response::IntoResponse::<#{Marker}>::into_response(#{RuntimeError}::from(e))
                         }
                     }
                 }
@@ -332,9 +324,7 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
                 """
                 match #{serialize_response}(self.0) {
                     Ok(response) => response,
-                    Err(e) => #{SmithyHttpServer}::response::IntoResponse::<#{Marker}>::into_response(#{RuntimeError} {
-                        kind: e.into()
-                    })
+                    Err(e) => #{SmithyHttpServer}::response::IntoResponse::<#{Marker}>::into_response(#{RuntimeError}::from(e))
                 }
                 """.trimIndent()
 

--- a/rust-runtime/aws-smithy-http-server-python/src/server.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/server.rs
@@ -383,7 +383,6 @@ event_loop.add_signal_handler(signal.SIGINT,
     ///         fn context(&self) -> &Option<PyObject> { todo!() }
     ///         fn handlers(&mut self) -> &mut HashMap<String, PyHandler> { todo!() }
     ///         fn middlewares(&mut self) -> &mut PyMiddlewares { todo!() }
-    ///         fn protocol(&self) -> &'static str { "proto1" }
     ///     }
     ///
     ///     #[pymethods]

--- a/rust-runtime/aws-smithy-http-server-python/src/server.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/server.rs
@@ -63,8 +63,6 @@ pub trait PyApp: Clone + pyo3::IntoPy<PyObject> {
 
     fn middlewares(&mut self) -> &mut PyMiddlewares;
 
-    fn protocol(&self) -> &'static str;
-
     /// Handle the graceful termination of Python workers by looping through all the
     /// active workers and calling `terminate()` on them. If termination fails, this
     /// method will try to `kill()` any failed worker.

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -131,7 +131,7 @@ impl Deref for ModeledErrorExtension {
 }
 
 /// Extension type used to store the _name_ of the [`crate::runtime_error::RuntimeError`] that
-/// occurred during request handling (see [`crate::runtime_error::RuntimeErrorKind::name`]).
+/// occurred during request handling (see [`crate::runtime_error::RuntimeError::name`]).
 /// These are _unmodeled_ errors; the operation handler was not invoked.
 #[derive(Debug, Clone)]
 pub struct RuntimeErrorExtension(String);

--- a/rust-runtime/aws-smithy-http-server/src/protocols.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocols.rs
@@ -7,15 +7,6 @@
 use crate::rejection::MissingContentTypeReason;
 use crate::request::RequestParts;
 
-/// Supported protocols.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Protocol {
-    RestJson1,
-    RestXml,
-    AwsJson10,
-    AwsJson11,
-}
-
 /// When there are no modeled inputs,
 /// a request body is empty and the content-type request header must not be set
 pub fn content_type_header_empty_body_no_modeled_input<B>(

--- a/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
@@ -11,7 +11,7 @@
 //! the framework, `RuntimeError` is surfaced to clients in HTTP responses: indeed, it implements
 //! [`RuntimeError::into_response`]. Rejections can be "grouped" and converted into a
 //! specific `RuntimeError` kind: for example, all request rejections due to serialization issues
-//! can be conflated under the [`RuntimeErrorKind::Serialization`] enum variant.
+//! can be conflated under the [`RuntimeError::Serialization`] enum variant.
 //!
 //! The HTTP response representation of the specific `RuntimeError` can be protocol-specific: for
 //! example, the runtime error in the RestJson1 protocol sets the `X-Amzn-Errortype` header.

--- a/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
@@ -31,7 +31,7 @@ use crate::proto::rest_xml::AwsRestXml;
 use crate::response::IntoResponse;
 
 #[derive(Debug)]
-pub enum RuntimeErrorKind {
+pub enum RuntimeError {
     /// Request failed to deserialize or response failed to serialize.
     Serialization(crate::Error),
     /// As of writing, this variant can only occur upon failure to extract an
@@ -45,22 +45,22 @@ pub enum RuntimeErrorKind {
 /// String representation of the runtime error type.
 /// Used as the value of the `X-Amzn-Errortype` header in RestJson1.
 /// Used as the value passed to construct an [`crate::extension::RuntimeErrorExtension`].
-impl RuntimeErrorKind {
+impl RuntimeError {
     pub fn name(&self) -> &'static str {
         match self {
-            RuntimeErrorKind::Serialization(_) => "SerializationException",
-            RuntimeErrorKind::InternalFailure(_) => "InternalFailureException",
-            RuntimeErrorKind::NotAcceptable => "NotAcceptableException",
-            RuntimeErrorKind::UnsupportedMediaType => "UnsupportedMediaTypeException",
+            Self::Serialization(_) => "SerializationException",
+            Self::InternalFailure(_) => "InternalFailureException",
+            Self::NotAcceptable => "NotAcceptableException",
+            Self::UnsupportedMediaType => "UnsupportedMediaTypeException",
         }
     }
 
     pub fn status_code(&self) -> StatusCode {
         match self {
-            RuntimeErrorKind::Serialization(_) => StatusCode::BAD_REQUEST,
-            RuntimeErrorKind::InternalFailure(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            RuntimeErrorKind::NotAcceptable => StatusCode::NOT_ACCEPTABLE,
-            RuntimeErrorKind::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            Self::Serialization(_) => StatusCode::BAD_REQUEST,
+            Self::InternalFailure(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::NotAcceptable => StatusCode::NOT_ACCEPTABLE,
+            Self::UnsupportedMediaType => StatusCode::UNSUPPORTED_MEDIA_TYPE,
         }
     }
 }
@@ -69,48 +69,35 @@ pub struct InternalFailureException;
 
 impl IntoResponse<AwsJson10> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsJson10>::into_response(RuntimeError {
-            kind: RuntimeErrorKind::InternalFailure(crate::Error::new(String::new())),
-        })
+        IntoResponse::<AwsJson10>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
 impl IntoResponse<AwsJson11> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsJson11>::into_response(RuntimeError {
-            kind: RuntimeErrorKind::InternalFailure(crate::Error::new(String::new())),
-        })
+        IntoResponse::<AwsJson11>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
 impl IntoResponse<AwsRestJson1> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsRestJson1>::into_response(RuntimeError {
-            kind: RuntimeErrorKind::InternalFailure(crate::Error::new(String::new())),
-        })
+        IntoResponse::<AwsRestJson1>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
 impl IntoResponse<AwsRestXml> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsRestXml>::into_response(RuntimeError {
-            kind: RuntimeErrorKind::InternalFailure(crate::Error::new(String::new())),
-        })
+        IntoResponse::<AwsRestXml>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
-}
-
-#[derive(Debug)]
-pub struct RuntimeError {
-    pub kind: RuntimeErrorKind,
 }
 
 impl IntoResponse<AwsRestJson1> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
-            .status(self.kind.status_code())
+            .status(self.status_code())
             .header("Content-Type", "application/json")
-            .header("X-Amzn-Errortype", self.kind.name())
-            .extension(RuntimeErrorExtension::new(self.kind.name().to_string()))
+            .header("X-Amzn-Errortype", self.name())
+            .extension(RuntimeErrorExtension::new(self.name().to_string()))
             // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#empty-body-serialization
             .body(crate::body::to_boxed("{}"))
             .expect("invalid HTTP response for `RuntimeError`; please file a bug report under https://github.com/awslabs/smithy-rs/issues")
@@ -120,9 +107,9 @@ impl IntoResponse<AwsRestJson1> for RuntimeError {
 impl IntoResponse<AwsRestXml> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
-            .status(self.kind.status_code())
+            .status(self.status_code())
             .header("Content-Type", "application/xml")
-            .extension(RuntimeErrorExtension::new(self.kind.name().to_string()))
+            .extension(RuntimeErrorExtension::new(self.name().to_string()))
             .body(crate::body::to_boxed(""))
             .expect("invalid HTTP response for `RuntimeError`; please file a bug report under https://github.com/awslabs/smithy-rs/issues")
     }
@@ -131,9 +118,9 @@ impl IntoResponse<AwsRestXml> for RuntimeError {
 impl IntoResponse<AwsJson10> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
-            .status(self.kind.status_code())
+            .status(self.status_code())
             .header("Content-Type", "application/x-amz-json-1.0")
-            .extension(RuntimeErrorExtension::new(self.kind.name().to_string()))
+            .extension(RuntimeErrorExtension::new(self.name().to_string()))
             // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_0-protocol.html#empty-body-serialization
             .body(crate::body::to_boxed(""))
             .expect("invalid HTTP response for `RuntimeError`; please file a bug report under https://github.com/awslabs/smithy-rs/issues")
@@ -143,32 +130,32 @@ impl IntoResponse<AwsJson10> for RuntimeError {
 impl IntoResponse<AwsJson11> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
-            .status(self.kind.status_code())
+            .status(self.status_code())
             .header("Content-Type", "application/x-amz-json-1.1")
-            .extension(RuntimeErrorExtension::new(self.kind.name().to_string()))
+            .extension(RuntimeErrorExtension::new(self.name().to_string()))
             // See https://awslabs.github.io/smithy/1.0/spec/aws/aws-json-1_1-protocol.html#empty-body-serialization
             .body(crate::body::to_boxed(""))
             .expect("invalid HTTP response for `RuntimeError`; please file a bug report under https://github.com/awslabs/smithy-rs/issues")
     }
 }
 
-impl From<crate::rejection::RequestExtensionNotFoundRejection> for RuntimeErrorKind {
+impl From<crate::rejection::RequestExtensionNotFoundRejection> for RuntimeError {
     fn from(err: crate::rejection::RequestExtensionNotFoundRejection) -> Self {
-        RuntimeErrorKind::InternalFailure(crate::Error::new(err))
+        Self::InternalFailure(crate::Error::new(err))
     }
 }
 
-impl From<crate::rejection::ResponseRejection> for RuntimeErrorKind {
+impl From<crate::rejection::ResponseRejection> for RuntimeError {
     fn from(err: crate::rejection::ResponseRejection) -> Self {
-        RuntimeErrorKind::Serialization(crate::Error::new(err))
+        Self::Serialization(crate::Error::new(err))
     }
 }
 
-impl From<crate::rejection::RequestRejection> for RuntimeErrorKind {
+impl From<crate::rejection::RequestRejection> for RuntimeError {
     fn from(err: crate::rejection::RequestRejection) -> Self {
         match err {
-            crate::rejection::RequestRejection::MissingContentType(_reason) => RuntimeErrorKind::UnsupportedMediaType,
-            _ => RuntimeErrorKind::Serialization(crate::Error::new(err)),
+            crate::rejection::RequestRejection::MissingContentType(_reason) => Self::UnsupportedMediaType,
+            _ => Self::Serialization(crate::Error::new(err)),
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context

The `Protocol` enum defines a closed set of protocols supported by the `rust-runtime` crates. Its use within interfaces restricts extensibility.

While this is not a solution to https://github.com/awslabs/smithy-rs/issues/1703 it does progress towards the general goal.

## Description

- Remove `Protocol` enum from `aws-smithy-http-server`.
- Remove dependence on `Protocol` across `aws-smithy-http-server`.
    - Use individual `IntoResponse<P>` on the `RuntimeError`.
    - Remove `RuntimeError` and rename `RuntimeErrorKind` to `RuntimeError`.
- Remove dependence on `Protocol` across `aws-smithy-http-server-python`.
    - Middleware constructors now require a `P` with `PyMiddlewareException: IntoResponse<P>`. It is no longer fallible.
    - Remove `PyApp::protocol` method.

## Notes

The most contentious changes occur within the `aws-smithy-http-server-python` changes.
