### PR TITLE
Create `DisplayErrorContext` and use it in tracing statements

### DIFF
--- a/aws/rust-runtime/aws-config/src/ecs.rs
+++ b/aws/rust-runtime/aws-config/src/ecs.rs
@@ -53,6 +53,7 @@ use std::net::IpAddr;
 
 use aws_smithy_client::erase::boxclone::BoxCloneService;
 use aws_smithy_http::endpoint::Endpoint;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::credentials;
 use aws_types::credentials::{future, CredentialsError, ProvideCredentials};
 use http::uri::{InvalidUri, Scheme};
@@ -182,7 +183,7 @@ impl Provider {
         let mut relative_uri = match relative_uri.parse::<Uri>() {
             Ok(uri) => uri,
             Err(invalid_uri) => {
-                tracing::warn!(uri = ?invalid_uri, "invalid URI loaded from environment");
+                tracing::warn!(uri = %DisplayErrorContext(&invalid_uri), "invalid URI loaded from environment");
                 return Err(EcsConfigurationErr::InvalidRelativeUri {
                     err: invalid_uri,
                     uri: relative_uri,

--- a/aws/rust-runtime/aws-config/src/environment/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/environment/app_name.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::app_name::AppName;
 use aws_types::os_shim_internal::Env;
 
@@ -32,7 +33,7 @@ impl EnvironmentVariableAppNameProvider {
             match AppName::new(name) {
                 Ok(name) => Some(name),
                 Err(err) => {
-                    tracing::warn!(err = %err, "`AWS_SDK_UA_APP_ID` environment variable value was invalid");
+                    tracing::warn!(err = %DisplayErrorContext(&err), "`AWS_SDK_UA_APP_ID` environment variable value was invalid");
                     None
                 }
             }

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -27,6 +27,7 @@ use aws_smithy_http::retry::ClassifyRetry;
 use aws_smithy_http_tower::map_request::{
     AsyncMapRequestLayer, AsyncMapRequestService, MapRequestLayer, MapRequestService,
 };
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_smithy_types::retry::{ErrorKind, RetryKind};
 use aws_types::os_shim_internal::{Env, Fs};
 
@@ -163,7 +164,7 @@ impl LazyClient {
             .get_or_init(|| async {
                 let client = builder.clone().build().await;
                 if let Err(err) = &client {
-                    tracing::warn!(err = % err, "failed to create IMDS client")
+                    tracing::warn!(err = %DisplayErrorContext(err), "failed to create IMDS client")
                 }
                 client
             })

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -133,7 +133,7 @@ impl ImdsCredentialsProvider {
             Err(ImdsError::ErrorResponse { response, .. }) if response.status().as_u16() == 404 => {
                 tracing::info!(
                     "received 404 from IMDS when loading profile information. \
-                Hint: This instance may not have an IAM role associated."
+                    Hint: This instance may not have an IAM role associated."
                 );
                 Err(CredentialsError::not_loaded("received 404 from IMDS"))
             }

--- a/aws/rust-runtime/aws-config/src/imds/region.rs
+++ b/aws/rust-runtime/aws-config/src/imds/region.rs
@@ -12,10 +12,9 @@ use crate::imds;
 use crate::imds::client::LazyClient;
 use crate::meta::region::{future, ProvideRegion};
 use crate::provider_config::ProviderConfig;
-
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal::Env;
 use aws_types::region::Region;
-
 use tracing::Instrument;
 
 /// IMDSv2 Region Provider
@@ -53,11 +52,11 @@ impl ImdsRegionProvider {
         let client = self.client.client().await.ok()?;
         match client.get(REGION_PATH).await {
             Ok(region) => {
-                tracing::debug!(region = % region, "loaded region from IMDS");
+                tracing::debug!(region = %region, "loaded region from IMDS");
                 Some(Region::new(region))
             }
             Err(err) => {
-                tracing::warn!(err = % err, "failed to load region from IMDS");
+                tracing::warn!(err = %DisplayErrorContext(&err), "failed to load region from IMDS");
                 None
             }
         }

--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::borrow::Cow;
-
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::credentials::{self, future, CredentialsError, ProvideCredentials};
+use std::borrow::Cow;
 use tracing::Instrument;
 
 /// Credentials provider that checks a series of inner providers
@@ -86,7 +86,7 @@ impl CredentialsProviderChain {
                     tracing::debug!(provider = %name, context = %context, "provider in chain did not provide credentials");
                 }
                 Err(e) => {
-                    tracing::warn!(provider = %name, error = %e, "provider failed to provide credentials");
+                    tracing::warn!(provider = %name, error = %DisplayErrorContext(&e), "provider failed to provide credentials");
                     return Err(e);
                 }
             }

--- a/aws/rust-runtime/aws-config/src/profile/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/profile/app_name.rs
@@ -7,6 +7,7 @@
 
 use super::profile_file::ProfileFiles;
 use crate::provider_config::ProviderConfig;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::app_name::AppName;
 use aws_types::os_shim_internal::{Env, Fs};
 
@@ -63,7 +64,9 @@ impl ProfileFileAppNameProvider {
     pub async fn app_name(&self) -> Option<AppName> {
         let profile = super::parser::load(&self.fs, &self.env, &self.profile_files)
             .await
-            .map_err(|err| tracing::warn!(err = %err, "failed to parse profile"))
+            .map_err(
+                |err| tracing::warn!(err = %DisplayErrorContext(&err), "failed to parse profile"),
+            )
             .ok()?;
         let selected_profile_name = self
             .profile_override

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -28,6 +28,7 @@ use crate::profile::parser::ProfileParseError;
 use crate::profile::profile_file::ProfileFiles;
 use crate::profile::Profile;
 use crate::provider_config::ProviderConfig;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::credentials::{self, future, CredentialsError, ProvideCredentials};
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -186,7 +187,7 @@ impl ProfileFileCredentialsProvider {
                 creds
             }
             Err(e) => {
-                tracing::warn!(error = %e, "failed to load base credentials");
+                tracing::warn!(error = %DisplayErrorContext(&e), "failed to load base credentials");
                 return Err(CredentialsError::provider_error(e));
             }
         };

--- a/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
@@ -3,12 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::borrow::Cow;
-use std::collections::HashMap;
-
 use crate::profile::parser::parse::{RawProfileSet, WHITESPACE};
 use crate::profile::profile_file::ProfileFileKind;
 use crate::profile::{Profile, ProfileSet, Property};
+use std::borrow::Cow;
+use std::collections::HashMap;
 
 const DEFAULT: &str = "default";
 const PROFILE_PREFIX: &str = "profile";
@@ -84,8 +83,8 @@ pub(super) fn merge_in(
     let valid_profiles = validated_profiles
         .filter_map(|(name, profile)| match name {
             Ok(profile_name) => Some((profile_name, profile)),
-            Err(e) => {
-                tracing::warn!("{}", e);
+            Err(err_str) => {
+                tracing::warn!("{}", err_str);
                 None
             }
         })

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -6,6 +6,7 @@
 use crate::fs_util::{home_dir, Os};
 use crate::profile::credentials::{CouldNotReadProfileFile, ProfileFileError};
 use crate::profile::profile_file::{ProfileFile, ProfileFileKind, ProfileFiles};
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal;
 use std::borrow::Cow;
 use std::io::ErrorKind;
@@ -64,7 +65,7 @@ fn file_contents_to_string(path: &Path, contents: Vec<u8>) -> String {
     match String::from_utf8(contents) {
         Ok(contents) => contents,
         Err(e) => {
-            tracing::warn!(path = ?path, error = %e, "config file did not contain utf-8 encoded data");
+            tracing::warn!(path = ?path, error = %DisplayErrorContext(&e), "config file did not contain utf-8 encoded data");
             Default::default()
         }
     }
@@ -113,7 +114,7 @@ async fn load_config_file(
                             tracing::warn!(path = %path, env = %kind.override_environment_variable(), "config file overridden via environment variable not found")
                         }
                         _other => {
-                            tracing::warn!(path = %path, error = %e, "failed to read config file")
+                            tracing::warn!(path = %path, error = %DisplayErrorContext(&e), "failed to read config file")
                         }
                     };
                     Default::default()

--- a/aws/rust-runtime/aws-config/src/profile/region.rs
+++ b/aws/rust-runtime/aws-config/src/profile/region.rs
@@ -6,12 +6,12 @@
 //! Load a region from an AWS profile
 
 use crate::meta::region::{future, ProvideRegion};
+use crate::profile::profile_file::ProfileFiles;
+use crate::profile::ProfileSet;
 use crate::provider_config::ProviderConfig;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal::{Env, Fs};
 use aws_types::region::Region;
-
-use super::profile_file::ProfileFiles;
-use super::ProfileSet;
 
 /// Load a region from a profile file
 ///
@@ -105,7 +105,9 @@ impl ProfileFileRegionProvider {
     async fn region(&self) -> Option<Region> {
         let profile_set = super::parser::load(&self.fs, &self.env, &self.profile_files)
             .await
-            .map_err(|err| tracing::warn!(err = %err, "failed to parse profile"))
+            .map_err(
+                |err| tracing::warn!(err = %DisplayErrorContext(&err), "failed to parse profile"),
+            )
             .ok()?;
 
         resolve_profile_chain_for_region(&profile_set, self.profile_override.as_deref())

--- a/aws/rust-runtime/aws-config/src/profile/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/retry_config.rs
@@ -5,13 +5,12 @@
 
 //! Load retry configuration properties from an AWS profile
 
-use std::str::FromStr;
-
+use crate::profile::profile_file::ProfileFiles;
+use crate::provider_config::ProviderConfig;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_smithy_types::retry::{RetryConfigBuilder, RetryConfigErr, RetryMode};
 use aws_types::os_shim_internal::{Env, Fs};
-
-use super::profile_file::ProfileFiles;
-use crate::provider_config::ProviderConfig;
+use std::str::FromStr;
 
 /// Load retry configuration properties from a profile file
 ///
@@ -106,7 +105,7 @@ impl ProfileFileRetryConfigProvider {
         let profile = match super::parser::load(&self.fs, &self.env, &self.profile_files).await {
             Ok(profile) => profile,
             Err(err) => {
-                tracing::warn!(err = %err, "failed to parse profile");
+                tracing::warn!(err = %DisplayErrorContext(&err), "failed to parse profile");
                 // return an empty builder
                 return Ok(RetryConfigBuilder::new());
             }

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -236,7 +236,7 @@ impl Inner {
                     }
                     _ => {}
                 }
-                tracing::warn!(error = ?err.message(), "sts refused to grant assume role");
+                tracing::warn!(error = ?err.message(), "STS refused to grant assume role");
                 Err(CredentialsError::provider_error(SdkError::ServiceError {
                     err,
                     raw,

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -61,14 +61,14 @@
 //! # }
 //! ```
 
-use aws_sdk_sts::Region;
-use aws_types::os_shim_internal::{Env, Fs};
-
 use crate::provider_config::ProviderConfig;
 use crate::sts;
 use aws_sdk_sts::middleware::DefaultMiddleware;
+use aws_sdk_sts::Region;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::credentials::{self, future, CredentialsError, ProvideCredentials};
+use aws_types::os_shim_internal::{Env, Fs};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use tracing::Instrument;
@@ -251,7 +251,7 @@ async fn load_credentials(
         .await
         .expect("valid operation");
     let resp = client.call(operation).await.map_err(|sdk_error| {
-        tracing::warn!(error = ?sdk_error, "sts returned an error assuming web identity role");
+        tracing::warn!(error = %DisplayErrorContext(&sdk_error), "STS returned an error assuming web identity role");
         CredentialsError::provider_error(sdk_error)
     })?;
     sts::util::into_credentials(resp.credentials, "WebIdentityToken")

--- a/aws/rust-runtime/aws-inlineable/src/http_body_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_body_checksum.rs
@@ -204,6 +204,7 @@ mod tests {
     use aws_smithy_checksums::ChecksumAlgorithm;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_http::byte_stream::ByteStream;
+    use aws_smithy_types::error::display::DisplayErrorContext;
     use bytes::{Bytes, BytesMut};
     use http_body::Body;
     use std::sync::Once;
@@ -335,7 +336,7 @@ mod tests {
 
         let mut validated_body = Vec::new();
         if let Err(e) = tokio::io::copy(&mut body.into_async_read(), &mut validated_body).await {
-            tracing::error!("{}", e);
+            tracing::error!("{}", DisplayErrorContext(&e));
             panic!("checksum validation has failed");
         };
         let body = std::str::from_utf8(&validated_body).unwrap();

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -86,6 +86,7 @@ use aws_smithy_async::future::timeout::TimedOutError;
 use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep};
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::result::ConnectorError;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_smithy_types::retry::ErrorKind;
 use http::Uri;
 use hyper::client::connect::{Connected, Connection};
@@ -177,7 +178,7 @@ fn to_connector_error(err: hyper::Error) -> ConnectorError {
     else if err.is_incomplete_message() {
         ConnectorError::other(err.into(), Some(ErrorKind::TransientError))
     } else {
-        tracing::warn!(err = ?err, "unrecognized error from Hyper. If this error should be retried, please file an issue.");
+        tracing::warn!(err = %DisplayErrorContext(&err), "unrecognized error from Hyper. If this error should be retried, please file an issue.");
         ConnectorError::other(err.into(), None)
     }
 }

--- a/rust-runtime/aws-smithy-types/src/error.rs
+++ b/rust-runtime/aws-smithy-types/src/error.rs
@@ -1,0 +1,147 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Generic errors for Smithy codegen
+
+use crate::retry::{ErrorKind, ProvideErrorKind};
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+
+pub mod display;
+
+/// Generic Error type
+///
+/// For many services, Errors are modeled. However, many services only partially model errors or don't
+/// model errors at all. In these cases, the SDK will return this generic error type to expose the
+/// `code`, `message` and `request_id`.
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+pub struct Error {
+    code: Option<String>,
+    message: Option<String>,
+    request_id: Option<String>,
+    extras: HashMap<&'static str, String>,
+}
+
+/// Builder for [`Error`].
+#[derive(Debug, Default)]
+pub struct Builder {
+    inner: Error,
+}
+
+impl Builder {
+    /// Sets the error message.
+    pub fn message(&mut self, message: impl Into<String>) -> &mut Self {
+        self.inner.message = Some(message.into());
+        self
+    }
+
+    /// Sets the error code.
+    pub fn code(&mut self, code: impl Into<String>) -> &mut Self {
+        self.inner.code = Some(code.into());
+        self
+    }
+
+    /// Sets the request ID the error happened for.
+    pub fn request_id(&mut self, request_id: impl Into<String>) -> &mut Self {
+        self.inner.request_id = Some(request_id.into());
+        self
+    }
+
+    /// Set a custom field on the error metadata
+    ///
+    /// Typically, these will be accessed with an extension trait:
+    /// ```rust
+    /// use aws_smithy_types::Error;
+    /// const HOST_ID: &str = "host_id";
+    /// trait S3ErrorExt {
+    ///     fn extended_request_id(&self) -> Option<&str>;
+    /// }
+    ///
+    /// impl S3ErrorExt for Error {
+    ///     fn extended_request_id(&self) -> Option<&str> {
+    ///         self.extra(HOST_ID)
+    ///     }
+    /// }
+    ///
+    /// fn main() {
+    ///     // Extension trait must be brought into scope
+    ///     use S3ErrorExt;
+    ///     let sdk_response: Result<(), Error> = Err(Error::builder().custom(HOST_ID, "x-1234").build());
+    ///     if let Err(err) = sdk_response {
+    ///         println!("request id: {:?}, extended request id: {:?}", err.request_id(), err.extended_request_id());
+    ///     }
+    /// }
+    /// ```
+    pub fn custom(&mut self, key: &'static str, value: impl Into<String>) -> &mut Self {
+        self.inner.extras.insert(key, value.into());
+        self
+    }
+
+    /// Creates the error.
+    pub fn build(&mut self) -> Error {
+        std::mem::take(&mut self.inner)
+    }
+}
+
+impl Error {
+    /// Returns the error code.
+    pub fn code(&self) -> Option<&str> {
+        self.code.as_deref()
+    }
+    /// Returns the error message.
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+    /// Returns the request ID the error occurred for, if it's available.
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+    /// Returns additional information about the error if it's present.
+    pub fn extra(&self, key: &'static str) -> Option<&str> {
+        self.extras.get(key).map(|k| k.as_str())
+    }
+
+    /// Creates an `Error` builder.
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    /// Converts an `Error` into a builder.
+    pub fn into_builder(self) -> Builder {
+        Builder { inner: self }
+    }
+}
+
+impl ProvideErrorKind for Error {
+    fn retryable_error_kind(&self) -> Option<ErrorKind> {
+        None
+    }
+
+    fn code(&self) -> Option<&str> {
+        Error::code(self)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let mut fmt = f.debug_struct("Error");
+        if let Some(code) = &self.code {
+            fmt.field("code", code);
+        }
+        if let Some(message) = &self.message {
+            fmt.field("message", message);
+        }
+        if let Some(req_id) = &self.request_id {
+            fmt.field("request_id", req_id);
+        }
+        for (k, v) in &self.extras {
+            fmt.field(k, &v);
+        }
+        fmt.finish()
+    }
+}
+
+impl std::error::Error for Error {}

--- a/rust-runtime/aws-smithy-types/src/error/display.rs
+++ b/rust-runtime/aws-smithy-types/src/error/display.rs
@@ -10,10 +10,17 @@ use std::fmt;
 
 /// Provides a `Display` impl for an `Error` that outputs the full error context
 ///
-/// This is useful for emitting errors with `tracing` in cases where the error
-/// is not returned back to the customer.
+/// This utility follows the error cause/source chain and displays every error message
+/// in the chain separated by ": ". At the end of the chain, it outputs a debug view
+/// of the entire error chain.
+///
+// Internally in the SDK, this is useful for emitting errors with `tracing` in cases
+// where the error is not returned back to the customer.
 #[derive(Debug)]
-pub struct DisplayErrorContext<E: Error>(pub E);
+pub struct DisplayErrorContext<E: Error>(
+    /// The error to display full context for
+    pub E,
+);
 
 impl<E: Error> fmt::Display for DisplayErrorContext<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/rust-runtime/aws-smithy-types/src/error/display.rs
+++ b/rust-runtime/aws-smithy-types/src/error/display.rs
@@ -1,0 +1,92 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Error wrapper that displays error context
+
+use std::error::Error;
+use std::fmt;
+
+/// Provides a `Display` impl for an `Error` that outputs the full error context
+///
+/// This is useful for emitting errors with `tracing` in cases where the error
+/// is not returned back to the customer.
+#[derive(Debug)]
+pub struct DisplayErrorContext<E: Error>(pub E);
+
+impl<E: Error> fmt::Display for DisplayErrorContext<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write_err(f, &self.0)?;
+        // Also add a debug version of the error at the end
+        write!(f, " ({:?})", self.0)
+    }
+}
+
+fn write_err(f: &mut fmt::Formatter<'_>, err: &dyn Error) -> fmt::Result {
+    write!(f, "{}", err)?;
+    if let Some(source) = err.source() {
+        write!(f, ": ")?;
+        write_err(f, source)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+    use std::fmt;
+
+    #[derive(Debug)]
+    struct TestError {
+        what: &'static str,
+        source: Option<Box<dyn Error>>,
+    }
+
+    impl fmt::Display for TestError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "{}", self.what)
+        }
+    }
+
+    impl Error for TestError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            self.source.as_deref()
+        }
+    }
+
+    #[test]
+    fn no_sources() {
+        assert_eq!(
+            "test (TestError { what: \"test\", source: None })",
+            format!(
+                "{}",
+                DisplayErrorContext(TestError {
+                    what: "test",
+                    source: None
+                })
+            )
+        );
+    }
+
+    #[test]
+    fn sources() {
+        assert_eq!(
+            "foo: bar: baz (TestError { what: \"foo\", source: Some(TestError { what: \"bar\", source: Some(TestError { what: \"baz\", source: None }) }) })",
+            format!(
+                "{}",
+                DisplayErrorContext(TestError {
+                    what: "foo",
+                    source: Some(Box::new(TestError {
+                        what: "bar",
+                        source: Some(Box::new(TestError {
+                            what: "baz",
+                            source: None
+                        }))
+                    }) as Box<_>)
+                })
+            )
+        );
+    }
+}

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -18,11 +18,13 @@ use std::collections::HashMap;
 pub mod base64;
 pub mod date_time;
 pub mod endpoint;
+pub mod error;
 pub mod primitive;
 pub mod retry;
 pub mod timeout;
 
 pub use crate::date_time::DateTime;
+pub use error::Error;
 
 /// Binary Blob Type
 ///
@@ -552,148 +554,4 @@ mod number {
             1452089100f32
         );
     }
-}
-
-pub use error::Error;
-
-/// Generic errors for Smithy codegen
-pub mod error {
-    use crate::retry::{ErrorKind, ProvideErrorKind};
-    use std::collections::HashMap;
-    use std::fmt;
-    use std::fmt::{Display, Formatter};
-
-    /// Generic Error type
-    ///
-    /// For many services, Errors are modeled. However, many services only partially model errors or don't
-    /// model errors at all. In these cases, the SDK will return this generic error type to expose the
-    /// `code`, `message` and `request_id`.
-    #[derive(Debug, Eq, PartialEq, Default, Clone)]
-    pub struct Error {
-        code: Option<String>,
-        message: Option<String>,
-        request_id: Option<String>,
-        extras: HashMap<&'static str, String>,
-    }
-
-    /// Builder for [`Error`].
-    #[derive(Debug, Default)]
-    pub struct Builder {
-        inner: Error,
-    }
-
-    impl Builder {
-        /// Sets the error message.
-        pub fn message(&mut self, message: impl Into<String>) -> &mut Self {
-            self.inner.message = Some(message.into());
-            self
-        }
-
-        /// Sets the error code.
-        pub fn code(&mut self, code: impl Into<String>) -> &mut Self {
-            self.inner.code = Some(code.into());
-            self
-        }
-
-        /// Sets the request ID the error happened for.
-        pub fn request_id(&mut self, request_id: impl Into<String>) -> &mut Self {
-            self.inner.request_id = Some(request_id.into());
-            self
-        }
-
-        /// Set a custom field on the error metadata
-        ///
-        /// Typically, these will be accessed with an extension trait:
-        /// ```rust
-        /// use aws_smithy_types::Error;
-        /// const HOST_ID: &str = "host_id";
-        /// trait S3ErrorExt {
-        ///     fn extended_request_id(&self) -> Option<&str>;
-        /// }
-        ///
-        /// impl S3ErrorExt for Error {
-        ///     fn extended_request_id(&self) -> Option<&str> {
-        ///         self.extra(HOST_ID)
-        ///     }
-        /// }
-        ///
-        /// fn main() {
-        ///     // Extension trait must be brought into scope
-        ///     use S3ErrorExt;
-        ///     let sdk_response: Result<(), Error> = Err(Error::builder().custom(HOST_ID, "x-1234").build());
-        ///     if let Err(err) = sdk_response {
-        ///         println!("request id: {:?}, extended request id: {:?}", err.request_id(), err.extended_request_id());
-        ///     }
-        /// }
-        /// ```
-        pub fn custom(&mut self, key: &'static str, value: impl Into<String>) -> &mut Self {
-            self.inner.extras.insert(key, value.into());
-            self
-        }
-
-        /// Creates the error.
-        pub fn build(&mut self) -> Error {
-            std::mem::take(&mut self.inner)
-        }
-    }
-
-    impl Error {
-        /// Returns the error code.
-        pub fn code(&self) -> Option<&str> {
-            self.code.as_deref()
-        }
-        /// Returns the error message.
-        pub fn message(&self) -> Option<&str> {
-            self.message.as_deref()
-        }
-        /// Returns the request ID the error occurred for, if it's available.
-        pub fn request_id(&self) -> Option<&str> {
-            self.request_id.as_deref()
-        }
-        /// Returns additional information about the error if it's present.
-        pub fn extra(&self, key: &'static str) -> Option<&str> {
-            self.extras.get(key).map(|k| k.as_str())
-        }
-
-        /// Creates an `Error` builder.
-        pub fn builder() -> Builder {
-            Builder::default()
-        }
-
-        /// Converts an `Error` into a builder.
-        pub fn into_builder(self) -> Builder {
-            Builder { inner: self }
-        }
-    }
-
-    impl ProvideErrorKind for Error {
-        fn retryable_error_kind(&self) -> Option<ErrorKind> {
-            None
-        }
-
-        fn code(&self) -> Option<&str> {
-            Error::code(self)
-        }
-    }
-
-    impl Display for Error {
-        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-            let mut fmt = f.debug_struct("Error");
-            if let Some(code) = &self.code {
-                fmt.field("code", code);
-            }
-            if let Some(message) = &self.message {
-                fmt.field("message", message);
-            }
-            if let Some(req_id) = &self.request_id {
-                fmt.field("request_id", req_id);
-            }
-            for (k, v) in &self.extras {
-                fmt.field(k, &v);
-            }
-            fmt.finish()
-        }
-    }
-
-    impl std::error::Error for Error {}
 }


### PR DESCRIPTION
## Motivation and Context
This PR implements the `DisplayErrorContext` utility from [RFC-0022: Error Context and Compatibility](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).

This is the first PR in a series that will fully implement the RFC, tracked in #1926.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._