### PR TITLE
Correctly serialize `String`s in XML

### DIFF
--- a/codegen-client-test/model/rest-xml-extras.smithy
+++ b/codegen-client-test/model/rest-xml-extras.smithy
@@ -20,6 +20,7 @@ service RestXmlExtras {
         ChecksumRequired,
         StringHeader,
         CreateFoo,
+        RequiredMember,
     ]
 }
 
@@ -242,5 +243,17 @@ structure StringHeaderOutput {
     field: String,
 
     @httpHeader("x-enum")
-    enumHeader: StringEnum
+    enumHeader: StringEnum,
+}
+
+/// This operation tests that we can serialize `required` members.
+@http(uri: "/required-member", method: "GET")
+operation RequiredMember {
+    input: RequiredMemberInputOutput
+    output: RequiredMemberInputOutput
+}
+
+structure RequiredMemberInputOutput {
+    @required
+    requiredString: String
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/ValueExpression.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/ValueExpression.kt
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.rust.codegen.core.smithy.protocols.serialize
 
+import software.amazon.smithy.rust.codegen.core.rustlang.autoDeref
+
 sealed class ValueExpression {
     abstract val name: String
 
@@ -12,7 +14,7 @@ sealed class ValueExpression {
     data class Value(override val name: String) : ValueExpression()
 
     fun asValue(): String = when (this) {
-        is Reference -> "*$name"
+        is Reference -> autoDeref(name)
         is Value -> name
     }
 


### PR DESCRIPTION
The logic that keeps track of whether we're working with a borrowed or
an owned value is flawed. It just so happened to work when requesting
owned values from borrowed values because we called `autoDeref` before
creating the value expression. That logic should instead be used
_within_ `ValueExpression` to appease Clippy there too.

Fixes #1831.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
