### PR TITLE
Ability to override the IMDS client in `DefaultCredentialsChain`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -180,3 +180,9 @@ message = "Enable local maven repo dependency override."
 references = ["smithy-rs#1852"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ogudavid"
+
+[[aws-sdk-rust]]
+message = "Ability to override the IMDS client in `DefaultCredentialsChain`"
+references = ["aws-sdk-rust#625"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "kevinpark1217"

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -212,6 +212,14 @@ impl Builder {
         self
     }
 
+    /// Override the IMDS client used for this provider
+    ///
+    /// When unset, the default IMDS client will be used.
+    pub fn imds_client(mut self, client: crate::imds::Client) -> Self {
+        self.imds_builder = self.imds_builder.imds_client(client);
+        self
+    }
+
     /// Override the configuration used for this provider
     pub fn configure(mut self, config: ProviderConfig) -> Self {
         self.region_chain = self.region_chain.configure(&config);


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

This is an alternative method for me to implement necessary retry and timeout for the IMDS client, rather than through environment variables and profile as attempted in #1821 and outlined in [aws-sdk-rust#625](https://github.com/awslabs/aws-sdk-rust/issues/625).

This should give me enough flexibility to navigate around some limitations and be able to implement timeout and retry attempts in code.
            
## Description
<!--- Describe your changes in detail -->

Simple additional helper method to set the IMDS client with custom retry and timeout settings.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

```rust
let attempts = 10;
let timeout = Duration::from_secs(60);

let imds_client = imds::Client::builder()
    .max_attempts(attempts)
    .connect_timeout(timeout)
    .read_timeout(timeout)
    .build()
    .await?;

let chain = DefaultCredentialsChain::builder()
    .region(region)
    .imds_client(imds_client);
```


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
