### PR TITLE
Remove unused generic from customizable ops

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -110,7 +110,7 @@ class CustomizableOperationGenerator(
                 }
 
                 /// Convenience for `map_request` where infallible direct mutation of request is acceptable
-                pub fn mutate_request<E>(self, f: impl FnOnce(&mut #{HttpRequest}<SdkBody>)) -> Self {
+                pub fn mutate_request(self, f: impl FnOnce(&mut #{HttpRequest}<SdkBody>)) -> Self {
                     self.map_request(|mut req| {
                         f(&mut req);
                         Result::<_, Infallible>::Ok(req)


### PR DESCRIPTION
## Motivation and Context
This generic arg isn't used and causes confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
