### PR TITLE
Add PluginExt extension trait and FilterByOperationName plugin

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/operation/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/mod.rs
@@ -193,8 +193,11 @@ pub use upgrade::*;
 ///
 /// The `L` is held and applied lazily during [`Upgradable::upgrade`].
 pub struct Operation<S, L = Identity> {
-    inner: S,
-    layer: L,
+    /// The inner [`Service`](tower::Service) representing the logic of the operation.
+    pub inner: S,
+    /// The [`Layer`](tower::Layer) applied to the HTTP [`Service`](tower::Service) after `S` has been wrapped in
+    /// [`Upgrade`].
+    pub layer: L,
 }
 
 impl<S, L> Operation<S, L> {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -1,0 +1,42 @@
+use tower::util::Either;
+
+use crate::operation::{Operation, OperationShape};
+
+use super::Plugin;
+
+pub struct FilterByOperationName<Inner, F> {
+    inner: Inner,
+    predicate: F,
+}
+
+impl<Inner, F> FilterByOperationName<Inner, F> {
+    /// Creates a new [`FilterByOperationName`].
+    pub fn new(inner: Inner, predicate: F) -> Self {
+        Self { inner, predicate }
+    }
+}
+
+impl<P, Op, S, L, Inner, F> Plugin<P, Op, S, L> for FilterByOperationName<Inner, F>
+where
+    F: Fn(&'static str) -> bool,
+    Inner: Plugin<P, Op, S, L>,
+    Op: OperationShape,
+{
+    type Service = Either<Inner::Service, S>;
+    type Layer = Either<Inner::Layer, L>;
+
+    fn map(&self, input: Operation<S, L>) -> Operation<Self::Service, Self::Layer> {
+        if (self.predicate)(Op::NAME) {
+            let Operation { inner, layer } = self.inner.map(input);
+            Operation {
+                inner: Either::A(inner),
+                layer: Either::A(layer),
+            }
+        } else {
+            Operation {
+                inner: Either::B(input.inner),
+                layer: Either::B(input.layer),
+            }
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -9,6 +9,9 @@ use crate::operation::{Operation, OperationShape};
 
 use super::Plugin;
 
+/// A [`Plugin`] used to filter [`Plugin::map`] application using a predicate over the [`OperationShape::NAME`].
+///
+/// See [`PluginExt::filter_by_operation_name`](super::PluginExt::filter_by_operation_name) for more information.
 pub struct FilterByOperationName<Inner, F> {
     inner: Inner,
     predicate: F,

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -19,14 +19,14 @@ pub struct FilterByOperationName<Inner, F> {
 
 impl<Inner, F> FilterByOperationName<Inner, F> {
     /// Creates a new [`FilterByOperationName`].
-    pub fn new(inner: Inner, predicate: F) -> Self {
+    pub(crate) fn new(inner: Inner, predicate: F) -> Self {
         Self { inner, predicate }
     }
 }
 
 impl<P, Op, S, L, Inner, F> Plugin<P, Op, S, L> for FilterByOperationName<Inner, F>
 where
-    F: Fn(&'static str) -> bool,
+    F: Fn(&str) -> bool,
     Inner: Plugin<P, Op, S, L>,
     Op: OperationShape,
 {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 use tower::util::Either;
 
 use crate::operation::{Operation, OperationShape};

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -7,7 +7,7 @@ use crate::operation::Operation;
 
 use super::Plugin;
 
-/// An [`Plugin`] that maps an `input` [`Operation`] to itself.
+/// A [`Plugin`] that maps an `input` [`Operation`] to itself.
 pub struct IdentityPlugin;
 
 impl<P, Op, S, L> Plugin<P, Op, S, L> for IdentityPlugin {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -1,0 +1,15 @@
+use crate::operation::Operation;
+
+use super::Plugin;
+
+/// An [`Plugin`] that maps an `input` [`Operation`] to itself.
+pub struct IdentityPlugin;
+
+impl<P, Op, S, L> Plugin<P, Op, S, L> for IdentityPlugin {
+    type Service = S;
+    type Layer = L;
+
+    fn map(&self, input: Operation<S, L>) -> Operation<S, L> {
+        input
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 use crate::operation::Operation;
 
 use super::Plugin;

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -64,17 +64,22 @@ pub trait PluginExt<P, Op, S, L>: Plugin<P, Op, S, L> {
         PluginStack::new(self, other)
     }
 
-    /// Filters the application of the [`Plugin`] using a predicate over the [`OperationShape::NAME`].
+    /// Filters the application of the [`Plugin`] using a predicate over the
+    /// [`OperationShape::NAME`](crate::operation::OperationShape).
     ///
     /// # Example
     ///
     /// ```rust
-    /// # use aws_smithy_http_server::plugin::{Plugin, PluginExt};
+    /// # use aws_smithy_http_server::{plugin::{Plugin, PluginExt}, operation::{Operation, OperationShape}};
     /// # struct Pl;
-    /// # impl Plugin<(), (), (), ()> for Pl {}
+    /// # struct Op;
+    /// # impl OperationShape for Op { const NAME: &'static str = ""; type Input = (); type Output = (); type Error = (); }
+    /// # impl Plugin<(), Op, (), ()> for Pl { type Service = (); type Layer = (); fn map(&self, input: Operation<(), ()>) -> Operation<(), ()> { input }}
     /// # let plugin = Pl;
+    /// # let operation = Operation { inner: (), layer: () };
     /// // Prevents `plugin` from being applied to the `CheckHealth` operation.
     /// let filtered_plugin = plugin.filter_by_operation_name(|name| name != "com.aws.example#CheckHealth");
+    /// let new_operation = filtered_plugin.map(operation);
     /// ```
     fn filter_by_operation_name<F>(self, predicate: F) -> FilterByOperationName<Self, F>
     where

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -72,18 +72,19 @@ pub trait PluginExt<P, Op, S, L>: Plugin<P, Op, S, L> {
     /// ```rust
     /// # use aws_smithy_http_server::{plugin::{Plugin, PluginExt}, operation::{Operation, OperationShape}};
     /// # struct Pl;
-    /// # struct Op;
-    /// # impl OperationShape for Op { const NAME: &'static str = ""; type Input = (); type Output = (); type Error = (); }
-    /// # impl Plugin<(), Op, (), ()> for Pl { type Service = (); type Layer = (); fn map(&self, input: Operation<(), ()>) -> Operation<(), ()> { input }}
+    /// # struct CheckHealth;
+    /// # impl OperationShape for CheckHealth { const NAME: &'static str = ""; type Input = (); type Output = (); type Error = (); }
+    /// # impl Plugin<(), CheckHealth, (), ()> for Pl { type Service = (); type Layer = (); fn map(&self, input: Operation<(), ()>) -> Operation<(), ()> { input }}
     /// # let plugin = Pl;
     /// # let operation = Operation { inner: (), layer: () };
     /// // Prevents `plugin` from being applied to the `CheckHealth` operation.
-    /// let filtered_plugin = plugin.filter_by_operation_name(|name| name != "com.aws.example#CheckHealth");
+    /// let filtered_plugin = plugin.filter_by_operation_name(|name| name != CheckHealth::NAME);
     /// let new_operation = filtered_plugin.map(operation);
     /// ```
     fn filter_by_operation_name<F>(self, predicate: F) -> FilterByOperationName<Self, F>
     where
         Self: Sized,
+        F: Fn(&str) -> bool,
     {
         FilterByOperationName::new(self, predicate)
     }

--- a/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
@@ -1,0 +1,32 @@
+use crate::operation::Operation;
+
+use super::Plugin;
+
+/// A wrapper struct which composes an `Inner` and an `Outer` [`Plugin`].
+///
+/// The `Inner::map` is run _then_ the `Outer::map`.
+pub struct PluginStack<Inner, Outer> {
+    inner: Inner,
+    outer: Outer,
+}
+
+impl<Inner, Outer> PluginStack<Inner, Outer> {
+    /// Creates a new [`PluginStack`].
+    pub fn new(inner: Inner, outer: Outer) -> Self {
+        PluginStack { inner, outer }
+    }
+}
+
+impl<P, Op, S, L, Inner, Outer> Plugin<P, Op, S, L> for PluginStack<Inner, Outer>
+where
+    Inner: Plugin<P, Op, S, L>,
+    Outer: Plugin<P, Op, Inner::Service, Inner::Layer>,
+{
+    type Service = Outer::Service;
+    type Layer = Outer::Layer;
+
+    fn map(&self, input: Operation<S, L>) -> Operation<Self::Service, Self::Layer> {
+        let inner = self.inner.map(input);
+        self.outer.map(inner)
+    }
+}

--- a/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 use crate::operation::Operation;
 
 use super::Plugin;


### PR DESCRIPTION
## Motivation and Context

Customers may not want to apply a `Plugin` to every operation in their service. They might want to filter application by operation name.

## Description

- Refactor different `Plugin`s to live in their own folders.
- Add `PluginExt` extension trait, which has methods `stack` and `filter_by_operation_name`.
- Add `FilterByOperationName` `Plugin`.
