### PR TITLE
Add marker trait for numeric shapes that should be serialized even when equal to 0

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -137,3 +137,15 @@ message = "Fix regression where `connect_timeout` and `read_timeout` fields are 
 references = ["smithy-rs#1822"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "kevinpark1217"
+
+[[smithy-rs]]
+message = "Add new trait `SerializeZeroValues` and a update serializer generation to respect it. Shapes with this trait will not skip serializing zero values."
+references = ["aws-sdk-rust#630"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
+author = "Velf"
+
+[[aws-sdk-rust]]
+message = "Fix bug that occurred when serializing a `SelectObjectContent` operation with a `ScanRange` starting at 0. Zero values will now be properly serialized."
+references = ["aws-sdk-rust#630"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "Velfi"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/s3/S3Decorator.kt
@@ -61,7 +61,6 @@ class S3Decorator : RustCodegenDecorator<ClientProtocolGenerator, ClientCodegenC
         ShapeId.from("com.amazonaws.s3#Start"),
     )
 
-
     private fun applies(serviceId: ShapeId) =
         serviceId == ShapeId.from("com.amazonaws.s3#AmazonS3")
 

--- a/aws/sdk/integration-tests/s3/tests/select-object-content.rs
+++ b/aws/sdk/integration-tests/s3/tests/select-object-content.rs
@@ -13,7 +13,6 @@ use aws_sdk_s3::operation::SelectObjectContent;
 use aws_sdk_s3::{Client, Config, Credentials, Region};
 use aws_smithy_client::dvr::{Event, ReplayingConnection};
 use aws_smithy_client::test_connection::TestConnection;
-use aws_smithy_http::body::SdkBody;
 use aws_smithy_protocol_test::{assert_ok, validate_body, MediaType};
 use std::error::Error as StdError;
 use std::time::{Duration, UNIX_EPOCH};

--- a/aws/sdk/integration-tests/s3/tests/select-object-content.rs
+++ b/aws/sdk/integration-tests/s3/tests/select-object-content.rs
@@ -3,14 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use aws_http::user_agent::AwsUserAgent;
+use aws_sdk_s3::middleware::DefaultMiddleware;
 use aws_sdk_s3::model::{
     CompressionType, CsvInput, CsvOutput, ExpressionType, FileHeaderInfo, InputSerialization,
     OutputSerialization, SelectObjectContentEventStream,
 };
+use aws_sdk_s3::operation::SelectObjectContent;
 use aws_sdk_s3::{Client, Config, Credentials, Region};
 use aws_smithy_client::dvr::{Event, ReplayingConnection};
+use aws_smithy_client::test_connection::TestConnection;
+use aws_smithy_http::body::SdkBody;
 use aws_smithy_protocol_test::{assert_ok, validate_body, MediaType};
 use std::error::Error as StdError;
+use std::time::{Duration, UNIX_EPOCH};
 
 #[tokio::test]
 async fn test_success() {
@@ -93,4 +99,92 @@ fn body_validator(expected_body: &[u8], actual_body: &[u8]) -> Result<(), Box<dy
     let actual = std::str::from_utf8(actual_body).unwrap();
     assert_ok(validate_body(actual, expected, MediaType::Xml));
     Ok(())
+}
+
+#[tokio::test]
+async fn test_scan_range_starting_at_zero() {
+    pub type Client<C> = aws_smithy_client::Client<C, DefaultMiddleware>;
+    let request_body_xml: &[u8] = br#"<SelectObjectContentRequest xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Expression>SELECT * FROM s3object s WHERE s.id=&apos;1&apos;</Expression><ExpressionType>SQL</ExpressionType><InputSerialization><CSV><FileHeaderInfo>USE</FileHeaderInfo></CSV><CompressionType>NONE</CompressionType></InputSerialization><OutputSerialization><CSV></CSV></OutputSerialization><ScanRange><Start>0</Start><End>1000</End></ScanRange></SelectObjectContentRequest>"#;
+
+    let creds = Credentials::new(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+        None,
+        "test",
+    );
+    let conf = aws_sdk_s3::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .build();
+    let conn = TestConnection::new(vec![(
+        http::Request::builder()
+            .header("authorization", "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210618/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=e817c816a21d8e74671d30cc1f85ff353e6e904050690e064486ac974902ab3b")
+            .uri("https://s3.us-east-1.amazonaws.com/test-bucket/test-file.csv?select&select-type=2&x-id=SelectObjectContent")
+            .body(request_body_xml.into())
+            .unwrap(),
+        http::Response::builder().status(200).body("").unwrap(),
+    )]);
+    let client = Client::new(conn.clone());
+    let mut op = SelectObjectContent::builder()
+        .bucket("test-bucket")
+        .key("test-file.csv")
+        .expression_type(ExpressionType::Sql)
+        .expression(r#"SELECT * FROM s3object s WHERE s.id='1'"#)
+        .input_serialization(
+            InputSerialization::builder()
+                .csv(
+                    CsvInput::builder()
+                        .file_header_info(FileHeaderInfo::Use)
+                        .build(),
+                )
+                .compression_type(CompressionType::None)
+                .build(),
+        )
+        .output_serialization(
+            OutputSerialization::builder()
+                .csv(CsvOutput::builder().build())
+                .build(),
+        )
+        .scan_range(
+            aws_sdk_s3::model::ScanRange::builder()
+                .start(0)
+                .end(1000)
+                .build(),
+        )
+        .build()
+        .unwrap()
+        .make_operation(&conf)
+        .await
+        .unwrap();
+    op.properties_mut()
+        .insert(UNIX_EPOCH + Duration::from_secs(1624036048));
+    op.properties_mut().insert(AwsUserAgent::for_tests());
+
+    // Event streams have an output even when the response body is empty
+    let mut output = client.call(op).await.unwrap();
+    let mut received = Vec::new();
+    while let Some(event) = output.payload.recv().await.unwrap() {
+        match event {
+            SelectObjectContentEventStream::Records(records) => {
+                received.push(
+                    std::str::from_utf8(records.payload.as_ref().unwrap().as_ref())
+                        .unwrap()
+                        .trim()
+                        .to_string(),
+                );
+            }
+            SelectObjectContentEventStream::Stats(stats) => {
+                let stats = stats.details.unwrap();
+                received.push(format!(
+                    "scanned:{},processed:{},returned:{}",
+                    stats.bytes_scanned, stats.bytes_processed, stats.bytes_returned
+                ))
+            }
+            SelectObjectContentEventStream::End(_) => {}
+            otherwise => panic!("unexpected message: {:?}", otherwise),
+        }
+    }
+
+    conn.assert_requests_match(&[]);
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -340,7 +340,7 @@ class JsonSerializerGenerator(
             }
         } else {
             with(serializerUtil) {
-                ignoreZeroValues(context.shape, context.valueExpression) {
+                zeroValues(context.shape, context.valueExpression) {
                     serializeMemberValue(context, targetShape)
                 }
             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/QuerySerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/QuerySerializerGenerator.kt
@@ -95,7 +95,7 @@ abstract class QuerySerializerGenerator(codegenContext: CodegenContext) : Struct
     private val serializerError = runtimeConfig.serializationError()
     private val smithyTypes = CargoDependency.SmithyTypes(runtimeConfig).asType()
     private val smithyQuery = CargoDependency.smithyQuery(runtimeConfig).asType()
-    private val serdeUtil = SerializerUtil(model)
+    private val serializerUtil = SerializerUtil(model)
     private val codegenScope = arrayOf(
         "String" to RuntimeType.String,
         "Error" to serializerError,
@@ -193,8 +193,8 @@ abstract class QuerySerializerGenerator(codegenContext: CodegenContext) : Struct
                 }
             }
         } else {
-            with(serdeUtil) {
-                ignoreZeroValues(context.shape, context.valueExpression) {
+            with(serializerUtil) {
+                zeroValues(context.shape, context.valueExpression) {
                     serializeMemberValue(context, targetShape)
                 }
             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGenerator.kt
@@ -76,7 +76,7 @@ class XmlBindingTraitSerializerGenerator(
 
     private val xmlIndex = XmlNameIndex.of(model)
     private val rootNamespace = codegenContext.serviceShape.getTrait<XmlNamespaceTrait>()
-    private val util = SerializerUtil(model)
+    private val serializerUtil = SerializerUtil(model)
 
     sealed class Ctx {
         abstract val input: String
@@ -461,8 +461,8 @@ class XmlBindingTraitSerializerGenerator(
                 inner(Ctx.updateInput(ctx, tmp))
             }
         } else {
-            with(util) {
-                ignoreZeroValues(member, ValueExpression.Value(autoDeref(ctx.input))) {
+            with(serializerUtil) {
+                zeroValues(member, ValueExpression.Value(autoDeref(ctx.input))) {
                     inner(ctx)
                 }
             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/traits/SerializeZeroValues.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/traits/SerializeZeroValues.kt
@@ -1,0 +1,18 @@
+package software.amazon.smithy.rust.codegen.core.smithy.traits
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.traits.Trait
+
+/**
+ * Trait indicating that this shape should be serialized, even when equal to 0 (or 0.0 for floats)
+ *
+ * This is used to mitigate issues that arise from APIs expecting 0 values
+ * because operation serialization normally skips serializing 0 values.
+ */
+class SerializeZeroValues : Trait {
+    val ID = ShapeId.from("smithy.api.internal#serializeZeroValues")
+    override fun toNode(): Node = Node.objectNode()
+
+    override fun toShapeId(): ShapeId = ID
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/traits/SerializeZeroValues.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/traits/SerializeZeroValues.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.rust.codegen.core.smithy.traits
 
 import software.amazon.smithy.model.node.Node


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-rust#630

## Description
<!--- Describe your changes in detail -->
update: serializer generation to serialize zero values for shapes with the `SerializeZeroValues` trait
fix: bug that occurs when serializing a `"com.amazonaws.s3#ScanRange"` starting at zero
add: `SerializeZeroValues` smithy trait
update: unify names of `serializerUtil` vars in serializer codegen
update: CHANGELOG.next.toml with release notes

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I verified that this change fixes the bug and included an integration test.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
