### PR TITLE
Mark `release-2022-10-13` as yanked to fix SDK canary

### DIFF
--- a/tools/ci-cdk/canary-runner/src/generate_matrix.rs
+++ b/tools/ci-cdk/canary-runner/src/generate_matrix.rs
@@ -16,6 +16,7 @@ const KNOWN_YANKED_RELEASE_TAGS: &[&str] = &[
     // There wasn't a release on this date, so this is fine for testing
     "release-2022-07-04",
     // Add release tags here to get the canary passing after yanking a release
+    "release-2022-10-13",
 ];
 
 #[derive(Debug, Parser, Eq, PartialEq)]


### PR DESCRIPTION
## Motivation and Context
`release-2022-10-13` was yanked, and the canary runner needs to be updated as such since the canary is currently failing for it:
https://github.com/awslabs/aws-sdk-rust/actions/runs/3261449431

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
