### PR TITLE
Add `#[non_exhaustive]` to example actionable error in RFC

### DIFF
--- a/design/src/rfcs/rfc0022_error_context_and_compatibility.md
+++ b/design/src/rfcs/rfc0022_error_context_and_compatibility.md
@@ -233,6 +233,7 @@ Actionable errors are represented as enums. If an error variant has an error sou
 information, it must use a separate context struct that is referenced via tuple in the enum. For example:
 
 ```rust
+#[non_exhaustive]
 pub enum Error {
     // Good: This is exhaustive and uses a tuple, but its sole member is an extensible struct with private fields
     VariantA(VariantA),

--- a/design/src/rfcs/rfc0022_error_context_and_compatibility.md
+++ b/design/src/rfcs/rfc0022_error_context_and_compatibility.md
@@ -233,6 +233,7 @@ Actionable errors are represented as enums. If an error variant has an error sou
 information, it must use a separate context struct that is referenced via tuple in the enum. For example:
 
 ```rust
+// Good: new error types can be added in the future
 #[non_exhaustive]
 pub enum Error {
     // Good: This is exhaustive and uses a tuple, but its sole member is an extensible struct with private fields


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._