### PR TITLE
Revamp errors in `aws-smithy-eventstream`

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/EventStreamUnmarshallerGenerator.kt
@@ -125,7 +125,7 @@ class EventStreamUnmarshallerGenerator(
                     }
                     rustBlock("value => ") {
                         rustTemplate(
-                            "return Err(#{Error}::Unmarshalling(format!(\"unrecognized :message-type: {}\", value)));",
+                            "return Err(#{Error}::unmarshalling(format!(\"unrecognized :message-type: {}\", value)));",
                             *codegenScope,
                         )
                     }
@@ -156,7 +156,7 @@ class EventStreamUnmarshallerGenerator(
                         *codegenScope,
                     )
                     false -> rustTemplate(
-                        "return Err(#{Error}::Unmarshalling(format!(\"unrecognized :event-type: {}\", _unknown_variant)));",
+                        "return Err(#{Error}::unmarshalling(format!(\"unrecognized :event-type: {}\", _unknown_variant)));",
                         *codegenScope,
                     )
                 }
@@ -250,7 +250,7 @@ class EventStreamUnmarshallerGenerator(
                 """
                 let content_type = response_headers.content_type().unwrap_or_default();
                 if content_type != ${contentType.dq()} {
-                    return Err(#{Error}::Unmarshalling(format!(
+                    return Err(#{Error}::unmarshalling(format!(
                         "expected :content-type to be '$contentType', but was '{}'",
                         content_type
                     )))
@@ -269,7 +269,7 @@ class EventStreamUnmarshallerGenerator(
                     rustTemplate(
                         """
                         std::str::from_utf8(message.payload())
-                            .map_err(|_| #{Error}::Unmarshalling("message payload is not valid UTF-8".into()))?
+                            .map_err(|_| #{Error}::unmarshalling("message payload is not valid UTF-8"))?
                         """,
                         *codegenScope,
                     )
@@ -288,7 +288,7 @@ class EventStreamUnmarshallerGenerator(
             """
             #{parser}(&message.payload()[..])
                 .map_err(|err| {
-                    #{Error}::Unmarshalling(format!("failed to unmarshall $memberName: {}", err))
+                    #{Error}::unmarshalling(format!("failed to unmarshall $memberName: {}", err))
                 })?
             """,
             "parser" to parser,
@@ -336,7 +336,7 @@ class EventStreamUnmarshallerGenerator(
                                     """
                                     builder = #{parser}(&message.payload()[..], builder)
                                         .map_err(|err| {
-                                            #{Error}::Unmarshalling(format!("failed to unmarshall ${member.memberName}: {}", err))
+                                            #{Error}::unmarshalling(format!("failed to unmarshall ${member.memberName}: {}", err))
                                         })?;
                                     return Ok(#{UnmarshalledMessage}::Error(
                                         #{OpError}::new(
@@ -360,7 +360,7 @@ class EventStreamUnmarshallerGenerator(
                                     """
                                     builder = #{parser}(&message.payload()[..], builder)
                                         .map_err(|err| {
-                                            #{Error}::Unmarshalling(format!("failed to unmarshall ${member.memberName}: {}", err))
+                                            #{Error}::unmarshalling(format!("failed to unmarshall ${member.memberName}: {}", err))
                                         })?;
                                     """,
                                     "parser" to parser,
@@ -394,7 +394,7 @@ class EventStreamUnmarshallerGenerator(
             CodegenTarget.SERVER -> {
                 rustTemplate(
                     """
-                    return Err(aws_smithy_eventstream::error::Error::Unmarshalling(
+                    return Err(aws_smithy_eventstream::error::Error::unmarshalling(
                     format!("unrecognized exception: {}", response_headers.smithy_type.as_str()),
                     ));
                     """,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamErrorMarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamErrorMarshallerGenerator.kt
@@ -124,7 +124,7 @@ class EventStreamErrorMarshallerGenerator(
                             rustTemplate(
                                 """
                                 $errorName::Unhandled(_inner) => return Err(
-                                    #{Error}::Marshalling(${unknownVariantError(unionSymbol.rustType().name).dq()}.to_owned())
+                                    #{Error}::marshalling(${unknownVariantError(unionSymbol.rustType().name).dq()}.to_owned())
                                 ),
                                 """,
                                 *codegenScope,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamMarshallerGenerator.kt
@@ -112,7 +112,7 @@ open class EventStreamMarshallerGenerator(
                         rustTemplate(
                             """
                             Self::Input::${UnionGenerator.UnknownVariantName} => return Err(
-                                #{Error}::Marshalling(${unknownVariantError(unionSymbol.rustType().name).dq()}.to_owned())
+                                #{Error}::marshalling(${unknownVariantError(unionSymbol.rustType().name).dq()}.to_owned())
                             )
                             """,
                             *codegenScope,
@@ -212,7 +212,7 @@ open class EventStreamMarshallerGenerator(
                     rustTemplate(
                         """
                         #{serializerFn}(&$input)
-                            .map_err(|err| #{Error}::Marshalling(format!("{}", err)))?
+                            .map_err(|err| #{Error}::marshalling(format!("{}", err)))?
                         """,
                         "serializerFn" to serializerFn,
                         *codegenScope,

--- a/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
@@ -215,7 +215,9 @@ mod tests {
         type Input = TestServiceError;
 
         fn marshall(&self, _input: Self::Input) -> Result<Message, EventStreamError> {
-            Err(EventStreamError::InvalidMessageLength)
+            Err(Message::read_from(&b""[..])
+                .err()
+                .expect("this should always fail"))
         }
     }
 


### PR DESCRIPTION
## Motivation and Context
This PR revamps errors in `aws-smithy-eventstream` to adhere to [RFC-0022: Error Context and Compatibility](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).

This PR is part of a series that will fully implement the RFC, tracked in #1926.

Changelog entries added in #1951.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
