### PR TITLE
Refactor some tests that use `testCodegenContext` and `testSymbolProvider`

### DIFF
--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/ResponseBindingGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/ResponseBindingGeneratorTest.kt
@@ -23,7 +23,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
-import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 
@@ -68,8 +67,8 @@ class ResponseBindingGeneratorTest {
     """.asSmithyModel()
     private val model = OperationNormalizer.transform(baseModel)
     private val operationShape = model.expectShape(ShapeId.from("smithy.example#PutObject"), OperationShape::class.java)
-    private val symbolProvider = testSymbolProvider(model)
-    private val testCodegenContext: CodegenContext = testCodegenContext(model)
+    private val codegenContext: CodegenContext = testCodegenContext(model)
+    private val symbolProvider = codegenContext.symbolProvider
 
     private fun RustWriter.renderOperation() {
         operationShape.outputShape(model).renderWithModelBuilder(model, symbolProvider, this)
@@ -79,8 +78,8 @@ class ResponseBindingGeneratorTest {
                 .filter { it.location == HttpLocation.HEADER }
             bindings.forEach { binding ->
                 val runtimeType = ResponseBindingGenerator(
-                    RestJson(testCodegenContext),
-                    testCodegenContext,
+                    RestJson(codegenContext),
+                    codegenContext,
                     operationShape,
                 ).generateDeserializeHeaderFn(binding)
                 // little hack to force these functions to be generated

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/AwsQueryParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/AwsQueryParserGeneratorTest.kt
@@ -43,11 +43,9 @@ class AwsQueryParserGeneratorTest {
     @Test
     fun `it modifies operation parsing to include Response and Result tags`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
-        val parserGenerator = AwsQueryParserGenerator(
-            testCodegenContext(model),
-            RuntimeType.wrappedXmlErrors(TestRuntimeConfig),
-        )
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
+        val parserGenerator = AwsQueryParserGenerator(codegenContext, RuntimeType.wrappedXmlErrors(TestRuntimeConfig))
         val operationParser = parserGenerator.operationParser(model.lookup("test#SomeOperation"))!!
         val project = TestWorkspace.testProject(testSymbolProvider(model))
 

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/Ec2QueryParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/Ec2QueryParserGeneratorTest.kt
@@ -43,11 +43,9 @@ class Ec2QueryParserGeneratorTest {
     @Test
     fun `it modifies operation parsing to include Response and Result tags`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
-        val parserGenerator = Ec2QueryParserGenerator(
-            testCodegenContext(model),
-            RuntimeType.wrappedXmlErrors(TestRuntimeConfig),
-        )
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
+        val parserGenerator = Ec2QueryParserGenerator(codegenContext, RuntimeType.wrappedXmlErrors(TestRuntimeConfig))
         val operationParser = parserGenerator.operationParser(model.lookup("test#SomeOperation"))!!
         val project = TestWorkspace.testProject(testSymbolProvider(model))
 

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGeneratorTest.kt
@@ -113,9 +113,10 @@ class JsonParserGeneratorTest {
     @Test
     fun `generates valid deserializers`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
         val parserGenerator = JsonParserGenerator(
-            testCodegenContext(model),
+            codegenContext,
             HttpTraitHttpBindingResolver(model, ProtocolContentTypes.consistent("application/json")),
             ::restJsonFieldName,
         )

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/XmlBindingTraitParserGeneratorTest.kt
@@ -91,9 +91,10 @@ internal class XmlBindingTraitParserGeneratorTest {
     @Test
     fun `generates valid parsers`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
         val parserGenerator = XmlBindingTraitParserGenerator(
-            testCodegenContext(model),
+            codegenContext,
             RuntimeType.wrappedXmlErrors(TestRuntimeConfig),
         ) { _, inner -> inner("decoder") }
         val operationParser = parserGenerator.operationParser(model.lookup("test#Op"))!!

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/AwsQuerySerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/AwsQuerySerializerGeneratorTest.kt
@@ -21,7 +21,6 @@ import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.renderWithModelBuilder
 import software.amazon.smithy.rust.codegen.core.testutil.testCodegenContext
-import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
@@ -89,16 +88,17 @@ class AwsQuerySerializerGeneratorTest {
     @ParameterizedTest
     @CsvSource("true", "false")
     fun `generates valid serializers`(generateUnknownVariant: Boolean) {
-        val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
-        val target = when (generateUnknownVariant) {
+        val codegenTarget = when (generateUnknownVariant) {
             true -> CodegenTarget.CLIENT
             false -> CodegenTarget.SERVER
         }
-        val parserGenerator = AwsQuerySerializerGenerator(testCodegenContext(model, codegenTarget = target))
+        val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
+        val codegenContext = testCodegenContext(model, codegenTarget = codegenTarget)
+        val symbolProvider = codegenContext.symbolProvider
+        val parserGenerator = AwsQuerySerializerGenerator(testCodegenContext(model, codegenTarget = codegenTarget))
         val operationGenerator = parserGenerator.operationInputSerializer(model.lookup("test#Op"))
 
-        val project = TestWorkspace.testProject(testSymbolProvider(model))
+        val project = TestWorkspace.testProject(symbolProvider)
         project.lib {
             unitTest(
                 "query_serializer",

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/Ec2QuerySerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/Ec2QuerySerializerGeneratorTest.kt
@@ -86,8 +86,9 @@ class Ec2QuerySerializerGeneratorTest {
     @Test
     fun `generates valid serializers`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
-        val parserGenerator = Ec2QuerySerializerGenerator(testCodegenContext(model))
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
+        val parserGenerator = Ec2QuerySerializerGenerator(codegenContext)
         val operationGenerator = parserGenerator.operationInputSerializer(model.lookup("test#Op"))
 
         val project = TestWorkspace.testProject(testSymbolProvider(model))

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGeneratorTest.kt
@@ -101,9 +101,10 @@ class JsonSerializerGeneratorTest {
     @Test
     fun `generates valid serializers`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
         val parserSerializer = JsonSerializerGenerator(
-            testCodegenContext(model),
+            codegenContext,
             HttpTraitHttpBindingResolver(model, ProtocolContentTypes.consistent("application/json")),
             ::restJsonFieldName,
         )

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/XmlBindingTraitSerializerGeneratorTest.kt
@@ -105,9 +105,10 @@ internal class XmlBindingTraitSerializerGeneratorTest {
     @Test
     fun `generates valid serializers`() {
         val model = RecursiveShapeBoxer.transform(OperationNormalizer.transform(baseModel))
-        val symbolProvider = testSymbolProvider(model)
+        val codegenContext = testCodegenContext(model)
+        val symbolProvider = codegenContext.symbolProvider
         val parserGenerator = XmlBindingTraitSerializerGenerator(
-            testCodegenContext(model),
+            codegenContext,
             HttpTraitHttpBindingResolver(model, ProtocolContentTypes.consistent("application/xml")),
         )
         val operationSerializer = parserGenerator.payloadSerializer(model.lookup("test#OpInput\$payload"))


### PR DESCRIPTION
Tests that use `testCodegenContext` should rely on the symbol provider
hosted within instead of calling `testSymbolProvider`.
`testCodegenContext` depends on `testSymbolProvider`, but this is an
implementation detail that tests should not rely on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
