### PR TITLE
Fix broken module path in instrumentation documentation

### DIFF
--- a/design/src/server/instrumentation.md
+++ b/design/src/server/instrumentation.md
@@ -53,7 +53,7 @@ Smithy provides an out-the-box middleware which:
 - Opens a DEBUG level span, prior to request handling, including the operation name and request URI and headers.
 - Emits a DEBUG level event, after to request handling, including the response headers and status code.
 
-This is applied by default and can be enabled and disabled by filtering on `aws_smithy_http_server::logging`.
+This is applied by default and can be enabled and disabled by filtering on `aws_smithy_http_server::instrumentation`.
 
 <!-- TODO: Link to it when the logging module is no longer `#[doc(hidden)]` -->
 
@@ -83,21 +83,21 @@ RUST_LOG=aws_smithy_http_server=debug,pokemon_service=debug cargo r
 and then using `cargo t` to run integration tests against the server, yields the following logs:
 
 ```text
-  2022-09-27T09:13:35.372517Z DEBUG aws_smithy_http_server::logging::service: response, headers: {"content-type": "application/json", "content-length": "17"}, status_code: 200 OK
+  2022-09-27T09:13:35.372517Z DEBUG aws_smithy_http_server::instrumentation::service: response, headers: {"content-type": "application/json", "content-length": "17"}, status_code: 200 OK
     at /smithy-rs/rust-runtime/aws-smithy-http-server/src/logging/service.rs:47
-    in aws_smithy_http_server::logging::service::request with operation: get_server_statistics, method: GET, uri: /stats, headers: {"host": "localhost:13734"}
+    in aws_smithy_http_server::instrumentation::service::request with operation: get_server_statistics, method: GET, uri: /stats, headers: {"host": "localhost:13734"}
 
   2022-09-27T09:13:35.374104Z DEBUG pokemon_service: attempting to authenticate storage user
     at pokemon-service/src/lib.rs:184
-    in aws_smithy_http_server::logging::service::request with operation: get_storage, method: GET, uri: /pokedex/{redacted}, headers: {"passcode": "{redacted}", "host": "localhost:13734"}
+    in aws_smithy_http_server::instrumentation::service::request with operation: get_storage, method: GET, uri: /pokedex/{redacted}, headers: {"passcode": "{redacted}", "host": "localhost:13734"}
 
   2022-09-27T09:13:35.374152Z DEBUG pokemon_service: authentication failed
     at pokemon-service/src/lib.rs:188
-    in aws_smithy_http_server::logging::service::request with operation: get_storage, method: GET, uri: /pokedex/{redacted}, headers: {"passcode": "{redacted}", "host": "localhost:13734"}
+    in aws_smithy_http_server::instrumentation::service::request with operation: get_storage, method: GET, uri: /pokedex/{redacted}, headers: {"passcode": "{redacted}", "host": "localhost:13734"}
 
-  2022-09-27T09:13:35.374230Z DEBUG aws_smithy_http_server::logging::service: response, headers: {"content-type": "application/json", "x-amzn-errortype": "NotAuthorized", "content-length": "2"}, status_code: 401 Unauthorized
+  2022-09-27T09:13:35.374230Z DEBUG aws_smithy_http_server::instrumentation::service: response, headers: {"content-type": "application/json", "x-amzn-errortype": "NotAuthorized", "content-length": "2"}, status_code: 401 Unauthorized
     at /smithy-rs/rust-runtime/aws-smithy-http-server/src/logging/service.rs:47
-    in aws_smithy_http_server::logging::service::request with operation: get_storage, method: GET, uri: /pokedex/{redacted}, headers: {"passcode": "{redacted}", "host": "localhost:13734"}
+    in aws_smithy_http_server::instrumentation::service::request with operation: get_storage, method: GET, uri: /pokedex/{redacted}, headers: {"passcode": "{redacted}", "host": "localhost:13734"}
 ```
 
 ## Interactions with Sensitivity

--- a/design/src/server/pokemon_service.md
+++ b/design/src/server/pokemon_service.md
@@ -150,9 +150,9 @@ aws_smithy_http_server::routing::Router::new_rest_json_router(vec![
 At this level, logging might be prohibited by the [`@sensitive`][10] trait. If there are no `@sensitive` shapes, the generated code looks like:
 
 ```rust
-let request_fmt = aws_smithy_http_server::logging::sensitivity::RequestFmt::new();
-let response_fmt = aws_smithy_http_server::logging::sensitivity::ResponseFmt::new();
-let svc = aws_smithy_http_server::logging::InstrumentOperation::new(
+let request_fmt = aws_smithy_http_server::instrumentation::sensitivity::RequestFmt::new();
+let response_fmt = aws_smithy_http_server::instrumentation::sensitivity::ResponseFmt::new();
+let svc = aws_smithy_http_server::instrumentation::InstrumentOperation::new(
     svc,
     "capture_pokemon_operation",
 )
@@ -164,20 +164,20 @@ Accessing the Pokédex is modeled as a restricted operation: a passcode is neede
 To not log the passcode, the code will be generated [here][11] as:
 
 ```rust
-let request_fmt = aws_smithy_http_server::logging::sensitivity::RequestFmt::new()
+let request_fmt = aws_smithy_http_server::instrumentation::sensitivity::RequestFmt::new()
     .header(|name: &http::header::HeaderName| {
         #[allow(unused_variables)]
         let name = name.as_str();
         let name_match = matches!(name, "passcode");
         let key_suffix = None;
         let value = name_match;
-        aws_smithy_http_server::logging::sensitivity::headers::HeaderMarker {
+        aws_smithy_http_server::instrumentation::sensitivity::headers::HeaderMarker {
             value,
             key_suffix,
         }
     })
     .label(|index: usize| matches!(index, 1));
-let response_fmt = aws_smithy_http_server::logging::sensitivity::ResponseFmt::new();
+let response_fmt = aws_smithy_http_server::instrumentation::sensitivity::ResponseFmt::new();
 ```
 
 Each route is a pair, [`BoxCloneService`][12] wrapping the service operation (the implementation) and


### PR DESCRIPTION
## Motivation and Context

The path is no longer `aws_smithy_http_server::logging`, it's `aws_smithy_http_server::instrumentation`.

## Description

Change `aws_smithy_http_server::logging` to `aws_smithy_http_server::instrumentation`.
