### PR TITLE
Revamp errors in `aws-smithy-http`

### DIFF
--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -218,7 +218,7 @@ impl Client {
                     InnerImdsError::InvalidUtf8 => {
                         ImdsError::Unexpected("IMDS returned invalid UTF-8".into())
                     }
-                    _ => ImdsError::ErrorResponse {
+                    InnerImdsError::BadStatus => ImdsError::ErrorResponse {
                         response: context.into_raw().into_parts().0,
                     },
                 },

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -206,23 +206,26 @@ impl Client {
             .call(operation)
             .await
             .map_err(|err| match err {
-                SdkError::ConstructionFailure(err) => match err.downcast::<ImdsError>() {
-                    Ok(token_failure) => *token_failure,
-                    Err(other) => ImdsError::Unexpected(other),
+                SdkError::ConstructionFailure(_) if err.source().is_some() => {
+                    match err.into_source().map(|e| e.downcast::<ImdsError>()) {
+                        Ok(Ok(token_failure)) => *token_failure,
+                        Ok(Err(err)) => ImdsError::Unexpected(err),
+                        Err(err) => ImdsError::Unexpected(err.into()),
+                    }
+                }
+                SdkError::ConstructionFailure(_) => ImdsError::Unexpected(err.into()),
+                SdkError::ServiceError(context) => match context.err() {
+                    InnerImdsError::InvalidUtf8 => {
+                        ImdsError::Unexpected("IMDS returned invalid UTF-8".into())
+                    }
+                    _ => ImdsError::ErrorResponse {
+                        response: context.into_raw().into_parts().0,
+                    },
                 },
-                SdkError::TimeoutError(err) => ImdsError::IoError(err),
-                SdkError::DispatchFailure(err) => ImdsError::IoError(err.into()),
-                SdkError::ResponseError { err, .. } => ImdsError::IoError(err),
-                SdkError::ServiceError {
-                    err: InnerImdsError::BadStatus,
-                    raw,
-                } => ImdsError::ErrorResponse {
-                    response: raw.into_parts().0,
-                },
-                SdkError::ServiceError {
-                    err: InnerImdsError::InvalidUtf8,
-                    ..
-                } => ImdsError::Unexpected("IMDS returned invalid UTF-8".into()),
+                SdkError::TimeoutError(_)
+                | SdkError::DispatchFailure(_)
+                | SdkError::ResponseError(_) => ImdsError::IoError(err.into()),
+                _ => ImdsError::Unexpected(err.into()),
             })
     }
 
@@ -735,9 +738,8 @@ impl<T, E> ClassifyRetry<SdkSuccess<T>, SdkError<E>> for ImdsResponseRetryClassi
     fn classify_retry(&self, response: Result<&SdkSuccess<T>, &SdkError<E>>) -> RetryKind {
         match response {
             Ok(_) => RetryKind::Unnecessary,
-            Err(SdkError::ResponseError { raw, .. }) | Err(SdkError::ServiceError { raw, .. }) => {
-                Self::classify(raw)
-            }
+            Err(SdkError::ResponseError(context)) => Self::classify(context.raw()),
+            Err(SdkError::ServiceError(context)) => Self::classify(context.raw()),
             _ => RetryKind::UnretryableFailure,
         }
     }
@@ -763,6 +765,21 @@ pub(crate) mod test {
     use std::io;
     use std::time::{Duration, UNIX_EPOCH};
     use tracing_test::traced_test;
+
+    macro_rules! assert_full_error_contains {
+        ($err:expr, $contains:expr) => {
+            let err = $err;
+            let message = format!(
+                "{}",
+                aws_smithy_types::error::display::DisplayErrorContext(&err)
+            );
+            assert!(
+                message.contains($contains),
+                "Error message '{message}' didn't contain text '{}'",
+                $contains
+            );
+        };
+    }
 
     const TOKEN_A: &str = "AQAEAFTNrA4eEGx0AQgJ1arIq_Cc-t4tWt3fB0Hd8RKhXlKc5ccvhg==";
     const TOKEN_B: &str = "alternatetoken==";
@@ -1027,7 +1044,7 @@ pub(crate) mod test {
         )]);
         let client = make_client(&connection).await;
         let err = client.get("/latest/metadata").await.expect_err("no token");
-        assert!(format!("{}", err).contains("forbidden"), "{}", err);
+        assert_full_error_contains!(err, "forbidden");
         connection.assert_requests_match(&[]);
     }
 
@@ -1050,10 +1067,10 @@ pub(crate) mod test {
         );
 
         // Emulate a failure to parse the response body (using an io error since it's easy to construct in a test)
-        let failure = SdkError::<()>::ResponseError {
-            err: Box::new(io::Error::new(io::ErrorKind::BrokenPipe, "fail to parse")),
-            raw: response_200(),
-        };
+        let failure = SdkError::<()>::response_error(
+            io::Error::new(io::ErrorKind::BrokenPipe, "fail to parse"),
+            response_200(),
+        );
         assert_eq!(
             RetryKind::UnretryableFailure,
             classifier.classify_retry(Err::<&SdkSuccess<()>, _>(&failure))
@@ -1069,7 +1086,7 @@ pub(crate) mod test {
         )]);
         let client = make_client(&connection).await;
         let err = client.get("/latest/metadata").await.expect_err("no token");
-        assert!(format!("{}", err).contains("Invalid Token"), "{}", err);
+        assert_full_error_contains!(err, "Invalid Token");
         connection.assert_requests_match(&[]);
     }
 
@@ -1090,7 +1107,7 @@ pub(crate) mod test {
         ]);
         let client = make_client(&connection).await;
         let err = client.get("/latest/metadata").await.expect_err("no token");
-        assert!(format!("{}", err).contains("invalid UTF-8"), "{}", err);
+        assert_full_error_contains!(err, "invalid UTF-8");
         connection.assert_requests_match(&[]);
     }
 
@@ -1099,6 +1116,7 @@ pub(crate) mod test {
     #[cfg(any(feature = "rustls", feature = "native-tls"))]
     async fn one_second_connect_timeout() {
         use crate::imds::client::ImdsError;
+        use aws_smithy_types::error::display::DisplayErrorContext;
         use std::time::SystemTime;
 
         let client = Client::builder()
@@ -1124,7 +1142,8 @@ pub(crate) mod test {
             time_elapsed
         );
         match resp {
-            ImdsError::FailedToLoadToken(err) if format!("{}", err).contains("timeout") => {} // ok,
+            ImdsError::FailedToLoadToken(err)
+                if format!("{}", DisplayErrorContext(&err)).contains("timeout") => {} // ok,
             other => panic!(
                 "wrong error, expected construction failure with TimedOutError inside: {}",
                 other
@@ -1182,12 +1201,7 @@ pub(crate) mod test {
                 test, test_case.docs
             ),
             (Err(substr), Err(err)) => {
-                assert!(
-                    format!("{}", err).contains(substr),
-                    "`{}` did not contain `{}`",
-                    err,
-                    substr
-                );
+                assert_full_error_contains!(err, substr);
                 return;
             }
             (Ok(_uri), Err(e)) => panic!(

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -14,6 +14,7 @@ use aws_types::os_shim_internal::{Env, Fs};
 use serde::Deserialize;
 
 use crate::connector::default_connector;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::Debug;
@@ -100,12 +101,11 @@ where
                 assert_eq!(expected, &actual.into(), "incorrect result was returned")
             }
             (Err(err), GenericTestResult::ErrorContains(substr)) => {
+                let message = format!("{}", DisplayErrorContext(&err));
                 assert!(
-                    format!("{}", err).contains(substr),
-                    "`{}` did not contain `{}`",
-                    err,
-                    substr
-                )
+                    message.contains(substr),
+                    "`{message}` did not contain `{substr}`"
+                );
             }
             (Err(actual_error), GenericTestResult::Ok(expected_creds)) => panic!(
                 "expected credentials ({:?}) but an error was returned: {}",

--- a/aws/rust-runtime/aws-http/src/retry.rs
+++ b/aws/rust-runtime/aws-http/src/retry.rs
@@ -141,10 +141,10 @@ mod test {
         err: E,
         raw: http::Response<&'static str>,
     ) -> Result<SdkSuccess<()>, SdkError<E>> {
-        Err(SdkError::ServiceError {
+        Err(SdkError::service_error(
             err,
-            raw: operation::Response::new(raw.map(SdkBody::from)),
-        })
+            operation::Response::new(raw.map(SdkBody::from)),
+        ))
     }
 
     #[test]
@@ -263,10 +263,10 @@ mod test {
         let policy = AwsResponseRetryClassifier::new();
         assert_eq!(
             policy.classify_retry(
-                Result::<SdkSuccess<()>, SdkError<UnmodeledError>>::Err(SdkError::ResponseError {
-                    err: Box::new(UnmodeledError),
-                    raw: operation::Response::new(http::Response::new("OK").map(SdkBody::from)),
-                })
+                Result::<SdkSuccess<()>, SdkError<UnmodeledError>>::Err(SdkError::response_error(
+                    UnmodeledError,
+                    operation::Response::new(http::Response::new("OK").map(SdkBody::from)),
+                ))
                 .as_ref()
             ),
             RetryKind::Error(ErrorKind::TransientError)
@@ -276,7 +276,7 @@ mod test {
     #[test]
     fn test_timeout_error() {
         let policy = AwsResponseRetryClassifier::new();
-        let err: Result<(), SdkError<UnmodeledError>> = Err(SdkError::TimeoutError("blah".into()));
+        let err: Result<(), SdkError<UnmodeledError>> = Err(SdkError::timeout_error("blah"));
         assert_eq!(
             policy.classify_retry(err.as_ref()),
             RetryKind::Error(ErrorKind::TransientError)

--- a/aws/rust-runtime/aws-inlineable/src/glacier_checksums.rs
+++ b/aws/rust-runtime/aws-inlineable/src/glacier_checksums.rs
@@ -28,7 +28,7 @@ const X_AMZ_CONTENT_SHA256: &str = "x-amz-content-sha256";
 /// chunk (if it exists) is paired at the end.
 ///
 /// See <https://docs.aws.amazon.com/amazonglacier/latest/dev/checksum-calculations.html> for more information.
-pub async fn add_checksum_treehash(request: &mut Request) -> Result<(), byte_stream::Error> {
+pub async fn add_checksum_treehash(request: &mut Request) -> Result<(), byte_stream::error::Error> {
     let cloneable = request.http().body().try_clone();
     let http_request = request.http_mut();
     let body_to_process = if let Some(cloned_body) = cloneable {
@@ -67,7 +67,7 @@ const MEGABYTE: usize = 1024 * 1024;
 async fn compute_hashes(
     body: SdkBody,
     chunk_size: usize,
-) -> Result<(Digest, Vec<Digest>), byte_stream::Error> {
+) -> Result<(Digest, Vec<Digest>), byte_stream::error::Error> {
     let mut hashes = vec![];
     let mut remaining_in_chunk = chunk_size;
     let mut body = ByteStream::new(body);

--- a/aws/rust-runtime/aws-inlineable/src/http_body_checksum.rs
+++ b/aws/rust-runtime/aws-inlineable/src/http_body_checksum.rs
@@ -5,6 +5,7 @@
 
 //! Functions for modifying requests and responses for the purposes of checksum validation
 
+use aws_smithy_http::operation::error::BuildError;
 use http::header::HeaderName;
 
 /// Errors related to constructing checksum-validated HTTP requests
@@ -43,7 +44,7 @@ pub(crate) fn add_checksum_calculation_to_request(
     request: &mut http::request::Request<aws_smithy_http::body::SdkBody>,
     property_bag: &mut aws_smithy_http::property_bag::PropertyBag,
     checksum_algorithm: aws_smithy_checksums::ChecksumAlgorithm,
-) -> Result<(), aws_smithy_http::operation::BuildError> {
+) -> Result<(), BuildError> {
     match request.body().bytes() {
         // Body is in-memory: read it and insert the checksum as a header.
         Some(data) => {
@@ -72,14 +73,16 @@ fn wrap_streaming_request_body_in_checksum_calculating_body(
     request: &mut http::request::Request<aws_smithy_http::body::SdkBody>,
     property_bag: &mut aws_smithy_http::property_bag::PropertyBag,
     checksum_algorithm: aws_smithy_checksums::ChecksumAlgorithm,
-) -> Result<(), aws_smithy_http::operation::BuildError> {
+) -> Result<(), BuildError> {
     use aws_http::content_encoding::{AwsChunkedBody, AwsChunkedBodyOptions};
     use aws_smithy_checksums::{body::calculate, http::HttpChecksum};
     use http_body::Body;
 
-    let original_body_size = request.body().size_hint().exact().ok_or_else(|| {
-        aws_smithy_http::operation::BuildError::Other(Box::new(Error::UnsizedRequestBody))
-    })?;
+    let original_body_size = request
+        .body()
+        .size_hint()
+        .exact()
+        .ok_or_else(|| BuildError::other(Error::UnsizedRequestBody))?;
 
     // Streaming request bodies with trailers require special signing
     property_bag.insert(aws_sig_auth::signer::SignableBody::StreamingUnsignedPayloadTrailer);
@@ -100,9 +103,10 @@ fn wrap_streaming_request_body_in_checksum_calculating_body(
         })
     };
 
-    let encoded_content_length = body.size_hint().exact().ok_or_else(|| {
-        aws_smithy_http::operation::BuildError::Other(Box::new(Error::UnsizedRequestBody))
-    })?;
+    let encoded_content_length = body
+        .size_hint()
+        .exact()
+        .ok_or_else(|| BuildError::other(Error::UnsizedRequestBody))?;
 
     let headers = request.headers_mut();
 
@@ -123,7 +127,7 @@ fn wrap_streaming_request_body_in_checksum_calculating_body(
     headers.insert(
         http::header::CONTENT_ENCODING,
         http::HeaderValue::from_str(aws_http::content_encoding::header_value::AWS_CHUNKED)
-            .map_err(|err| aws_smithy_http::operation::BuildError::Other(Box::new(err)))
+            .map_err(BuildError::other)
             .expect("\"aws-chunked\" will always be a valid HeaderValue"),
     );
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -302,7 +302,7 @@ private fun renderCustomizableOperationSendMethod(
             /// Sends this operation's request
             pub async fn send<T, E>(self) -> Result<T, SdkError<E>>
             where
-                E: std::error::Error,
+                E: std::error::Error + 'static,
                 O: #{ParseHttpResponse}<Output = Result<T, E>> + Send + Sync + Clone + 'static,
                 Retry: #{ClassifyRetry}<#{SdkSuccess}<T>, SdkError<E>> + Send + Sync + Clone,
             {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -197,7 +197,7 @@ class AwsInputPresignedMethod(
                 """
                 let (mut request, _) = self.$makeOperationFn(config)
                     .await
-                    .map_err(|err| #{SdkError}::ConstructionFailure(err.into()))?
+                    .map_err(#{SdkError}::construction_failure)?
                     .into_request_response();
                 """,
                 *codegenScope,
@@ -272,7 +272,7 @@ class AwsPresignedFluentBuilderMethod(
                 ) {
                     rustTemplate(
                         """
-                        let input = self.inner.build().map_err(|err| #{SdkError}::ConstructionFailure(err.into()))?;
+                        let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
                         input.presigned(&self.handle.conf, presigning_config).await
                         """,
                         *codegenScope,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -99,7 +99,7 @@ private fun HttpChecksumTrait.checksumAlgorithmToStr(
             let checksum_algorithm = match checksum_algorithm {
                 Some(algo) => Some(
                     algo.parse::<#{ChecksumAlgorithm}>()
-                    .map_err(|err| #{BuildError}::Other(Box::new(err)))?
+                    .map_err(#{BuildError}::other)?
                 ),
                 None => None,
             };

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/TreeHashHeader.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/TreeHashHeader.kt
@@ -45,7 +45,7 @@ class TreeHashHeader(private val runtimeConfig: RuntimeConfig) : OperationCustom
                     """
                     #{glacier_checksums}::add_checksum_treehash(
                         &mut ${section.request}
-                    ).await.map_err(|e|#{BuildError}::Other(e.into()))?;
+                    ).await.map_err(#{BuildError}::other)?;
                     """,
                     "glacier_checksums" to glacierChecksums, "BuildError" to runtimeConfig.operationBuildError(),
                 )

--- a/aws/sdk/integration-tests/kms/tests/integration.rs
+++ b/aws/sdk/integration-tests/kms/tests/integration.rs
@@ -194,7 +194,7 @@ async fn generate_random_keystore_not_found() {
     let client = Client::new(conn.clone());
     let err = client.call(op).await.expect_err("key store doesn't exist");
     let inner = match err {
-        SdkError::ServiceError { err, .. } => err,
+        SdkError::ServiceError(context) => context.into_err(),
         other => panic!("Incorrect error received: {:}", other),
     };
     assert!(inner.is_custom_key_store_not_found_exception());

--- a/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
+++ b/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
@@ -87,13 +87,12 @@ async fn errors_are_retryable() {
             br#"{ "code": "LimitExceededException" }"#,
         ))
         .unwrap();
-    let err = op
-        .response_handler
-        .parse(&http_response)
-        .map_err(|e| SdkError::ServiceError {
-            err: e,
-            raw: operation::Response::new(http_response.map(SdkBody::from)),
-        });
+    let err = op.response_handler.parse(&http_response).map_err(|e| {
+        SdkError::service_error(
+            e,
+            operation::Response::new(http_response.map(SdkBody::from)),
+        )
+    });
     let retry_kind = op.retry_classifier.classify_retry(err.as_ref());
     assert_eq!(retry_kind, RetryKind::Error(ErrorKind::ThrottlingError));
 }
@@ -105,13 +104,12 @@ async fn unmodeled_errors_are_retryable() {
         .status(400)
         .body(Bytes::from_static(br#"{ "code": "ThrottlingException" }"#))
         .unwrap();
-    let err = op
-        .response_handler
-        .parse(&http_response)
-        .map_err(|e| SdkError::ServiceError {
-            err: e,
-            raw: operation::Response::new(http_response.map(SdkBody::from)),
-        });
+    let err = op.response_handler.parse(&http_response).map_err(|e| {
+        SdkError::service_error(
+            e,
+            operation::Response::new(http_response.map(SdkBody::from)),
+        )
+    });
     let retry_kind = op.retry_classifier.classify_retry(err.as_ref());
     assert_eq!(retry_kind, RetryKind::Error(ErrorKind::ThrottlingError));
 }

--- a/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
+++ b/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
@@ -116,7 +116,7 @@ async fn timeout_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std
         .await
         .unwrap_err();
 
-    assert_eq!(format!("{:?}", err), "TimeoutError(RequestTimeoutError { kind: \"operation timeout (all attempts including retries)\", duration: 500ms })");
+    assert_eq!("TimeoutError(TimeoutError { source: RequestTimeoutError { kind: \"operation timeout (all attempts including retries)\", duration: 500ms } })", format!("{:?}", err));
     // Assert 500ms have passed with a 10ms margin of error
     assert_elapsed!(now, Duration::from_millis(500), Duration::from_millis(10));
 
@@ -152,8 +152,8 @@ async fn retry_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std::
         resp
     );
     assert_eq!(
-        conn.num_calls(),
         3,
+        conn.num_calls(),
         "client level timeouts should be retried"
     );
 

--- a/aws/sdk/integration-tests/s3/tests/query-strings-are-correctly-encoded.rs
+++ b/aws/sdk/integration-tests/s3/tests/query-strings-are-correctly-encoded.rs
@@ -97,11 +97,8 @@ async fn test_query_strings_are_correctly_encoded() {
             .prefix(char)
             .send()
             .await;
-        if let Err(SdkError::ServiceError {
-            err: ListObjectsV2Error { kind, .. },
-            ..
-        }) = res
-        {
+        if let Err(SdkError::ServiceError(context)) = res {
+            let ListObjectsV2Error { kind, .. } = context.err();
             match kind {
                 ListObjectsV2ErrorKind::Unhandled(e)
                     if e.to_string().contains("SignatureDoesNotMatch") =>

--- a/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
+++ b/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
@@ -75,19 +75,18 @@ async fn test_error() {
         start_request("us-east-1", include_str!("error.json"), input_stream).await;
 
     match output.transcript_result_stream.recv().await {
-        Err(SdkError::ServiceError {
-            err:
-                TranscriptResultStreamError {
-                    kind: TranscriptResultStreamErrorKind::BadRequestException(err),
-                    ..
-                },
-            ..
-        }) => {
-            assert_eq!(
-                Some("A complete signal was sent without the preceding empty frame."),
-                err.message()
-            );
-        }
+        Err(SdkError::ServiceError(context)) => match context.err() {
+            TranscriptResultStreamError {
+                kind: TranscriptResultStreamErrorKind::BadRequestException(err),
+                ..
+            } => {
+                assert_eq!(
+                    Some("A complete signal was sent without the preceding empty frame."),
+                    err.message()
+                );
+            }
+            otherwise => panic!("Expected BadRequestException, got: {:?}", otherwise),
+        },
         otherwise => panic!("Expected BadRequestException, got: {:?}", otherwise),
     }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingGenerator.kt
@@ -58,7 +58,6 @@ class EndpointTraitBindings(
                 "EndpointPrefix" to endpointPrefix,
             )
         } else {
-            val operationBuildError = OperationBuildError(runtimeConfig)
             writer.rustBlock("") {
                 // build a list of args: `labelname = "field"`
                 // these eventually end up in the format! macro invocation:
@@ -66,23 +65,22 @@ class EndpointTraitBindings(
                 val args = endpointTrait.hostPrefix.labels.map { label ->
                     val memberShape = inputShape.getMember(label.content).get()
                     val field = symbolProvider.toMemberName(memberShape)
-                    val invalidFieldError = operationBuildError.invalidField(
-                        writer,
-                        field,
-                        "$field was unset or empty but must be set as part of the endpoint prefix",
-                    )
                     if (symbolProvider.toSymbol(memberShape).isOptional()) {
                         rust("let $field = $input.$field.as_deref().unwrap_or_default();")
                     } else {
                         // NOTE: this is dead code until we start respecting @required
                         rust("let $field = &$input.$field;")
                     }
-                    rust(
+                    rustTemplate(
                         """
                         if $field.is_empty() {
-                            return Err($invalidFieldError)
+                            return Err(#{invalidFieldError:W})
                         }
                         """,
+                        "invalidFieldError" to OperationBuildError(runtimeConfig).invalidField(
+                            field,
+                            "$field was unset or empty but must be set as part of the endpoint prefix",
+                        ),
                     )
                     "${label.content} = $field"
                 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGenerator.kt
@@ -172,14 +172,14 @@ class PaginatorGenerator private constructor(
                     let handle = self.handle;
                     #{fn_stream}::FnStream::new(move |tx| Box::pin(async move {
                         // Build the input for the first time. If required fields are missing, this is where we'll produce an early error.
-                        let mut input = match builder.build().map_err(|err| #{SdkError}::ConstructionFailure(err.into())) {
+                        let mut input = match builder.build().map_err(#{SdkError}::construction_failure) {
                             Ok(input) => input,
                             Err(e) => { let _ = tx.send(Err(e)).await; return; }
                         };
                         loop {
                             let op = match input.make_operation(&handle.conf)
                                 .await
-                                .map_err(|err| #{SdkError}::ConstructionFailure(err.into())) {
+                                .map_err(#{SdkError}::construction_failure) {
                                 Ok(op) => op,
                                 Err(e) => {
                                     let _ = tx.send(Err(e)).await;

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -167,7 +167,7 @@ class CustomizableOperationGenerator(
                 /// Sends this operation's request
                 pub async fn send<T, E>(self) -> Result<T, SdkError<E>>
                 where
-                    E: std::error::Error,
+                    E: std::error::Error + 'static,
                     O: #{ParseHttpResponse}<Output = Result<T, E>> + Send + Sync + Clone + 'static,
                     Retry: Send + Sync + Clone,
                     <R as #{NewRequestPolicy}>::Policy: #{SmithyRetryPolicy}<O, T, E, Retry> + Clone,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -283,10 +283,10 @@ class FluentClientGenerator(
                             #{SdkError}<#{OperationError}>
                         > #{send_bounds:W} {
                             let handle = self.handle.clone();
-                            let operation = self.inner.build().map_err(|err|#{SdkError}::ConstructionFailure(err.into()))?
+                            let operation = self.inner.build().map_err(#{SdkError}::construction_failure)?
                                 .make_operation(&handle.conf)
                                 .await
-                                .map_err(|err|#{SdkError}::ConstructionFailure(err.into()))?;
+                                .map_err(#{SdkError}::construction_failure)?;
                             Ok(crate::operation::customize::CustomizableOperation { handle, operation })
                         }
 
@@ -300,10 +300,10 @@ class FluentClientGenerator(
                         /// set when configuring the client.
                         pub async fn send(self) -> std::result::Result<#{OperationOutput}, #{SdkError}<#{OperationError}>>
                         #{send_bounds:W} {
-                            let op = self.inner.build().map_err(|err|#{SdkError}::ConstructionFailure(err.into()))?
+                            let op = self.inner.build().map_err(#{SdkError}::construction_failure)?
                                 .make_operation(&self.handle.conf)
                                 .await
-                                .map_err(|err|#{SdkError}::ConstructionFailure(err.into()))?;
+                                .map_err(#{SdkError}::construction_failure)?;
                             self.handle.client.call(op).await
                         }
                         """,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/TopLevelErrorGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/TopLevelErrorGenerator.kt
@@ -107,7 +107,7 @@ class TopLevelErrorGenerator(private val codegenContext: CodegenContext, private
                 ) {
                     rustBlock("match err") {
                         val operationErrors = errors.map { model.expectShape(it) }
-                        rustBlock("#T::ServiceError { err, ..} => match err.kind", sdkError) {
+                        rustBlock("#T::ServiceError(context) => match context.into_err().kind", sdkError) {
                             operationErrors.forEach { errorShape ->
                                 val errSymbol = symbolProvider.toSymbol(errorShape)
                                 rust(

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/RequestBindingGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/RequestBindingGeneratorTest.kt
@@ -245,7 +245,7 @@ class RequestBindingGeneratorTest {
                         .prefix("😹".to_string(), "😹".to_string())
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't make a header out of a cat emoji");
-                    assert_eq!(format!("{}", err), "Invalid field in input: prefix (Details: `😹` cannot be used as a header name: invalid HTTP header name)");
+                    assert_eq!(format!("{}", err), "invalid field in input: prefix (details: `😹` cannot be used as a header name: invalid HTTP header name)");
                 """,
             )
 
@@ -260,7 +260,7 @@ class RequestBindingGeneratorTest {
                         .prefix("valid-key".to_string(), "\n can't put a newline in a header value".to_string())
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't make a header with a newline");
-                    assert_eq!(format!("{}", err), "Invalid field in input: prefix (Details: `\n can\'t put a newline in a header value` cannot be used as a header value: failed to parse header value)");
+                    assert_eq!(format!("{}", err), "invalid field in input: prefix (details: `\n can\'t put a newline in a header value` cannot be used as a header value: failed to parse header value)");
                 """,
             )
 
@@ -275,7 +275,7 @@ class RequestBindingGeneratorTest {
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't make a header with a newline");
                     // make sure we obey the sensitive trait
-                    assert_eq!(format!("{}", err), "Invalid field in input: string_header (Details: `*** Sensitive Data Redacted ***` cannot be used as a header value: failed to parse header value)");
+                    assert_eq!(format!("{}", err), "invalid field in input: string_header (details: `*** Sensitive Data Redacted ***` cannot be used as a header value: failed to parse header value)");
                 """,
             )
 
@@ -289,7 +289,9 @@ class RequestBindingGeneratorTest {
                         .key(ts.clone())
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-                    assert!(matches!(err, ${format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
+                    let message = format!("{err}");
+                    let expected = "bucket_name was missing: cannot be empty or unset";
+                    assert!(message.contains(expected), "expected '{message}' to contain '{expected}'");
                 """,
             )
 
@@ -303,7 +305,9 @@ class RequestBindingGeneratorTest {
                         // .key(ts.clone())
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-                    assert!(matches!(err, ${format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
+                    let message = format!("{err}");
+                    let expected = "key was missing: cannot be empty or unset";
+                    assert!(message.contains(expected), "expected '{message}' to contain '{expected}'");
                 """,
             )
 
@@ -316,7 +320,9 @@ class RequestBindingGeneratorTest {
                         .key(ts.clone())
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-                    assert!(matches!(err, ${format(TestRuntimeConfig.operationBuildError())}::MissingField { .. }))
+                    let message = format!("{err}");
+                    let expected = "bucket_name was missing: cannot be empty or unset";
+                    assert!(message.contains(expected), "expected '{message}' to contain '{expected}'");
                 """,
             )
         }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/RequestBindingGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/RequestBindingGeneratorTest.kt
@@ -289,7 +289,7 @@ class RequestBindingGeneratorTest {
                         .key(ts.clone())
                         .build().unwrap();
                     let err = inp.test_request_builder_base().expect_err("can't build request with bucket unset");
-                    let message = format!("{err}");
+                    let message = err.to_string();
                     let expected = "bucket_name was missing: cannot be empty or unset";
                     assert!(message.contains(expected), "expected '{message}' to contain '{expected}'");
                 """,

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -535,6 +535,7 @@ mod timeout_middleware {
         use aws_smithy_async::assert_elapsed;
         use aws_smithy_async::rt::sleep::TokioSleep;
         use aws_smithy_http::body::SdkBody;
+        use aws_smithy_types::error::display::DisplayErrorContext;
         use aws_smithy_types::timeout::TimeoutConfig;
         use std::sync::Arc;
         use std::time::Duration;
@@ -576,9 +577,12 @@ mod timeout_middleware {
                 "expected resp.is_timeout() to be true but it was false, resp == {:?}",
                 resp
             );
-            assert_eq!(
-                format!("{}", resp),
-                "timeout: error trying to connect: HTTP connect timeout occurred after 1s"
+            let message = format!("{}", DisplayErrorContext(&resp));
+            let expected =
+                "timeout: error trying to connect: HTTP connect timeout occurred after 1s";
+            assert!(
+                message.contains(expected),
+                "expected '{message}' to contain '{expected}'"
             );
             assert_elapsed!(now, Duration::from_secs(1));
         }
@@ -612,9 +616,11 @@ mod timeout_middleware {
                 "expected resp.is_timeout() to be true but it was false, resp == {:?}",
                 resp
             );
-            assert_eq!(
-                format!("{}", resp),
-                "timeout: HTTP read timeout occurred after 2s"
+            let message = format!("{}", DisplayErrorContext(&resp));
+            let expected = "timeout: HTTP read timeout occurred after 2s";
+            assert!(
+                message.contains(expected),
+                "expected '{message}' to contain '{expected}'"
             );
             assert_elapsed!(now, Duration::from_secs(2));
         }

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -577,7 +577,7 @@ mod timeout_middleware {
                 "expected resp.is_timeout() to be true but it was false, resp == {:?}",
                 resp
             );
-            let message = format!("{}", DisplayErrorContext(&resp));
+            let message = DisplayErrorContext(&resp).to_string();
             let expected =
                 "timeout: error trying to connect: HTTP connect timeout occurred after 1s";
             assert!(

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -176,6 +176,7 @@ where
     pub async fn call<O, T, E, Retry>(&self, input: Operation<O, Retry>) -> Result<T, SdkError<E>>
     where
         O: Send + Sync,
+        E: 'static,
         Retry: Send + Sync,
         R::Policy: bounds::SmithyRetryPolicy<O, T, E, Retry>,
         bounds::Parsed<<M as bounds::SmithyMiddleware<C>>::Service, O, Retry>:
@@ -194,6 +195,7 @@ where
     ) -> Result<SdkSuccess<T>, SdkError<E>>
     where
         O: Send + Sync,
+        E: 'static,
         Retry: Send + Sync,
         R::Policy: bounds::SmithyRetryPolicy<O, T, E, Retry>,
         // This bound is not _technically_ inferred by all the previous bounds, but in practice it

--- a/rust-runtime/aws-smithy-client/src/timeout.rs
+++ b/rust-runtime/aws-smithy-client/src/timeout.rs
@@ -25,8 +25,8 @@ struct RequestTimeoutError {
 }
 
 impl RequestTimeoutError {
-    pub fn new_boxed(kind: &'static str, duration: Duration) -> Box<Self> {
-        Box::new(Self { kind, duration })
+    pub fn new(kind: &'static str, duration: Duration) -> Self {
+        Self { kind, duration }
     }
 }
 
@@ -195,8 +195,8 @@ where
         };
         match future.poll(cx) {
             Poll::Ready(Ok(response)) => Poll::Ready(response),
-            Poll::Ready(Err(_timeout)) => Poll::Ready(Err(SdkError::TimeoutError(
-                RequestTimeoutError::new_boxed(kind, *duration),
+            Poll::Ready(Err(_timeout)) => Poll::Ready(Err(SdkError::timeout_error(
+                RequestTimeoutError::new(kind, *duration),
             ))),
             Poll::Pending => Poll::Pending,
         }
@@ -262,7 +262,7 @@ mod test {
         let err: SdkError<Box<dyn std::error::Error + 'static>> =
             svc.ready().await.unwrap().call(op).await.unwrap_err();
 
-        assert_eq!(format!("{:?}", err), "TimeoutError(RequestTimeoutError { kind: \"operation timeout (all attempts including retries)\", duration: 250ms })");
+        assert_eq!(format!("{:?}", err), "TimeoutError(TimeoutError { source: RequestTimeoutError { kind: \"operation timeout (all attempts including retries)\", duration: 250ms } })");
         assert_elapsed!(now, Duration::from_secs_f32(0.25));
     }
 }

--- a/rust-runtime/aws-smithy-client/tests/e2e_test.rs
+++ b/rust-runtime/aws-smithy-client/tests/e2e_test.rs
@@ -75,7 +75,7 @@ mod test_operation {
     {
         fn classify_retry(&self, err: Result<&T, &SdkError<E>>) -> RetryKind {
             let kind = match err {
-                Err(SdkError::ServiceError { err, .. }) => err.retryable_error_kind(),
+                Err(SdkError::ServiceError(context)) => context.err().retryable_error_kind(),
                 Ok(_) => return RetryKind::Unnecessary,
                 _ => panic!("test handler only handles modeled errors got: {:?}", err),
             };

--- a/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/Cargo.toml
@@ -12,4 +12,5 @@ tokio = { version = "1.20.1", features = ["full"] }
 
 # Local paths
 aws-smithy-client  = { path = "../../../aws-smithy-client/", features = ["rustls"] }
+aws-smithy-types  = { path = "../../../aws-smithy-types/" }
 pokemon-service-client = { path = "../pokemon-service-client/" }

--- a/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-test/tests/simple_integration_test.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use crate::helpers::{client, PokemonService};
+use aws_smithy_types::error::display::DisplayErrorContext;
 use tokio::time;
 
 mod helpers;
@@ -40,9 +41,12 @@ async fn simple_integration_test() {
         .send()
         .await
         .unwrap_err();
-    assert_eq!(
-        r#"ResourceNotFoundError [ResourceNotFoundException]: Requested Pokémon not available"#,
-        pokemon_species_error.to_string()
+    let message = DisplayErrorContext(pokemon_species_error).to_string();
+    let expected =
+        r#"ResourceNotFoundError [ResourceNotFoundException]: Requested Pokémon not available"#;
+    assert!(
+        message.contains(expected),
+        "expected '{message}' to contain '{expected}'"
     );
 
     let service_statistics_out = client().get_server_statistics().send().await.unwrap();

--- a/rust-runtime/aws-smithy-http-server-python/src/types.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/types.rs
@@ -286,7 +286,7 @@ impl<'date> From<&'date DateTime> for &'date aws_smithy_types::DateTime {
 pub struct ByteStream(Arc<Mutex<aws_smithy_http::byte_stream::ByteStream>>);
 
 impl futures::stream::Stream for ByteStream {
-    type Item = Result<Bytes, aws_smithy_http::byte_stream::Error>;
+    type Item = Result<Bytes, aws_smithy_http::byte_stream::error::Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let stream = self.0.lock();

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
@@ -59,4 +59,5 @@ hyper-rustls = { version = "0.23.0", features = ["http2"] }
 # Local paths
 aws-smithy-client = { path = "../../../aws-smithy-client/", features = ["rustls"] }
 aws-smithy-http = { path = "../../../aws-smithy-http/" }
+aws-smithy-types = { path = "../../../aws-smithy-types/" }
 pokemon-service-client = { path = "../pokemon-service-client/" }

--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -95,8 +95,8 @@ pub enum ResponseRejection {
 
 impl std::error::Error for ResponseRejection {}
 
-convert_to_response_rejection!(aws_smithy_http::operation::BuildError, Build);
-convert_to_response_rejection!(aws_smithy_http::operation::SerializationError, Serialization);
+convert_to_response_rejection!(aws_smithy_http::operation::error::BuildError, Build);
+convert_to_response_rejection!(aws_smithy_http::operation::error::SerializationError, Serialization);
 convert_to_response_rejection!(http::Error, Http);
 
 /// Errors that can occur when deserializing an HTTP request into an _operation input_, the input

--- a/rust-runtime/aws-smithy-http-tower/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-tower/Cargo.toml
@@ -8,6 +8,7 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [dependencies]
+aws-smithy-types = { path = "../aws-smithy-types" }
 aws-smithy-http = { path = "../aws-smithy-http" }
 tower = { version = "0.4.4" }
 pin-project-lite = "0.2.9"

--- a/rust-runtime/aws-smithy-http-tower/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-tower/src/lib.rs
@@ -42,10 +42,10 @@ impl<E> From<SendOperationError> for SdkError<E> {
     fn from(err: SendOperationError) -> Self {
         match err {
             SendOperationError::RequestDispatchError(e) => {
-                aws_smithy_http::result::SdkError::DispatchFailure(e)
+                aws_smithy_http::result::SdkError::dispatch_failure(e)
             }
             SendOperationError::RequestConstructionError(e) => {
-                aws_smithy_http::result::SdkError::ConstructionFailure(e)
+                aws_smithy_http::result::SdkError::construction_failure(e)
             }
         }
     }

--- a/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
+++ b/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
@@ -9,6 +9,7 @@ use aws_smithy_http::operation;
 use aws_smithy_http::operation::Operation;
 use aws_smithy_http::response::ParseHttpResponse;
 use aws_smithy_http::result::SdkError;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -77,7 +78,7 @@ where
         + Send
         + Sync
         + 'static,
-    FailureResponse: std::error::Error,
+    FailureResponse: std::error::Error + 'static,
 {
     type Response = aws_smithy_http::result::SdkSuccess<SuccessResponse>;
     type Error = aws_smithy_http::result::SdkError<FailureResponse>;
@@ -119,21 +120,19 @@ where
             };
             match &resp {
                 Ok(_) => inner_span.record("status", &"ok"),
-                Err(SdkError::ServiceError { err, .. }) => inner_span
-                    .record("status", &"service_err")
-                    .record("message", &display(&err)),
-                Err(SdkError::ResponseError { err, .. }) => inner_span
-                    .record("status", &"response_err")
-                    .record("message", &display(&err)),
-                Err(SdkError::DispatchFailure(err)) => inner_span
-                    .record("status", &"dispatch_failure")
-                    .record("message", &display(err)),
-                Err(SdkError::ConstructionFailure(err)) => inner_span
-                    .record("status", &"construction_failure")
-                    .record("message", &display(err)),
-                Err(SdkError::TimeoutError(err)) => inner_span
-                    .record("status", &"timeout_error")
-                    .record("message", &display(err)),
+                Err(err) => inner_span
+                    .record(
+                        "status",
+                        &match err {
+                            SdkError::ConstructionFailure(_) => "construction_failure",
+                            SdkError::DispatchFailure(_) => "dispatch_failure",
+                            SdkError::ResponseError(_) => "response_error",
+                            SdkError::ServiceError(_) => "service_error",
+                            SdkError::TimeoutError(_) => "timeout_error",
+                            _ => "error",
+                        },
+                    )
+                    .record("message", &display(DisplayErrorContext(err))),
             };
             resp
         }

--- a/rust-runtime/aws-smithy-http/src/byte_stream/bytestream_util.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream/bytestream_util.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::body::SdkBody;
+use crate::byte_stream::{error::Error, error::ErrorKind, ByteStream};
 use bytes::Bytes;
 use futures_core::ready;
 use http::HeaderMap;
@@ -14,10 +16,6 @@ use std::task::{Context, Poll};
 use tokio::fs::File;
 use tokio::io::{self, AsyncReadExt, AsyncSeekExt};
 use tokio_util::io::ReaderStream;
-
-use crate::body::SdkBody;
-
-use super::{ByteStream, Error};
 
 // 4KB corresponds to the default buffer size used by Tokio's ReaderStream
 const DEFAULT_BUFFER_SIZE: usize = 4096;
@@ -181,19 +179,13 @@ impl FsBuilder {
         // notify users when file/chunk is smaller than expected.
         let file_length = self.get_file_size().await?;
         if offset > file_length {
-            return Err(Error(Box::new(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "offset must be less than or equal to file size but was greater than",
-            ))));
+            return Err(ErrorKind::OffsetLargerThanFileSize.into());
         }
 
         let length = match self.length {
             Some(Length::Exact(length)) => {
                 if length > file_length - offset {
-                    return Err(Error(Box::new(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        "Length::Exact was larger than file size minus read offset",
-                    ))));
+                    return Err(ErrorKind::LengthLargerThanFileSizeMinusReadOffset.into());
                 }
                 length
             }
@@ -217,10 +209,7 @@ impl FsBuilder {
         } else if let Some(mut file) = self.file {
             // When starting from a `File`, we need to do our own seeking
             if offset != 0 {
-                let _s = file
-                    .seek(std::io::SeekFrom::Start(offset))
-                    .await
-                    .map_err(|err| Error(err.into()))?;
+                let _s = file.seek(std::io::SeekFrom::Start(offset)).await?;
             }
 
             let body = SdkBody::from_dyn(http_body::combinators::BoxBody::new(
@@ -234,13 +223,12 @@ impl FsBuilder {
     }
 
     async fn get_file_size(&self) -> Result<u64, Error> {
-        match self.path.as_ref() {
+        Ok(match self.path.as_ref() {
             Some(path) => tokio::fs::metadata(path).await,
             // If it's not path-based then it's file-based
             None => self.file.as_ref().unwrap().metadata().await,
         }
-        .map(|metadata| metadata.len())
-        .map_err(|err| Error(err.into()))
+        .map(|metadata| metadata.len())?)
     }
 }
 

--- a/rust-runtime/aws-smithy-http/src/byte_stream/error.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream/error.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::error::Error as StdError;
+use std::fmt;
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+
+#[derive(Debug)]
+pub(super) enum ErrorKind {
+    #[cfg(feature = "rt-tokio")]
+    OffsetLargerThanFileSize,
+    #[cfg(feature = "rt-tokio")]
+    LengthLargerThanFileSizeMinusReadOffset,
+    IoError(IoError),
+    StreamingError(Box<dyn StdError + Send + Sync + 'static>),
+}
+
+/// An error occurred in the byte stream
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+impl Error {
+    pub(super) fn streaming(err: impl Into<Box<dyn StdError + Send + Sync + 'static>>) -> Self {
+        ErrorKind::StreamingError(err.into()).into()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Self {
+        ErrorKind::IoError(err).into()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            #[cfg(feature = "rt-tokio")]
+            ErrorKind::OffsetLargerThanFileSize => write!(
+                f,
+                "offset must be less than or equal to file size but was greater than"
+            ),
+            #[cfg(feature = "rt-tokio")]
+            ErrorKind::LengthLargerThanFileSizeMinusReadOffset => write!(
+                f,
+                "`Length::Exact` was larger than file size minus read offset"
+            ),
+            ErrorKind::IoError(_) => write!(f, "IO error"),
+            ErrorKind::StreamingError(_) => write!(f, "streaming error"),
+        }
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match &self.kind {
+            ErrorKind::IoError(err) => Some(err as _),
+            ErrorKind::StreamingError(err) => Some(err.as_ref() as _),
+            #[cfg(feature = "rt-tokio")]
+            ErrorKind::OffsetLargerThanFileSize
+            | ErrorKind::LengthLargerThanFileSizeMinusReadOffset => None,
+        }
+    }
+}
+
+impl From<Error> for IoError {
+    fn from(err: Error) -> Self {
+        IoError::new(IoErrorKind::Other, err)
+    }
+}

--- a/rust-runtime/aws-smithy-http/src/endpoint/error.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/error.rs
@@ -1,0 +1,79 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::error::Error as StdError;
+use std::fmt;
+
+/// Endpoint resolution failed
+#[derive(Debug)]
+pub struct ResolveEndpointError {
+    message: String,
+    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+}
+
+impl ResolveEndpointError {
+    /// Create an [`ResolveEndpointError`] with a message
+    pub fn message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    /// Add a source to the error
+    pub fn with_source(self, source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self {
+            source: Some(source.into()),
+            ..self
+        }
+    }
+}
+
+impl fmt::Display for ResolveEndpointError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl StdError for ResolveEndpointError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source.as_ref().map(|err| err.as_ref() as _)
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub(super) enum InvalidEndpointErrorKind {
+    EndpointMustHaveScheme,
+    FailedToConstructAuthority,
+    FailedToConstructUri,
+}
+
+#[derive(Debug)]
+pub struct InvalidEndpointError {
+    kind: InvalidEndpointErrorKind,
+}
+
+impl From<InvalidEndpointErrorKind> for InvalidEndpointError {
+    fn from(kind: InvalidEndpointErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl fmt::Display for InvalidEndpointError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use InvalidEndpointErrorKind as ErrorKind;
+        match self.kind {
+            ErrorKind::EndpointMustHaveScheme => write!(f, "endpoint must contain a valid scheme"),
+            ErrorKind::FailedToConstructAuthority => write!(
+                f,
+                "endpoint must contain a valid authority when combined with endpoint prefix"
+            ),
+            ErrorKind::FailedToConstructUri => write!(f, "failed to construct URI"),
+        }
+    }
+}
+
+impl StdError for InvalidEndpointError {}

--- a/rust-runtime/aws-smithy-http/src/event_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream.rs
@@ -16,4 +16,4 @@ pub type BoxError = Box<dyn StdError + Send + Sync + 'static>;
 pub use sender::{EventStreamSender, MessageStreamAdapter, MessageStreamError};
 
 #[doc(inline)]
-pub use receiver::{Error, RawMessage, Receiver};
+pub use receiver::{RawMessage, Receiver, ReceiverError};

--- a/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
@@ -162,10 +162,7 @@ impl<T, E> Receiver<T, E> {
                     Err(SdkError::service_error(err, RawMessage::Decoded(message)))
                 }
             },
-            Err(err) => Err(SdkError::response_error(
-                Box::new(err),
-                RawMessage::Decoded(message),
-            )),
+            Err(err) => Err(SdkError::response_error(err, RawMessage::Decoded(message))),
         }
     }
 
@@ -195,7 +192,7 @@ impl<T, E> Receiver<T, E> {
                     .decode_frame(self.buffer.buffered())
                     .map_err(|err| {
                         SdkError::response_error(
-                            Box::new(err),
+                            err,
                             // the buffer has been consumed
                             RawMessage::Invalid(None),
                         )

--- a/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/receiver.rs
@@ -103,22 +103,25 @@ impl From<&mut SegmentedBuf<Bytes>> for RawMessage {
 }
 
 #[derive(Debug)]
-#[non_exhaustive]
-pub enum Error {
+enum ReceiverErrorKind {
     /// The stream ended before a complete message frame was received.
-    #[non_exhaustive]
     UnexpectedEndOfStream,
 }
 
-impl fmt::Display for Error {
+#[derive(Debug)]
+pub struct ReceiverError {
+    kind: ReceiverErrorKind,
+}
+
+impl fmt::Display for ReceiverError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UnexpectedEndOfStream => write!(f, "unexpected end of stream"),
+        match self.kind {
+            ReceiverErrorKind::UnexpectedEndOfStream => write!(f, "unexpected end of stream"),
         }
     }
 }
 
-impl StdError for Error {}
+impl StdError for ReceiverError {}
 
 /// Receives Smithy-modeled messages out of an Event Stream.
 #[derive(Debug)]
@@ -155,15 +158,14 @@ impl<T, E> Receiver<T, E> {
         match self.unmarshaller.unmarshall(&message) {
             Ok(unmarshalled) => match unmarshalled {
                 UnmarshalledMessage::Event(event) => Ok(Some(event)),
-                UnmarshalledMessage::Error(err) => Err(SdkError::ServiceError {
-                    err,
-                    raw: RawMessage::Decoded(message),
-                }),
+                UnmarshalledMessage::Error(err) => {
+                    Err(SdkError::service_error(err, RawMessage::Decoded(message)))
+                }
             },
-            Err(err) => Err(SdkError::ResponseError {
-                err: Box::new(err),
-                raw: RawMessage::Decoded(message),
-            }),
+            Err(err) => Err(SdkError::response_error(
+                Box::new(err),
+                RawMessage::Decoded(message),
+            )),
         }
     }
 
@@ -174,7 +176,7 @@ impl<T, E> Receiver<T, E> {
                 .data()
                 .await
                 .transpose()
-                .map_err(|err| SdkError::DispatchFailure(ConnectorError::io(err)))?;
+                .map_err(|err| SdkError::dispatch_failure(ConnectorError::io(err)))?;
             let buffer = mem::replace(&mut self.buffer, RecvBuf::Empty);
             if let Some(chunk) = next_chunk {
                 self.buffer = buffer.with_partial(chunk);
@@ -191,9 +193,12 @@ impl<T, E> Receiver<T, E> {
                 if let DecodedFrame::Complete(message) = self
                     .decoder
                     .decode_frame(self.buffer.buffered())
-                    .map_err(|err| SdkError::ResponseError {
-                        err: Box::new(err),
-                        raw: RawMessage::Invalid(None), // the buffer has been consumed
+                    .map_err(|err| {
+                        SdkError::response_error(
+                            Box::new(err),
+                            // the buffer has been consumed
+                            RawMessage::Invalid(None),
+                        )
                     })?
                 {
                     return Ok(Some(message));
@@ -203,10 +208,12 @@ impl<T, E> Receiver<T, E> {
             self.buffer_next_chunk().await?;
         }
         if self.buffer.has_data() {
-            return Err(SdkError::ResponseError {
-                err: Error::UnexpectedEndOfStream.into(),
-                raw: self.buffer.buffered().into(),
-            });
+            return Err(SdkError::response_error(
+                ReceiverError {
+                    kind: ReceiverErrorKind::UnexpectedEndOfStream,
+                },
+                self.buffer.buffered().into(),
+            ));
         }
         Ok(None)
     }

--- a/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
@@ -55,7 +55,7 @@ pub struct MessageStreamError {
 }
 
 #[derive(Debug)]
-pub enum MessageStreamErrorKind {
+enum MessageStreamErrorKind {
     Unhandled(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 

--- a/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
+++ b/rust-runtime/aws-smithy-http/src/event_stream/sender.rs
@@ -83,11 +83,18 @@ impl MessageStreamError {
     }
 }
 
-impl StdError for MessageStreamError {}
+impl StdError for MessageStreamError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        match &self.kind {
+            MessageStreamErrorKind::Unhandled(source) => Some(source.as_ref() as _),
+        }
+    }
+}
+
 impl fmt::Display for MessageStreamError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.kind {
-            MessageStreamErrorKind::Unhandled(inner) => std::fmt::Display::fmt(inner, f),
+            MessageStreamErrorKind::Unhandled(_) => write!(f, "message stream error"),
         }
     }
 }
@@ -137,29 +144,29 @@ impl<T, E: StdError + Send + Sync + 'static> Stream for MessageStreamAdapter<T, 
                         Ok(message) => self
                             .marshaller
                             .marshall(message)
-                            .map_err(|err| SdkError::ConstructionFailure(Box::new(err)))?,
+                            .map_err(SdkError::construction_failure)?,
                         Err(message) => self
                             .error_marshaller
                             .marshall(message)
-                            .map_err(|err| SdkError::ConstructionFailure(Box::new(err)))?,
+                            .map_err(SdkError::construction_failure)?,
                     };
                     let message = self
                         .signer
                         .sign(message)
-                        .map_err(|err| SdkError::ConstructionFailure(err))?;
+                        .map_err(SdkError::construction_failure)?;
                     let mut buffer = Vec::new();
                     message
                         .write_to(&mut buffer)
-                        .map_err(|err| SdkError::ConstructionFailure(Box::new(err)))?;
+                        .map_err(SdkError::construction_failure)?;
                     Poll::Ready(Some(Ok(Bytes::from(buffer))))
                 } else if !self.end_signal_sent {
                     self.end_signal_sent = true;
                     let mut buffer = Vec::new();
                     match self.signer.sign_empty() {
                         Some(sign) => {
-                            sign.map_err(|err| SdkError::ConstructionFailure(err))?
+                            sign.map_err(SdkError::construction_failure)?
                                 .write_to(&mut buffer)
-                                .map_err(|err| SdkError::ConstructionFailure(Box::new(err)))?;
+                                .map_err(SdkError::construction_failure)?;
                             Poll::Ready(Some(Ok(Bytes::from(buffer))))
                         }
                         None => Poll::Ready(None),

--- a/rust-runtime/aws-smithy-http/src/header.rs
+++ b/rust-runtime/aws-smithy-http/src/header.rs
@@ -5,49 +5,50 @@
 
 //! Utilities for parsing information from headers
 
+use aws_smithy_types::date_time::Format;
+use aws_smithy_types::primitive::Parse;
+use aws_smithy_types::DateTime;
+use http::header::{HeaderMap, HeaderName, HeaderValue, ValueIter};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::error::Error;
 use std::fmt;
-use std::fmt::{Display, Formatter};
 use std::str::FromStr;
 
-use http::header::{HeaderMap, HeaderName, HeaderValue, ValueIter};
-
-use aws_smithy_types::date_time::Format;
-use aws_smithy_types::primitive::Parse;
-use aws_smithy_types::DateTime;
-
-#[derive(Debug, Eq, PartialEq)]
-#[non_exhaustive]
+#[derive(Debug)]
 pub struct ParseError {
-    message: Option<Cow<'static, str>>,
+    message: Cow<'static, str>,
+    source: Option<Box<dyn Error + Send + Sync + 'static>>,
 }
 
 impl ParseError {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Self {
-        Self { message: None }
-    }
-
-    pub fn new_with_message(message: impl Into<Cow<'static, str>>) -> Self {
+    /// Create a new parse error with the given `message`
+    pub fn new(message: impl Into<Cow<'static, str>>) -> Self {
         Self {
-            message: Some(message.into()),
+            message: message.into(),
+            source: None,
+        }
+    }
+
+    fn with_source(self, source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+        Self {
+            source: Some(source.into()),
+            ..self
         }
     }
 }
 
-impl Display for ParseError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "Output failed to parse in headers")?;
-        if let Some(message) = &self.message {
-            write!(f, ". {}", message)?;
-        }
-        Ok(())
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "output failed to parse in headers: {}", self.message)
     }
 }
 
-impl Error for ParseError {}
+impl Error for ParseError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source.as_ref().map(|err| err.as_ref() as _)
+    }
+}
 
 /// Read all the dates from the header map at `key` according the `format`
 ///
@@ -61,10 +62,10 @@ pub fn many_dates(
     for header in values {
         let mut header = header
             .to_str()
-            .map_err(|_| ParseError::new_with_message("header was not valid utf-8 string"))?;
+            .map_err(|_| ParseError::new("header was not valid utf-8 string"))?;
         while !header.is_empty() {
             let (v, next) = DateTime::read(header, format, ',').map_err(|err| {
-                ParseError::new_with_message(format!("header could not be parsed as date: {}", err))
+                ParseError::new(format!("header could not be parsed as date: {}", err))
             })?;
             out.push(v);
             header = next;
@@ -86,23 +87,21 @@ pub fn headers_for_prefix<'a>(
         .map(move |h| (&h.as_str()[key.len()..], h))
 }
 
-pub fn read_many_from_str<T: FromStr>(
-    values: ValueIter<HeaderValue>,
-) -> Result<Vec<T>, ParseError> {
+pub fn read_many_from_str<T: FromStr>(values: ValueIter<HeaderValue>) -> Result<Vec<T>, ParseError>
+where
+    T::Err: Error + Send + Sync + 'static,
+{
     read_many(values, |v: &str| {
-        v.parse()
-            .map_err(|_err| ParseError::new_with_message("failed during FromString conversion"))
+        v.parse().map_err(|err| {
+            ParseError::new("failed during `FromString` conversion").with_source(err)
+        })
     })
 }
 
 pub fn read_many_primitive<T: Parse>(values: ValueIter<HeaderValue>) -> Result<Vec<T>, ParseError> {
     read_many(values, |v: &str| {
-        T::parse_smithy_primitive(v).map_err(|primitive| {
-            ParseError::new_with_message(format!(
-                "failed reading a list of primitives: {}",
-                primitive
-            ))
-        })
+        T::parse_smithy_primitive(v)
+            .map_err(|err| ParseError::new("failed reading a list of primitives").with_source(err))
     })
 }
 
@@ -126,20 +125,21 @@ fn read_many<T>(
 /// Read exactly one or none from a headers iterator
 ///
 /// This function does not perform comma splitting like `read_many`
-pub fn one_or_none<T: FromStr>(
-    mut values: ValueIter<HeaderValue>,
-) -> Result<Option<T>, ParseError> {
+pub fn one_or_none<T: FromStr>(mut values: ValueIter<HeaderValue>) -> Result<Option<T>, ParseError>
+where
+    T::Err: Error + Send + Sync + 'static,
+{
     let first = match values.next() {
         Some(v) => v,
         None => return Ok(None),
     };
-    let value = std::str::from_utf8(first.as_bytes())
-        .map_err(|_| ParseError::new_with_message("invalid utf-8"))?;
+    let value =
+        std::str::from_utf8(first.as_bytes()).map_err(|_| ParseError::new("invalid utf-8"))?;
     match values.next() {
         None => T::from_str(value.trim())
-            .map_err(|_| ParseError::new())
+            .map_err(|err| ParseError::new("failed to parse string").with_source(err))
             .map(Some),
-        Some(_) => Err(ParseError::new_with_message(
+        Some(_) => Err(ParseError::new(
             "expected a single value but found multiple",
         )),
     }
@@ -231,7 +231,7 @@ mod parse_multi_header {
         let next_delim = input.iter().position(|&b| b == b',').unwrap_or(input.len());
         let (first, next) = input.split_at(next_delim);
         let first = std::str::from_utf8(first)
-            .map_err(|_| ParseError::new_with_message("header was not valid utf8"))?;
+            .map_err(|_| ParseError::new("header was not valid utf-8"))?;
         Ok((Cow::Borrowed(first), then_comma(next).unwrap()))
     }
 
@@ -241,10 +241,10 @@ mod parse_multi_header {
         for index in 0..input.len() {
             match input[index] {
                 b'"' if index == 0 || input[index - 1] != b'\\' => {
-                    let mut inner =
-                        Cow::Borrowed(std::str::from_utf8(&input[0..index]).map_err(|_| {
-                            ParseError::new_with_message("header was not valid utf8")
-                        })?);
+                    let mut inner = Cow::Borrowed(
+                        std::str::from_utf8(&input[0..index])
+                            .map_err(|_| ParseError::new("header was not valid utf-8"))?,
+                    );
                     inner = replace(inner, "\\\"", "\"");
                     inner = replace(inner, "\\\\", "\\");
                     let rest = then_comma(&input[(index + 1)..])?;
@@ -253,7 +253,7 @@ mod parse_multi_header {
                 _ => {}
             }
         }
-        Err(ParseError::new_with_message(
+        Err(ParseError::new(
             "header value had quoted value without end quote",
         ))
     }
@@ -264,7 +264,7 @@ mod parse_multi_header {
         } else if s.starts_with(b",") {
             Ok(&s[1..])
         } else {
-            Err(ParseError::new_with_message("expected delimiter `,`"))
+            Err(ParseError::new("expected delimiter `,`"))
         }
     }
 }
@@ -337,6 +337,7 @@ mod test {
     };
 
     use super::quote_header_value;
+    use aws_smithy_types::error::display::DisplayErrorContext;
 
     #[test]
     fn put_on_request_if_absent() {
@@ -388,13 +389,18 @@ mod test {
                 .expect("valid"),
             vec![0.0, f32::INFINITY, f32::NEG_INFINITY, 5555.5]
         );
-        assert_eq!(
-            read_many_primitive::<f32>(test_request.headers().get_all("X-Float-Error").iter())
-                .expect_err("invalid"),
-            ParseError::new_with_message(
-                "failed reading a list of primitives: failed to parse input as f32"
+        let message = format!(
+            "{}",
+            DisplayErrorContext(
+                read_many_primitive::<f32>(test_request.headers().get_all("X-Float-Error").iter())
+                    .expect_err("invalid")
             )
-        )
+        );
+        let expected = "output failed to parse in headers: failed reading a list of primitives: failed to parse input as f32";
+        assert!(
+            message.starts_with(expected),
+            "expected '{message}' to start with '{expected}'"
+        );
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-http/src/middleware.rs
+++ b/rust-runtime/aws-smithy-http/src/middleware.rs
@@ -100,13 +100,13 @@ where
     let body = match read_body(body).await {
         Ok(body) => body,
         Err(err) => {
-            return Err(SdkError::ResponseError {
-                raw: operation::Response::from_parts(
+            return Err(SdkError::response_error(
+                err,
+                operation::Response::from_parts(
                     http::Response::from_parts(parts, SdkBody::taken()),
                     properties,
                 ),
-                err,
-            });
+            ));
         }
     };
 
@@ -139,6 +139,6 @@ fn sdk_result<T, E>(
 ) -> Result<SdkSuccess<T>, SdkError<E>> {
     match parsed {
         Ok(parsed) => Ok(SdkSuccess { raw, parsed }),
-        Err(err) => Err(SdkError::ServiceError { raw, err }),
+        Err(err) => Err(SdkError::service_error(err, raw)),
     }
 }

--- a/rust-runtime/aws-smithy-http/src/operation.rs
+++ b/rust-runtime/aws-smithy-http/src/operation.rs
@@ -6,12 +6,10 @@
 use crate::body::SdkBody;
 use crate::property_bag::{PropertyBag, SharedPropertyBag};
 use crate::retry::DefaultResponseRetryClassifier;
-use aws_smithy_types::date_time::DateTimeFormatError;
-use http::uri::InvalidUri;
 use std::borrow::Cow;
-use std::error::Error;
-use std::fmt::{Display, Formatter};
 use std::ops::{Deref, DerefMut};
+
+pub mod error;
 
 #[derive(Clone, Debug)]
 pub struct Metadata {
@@ -45,126 +43,6 @@ pub struct Parts<H, R> {
     pub response_handler: H,
     pub retry_classifier: R,
     pub metadata: Option<Metadata>,
-}
-
-/// An error occurred attempting to build an `Operation` from an input
-///
-/// These are almost always due to user error caused by limitations of specific fields due to
-/// protocol serialization (e.g. fields that can only be a subset ASCII because they are serialized
-/// as the name of an HTTP header)
-#[non_exhaustive]
-#[derive(Debug)]
-pub enum BuildError {
-    /// A field contained an invalid value
-    InvalidField {
-        field: &'static str,
-        details: String,
-    },
-    /// A field was missing
-    MissingField {
-        field: &'static str,
-        details: &'static str,
-    },
-    /// The serializer could not serialize the input
-    SerializationError(SerializationError),
-
-    /// The serializer did not produce a valid URI
-    ///
-    /// This typically indicates that a field contained invalid characters.
-    InvalidUri {
-        uri: String,
-        err: InvalidUri,
-        message: Cow<'static, str>,
-    },
-
-    /// An error occurred request construction
-    Other(Box<dyn Error + Send + Sync + 'static>),
-}
-
-impl From<SerializationError> for BuildError {
-    fn from(err: SerializationError) -> Self {
-        BuildError::SerializationError(err)
-    }
-}
-
-impl From<DateTimeFormatError> for BuildError {
-    fn from(err: DateTimeFormatError) -> Self {
-        BuildError::from(SerializationError::from(err))
-    }
-}
-
-impl Display for BuildError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            BuildError::InvalidField { field, details } => write!(
-                f,
-                "Invalid field in input: {} (Details: {})",
-                field, details
-            ),
-            BuildError::MissingField { field, details } => {
-                write!(f, "{} was missing. {}", field, details)
-            }
-            BuildError::SerializationError(inner) => {
-                write!(f, "failed to serialize input: {}", inner)
-            }
-            BuildError::Other(inner) => write!(f, "error during request construction: {}", inner),
-            BuildError::InvalidUri { uri, err, message } => {
-                write!(
-                    f,
-                    "generated URI `{}` was not a valid URI ({}): {}",
-                    uri, err, message
-                )
-            }
-        }
-    }
-}
-
-impl Error for BuildError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            BuildError::SerializationError(inner) => Some(inner as _),
-            BuildError::Other(inner) => Some(inner.as_ref()),
-            _ => None,
-        }
-    }
-}
-
-#[non_exhaustive]
-#[derive(Debug)]
-pub enum SerializationError {
-    #[non_exhaustive]
-    CannotSerializeUnknownVariant { union: &'static str },
-    #[non_exhaustive]
-    DateTimeFormatError { cause: DateTimeFormatError },
-}
-
-impl SerializationError {
-    pub fn unknown_variant(union: &'static str) -> Self {
-        Self::CannotSerializeUnknownVariant { union }
-    }
-}
-
-impl Display for SerializationError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::CannotSerializeUnknownVariant { union } => write!(
-                f,
-                "Cannot serialize `{}::Unknown`. Unknown union variants cannot be serialized. \
-                This can occur when round-tripping a response from the server that was not \
-                recognized by the SDK. Consider upgrading to the latest version of the SDK.",
-                union
-            ),
-            Self::DateTimeFormatError { cause } => write!(f, "{}", cause),
-        }
-    }
-}
-
-impl Error for SerializationError {}
-
-impl From<DateTimeFormatError> for SerializationError {
-    fn from(err: DateTimeFormatError) -> SerializationError {
-        SerializationError::DateTimeFormatError { cause: err }
-    }
 }
 
 // Generics:

--- a/rust-runtime/aws-smithy-http/src/operation/error.rs
+++ b/rust-runtime/aws-smithy-http/src/operation/error.rs
@@ -1,0 +1,185 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Errors for operations
+
+use aws_smithy_types::date_time::DateTimeFormatError;
+use http::uri::InvalidUri;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+enum SerializationErrorKind {
+    CannotSerializeUnknownVariant { union: &'static str },
+    DateTimeFormatError { cause: DateTimeFormatError },
+}
+
+#[derive(Debug)]
+pub struct SerializationError {
+    kind: SerializationErrorKind,
+}
+
+impl SerializationError {
+    pub fn unknown_variant(union: &'static str) -> Self {
+        Self {
+            kind: SerializationErrorKind::CannotSerializeUnknownVariant { union },
+        }
+    }
+}
+
+impl Display for SerializationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self.kind {
+            SerializationErrorKind::CannotSerializeUnknownVariant { union } => write!(
+                f,
+                "Cannot serialize `{union}::Unknown`. Unknown union variants cannot be serialized. \
+                This can occur when round-tripping a response from the server that was not \
+                recognized by the SDK. Consider upgrading to the latest version of the SDK.",
+            ),
+            SerializationErrorKind::DateTimeFormatError { .. } => {
+                write!(f, "failed to serialize timestamp")
+            }
+        }
+    }
+}
+
+impl Error for SerializationError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            SerializationErrorKind::CannotSerializeUnknownVariant { .. } => None,
+            SerializationErrorKind::DateTimeFormatError { cause } => Some(cause as _),
+        }
+    }
+}
+
+impl From<DateTimeFormatError> for SerializationError {
+    fn from(err: DateTimeFormatError) -> SerializationError {
+        Self {
+            kind: SerializationErrorKind::DateTimeFormatError { cause: err },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum BuildErrorKind {
+    /// A field contained an invalid value
+    InvalidField {
+        field: &'static str,
+        details: String,
+    },
+    /// A field was missing
+    MissingField {
+        field: &'static str,
+        details: &'static str,
+    },
+    /// The serializer could not serialize the input
+    SerializationError(SerializationError),
+
+    /// The serializer did not produce a valid URI
+    ///
+    /// This typically indicates that a field contained invalid characters.
+    InvalidUri {
+        uri: String,
+        message: Cow<'static, str>,
+        source: InvalidUri,
+    },
+
+    /// An error occurred request construction
+    Other(Box<dyn Error + Send + Sync + 'static>),
+}
+
+/// An error occurred attempting to build an `Operation` from an input
+///
+/// These are almost always due to user error caused by limitations of specific fields due to
+/// protocol serialization (e.g. fields that can only be a subset ASCII because they are serialized
+/// as the name of an HTTP header)
+#[derive(Debug)]
+pub struct BuildError {
+    kind: BuildErrorKind,
+}
+
+impl BuildError {
+    pub(crate) fn invalid_uri(uri: String, message: Cow<'static, str>, source: InvalidUri) -> Self {
+        Self {
+            kind: BuildErrorKind::InvalidUri {
+                uri,
+                message,
+                source,
+            },
+        }
+    }
+
+    /// Construct a build error for a missing field
+    pub fn missing_field(field: &'static str, details: &'static str) -> Self {
+        Self {
+            kind: BuildErrorKind::MissingField { field, details },
+        }
+    }
+
+    /// Construct a build error for a missing field
+    pub fn invalid_field(field: &'static str, details: impl Into<String>) -> Self {
+        Self {
+            kind: BuildErrorKind::InvalidField {
+                field,
+                details: details.into(),
+            },
+        }
+    }
+
+    /// Construct a build error from another underlying error
+    pub fn other(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+        Self {
+            kind: BuildErrorKind::Other(source.into()),
+        }
+    }
+}
+
+impl From<SerializationError> for BuildError {
+    fn from(err: SerializationError) -> Self {
+        Self {
+            kind: BuildErrorKind::SerializationError(err),
+        }
+    }
+}
+
+impl From<DateTimeFormatError> for BuildError {
+    fn from(err: DateTimeFormatError) -> Self {
+        Self::from(SerializationError::from(err))
+    }
+}
+
+impl Display for BuildError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            BuildErrorKind::InvalidField { field, details } => {
+                write!(f, "invalid field in input: {field} (details: {details})")
+            }
+            BuildErrorKind::MissingField { field, details } => {
+                write!(f, "{field} was missing: {details}")
+            }
+            BuildErrorKind::SerializationError(_) => {
+                write!(f, "failed to serialize input")
+            }
+            BuildErrorKind::InvalidUri { uri, message, .. } => {
+                write!(f, "generated URI `{uri}` was not a valid URI: {message}")
+            }
+            BuildErrorKind::Other(_) => {
+                write!(f, "error during request construction")
+            }
+        }
+    }
+}
+
+impl Error for BuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.kind {
+            BuildErrorKind::SerializationError(source) => Some(source as _),
+            BuildErrorKind::Other(source) => Some(source.as_ref()),
+            BuildErrorKind::InvalidUri { source, .. } => Some(source as _),
+            BuildErrorKind::InvalidField { .. } | BuildErrorKind::MissingField { .. } => None,
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http/src/result.rs
+++ b/rust-runtime/aws-smithy-http/src/result.rs
@@ -30,35 +30,213 @@ pub struct SdkSuccess<O> {
     pub parsed: O,
 }
 
+/// Error context for [`SdkError::ConstructionFailure`]
+#[derive(Debug)]
+pub struct ConstructionFailure {
+    source: BoxError,
+}
+
+/// Error context for [`SdkError::TimeoutError`]
+#[derive(Debug)]
+pub struct TimeoutError {
+    source: BoxError,
+}
+
+/// Error context for [`SdkError::DispatchFailure`]
+#[derive(Debug)]
+pub struct DispatchFailure {
+    source: ConnectorError,
+}
+
+impl DispatchFailure {
+    /// Returns true if the error is an IO error
+    pub fn is_io(&self) -> bool {
+        self.source.is_io()
+    }
+
+    /// Returns true if the error is an timeout error
+    pub fn is_timeout(&self) -> bool {
+        self.source.is_timeout()
+    }
+
+    /// Returns true if the error is a user-caused error (e.g., invalid HTTP request)
+    pub fn is_user(&self) -> bool {
+        self.source.is_user()
+    }
+
+    /// Returns the optional error kind associated with an unclassified error
+    pub fn is_other(&self) -> Option<ErrorKind> {
+        self.source.is_other()
+    }
+}
+
+/// Error context for [`SdkError::ResponseError`]
+#[derive(Debug)]
+pub struct ResponseError<R> {
+    /// Error encountered while parsing the response
+    source: BoxError,
+    /// Raw response that was available
+    raw: R,
+}
+
+impl<R> ResponseError<R> {
+    /// Returns a reference to the raw response
+    pub fn raw(&self) -> &R {
+        &self.raw
+    }
+
+    /// Converts this error context into the raw response
+    pub fn into_raw(self) -> R {
+        self.raw
+    }
+}
+
+/// Error context for [`SdkError::ServiceError`]
+#[derive(Debug)]
+pub struct ServiceError<E, R> {
+    /// Modeled service error
+    source: E,
+    /// Raw response from the service
+    raw: R,
+}
+
+impl<E, R> ServiceError<E, R> {
+    /// Returns the underlying error of type `E`
+    pub fn err(&self) -> &E {
+        &self.source
+    }
+
+    /// Converts this error context into the underlying error `E`
+    pub fn into_err(self) -> E {
+        self.source
+    }
+
+    /// Returns a reference to the raw response
+    pub fn raw(&self) -> &R {
+        &self.raw
+    }
+
+    /// Converts this error context into the raw response
+    pub fn into_raw(self) -> R {
+        self.raw
+    }
+}
+
 /// Failed SDK Result
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum SdkError<E, R = operation::Response> {
     /// The request failed during construction. It was not dispatched over the network.
-    ConstructionFailure(BoxError),
+    ConstructionFailure(ConstructionFailure),
 
     /// The request failed due to a timeout. The request MAY have been sent and received.
-    TimeoutError(BoxError),
+    TimeoutError(TimeoutError),
 
     /// The request failed during dispatch. An HTTP response was not received. The request MAY
     /// have been sent.
-    DispatchFailure(ConnectorError),
+    DispatchFailure(DispatchFailure),
 
     /// A response was received but it was not parseable according the the protocol (for example
     /// the server hung up while the body was being read)
-    ResponseError {
-        /// Error encountered while parsing the response
-        err: BoxError,
-        /// Raw response that was available
-        raw: R,
-    },
+    ResponseError(ResponseError<R>),
 
     /// An error response was received from the service
-    ServiceError {
-        /// Modeled service error
-        err: E,
-        /// Raw response from the service
-        raw: R,
-    },
+    ServiceError(ServiceError<E, R>),
+}
+
+impl<E, R> SdkError<E, R> {
+    /// Construct a `SdkError` for a construction failure
+    pub fn construction_failure(source: impl Into<BoxError>) -> Self {
+        Self::ConstructionFailure(ConstructionFailure {
+            source: source.into(),
+        })
+    }
+
+    /// Construct a `SdkError` for a timeout
+    pub fn timeout_error(source: impl Into<BoxError>) -> Self {
+        Self::TimeoutError(TimeoutError {
+            source: source.into(),
+        })
+    }
+
+    /// Construct a `SdkError` for a dispatch failure with a [`ConnectorError`]
+    pub fn dispatch_failure(source: ConnectorError) -> Self {
+        Self::DispatchFailure(DispatchFailure { source })
+    }
+
+    /// Construct a `SdkError` for a response error
+    pub fn response_error(source: impl Into<BoxError>, raw: R) -> Self {
+        Self::ResponseError(ResponseError {
+            source: source.into(),
+            raw,
+        })
+    }
+
+    /// Construct a `SdkError` for a service failure
+    pub fn service_error(source: E, raw: R) -> Self {
+        Self::ServiceError(ServiceError { source, raw })
+    }
+
+    /// Converts this error into its error source.
+    ///
+    /// If there is no error source, then `Err(Self)` is returned.
+    pub fn into_source(self) -> Result<Box<dyn Error + Send + Sync + 'static>, Self>
+    where
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        use SdkError::*;
+        match self {
+            ConstructionFailure(context) => Ok(context.source),
+            TimeoutError(context) => Ok(context.source),
+            ResponseError(context) => Ok(context.source),
+            DispatchFailure(context) => Ok(context.source.into()),
+            ServiceError(context) => Ok(context.source.into()),
+        }
+    }
+}
+
+impl<E, R> Display for SdkError<E, R> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            SdkError::ConstructionFailure(_) => write!(f, "failed to construct request"),
+            SdkError::TimeoutError(_) => write!(f, "request has timed out"),
+            SdkError::DispatchFailure(_) => write!(f, "dispatch failure"),
+            SdkError::ResponseError(_) => write!(f, "response error"),
+            SdkError::ServiceError(_) => write!(f, "service error"),
+        }
+    }
+}
+
+impl<E, R> Error for SdkError<E, R>
+where
+    E: Error + 'static,
+    R: Debug,
+{
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use SdkError::*;
+        match self {
+            ConstructionFailure(context) => Some(context.source.as_ref()),
+            TimeoutError(context) => Some(context.source.as_ref()),
+            ResponseError(context) => Some(context.source.as_ref()),
+            DispatchFailure(context) => Some(&context.source),
+            ServiceError(context) => Some(&context.source),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ConnectorErrorKind {
+    /// A timeout occurred while processing the request
+    Timeout,
+
+    /// A user-caused error (e.g., invalid HTTP request)
+    User,
+
+    /// Socket/IO error
+    Io,
+
+    /// An unclassified Error with an explicit error kind
+    Other(Option<ErrorKind>),
 }
 
 /// Error from the underlying Connector
@@ -69,19 +247,24 @@ pub enum SdkError<E, R = operation::Response> {
 /// connector error.
 #[derive(Debug)]
 pub struct ConnectorError {
-    err: BoxError,
     kind: ConnectorErrorKind,
+    source: BoxError,
 }
 
 impl Display for ConnectorError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {}", self.kind, self.err)
+        match self.kind {
+            ConnectorErrorKind::Timeout => write!(f, "timeout"),
+            ConnectorErrorKind::User => write!(f, "user error"),
+            ConnectorErrorKind::Io => write!(f, "io error"),
+            ConnectorErrorKind::Other(_) => write!(f, "other"),
+        }
     }
 }
 
 impl Error for ConnectorError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(self.err.as_ref())
+        Some(self.source.as_ref())
     }
 }
 
@@ -89,35 +272,35 @@ impl ConnectorError {
     /// Construct a [`ConnectorError`] from an error caused by a timeout
     ///
     /// Timeout errors are typically retried on a new connection.
-    pub fn timeout(err: BoxError) -> Self {
+    pub fn timeout(source: BoxError) -> Self {
         Self {
-            err,
             kind: ConnectorErrorKind::Timeout,
+            source,
         }
     }
 
     /// Construct a [`ConnectorError`] from an error caused by the user (e.g. invalid HTTP request)
-    pub fn user(err: BoxError) -> Self {
+    pub fn user(source: BoxError) -> Self {
         Self {
-            err,
             kind: ConnectorErrorKind::User,
+            source,
         }
     }
 
     /// Construct a [`ConnectorError`] from an IO related error (e.g. socket hangup)
-    pub fn io(err: BoxError) -> Self {
+    pub fn io(source: BoxError) -> Self {
         Self {
-            err,
             kind: ConnectorErrorKind::Io,
+            source,
         }
     }
 
     /// Construct a [`ConnectorError`] from an different unclassified error.
     ///
     /// Optionally, an explicit `Kind` may be passed.
-    pub fn other(err: BoxError, kind: Option<ErrorKind>) -> Self {
+    pub fn other(source: BoxError, kind: Option<ErrorKind>) -> Self {
         Self {
-            err,
+            source,
             kind: ConnectorErrorKind::Other(kind),
         }
     }
@@ -132,7 +315,7 @@ impl ConnectorError {
         matches!(self.kind, ConnectorErrorKind::Timeout)
     }
 
-    /// Returns true if the error is a user error
+    /// Returns true if the error is a user-caused error (e.g., invalid HTTP request)
     pub fn is_user(&self) -> bool {
         matches!(self.kind, ConnectorErrorKind::User)
     }
@@ -142,65 +325,6 @@ impl ConnectorError {
         match &self.kind {
             ConnectorErrorKind::Other(ek) => *ek,
             _ => None,
-        }
-    }
-}
-
-#[derive(Debug)]
-enum ConnectorErrorKind {
-    /// A timeout occurred while processing the request
-    Timeout,
-
-    /// A user-caused error (e.g. invalid HTTP request)
-    User,
-
-    /// Socket/IO error
-    Io,
-
-    /// An unclassified Error with an explicit error kind
-    Other(Option<ErrorKind>),
-}
-
-impl Display for ConnectorErrorKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            ConnectorErrorKind::Timeout => write!(f, "timeout"),
-            ConnectorErrorKind::User => write!(f, "user error"),
-            ConnectorErrorKind::Io => write!(f, "io error"),
-            ConnectorErrorKind::Other(Some(kind)) => write!(f, "{:?}", kind),
-            ConnectorErrorKind::Other(None) => write!(f, "other"),
-        }
-    }
-}
-
-impl<E, R> Display for SdkError<E, R>
-where
-    E: Error,
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            SdkError::ConstructionFailure(err) => write!(f, "failed to construct request: {}", err),
-            SdkError::TimeoutError(err) => write!(f, "request has timed out: {}", err),
-            SdkError::DispatchFailure(err) => Display::fmt(&err, f),
-            SdkError::ResponseError { err, .. } => Display::fmt(&err, f),
-            SdkError::ServiceError { err, .. } => Display::fmt(&err, f),
-        }
-    }
-}
-
-impl<E, R> Error for SdkError<E, R>
-where
-    E: Error + 'static,
-    R: Debug,
-{
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        use SdkError::*;
-        match self {
-            ConstructionFailure(err) | TimeoutError(err) | ResponseError { err, .. } => {
-                Some(err.as_ref())
-            }
-            DispatchFailure(err) => Some(err),
-            ServiceError { err, .. } => Some(err),
         }
     }
 }

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -8,7 +8,7 @@ use crate::{mk_canary, CanaryEnv};
 use anyhow::Context;
 use aws_sdk_s3 as s3;
 use s3::error::{GetObjectError, GetObjectErrorKind};
-use s3::types::{ByteStream, SdkError};
+use s3::types::ByteStream;
 use uuid::Uuid;
 
 const METADATA_TEST_VALUE: &str = "some   value";
@@ -44,7 +44,7 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
             } => {
                 // good
             }
-            err @ _ => Err(err).context("unexpected s3::GetObject failure")?,
+            err => Err(err).context("unexpected s3::GetObject failure")?,
         },
     }
 

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -34,14 +34,15 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
                 CanaryError(format!("Expected object {} to not exist in S3", test_key)).into(),
             );
         }
-        Err(SdkError::ServiceError {
-            err:
+        Err(SdkError::ServiceError(context))
+            if matches!(
+                context.err(),
                 GetObjectError {
                     kind: GetObjectErrorKind::NoSuchKey { .. },
                     ..
-                },
-            ..
-        }) => {
+                }
+            ) =>
+        {
             // good
         }
         Err(err) => {


### PR DESCRIPTION
## Motivation and Context
This PR revamps errors in `aws-smithy-http` to adhere to [RFC-0022: Error Context and Compatibility](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).

This PR is part of a series that will fully implement the RFC, tracked in #1926.

Changelog entries added in #1951.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
