### PR TITLE
Make protocol ZSTs match shape ID names

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
@@ -99,10 +99,10 @@ class ServerAwsJsonProtocol(
     override fun markerStruct(): RuntimeType {
         return when (version) {
             is AwsJsonVersion.Json10 -> {
-                ServerRuntimeType.Protocol("AwsJson10", "aws_json_10", runtimeConfig)
+                ServerRuntimeType.Protocol("AwsJson1_0", "aws_json_10", runtimeConfig)
             }
             is AwsJsonVersion.Json11 -> {
-                ServerRuntimeType.Protocol("AwsJson11", "aws_json_11", runtimeConfig)
+                ServerRuntimeType.Protocol("AwsJson1_1", "aws_json_11", runtimeConfig)
             }
         }
     }
@@ -211,7 +211,7 @@ class ServerRestJsonProtocol(
         fun fromCoreProtocol(restJson: RestJson): ServerRestJsonProtocol = ServerRestJsonProtocol(restJson.codegenContext)
     }
 
-    override fun markerStruct() = ServerRuntimeType.Protocol("AwsRestJson1", "rest_json_1", runtimeConfig)
+    override fun markerStruct() = ServerRuntimeType.Protocol("RestJson1", "rest_json_1", runtimeConfig)
 
     override fun routerType() = restRouterType(runtimeConfig)
 
@@ -240,7 +240,7 @@ class ServerRestXmlProtocol(
         }
     }
 
-    override fun markerStruct() = ServerRuntimeType.Protocol("AwsRestXml", "rest_xml", runtimeConfig)
+    override fun markerStruct() = ServerRuntimeType.Protocol("RestXml", "rest_xml", runtimeConfig)
 
     override fun routerType() = restRouterType(runtimeConfig)
 

--- a/design/src/rfcs/rfc0020_service_builder.md
+++ b/design/src/rfcs/rfc0020_service_builder.md
@@ -231,7 +231,7 @@ pub struct Route {
 enum Routes {
     RestXml(Vec<(Route, RequestSpec)>),
     RestJson1(Vec<(Route, RequestSpec)>),
-    AwsJson10(TinyMap<String, Route>),
+    AwsJson1_0(TinyMap<String, Route>),
     AwsJson11(TinyMap<String, Route>),
 }
 
@@ -729,8 +729,8 @@ Currently there is a single `Router` structure, described in [Router](#router), 
 enum Routes {
     RestXml(/* Container */),
     RestJson1(/* Container */),
-    AwsJson10(/* Container */),
-    AwsJson11(/* Container */),
+    AwsJson1_0(/* Container */),
+    AwsJson1_1(/* Container */),
 }
 ```
 

--- a/design/src/server/anatomy.md
+++ b/design/src/server/anatomy.md
@@ -241,16 +241,16 @@ Note that both traits are parameterized by `Protocol`. These [protocols](https:/
 
 ```rust
 /// [AWS REST JSON 1.0 Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-restjson1-protocol.html).
-pub struct AwsRestJson1;
+pub struct RestJson1;
 
 /// [AWS REST XML Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-restxml-protocol.html).
-pub struct AwsRestXml;
+pub struct RestXml;
 
 /// [AWS JSON 1.0 Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-json-1_0-protocol.html).
-pub struct AwsJson10;
+pub struct AwsJson1_0;
 
 /// [AWS JSON 1.1 Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-json-1_1-protocol.html).
-pub struct AwsJson11;
+pub struct AwsJson1_1;
 ```
 
 ## Upgrading a Model Service
@@ -526,15 +526,15 @@ To finalize the build and construct the complete service, `PokemonService`, each
     /// Constructs a [`PokemonService`] from the arguments provided to the builder.
     pub fn build(self) -> PokemonService<Route>
     where
-        Op1: Upgradable<AwsRestJson1, CheckHealth>,
+        Op1: Upgradable<RestJson1, CheckHealth>,
         Op1::Service: tower::Service<http::Request, Error = Infallible>,
 
-        Op2: Upgradable<AwsRestJson1, DoNothing>,
+        Op2: Upgradable<RestJson1, DoNothing>,
         Op2::Service: tower::Service<http::Request, Error = Infallible>,
 
         /* ... */
 
-        Op6: Upgradable<AwsRestJson1, GetStorage>,
+        Op6: Upgradable<RestJson1, GetStorage>,
         Op6::Service: tower::Service<http::Request, Error = Infallible>,
 ```
 
@@ -599,10 +599,10 @@ The build method then proceeds as follows:
     /// Constructs a [`PokemonService`] from the arguments provided to the builder.
     pub fn build(self) -> PokemonService<Route>
     where
-        Op1: Upgradable<AwsRestJson1, CheckHealth>,
+        Op1: Upgradable<RestJson1, CheckHealth>,
         Op1::Service: tower::Service<http::Request, Error = Infallible>,
 
-        Op2: Upgradable<AwsRestJson1, DoNothing>,
+        Op2: Upgradable<RestJson1, DoNothing>,
         Op2::Service: tower::Service<http::Request, Error = Infallible>,
 
         /* ... */
@@ -630,7 +630,7 @@ where
 /// The Pokémon Service allows you to retrieve information about Pokémon species.
 #[derive(Clone)]
 pub struct PokemonService<S> {
-    router: RoutingService<RestRouter<S>, AwsRestJson1>,
+    router: RoutingService<RestRouter<S>, RestJson1>,
 }
 ```
 

--- a/rust-runtime/aws-smithy-http-server-python/src/error.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/error.rs
@@ -8,8 +8,7 @@
 use aws_smithy_http_server::{
     body::{to_boxed, BoxBody},
     proto::{
-        aws_json_10::AwsJson10, aws_json_11::AwsJson11, rest_json_1::AwsRestJson1,
-        rest_xml::AwsRestXml,
+        aws_json_10::AwsJson1_0, aws_json_11::AwsJson1_1, rest_json_1::RestJson1, rest_xml::RestXml,
     },
     response::IntoResponse,
 };
@@ -68,7 +67,7 @@ impl From<PyErr> for PyMiddlewareException {
     }
 }
 
-impl IntoResponse<AwsRestJson1> for PyMiddlewareException {
+impl IntoResponse<RestJson1> for PyMiddlewareException {
     fn into_response(self) -> http::Response<BoxBody> {
         http::Response::builder()
             .status(self.status_code)
@@ -79,7 +78,7 @@ impl IntoResponse<AwsRestJson1> for PyMiddlewareException {
     }
 }
 
-impl IntoResponse<AwsRestXml> for PyMiddlewareException {
+impl IntoResponse<RestXml> for PyMiddlewareException {
     fn into_response(self) -> http::Response<BoxBody> {
         http::Response::builder()
             .status(self.status_code)
@@ -89,7 +88,7 @@ impl IntoResponse<AwsRestXml> for PyMiddlewareException {
     }
 }
 
-impl IntoResponse<AwsJson10> for PyMiddlewareException {
+impl IntoResponse<AwsJson1_0> for PyMiddlewareException {
     fn into_response(self) -> http::Response<BoxBody> {
         http::Response::builder()
             .status(self.status_code)
@@ -100,7 +99,7 @@ impl IntoResponse<AwsJson10> for PyMiddlewareException {
     }
 }
 
-impl IntoResponse<AwsJson11> for PyMiddlewareException {
+impl IntoResponse<AwsJson1_1> for PyMiddlewareException {
     fn into_response(self) -> http::Response<BoxBody> {
         http::Response::builder()
             .status(self.status_code)

--- a/rust-runtime/aws-smithy-http-server-python/src/middleware/handler.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/middleware/handler.rs
@@ -170,7 +170,7 @@ impl PyMiddlewares {
 
 #[cfg(test)]
 mod tests {
-    use aws_smithy_http_server::proto::rest_json_1::AwsRestJson1;
+    use aws_smithy_http_server::proto::rest_json_1::RestJson1;
     use http::HeaderValue;
     use hyper::body::to_bytes;
     use pretty_assertions::assert_eq;
@@ -180,7 +180,7 @@ mod tests {
     #[tokio::test]
     async fn request_middleware_chain_keeps_headers_changes() -> PyResult<()> {
         let locals = crate::tests::initialize();
-        let mut middlewares = PyMiddlewares::new::<AwsRestJson1>(vec![]);
+        let mut middlewares = PyMiddlewares::new::<RestJson1>(vec![]);
 
         Python::with_gil(|py| {
             let middleware = PyModule::new(py, "middleware").unwrap();
@@ -230,7 +230,7 @@ def second_middleware(request: Request):
     #[tokio::test]
     async fn request_middleware_return_response() -> PyResult<()> {
         let locals = crate::tests::initialize();
-        let mut middlewares = PyMiddlewares::new::<AwsRestJson1>(vec![]);
+        let mut middlewares = PyMiddlewares::new::<RestJson1>(vec![]);
 
         Python::with_gil(|py| {
             let middleware = PyModule::new(py, "middleware").unwrap();
@@ -265,7 +265,7 @@ def middleware(request: Request):
     #[tokio::test]
     async fn request_middleware_raise_middleware_exception() -> PyResult<()> {
         let locals = crate::tests::initialize();
-        let mut middlewares = PyMiddlewares::new::<AwsRestJson1>(vec![]);
+        let mut middlewares = PyMiddlewares::new::<RestJson1>(vec![]);
 
         Python::with_gil(|py| {
             let middleware = PyModule::new(py, "middleware").unwrap();
@@ -304,7 +304,7 @@ def middleware(request: Request):
     #[tokio::test]
     async fn request_middleware_raise_python_exception() -> PyResult<()> {
         let locals = crate::tests::initialize();
-        let mut middlewares = PyMiddlewares::new::<AwsRestJson1>(vec![]);
+        let mut middlewares = PyMiddlewares::new::<RestJson1>(vec![]);
 
         Python::with_gil(|py| {
             let middleware = PyModule::from_code(

--- a/rust-runtime/aws-smithy-http-server-python/src/middleware/layer.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/middleware/layer.rs
@@ -160,7 +160,7 @@ mod tests {
     use super::*;
 
     use aws_smithy_http_server::body::to_boxed;
-    use aws_smithy_http_server::proto::rest_json_1::AwsRestJson1;
+    use aws_smithy_http_server::proto::rest_json_1::RestJson1;
     use pyo3::prelude::*;
     use tower::{Service, ServiceBuilder, ServiceExt};
 
@@ -174,7 +174,7 @@ mod tests {
     #[tokio::test]
     async fn request_middlewares_are_chained_inside_layer() -> PyResult<()> {
         let locals = crate::tests::initialize();
-        let mut middlewares = PyMiddlewares::new::<AwsRestJson1>(vec![]);
+        let mut middlewares = PyMiddlewares::new::<RestJson1>(vec![]);
 
         Python::with_gil(|py| {
             let middleware = PyModule::new(py, "middleware").unwrap();
@@ -211,7 +211,7 @@ def second_middleware(request: Request):
         })?;
 
         let mut service = ServiceBuilder::new()
-            .layer(PyMiddlewareLayer::<AwsRestJson1>::new(middlewares, locals))
+            .layer(PyMiddlewareLayer::<RestJson1>::new(middlewares, locals))
             .service_fn(echo);
 
         let request = Request::get("/").body(Body::empty()).unwrap();

--- a/rust-runtime/aws-smithy-http-server/src/proto/aws_json_10/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/aws_json_10/mod.rs
@@ -6,4 +6,4 @@
 pub mod router;
 
 /// [AWS JSON 1.0 Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-json-1_0-protocol.html).
-pub struct AwsJson10;
+pub struct AwsJson1_0;

--- a/rust-runtime/aws-smithy-http-server/src/proto/aws_json_10/router.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/aws_json_10/router.rs
@@ -9,11 +9,11 @@ use crate::proto::aws_json::router::Error;
 use crate::response::IntoResponse;
 use crate::routers::{method_disallowed, UNKNOWN_OPERATION_EXCEPTION};
 
-use super::AwsJson10;
+use super::AwsJson1_0;
 
 pub use crate::proto::aws_json::router::*;
 
-impl IntoResponse<AwsJson10> for Error {
+impl IntoResponse<AwsJson1_0> for Error {
     fn into_response(self) -> http::Response<BoxBody> {
         match self {
             Error::MethodNotAllowed => method_disallowed(),

--- a/rust-runtime/aws-smithy-http-server/src/proto/aws_json_11/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/aws_json_11/mod.rs
@@ -6,4 +6,4 @@
 pub mod router;
 
 /// [AWS JSON 1.1 Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-json-1_1-protocol.html).
-pub struct AwsJson11;
+pub struct AwsJson1_1;

--- a/rust-runtime/aws-smithy-http-server/src/proto/aws_json_11/router.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/aws_json_11/router.rs
@@ -9,11 +9,11 @@ use crate::proto::aws_json::router::Error;
 use crate::response::IntoResponse;
 use crate::routers::{method_disallowed, UNKNOWN_OPERATION_EXCEPTION};
 
-use super::AwsJson11;
+use super::AwsJson1_1;
 
 pub use crate::proto::aws_json::router::*;
 
-impl IntoResponse<AwsJson11> for Error {
+impl IntoResponse<AwsJson1_1> for Error {
     fn into_response(self) -> http::Response<BoxBody> {
         match self {
             Error::MethodNotAllowed => method_disallowed(),

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/mod.rs
@@ -6,4 +6,4 @@
 pub mod router;
 
 /// [AWS REST JSON 1.0 Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-restjson1-protocol.html).
-pub struct AwsRestJson1;
+pub struct RestJson1;

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/router.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/router.rs
@@ -9,11 +9,11 @@ use crate::proto::rest::router::Error;
 use crate::response::IntoResponse;
 use crate::routers::{method_disallowed, UNKNOWN_OPERATION_EXCEPTION};
 
-use super::AwsRestJson1;
+use super::RestJson1;
 
 pub use crate::proto::rest::router::*;
 
-impl IntoResponse<AwsRestJson1> for Error {
+impl IntoResponse<RestJson1> for Error {
     fn into_response(self) -> http::Response<BoxBody> {
         match self {
             Error::NotFound => http::Response::builder()

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/mod.rs
@@ -6,4 +6,4 @@
 pub mod router;
 
 /// [AWS REST XML Protocol](https://awslabs.github.io/smithy/2.0/aws/protocols/aws-restxml-protocol.html).
-pub struct AwsRestXml;
+pub struct RestXml;

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/router.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/router.rs
@@ -11,12 +11,12 @@ use crate::response::IntoResponse;
 use crate::routers::method_disallowed;
 use crate::routers::UNKNOWN_OPERATION_EXCEPTION;
 
-use super::AwsRestXml;
+use super::RestXml;
 
 pub use crate::proto::rest::router::*;
 
 /// An AWS REST routing error.
-impl IntoResponse<AwsRestXml> for Error {
+impl IntoResponse<RestXml> for Error {
     fn into_response(self) -> http::Response<BoxBody> {
         match self {
             Error::NotFound => http::Response::builder()
@@ -26,7 +26,7 @@ impl IntoResponse<AwsRestXml> for Error {
                     UNKNOWN_OPERATION_EXCEPTION.to_string(),
                 ))
                 .body(empty())
-                .expect("invalid HTTP response for REST JSON routing error; please file a bug report under https://github.com/awslabs/smithy-rs/issues"),
+                .expect("invalid HTTP response for REST XML routing error; please file a bug report under https://github.com/awslabs/smithy-rs/issues"),
             Error::MethodNotAllowed => method_disallowed(),
         }
     }

--- a/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/mod.rs
@@ -16,8 +16,8 @@ use self::request_spec::RequestSpec;
 use crate::{
     body::{boxed, Body, BoxBody, HttpBody},
     proto::{
-        aws_json::router::AwsJsonRouter, aws_json_10::AwsJson10, aws_json_11::AwsJson11, rest::router::RestRouter,
-        rest_json_1::AwsRestJson1, rest_xml::AwsRestXml,
+        aws_json::router::AwsJsonRouter, aws_json_10::AwsJson1_0, aws_json_11::AwsJson1_1, rest::router::RestRouter,
+        rest_json_1::RestJson1, rest_xml::RestXml,
     },
 };
 use crate::{error::BoxError, routers::RoutingService};
@@ -75,10 +75,10 @@ pub struct Router<B = Body> {
 /// directly found in the `X-Amz-Target` HTTP header.
 #[derive(Debug)]
 enum Routes<B = Body> {
-    RestXml(RoutingService<RestRouter<Route<B>>, AwsRestXml>),
-    RestJson1(RoutingService<RestRouter<Route<B>>, AwsRestJson1>),
-    AwsJson10(RoutingService<AwsJsonRouter<Route<B>>, AwsJson10>),
-    AwsJson11(RoutingService<AwsJsonRouter<Route<B>>, AwsJson11>),
+    RestXml(RoutingService<RestRouter<Route<B>>, RestXml>),
+    RestJson1(RoutingService<RestRouter<Route<B>>, RestJson1>),
+    AwsJson1_0(RoutingService<AwsJsonRouter<Route<B>>, AwsJson1_0>),
+    AwsJson1_1(RoutingService<AwsJsonRouter<Route<B>>, AwsJson1_1>),
 }
 
 impl<B> Clone for Router<B> {
@@ -90,11 +90,11 @@ impl<B> Clone for Router<B> {
             Routes::RestXml(routes) => Router {
                 routes: Routes::RestXml(routes.clone()),
             },
-            Routes::AwsJson10(routes) => Router {
-                routes: Routes::AwsJson10(routes.clone()),
+            Routes::AwsJson1_0(routes) => Router {
+                routes: Routes::AwsJson1_0(routes.clone()),
             },
-            Routes::AwsJson11(routes) => Router {
-                routes: Routes::AwsJson11(routes.clone()),
+            Routes::AwsJson1_1(routes) => Router {
+                routes: Routes::AwsJson1_1(routes.clone()),
             },
         }
     }
@@ -141,11 +141,11 @@ where
             Routes::RestXml(routes) => Router {
                 routes: Routes::RestXml(routes.map(|router| router.layer(layer).boxed())),
             },
-            Routes::AwsJson10(routes) => Router {
-                routes: Routes::AwsJson10(routes.map(|router| router.layer(layer).boxed())),
+            Routes::AwsJson1_0(routes) => Router {
+                routes: Routes::AwsJson1_0(routes.map(|router| router.layer(layer).boxed())),
             },
-            Routes::AwsJson11(routes) => Router {
-                routes: Routes::AwsJson11(routes.map(|router| router.layer(layer).boxed())),
+            Routes::AwsJson1_1(routes) => Router {
+                routes: Routes::AwsJson1_1(routes.map(|router| router.layer(layer).boxed())),
             },
         }
     }
@@ -219,7 +219,7 @@ where
         );
 
         Self {
-            routes: Routes::AwsJson10(svc),
+            routes: Routes::AwsJson1_0(svc),
         }
     }
 
@@ -244,7 +244,7 @@ where
         );
 
         Self {
-            routes: Routes::AwsJson11(svc),
+            routes: Routes::AwsJson1_1(svc),
         }
     }
 }
@@ -269,8 +269,8 @@ where
             Routes::RestJson1(routes) => routes.call(req),
             Routes::RestXml(routes) => routes.call(req),
             // AwsJson routes.
-            Routes::AwsJson10(routes) => routes.call(req),
-            Routes::AwsJson11(routes) => routes.call(req),
+            Routes::AwsJson1_0(routes) => routes.call(req),
+            Routes::AwsJson1_1(routes) => routes.call(req),
         };
         RouterFuture::new(fut)
     }

--- a/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
+++ b/rust-runtime/aws-smithy-http-server/src/runtime_error.rs
@@ -24,10 +24,10 @@
 use http::StatusCode;
 
 use crate::extension::RuntimeErrorExtension;
-use crate::proto::aws_json_10::AwsJson10;
-use crate::proto::aws_json_11::AwsJson11;
-use crate::proto::rest_json_1::AwsRestJson1;
-use crate::proto::rest_xml::AwsRestXml;
+use crate::proto::aws_json_10::AwsJson1_0;
+use crate::proto::aws_json_11::AwsJson1_1;
+use crate::proto::rest_json_1::RestJson1;
+use crate::proto::rest_xml::RestXml;
 use crate::response::IntoResponse;
 
 #[derive(Debug)]
@@ -67,31 +67,31 @@ impl RuntimeError {
 
 pub struct InternalFailureException;
 
-impl IntoResponse<AwsJson10> for InternalFailureException {
+impl IntoResponse<AwsJson1_0> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsJson10>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
+        IntoResponse::<AwsJson1_0>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
-impl IntoResponse<AwsJson11> for InternalFailureException {
+impl IntoResponse<AwsJson1_1> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsJson11>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
+        IntoResponse::<AwsJson1_1>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
-impl IntoResponse<AwsRestJson1> for InternalFailureException {
+impl IntoResponse<RestJson1> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsRestJson1>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
+        IntoResponse::<RestJson1>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
-impl IntoResponse<AwsRestXml> for InternalFailureException {
+impl IntoResponse<RestXml> for InternalFailureException {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
-        IntoResponse::<AwsRestXml>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
+        IntoResponse::<RestXml>::into_response(RuntimeError::InternalFailure(crate::Error::new(String::new())))
     }
 }
 
-impl IntoResponse<AwsRestJson1> for RuntimeError {
+impl IntoResponse<RestJson1> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
             .status(self.status_code())
@@ -104,7 +104,7 @@ impl IntoResponse<AwsRestJson1> for RuntimeError {
     }
 }
 
-impl IntoResponse<AwsRestXml> for RuntimeError {
+impl IntoResponse<RestXml> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
             .status(self.status_code())
@@ -115,7 +115,7 @@ impl IntoResponse<AwsRestXml> for RuntimeError {
     }
 }
 
-impl IntoResponse<AwsJson10> for RuntimeError {
+impl IntoResponse<AwsJson1_0> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
             .status(self.status_code())
@@ -127,7 +127,7 @@ impl IntoResponse<AwsJson10> for RuntimeError {
     }
 }
 
-impl IntoResponse<AwsJson11> for RuntimeError {
+impl IntoResponse<AwsJson1_1> for RuntimeError {
     fn into_response(self) -> http::Response<crate::body::BoxBody> {
         http::Response::builder()
             .status(self.status_code())


### PR DESCRIPTION
## Motivation and Context

Currently, the protocol zero-sized types, `AwsRestXml` and `AwsRestJson`, are named differently to the actual Shape names. https://awslabs.github.io/smithy/2.0/aws/protocols/index.html

## Description

- Change`AwsRestXml` to `RestXml` to match the `restXml` shape.
- Change `AwsJson10` to `AwsJson1_0` to match `awsJson1_0` shape.
- Change `AwsJson11` to `AwsJson1_1` to match `awsJson1_1` shape.
- Change `AwsRestJson` to `RestJson` to match the `restJson` shape.
