### PR TITLE
Unpin xmlparser.

### DIFF
--- a/rust-runtime/aws-smithy-xml/Cargo.toml
+++ b/rust-runtime/aws-smithy-xml/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [dependencies]
-xmlparser = "=0.13.3"
+xmlparser = "0.13.3"
 
 [dev-dependencies]
 aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test" }


### PR DESCRIPTION
## Motivation and Context
Dependencies shouldn't be pinned. It causes dependency resolution failures as cargo selects `0.13.6` and then finds the constraint `=0.13.3` which it fails to resolve. Pinning dependencies is always a bad idea. Alternatively someone could improve the cargo version constraint solver.