### PR TITLE
Check that release workflow is run on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   main-branch-check:
     name: Check that workflow is running in main
+    runs-on: ubuntu-latest
     steps:
     - name: Main branch check
       if: ${{ github.ref_name != 'main' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
   main-branch-check:
     name: Check that workflow is running in main
     if: ${{ github.ref_name != "main" }}
+    uses: actions/github-script@v6
     script: |
       core.setFailed("The release workflow can only be ran on main (current branch: ${{ github.ref_name }})")
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
   rust_version: 1.61.0
 
 name: Release smithy-rs
-run_name: ${{ github.workflow }} - ${{ inputs.dry_run && "Dry run" || "Production run" }}
+run-name: ${{ github.workflow }} - ${{ inputs.dry_run && "Dry run" || "Production run" }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
   rust_version: 1.61.0
 
 name: Release smithy-rs
+run_name: "${{ github.workflow }} - ${{ inputs.dry_run && \"Dry run\" || \"Production run\"}}"
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,12 @@ on:
 jobs:
   main-branch-check:
     name: Check that workflow is running in main
-    if: ${{ github.ref_name != "main" }}
-    uses: actions/github-script@v6
-    script: |
-      core.setFailed("The release workflow can only be ran on main (current branch: ${{ github.ref_name }})")
+    steps:
+    - name: Main branch check
+      if: ${{ github.ref_name != "main" }}
+      uses: actions/github-script@v6
+      script: |
+        core.setFailed("The release workflow can only be ran on main (current branch: ${{ github.ref_name }})")
 
   # If a release is kicked off before an image is built after push to main,
   # or if a dry-run release is kicked off against a non-main branch to test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
     name: Check that workflow is running in main
     steps:
     - name: Main branch check
-      if: ${{ github.ref_name != "main" }}
+      if: ${{ github.ref_name != 'main' }}
       uses: actions/github-script@v6
       with:
         script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
   rust_version: 1.61.0
 
 name: Release smithy-rs
-run_name: "${{ github.workflow }} - ${{ inputs.dry_run && \"Dry run\" || \"Production run\"}}"
+run_name: ${{ github.workflow }} - ${{ inputs.dry_run && "Dry run" || "Production run" }}
 on:
   workflow_dispatch:
     inputs:
@@ -24,12 +24,20 @@ on:
         default: true
 
 jobs:
+  main-branch-check:
+    name: Check that workflow is running in main
+    if: ${{ github.ref_name != "main" }}
+    script: |
+      core.setFailed("The release workflow can only be ran on main (current branch: ${{ github.ref_name }})")
+
   # If a release is kicked off before an image is built after push to main,
   # or if a dry-run release is kicked off against a non-main branch to test
   # automation changes, we'll need to build a base image to work against.
   # This job will be a no-op if an image was already built on main.
   acquire-base-image:
     name: Acquire Base Image
+    needs:
+    - main-branch-check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
   rust_version: 1.61.0
 
 name: Release smithy-rs
-run-name: ${{ github.workflow }} - ${{ inputs.dry_run && "Dry run" || "Production run" }}
+run-name: ${{ github.workflow }} - ${{ inputs.dry_run && 'Dry run' || 'Production run' }}
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,8 +30,9 @@ jobs:
     - name: Main branch check
       if: ${{ github.ref_name != "main" }}
       uses: actions/github-script@v6
-      script: |
-        core.setFailed("The release workflow can only be ran on main (current branch: ${{ github.ref_name }})")
+      with:
+        script: |
+          core.setFailed("The release workflow can only be ran on main (current branch: ${{ github.ref_name }})")
 
   # If a release is kicked off before an image is built after push to main,
   # or if a dry-run release is kicked off against a non-main branch to test


### PR DESCRIPTION
## Motivation and Context
We've recently had problems with a release by selecting an older commit/branch. This PR adds a check to prevent that particular mistake from happening.
We've also had difficulty determining if a particular release workflow run was in "dry run" mode. This PR increases visibility in that respect.


## Description
- Updates the name of the release workflow to `Release smithy-rs - Dry run` or `Release smithy-rs - Production run` depending on `inputs.dry_run`
- Release workflow now checks that it was run on `main` and fails if not.

## Testing
I verified that the main branch check works on this branch: https://github.com/awslabs/smithy-rs/actions/runs/3250387459/jobs/5334004431 (it fails as expected).
From that run you can see that the workflow title was updated successfully as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
