### PR TITLE
Pin `derive_arbitrary` version

### DIFF
--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -8,10 +8,11 @@ license = "Apache-2.0"
 repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
-derive-arbitrary = ["arbitrary"]
+derive-arbitrary = ["arbitrary", "derive_arbitrary"]
 
 [dependencies]
-arbitrary = { version = "=1.1.3", optional = true, features = ["derive"] } # 1.1.4 requires Rust 1.63 to compile
+derive_arbitrary = { version = "=1.1.6", optional = true } # 1.2.0 requires Rust 1.63 to compile
+arbitrary = { version = "=1.1.3", optional = true } # 1.1.4 requires Rust 1.63 to compile
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 crc32fast = "1.3"

--- a/rust-runtime/aws-smithy-eventstream/fuzz/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/fuzz/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = { version = "=1.1.3", optional = true, features = ["derive"] } # 1.1.4 requires Rust 1.63 to compile
+derive_arbitrary = "=1.1.6" # 1.2.0 requires Rust 1.63 to compile
+arbitrary = "=1.1.3" # 1.1.4 requires Rust 1.63 to compile
 aws-smithy-types = { path = "../../aws-smithy-types" }
 bytes = "1"
 crc32fast = "1"

--- a/rust-runtime/aws-smithy-eventstream/fuzz/fuzz_targets/corrected_prelude_crc.rs
+++ b/rust-runtime/aws-smithy-eventstream/fuzz/fuzz_targets/corrected_prelude_crc.rs
@@ -5,13 +5,12 @@
 
 #![no_main]
 
-use arbitrary::Arbitrary;
 use aws_smithy_eventstream::frame::Message;
 use bytes::BufMut;
 use crc32fast::Hasher as Crc;
 use libfuzzer_sys::fuzz_target;
 
-#[derive(Arbitrary, Debug)]
+#[derive(derive_arbitrary::Arbitrary, Debug)]
 struct Input {
     headers: Vec<u8>,
     payload: Vec<u8>,

--- a/rust-runtime/aws-smithy-eventstream/fuzz/fuzz_targets/prelude.rs
+++ b/rust-runtime/aws-smithy-eventstream/fuzz/fuzz_targets/prelude.rs
@@ -5,13 +5,12 @@
 
 #![no_main]
 
-use arbitrary::Arbitrary;
 use aws_smithy_eventstream::frame::{Header, HeaderValue, Message};
 use bytes::{Buf, BufMut};
 use crc32fast::Hasher as Crc;
 use libfuzzer_sys::fuzz_target;
 
-#[derive(Arbitrary, Debug)]
+#[derive(derive_arbitrary::Arbitrary, Debug)]
 struct Input {
     total_len: u32,
     header_len: u32,

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -301,7 +301,7 @@ pub use value::HeaderValue;
 /// Event Stream header.
 #[non_exhaustive]
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "derive-arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "derive-arbitrary", derive(derive_arbitrary::Arbitrary))]
 pub struct Header {
     name: StrBytes,
     value: HeaderValue,


### PR DESCRIPTION
## Motivation and Context
Version 1.2.0 of `derive_arbitrary` requires Rust 1.63, so we need to pin the version to the previous release since our MSRV is 1.62.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
