### PR TITLE
Fix case sensitivity bug in `changelogger`

### DIFF
--- a/tools/changelogger/Cargo.lock
+++ b/tools/changelogger/Cargo.lock
@@ -87,6 +87,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "once_cell",
  "ordinal",
  "pretty_assertions",
  "serde",

--- a/tools/changelogger/Cargo.toml
+++ b/tools/changelogger/Cargo.toml
@@ -17,6 +17,7 @@ opt-level = 0
 [dependencies]
 anyhow = "1.0.57"
 clap = { version = "~3.2.1", features = ["derive"] }
+once_cell = "1.15.0"
 ordinal = "0.3.2"
 serde = { version = "1", features = ["derive"]}
 serde_json = "1"

--- a/tools/changelogger/tests/e2e_test.rs
+++ b/tools/changelogger/tests/e2e_test.rs
@@ -432,7 +432,7 @@ author = "rcoh"
 message = "Fourth change - client"
 references = ["smithy-rs#4"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
-author = "rcoh"
+author = "LukeMathWalker"
 "#;
     let tmp_dir = TempDir::new().unwrap();
     let source_path = tmp_dir.path().join("source.toml");


### PR DESCRIPTION
## Motivation and Context
This fixes a case sensitivity issue with the author check in `changelogger` discovered in the last release (#1854).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
