### PR TITLE
Revamp errors in `aws-smithy-json`

### DIFF
--- a/aws/rust-runtime/aws-config/src/json_credentials.rs
+++ b/aws/rust-runtime/aws-config/src/json_credentials.rs
@@ -36,8 +36,8 @@ impl From<EscapeError> for InvalidJsonCredentials {
     }
 }
 
-impl From<aws_smithy_json::deserialize::Error> for InvalidJsonCredentials {
-    fn from(err: aws_smithy_json::deserialize::Error) -> Self {
+impl From<aws_smithy_json::deserialize::error::DeserializeError> for InvalidJsonCredentials {
+    fn from(err: aws_smithy_json::deserialize::error::DeserializeError) -> Self {
         InvalidJsonCredentials::JsonError(err.into())
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
@@ -114,7 +114,7 @@ open class AwsJson(
         "Bytes" to RuntimeType.Bytes,
         "Error" to RuntimeType.GenericError(runtimeConfig),
         "HeaderMap" to RuntimeType.http.member("HeaderMap"),
-        "JsonError" to CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize::Error"),
+        "JsonError" to CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize::error::DeserializeError"),
         "Response" to RuntimeType.http.member("Response"),
         "json_errors" to RuntimeType.jsonErrors(runtimeConfig),
     )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RestJson.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/RestJson.kt
@@ -69,7 +69,7 @@ open class RestJson(val codegenContext: CodegenContext) : Protocol {
         "Bytes" to RuntimeType.Bytes,
         "Error" to RuntimeType.GenericError(runtimeConfig),
         "HeaderMap" to RuntimeType.http.member("HeaderMap"),
-        "JsonError" to CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize::Error"),
+        "JsonError" to CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize::error::DeserializeError"),
         "Response" to RuntimeType.http.member("Response"),
         "json_errors" to RuntimeType.jsonErrors(runtimeConfig),
     )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -25,6 +25,7 @@ import software.amazon.smithy.model.traits.TimestampFormatTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.asType
@@ -100,8 +101,7 @@ class JsonParserGenerator(
     private val jsonDeserModule = RustModule.private("json_deser")
     private val typeConversionGenerator = TypeConversionGenerator(model, symbolProvider, runtimeConfig)
     private val codegenScope = arrayOf(
-        "Error" to smithyJson.member("deserialize::Error"),
-        "ErrorReason" to smithyJson.member("deserialize::ErrorReason"),
+        "Error" to smithyJson.member("deserialize::error::DeserializeError"),
         "expect_blob_or_null" to smithyJson.member("deserialize::token::expect_blob_or_null"),
         "expect_bool_or_null" to smithyJson.member("deserialize::token::expect_bool_or_null"),
         "expect_document" to smithyJson.member("deserialize::token::expect_document"),
@@ -422,7 +422,7 @@ class JsonParserGenerator(
                 *codegenScope,
             ) {
                 startObjectOrNull {
-                    rust("let mut map = #T::new();", software.amazon.smithy.rust.codegen.core.rustlang.RustType.HashMap.RuntimeType)
+                    rust("let mut map = #T::new();", RustType.HashMap.RuntimeType)
                     objectKeyLoop(hasMembers = true) {
                         withBlock("let key =", "?;") {
                             deserializeStringInner(keyTarget, "key")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -1246,12 +1246,12 @@ private class ServerHttpBoundProtocolTraitImplGenerator(
         if (model.expectShape(binding.member.target) is StringShape) {
             return ServerRuntimeType.RequestRejection(runtimeConfig)
         }
-        when (codegenContext.protocol) {
+        return when (codegenContext.protocol) {
             RestJson1Trait.ID, AwsJson1_0Trait.ID, AwsJson1_1Trait.ID -> {
-                return CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize").member("Error")
+                CargoDependency.smithyJson(runtimeConfig).asType().member("deserialize::error::DeserializeError")
             }
             RestXmlTrait.ID -> {
-                return CargoDependency.smithyXml(runtimeConfig).asType().member("decode").member("XmlError")
+                CargoDependency.smithyXml(runtimeConfig).asType().member("decode").member("XmlError")
             }
             else -> {
                 TODO("Protocol ${codegenContext.protocol} not supported yet")

--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -232,7 +232,7 @@ impl From<MissingContentTypeReason> for RequestRejection {
 // type. Generated functions that use [crate::rejection::RequestRejection] can thus use `?` to
 // bubble up instead of having to sprinkle things like [`Result::map_err`] everywhere.
 
-convert_to_request_rejection!(aws_smithy_json::deserialize::Error, JsonDeserialize);
+convert_to_request_rejection!(aws_smithy_json::deserialize::error::DeserializeError, JsonDeserialize);
 convert_to_request_rejection!(aws_smithy_xml::decode::XmlError, XmlDeserialize);
 convert_to_request_rejection!(aws_smithy_http::header::ParseError, HeaderParse);
 convert_to_request_rejection!(aws_smithy_types::date_time::DateTimeParseError, DateTimeParse);

--- a/rust-runtime/aws-smithy-json/src/deserialize.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize.rs
@@ -512,51 +512,68 @@ mod tests {
     use aws_smithy_types::Number;
     use proptest::prelude::*;
 
+    #[track_caller]
+    fn expect_token(expected: Option<Result<Token, Error>>, actual: Option<Result<Token, Error>>) {
+        let (expected, actual) = (
+            expected.transpose().expect("err in expected"),
+            actual.transpose().expect("err in actual"),
+        );
+        assert_eq!(expected, actual);
+    }
+
+    macro_rules! expect_err {
+        ($kind:pat, $offset:expr, $value:expr) => {
+            let err: Error = $value.transpose().err().expect("expected error");
+            assert!(matches!(err.kind, $kind));
+            assert_eq!($offset, err.offset);
+        };
+    }
+
     #[test]
     fn test_empty() {
-        assert_eq!(None, json_token_iter(b"").next());
-        assert_eq!(None, json_token_iter(b" ").next());
-        assert_eq!(None, json_token_iter(b"\t").next());
+        assert!(json_token_iter(b"").next().is_none());
+        assert!(json_token_iter(b" ").next().is_none());
+        assert!(json_token_iter(b"\t").next().is_none());
     }
 
     #[test]
     fn test_empty_string() {
         let mut iter = json_token_iter(b"\"\"");
-        assert_eq!(value_string(0, ""), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(value_string(0, ""), iter.next());
+        expect_token(None, iter.next());
 
         let mut iter = json_token_iter(b" \r\n\t \"\"  ");
-        assert_eq!(value_string(5, ""), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(value_string(5, ""), iter.next());
+        expect_token(None, iter.next());
     }
 
     #[test]
     fn test_empty_array() {
         let mut iter = json_token_iter(b"[]");
-        assert_eq!(start_array(0), iter.next());
-        assert_eq!(end_array(1), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(start_array(0), iter.next());
+        expect_token(end_array(1), iter.next());
+        expect_token(None, iter.next());
     }
 
     #[test]
     fn test_empty_object() {
         let mut iter = json_token_iter(b"{}");
-        assert_eq!(start_object(0), iter.next());
-        assert_eq!(end_object(1), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(start_object(0), iter.next());
+        expect_token(end_object(1), iter.next());
+        expect_token(None, iter.next());
     }
 
     #[test]
     fn test_null() {
-        assert_eq!(value_null(1), json_token_iter(b" null ").next());
+        expect_token(value_null(1), json_token_iter(b" null ").next());
 
         let mut iter = json_token_iter(b"[null, null,null]");
-        assert_eq!(start_array(0), iter.next());
-        assert_eq!(value_null(1), iter.next());
-        assert_eq!(value_null(7), iter.next());
-        assert_eq!(value_null(12), iter.next());
-        assert_eq!(end_array(16), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(start_array(0), iter.next());
+        expect_token(value_null(1), iter.next());
+        expect_token(value_null(7), iter.next());
+        expect_token(value_null(12), iter.next());
+        expect_token(end_array(16), iter.next());
+        expect_token(None, iter.next());
 
         assert!(json_token_iter(b"n").next().unwrap().is_err());
         assert!(json_token_iter(b"nul").next().unwrap().is_err());
@@ -569,15 +586,15 @@ mod tests {
         assert!(json_token_iter(b"truee").next().unwrap().is_err());
         assert!(json_token_iter(b"f").next().unwrap().is_err());
         assert!(json_token_iter(b"falsee").next().unwrap().is_err());
-        assert_eq!(value_bool(1, true), json_token_iter(b" true ").next());
-        assert_eq!(value_bool(0, false), json_token_iter(b"false").next());
+        expect_token(value_bool(1, true), json_token_iter(b" true ").next());
+        expect_token(value_bool(0, false), json_token_iter(b"false").next());
 
         let mut iter = json_token_iter(b"[true,false]");
-        assert_eq!(start_array(0), iter.next());
-        assert_eq!(value_bool(1, true), iter.next());
-        assert_eq!(value_bool(6, false), iter.next());
-        assert_eq!(end_array(11), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(start_array(0), iter.next());
+        expect_token(value_bool(1, true), iter.next());
+        expect_token(value_bool(6, false), iter.next());
+        expect_token(end_array(11), iter.next());
+        expect_token(None, iter.next());
     }
 
     proptest! {
@@ -585,8 +602,8 @@ mod tests {
         fn string_prop_test(input in ".*") {
             let json: String = serde_json::to_string(&input).unwrap();
             let mut iter = json_token_iter(json.as_bytes());
-            assert_eq!(value_string(0, &json[1..(json.len() - 1)]), iter.next());
-            assert_eq!(None, iter.next());
+            expect_token(value_string(0, &json[1..(json.len() - 1)]), iter.next());
+            expect_token(None, iter.next());
         }
 
         #[test]
@@ -598,23 +615,23 @@ mod tests {
             } else {
                 Number::PosInt(input as u64)
             };
-            assert_eq!(value_number(0, expected), iter.next());
-            assert_eq!(None, iter.next());
+            expect_token(value_number(0, expected), iter.next());
+            expect_token(None, iter.next());
         }
 
         #[test]
         fn float_prop_test(input: f64) {
             let json = serde_json::to_string(&input).unwrap();
             let mut iter = json_token_iter(json.as_bytes());
-            assert_eq!(value_number(0, Number::Float(input)), iter.next());
-            assert_eq!(None, iter.next());
+            expect_token(value_number(0, Number::Float(input)), iter.next());
+            expect_token(None, iter.next());
         }
     }
 
     #[test]
     fn valid_numbers() {
         let expect = |number, input| {
-            assert_eq!(value_number(0, number), json_token_iter(input).next());
+            expect_token(value_number(0, number), json_token_iter(input).next());
         };
         expect(Number::Float(0.0), b"0.");
         expect(Number::Float(0.0), b"0e0");
@@ -635,7 +652,7 @@ mod tests {
     #[test]
     fn invalid_numbers_we_are_intentionally_accepting() {
         let expect = |number, input| {
-            assert_eq!(value_number(0, number), json_token_iter(input).next());
+            expect_token(value_number(0, number), json_token_iter(input).next());
         };
 
         expect(Number::NegInt(-1), b"-01");
@@ -651,39 +668,50 @@ mod tests {
 
     #[test]
     fn invalid_numbers() {
-        let unexpected_token = |input, token, offset, msg| {
-            let tokens: Vec<Result<Token, Error>> = json_token_iter(input).collect();
-            assert_eq!(
-                vec![Err(Error::new(
-                    ErrorKind::UnexpectedToken(token, msg),
-                    Some(offset)
-                ))],
-                tokens,
-                "input: \"{}\"",
-                std::str::from_utf8(input).unwrap(),
-            );
-        };
+        macro_rules! unexpected_token {
+            ($input:expr, $token:pat, $offset:expr, $msg:pat) => {
+                let tokens: Vec<Result<Token, Error>> = json_token_iter($input).collect();
+                assert_eq!(1, tokens.len());
+                expect_err!(
+                    ErrorKind::UnexpectedToken($token, $msg),
+                    Some($offset),
+                    tokens.into_iter().next()
+                );
+            };
+        }
 
         let invalid_number = |input, offset| {
             let tokens: Vec<Result<Token, Error>> = json_token_iter(input).collect();
-            assert_eq!(
-                vec![Err(Error::new(ErrorKind::InvalidNumber, Some(offset)))],
-                tokens,
-                "input: \"{}\"",
-                std::str::from_utf8(input).unwrap(),
+            assert_eq!(1, tokens.len());
+            expect_err!(
+                ErrorKind::InvalidNumber,
+                Some(offset),
+                tokens.into_iter().next()
             );
         };
 
-        let unexpected_trailer = "<whitespace>, '}', ']', ','";
-        let unexpected_start = "'{', '[', '\"', 'null', 'true', 'false', <number>";
-
-        unexpected_token(b".", '.', 0, unexpected_start);
-        unexpected_token(b".0", '.', 0, unexpected_start);
-        unexpected_token(b"0-05", '-', 1, unexpected_trailer);
-        unexpected_token(b"0x05", 'x', 1, unexpected_trailer);
-        unexpected_token(b"123.invalid", 'i', 4, unexpected_trailer);
-        unexpected_token(b"123invalid", 'i', 3, unexpected_trailer);
-        unexpected_token(b"asdf", 'a', 0, unexpected_start);
+        unexpected_token!(
+            b".",
+            '.',
+            0,
+            "'{', '[', '\"', 'null', 'true', 'false', <number>"
+        );
+        unexpected_token!(
+            b".0",
+            '.',
+            0,
+            "'{', '[', '\"', 'null', 'true', 'false', <number>"
+        );
+        unexpected_token!(b"0-05", '-', 1, "<whitespace>, '}', ']', ','");
+        unexpected_token!(b"0x05", 'x', 1, "<whitespace>, '}', ']', ','");
+        unexpected_token!(b"123.invalid", 'i', 4, "<whitespace>, '}', ']', ','");
+        unexpected_token!(b"123invalid", 'i', 3, "<whitespace>, '}', ']', ','");
+        unexpected_token!(
+            b"asdf",
+            'a',
+            0,
+            "'{', '[', '\"', 'null', 'true', 'false', <number>"
+        );
 
         invalid_number(b"-a", 0);
         invalid_number(b"1e", 0);
@@ -696,25 +724,22 @@ mod tests {
     #[test]
     fn test_unclosed_array() {
         let mut iter = json_token_iter(br#" [null "#);
-        assert_eq!(start_array(1), iter.next());
-        assert_eq!(value_null(2), iter.next());
-        assert_eq!(
-            Some(Err(Error::new(ErrorKind::UnexpectedEos, Some(7)))),
-            iter.next()
-        );
+        expect_token(start_array(1), iter.next());
+        expect_token(value_null(2), iter.next());
+        expect_err!(ErrorKind::UnexpectedEos, Some(7), iter.next());
     }
 
     #[test]
     fn test_array_with_items() {
         let mut iter = json_token_iter(b"[[], {}, \"test\"]");
-        assert_eq!(start_array(0), iter.next());
-        assert_eq!(start_array(1), iter.next());
-        assert_eq!(end_array(2), iter.next());
-        assert_eq!(start_object(5), iter.next());
-        assert_eq!(end_object(6), iter.next());
-        assert_eq!(value_string(9, "test"), iter.next());
-        assert_eq!(end_array(15), iter.next());
-        assert_eq!(None, iter.next());
+        expect_token(start_array(0), iter.next());
+        expect_token(start_array(1), iter.next());
+        expect_token(end_array(2), iter.next());
+        expect_token(start_object(5), iter.next());
+        expect_token(end_object(6), iter.next());
+        expect_token(value_string(9, "test"), iter.next());
+        expect_token(end_array(15), iter.next());
+        expect_token(None, iter.next());
     }
 
     #[test]
@@ -728,57 +753,52 @@ mod tests {
                   "some_struct": { "nested": "asdf" },
                   "some_array": ["one", "two"] }"#,
         );
-        assert_eq!(start_object(0), tokens.next());
-        assert_eq!(object_key(2, "some_int"), tokens.next());
-        assert_eq!(value_number(14, Number::PosInt(5)), tokens.next());
-        assert_eq!(object_key(35, "some_float"), tokens.next());
-        assert_eq!(value_number(49, Number::Float(5.2)), tokens.next());
-        assert_eq!(object_key(72, "some_negative"), tokens.next());
-        assert_eq!(value_number(89, Number::NegInt(-5)), tokens.next());
-        assert_eq!(object_key(111, "some_negative_float"), tokens.next());
-        assert_eq!(value_number(134, Number::Float(-2.4)), tokens.next());
-        assert_eq!(object_key(158, "some_string"), tokens.next());
-        assert_eq!(value_string(173, "test"), tokens.next());
-        assert_eq!(object_key(199, "some_struct"), tokens.next());
-        assert_eq!(start_object(214), tokens.next());
-        assert_eq!(object_key(216, "nested"), tokens.next());
-        assert_eq!(value_string(226, "asdf"), tokens.next());
-        assert_eq!(end_object(233), tokens.next());
-        assert_eq!(object_key(254, "some_array"), tokens.next());
-        assert_eq!(start_array(268), tokens.next());
-        assert_eq!(value_string(269, "one"), tokens.next());
-        assert_eq!(value_string(276, "two"), tokens.next());
-        assert_eq!(end_array(281), tokens.next());
-        assert_eq!(end_object(283), tokens.next());
-        assert_eq!(None, tokens.next());
+        expect_token(start_object(0), tokens.next());
+        expect_token(object_key(2, "some_int"), tokens.next());
+        expect_token(value_number(14, Number::PosInt(5)), tokens.next());
+        expect_token(object_key(35, "some_float"), tokens.next());
+        expect_token(value_number(49, Number::Float(5.2)), tokens.next());
+        expect_token(object_key(72, "some_negative"), tokens.next());
+        expect_token(value_number(89, Number::NegInt(-5)), tokens.next());
+        expect_token(object_key(111, "some_negative_float"), tokens.next());
+        expect_token(value_number(134, Number::Float(-2.4)), tokens.next());
+        expect_token(object_key(158, "some_string"), tokens.next());
+        expect_token(value_string(173, "test"), tokens.next());
+        expect_token(object_key(199, "some_struct"), tokens.next());
+        expect_token(start_object(214), tokens.next());
+        expect_token(object_key(216, "nested"), tokens.next());
+        expect_token(value_string(226, "asdf"), tokens.next());
+        expect_token(end_object(233), tokens.next());
+        expect_token(object_key(254, "some_array"), tokens.next());
+        expect_token(start_array(268), tokens.next());
+        expect_token(value_string(269, "one"), tokens.next());
+        expect_token(value_string(276, "two"), tokens.next());
+        expect_token(end_array(281), tokens.next());
+        expect_token(end_object(283), tokens.next());
+        expect_token(None, tokens.next());
     }
 
     #[test]
     fn test_object_trailing_comma() {
         let mut iter = json_token_iter(br#" { "test": "trailing", } "#);
-        assert_eq!(start_object(1), iter.next());
-        assert_eq!(object_key(3, "test"), iter.next());
-        assert_eq!(value_string(11, "trailing"), iter.next());
-        assert_eq!(
-            Some(Err(Error::new(
-                ErrorKind::UnexpectedToken('}', "'\"'"),
-                Some(23),
-            ))),
+        expect_token(start_object(1), iter.next());
+        expect_token(object_key(3, "test"), iter.next());
+        expect_token(value_string(11, "trailing"), iter.next());
+        expect_err!(
+            ErrorKind::UnexpectedToken('}', "'\"'"),
+            Some(23),
             iter.next()
         );
-        assert_eq!(None, iter.next());
+        assert!(iter.next().is_none());
     }
 
     #[test]
     fn test_object_no_colon() {
         let mut iter = json_token_iter(br#" {"test" "#);
-        assert_eq!(start_object(1), iter.next());
-        assert_eq!(object_key(2, "test"), iter.next());
-        assert_eq!(
-            Some(Err(Error::new(ErrorKind::UnexpectedEos, Some(9),))),
-            iter.next()
-        );
-        assert_eq!(None, iter.next());
+        expect_token(start_object(1), iter.next());
+        expect_token(object_key(2, "test"), iter.next());
+        expect_err!(ErrorKind::UnexpectedEos, Some(9), iter.next());
+        expect_token(None, iter.next());
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -188,9 +188,10 @@ pub fn expect_number_or_null(
 /// Expects a [Token::ValueString] or [Token::ValueNull]. If the value is a string, it interprets it as a base64 encoded [Blob] value.
 pub fn expect_blob_or_null(token: Option<Result<Token<'_>, Error>>) -> Result<Option<Blob>, Error> {
     Ok(match expect_string_or_null(token)? {
-        Some(value) => Some(Blob::new(base64::decode(value.as_escaped_str()).map_err(
-            |err| Error::custom(format!("failed to decode base64: {}", err)),
-        )?)),
+        Some(value) => Some(Blob::new(
+            base64::decode(value.as_escaped_str())
+                .map_err(|err| Error::custom_source("failed to decode base64", err))?,
+        )),
         None => None,
     })
 }
@@ -218,7 +219,7 @@ pub fn expect_timestamp_or_null(
         Format::DateTime | Format::HttpDate => expect_string_or_null(token)?
             .map(|v| DateTime::from_str(v.as_escaped_str(), timestamp_format))
             .transpose()
-            .map_err(|err| Error::custom(format!("failed to parse timestamp: {}", err)))?,
+            .map_err(|err| Error::custom_source("failed to parse timestamp", err))?,
     })
 }
 

--- a/rust-runtime/aws-smithy-json/src/deserialize/token.rs
+++ b/rust-runtime/aws-smithy-json/src/deserialize/token.rs
@@ -573,11 +573,14 @@ pub mod test {
             Ok(None),
             expect_timestamp_or_null(value_null(0), Format::HttpDate)
         );
-        for &invalid in &["NaN", "Infinity", "-Infinity"] {
+        for (invalid, display_name) in &[
+            ("NaN", "NaN"),
+            ("Infinity", "infinity"),
+            ("-Infinity", "infinity"),
+        ] {
             assert_eq!(
                 Err(Error::custom(format!(
-                    "{} is not a valid epoch",
-                    invalid.replace('-', "")
+                    "{display_name} is not a valid epoch"
                 ))),
                 expect_timestamp_or_null(value_string(0, invalid), Format::EpochSeconds)
             );

--- a/rust-runtime/inlineable/src/json_errors.rs
+++ b/rust-runtime/inlineable/src/json_errors.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_smithy_json::deserialize::token::skip_value;
-use aws_smithy_json::deserialize::{json_token_iter, Error as DeserializeError, Token};
+use aws_smithy_json::deserialize::{error::DeserializeError, json_token_iter, Token};
 use aws_smithy_types::Error as SmithyError;
 use bytes::Bytes;
 use http::header::ToStrError;


### PR DESCRIPTION
## Motivation and Context
This PR revamps errors in `aws-smithy-json` to adhere to [RFC-0022: Error Context and Compatibility](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).

This PR is part of a series that will fully implement the RFC, tracked in #1926.

Changelog entries added in #1951.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
