### PR TITLE
Revamp errors in `aws-smithy-checksums`

### DIFF
--- a/rust-runtime/aws-smithy-checksums/src/error.rs
+++ b/rust-runtime/aws-smithy-checksums/src/error.rs
@@ -1,0 +1,38 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::error::Error;
+use std::fmt;
+
+/// A checksum algorithm was unknown
+#[derive(Debug)]
+pub struct UnknownChecksumAlgorithmError {
+    checksum_algorithm: String,
+}
+
+impl UnknownChecksumAlgorithmError {
+    pub(crate) fn new(checksum_algorithm: impl Into<String>) -> Self {
+        Self {
+            checksum_algorithm: checksum_algorithm.into(),
+        }
+    }
+
+    /// The checksum algorithm that is unknown
+    pub fn checksum_algorithm(&self) -> &str {
+        &self.checksum_algorithm
+    }
+}
+
+impl fmt::Display for UnknownChecksumAlgorithmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            r#"unknown checksum algorithm "{}", please pass a known algorithm name ("crc32", "crc32c", "sha1", "sha256", "md5")"#,
+            self.checksum_algorithm
+        )
+    }
+}
+
+impl Error for UnknownChecksumAlgorithmError {}

--- a/rust-runtime/aws-smithy-checksums/src/lib.rs
+++ b/rust-runtime/aws-smithy-checksums/src/lib.rs
@@ -5,10 +5,12 @@
 
 //! Checksum calculation and verification callbacks.
 
+use crate::error::UnknownChecksumAlgorithmError;
 use bytes::Bytes;
 use std::str::FromStr;
 
 pub mod body;
+pub mod error;
 pub mod http;
 
 // Valid checksum algorithm names
@@ -29,7 +31,7 @@ pub enum ChecksumAlgorithm {
 }
 
 impl FromStr for ChecksumAlgorithm {
-    type Err = Error;
+    type Err = UnknownChecksumAlgorithmError;
 
     /// Create a new `ChecksumAlgorithm` from an algorithm name. Valid algorithm names are:
     /// - "crc32"
@@ -51,9 +53,7 @@ impl FromStr for ChecksumAlgorithm {
         } else if checksum_algorithm.eq_ignore_ascii_case(MD5_NAME) {
             Ok(Self::Md5)
         } else {
-            Err(Error::UnknownChecksumAlgorithm(
-                checksum_algorithm.to_owned(),
-            ))
+            Err(UnknownChecksumAlgorithmError::new(checksum_algorithm))
         }
     }
 }
@@ -81,27 +81,6 @@ impl ChecksumAlgorithm {
         }
     }
 }
-
-#[derive(Debug, PartialEq)]
-pub enum Error {
-    UnknownChecksumAlgorithm(String),
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::UnknownChecksumAlgorithm(algorithm) => {
-                write!(
-                    f,
-                    r#"unknown checksum algorithm "{}", please pass a known algorithm name ("crc32", "crc32c", "sha1", "sha256", "md5")"#,
-                    algorithm
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// Types implementing this trait can calculate checksums.
 ///
@@ -397,7 +376,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "called `Result::unwrap()` on an `Err` value: UnknownChecksumAlgorithm(\"some invalid checksum algorithm\")"]
+    #[should_panic = "called `Result::unwrap()` on an `Err` value: UnknownChecksumAlgorithmError { checksum_algorithm: \"some invalid checksum algorithm\" }"]
     fn test_checksum_algorithm_returns_error_for_unknown() {
         "some invalid checksum algorithm"
             .parse::<ChecksumAlgorithm>()

--- a/rust-runtime/aws-smithy-checksums/src/lib.rs
+++ b/rust-runtime/aws-smithy-checksums/src/lib.rs
@@ -376,10 +376,14 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "called `Result::unwrap()` on an `Err` value: UnknownChecksumAlgorithmError { checksum_algorithm: \"some invalid checksum algorithm\" }"]
     fn test_checksum_algorithm_returns_error_for_unknown() {
-        "some invalid checksum algorithm"
+        let error = "some invalid checksum algorithm"
             .parse::<ChecksumAlgorithm>()
-            .unwrap();
+            .err()
+            .expect("it should error");
+        assert_eq!(
+            "some invalid checksum algorithm",
+            error.checksum_algorithm()
+        );
     }
 }


### PR DESCRIPTION
## Motivation and Context
This PR revamps errors in `aws-smithy-checksums` to adhere to [RFC-0022: Error Context and Compatibility](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).

This PR is part of a series that will fully implement the RFC, tracked in #1926.

Changelog entries added in #1951.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
