### PR TITLE
Update `aws-smithy-xml` `xmlparser` dep to v0.13.5

### DIFF
--- a/rust-runtime/aws-smithy-xml/Cargo.toml
+++ b/rust-runtime/aws-smithy-xml/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [dependencies]
-xmlparser = "=0.13.3"
+xmlparser = "0.13.5"
 
 [dev-dependencies]
 aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test" }

--- a/rust-runtime/aws-smithy-xml/src/decode.rs
+++ b/rust-runtime/aws-smithy-xml/src/decode.rs
@@ -540,7 +540,7 @@ mod test {
     }
 
     #[test]
-    fn escape_data() {
+    fn unescape_data() {
         let xml = r#"<Response key="&quot;hey&quot;>">&gt;</Response>"#;
         let mut doc = Document::new(xml);
         let mut root = doc.root_element().unwrap();


### PR DESCRIPTION
Thanks to @dvc94ch for uncovering this issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
#1877 

## Description
<!--- Describe your changes in detail -->
This updates a dependency in response to a customer issue reported in #1877. Originally, this version was pinned because the next version (v0.13.4) removed support for [predefined entities](https://www.oreilly.com/library/view/xml-in-a/0596007647/re05.html). The latest version (v0.13.5) has re-added support so I've updated the `aws-smithy-xml` crate to that version. We also had preëxisting tests, but one had a misleading name so I updated that name as well.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran preëxisting tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
