### PR TITLE
Add test to exercise excluded headers in aws-sigv4

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -193,7 +193,7 @@ references = ["smithy-rs#1656"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "ysaito1001"
 
-[[smithy-rs]]
+[[aws-sdk-rust]]
 message = "Add test to exercise excluded headers in aws-sigv4."
 references = ["smithy-rs#1890"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -192,3 +192,9 @@ message = "Fix aws-sigv4 canonical request formatting fallibility."
 references = ["smithy-rs#1656"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "ysaito1001"
+
+[[smithy-rs]]
+message = "Add test to exercise excluded headers in aws-sigv4."
+references = ["smithy-rs#1890"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "ysaito1001"


### PR DESCRIPTION
## Motivation and Context
This commit addresses #1392 by adding a test for the functionality introduced in #1381.

## Description
Prior to this PR, there was an existing test `presigning_header_exclusion` that exercised the said functionality but it only covered the behavior partially, i.e. only a case where the `excluded_headers` field in `SigningSettings` contained just `user-agent`. The new test is a `proptest` and will randomly add headers to `excluded_headers` to verify the functionality works as expected.

## Testing
Ran `cargo t` within the `aws-sigv4` crate.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
