### PR TITLE
Fix `ktlint` tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,8 @@ tasks.register<JavaExec>("ktlint") {
     classpath = configurations.getByName("ktlint")
     main = "com.pinterest.ktlint.Main"
     args = listOf("--verbose", "--relative", "--") + lintPaths
+    // https://github.com/pinterest/ktlint/issues/1195#issuecomment-1009027802
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 tasks.register<JavaExec>("ktlintFormat") {
@@ -64,6 +66,8 @@ tasks.register<JavaExec>("ktlintFormat") {
     classpath = configurations.getByName("ktlint")
     main = "com.pinterest.ktlint.Main"
     args = listOf("--verbose", "--relative", "--format", "--") + lintPaths
+    // https://github.com/pinterest/ktlint/issues/1195#issuecomment-1009027802
+    jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 @Suppress("UnstableApiUsage")


### PR DESCRIPTION
## Description
Running `./gradlew ktlint` and `./gradlew ktlintFormat` locally gave me an error (trace below).
I found a solution for the problem here: https://github.com/pinterest/ktlint/issues/1195#issuecomment-1009027802.

[Apparently the `--add-opens` arguments allows ktlint to do some reflection it needs](https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-12F945EB-71D6-46AF-8C3D-D354FD0B1781).

```
Exception in thread "main" java.util.concurrent.ExecutionException: java.lang.ExceptionInInitializerError
        at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122)
        at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191)
        at com.pinterest.ktlint.internal.KtlintCommandLine.parallel(KtlintCommandLine.kt:578)
        at com.pinterest.ktlint.internal.KtlintCommandLine.parallel$default(KtlintCommandLine.kt:536)
        at com.pinterest.ktlint.internal.KtlintCommandLine.lintFiles(KtlintCommandLine.kt:283)
        at com.pinterest.ktlint.internal.KtlintCommandLine.run(KtlintCommandLine.kt:235)
        at com.pinterest.ktlint.Main.main(Main.kt:31)
Caused by: java.lang.ExceptionInInitializerError
        at org.jetbrains.kotlin.com.intellij.util.exception.FrequentErrorLogger.report(FrequentErrorLogger.java:47)
        at org.jetbrains.kotlin.com.intellij.util.exception.FrequentErrorLogger.info(FrequentErrorLogger.java:43)
        at org.jetbrains.kotlin.com.intellij.psi.impl.DebugUtil.handleUnspecifiedTrace(DebugUtil.java:628)
        at org.jetbrains.kotlin.com.intellij.psi.impl.DebugUtil.currentInvalidationTrace(DebugUtil.java:620)
        at org.jetbrains.kotlin.com.intellij.psi.impl.DebugUtil.calcInvalidationTrace(DebugUtil.java:614)
        at org.jetbrains.kotlin.com.intellij.psi.impl.DebugUtil.onInvalidated(DebugUtil.java:585)
        at org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeElement.onInvalidated(TreeElement.java:226)
        at org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeElement.invalidate(TreeElement.java:328)
        at org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeElement.rawRemove(TreeElement.java:312)
        at org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.TreeElement.rawReplaceWithList(TreeElement.java:319)
        at org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafElement.rawReplaceWithText(LeafElement.java:146)
        at com.pinterest.ktlint.ruleset.standard.NoBlankLineBeforeRbraceRule.visit(NoBlankLineBeforeRbraceRule.kt:29)
        at com.pinterest.ktlint.core.KtLint$format$1.invoke(KtLint.kt:251)
        at com.pinterest.ktlint.core.KtLint$format$1.invoke(KtLint.kt:244)
        at com.pinterest.ktlint.core.internal.VisitorProvider$sequentialVisitor$1$1$1$1.invoke(VisitorProvider.kt:123)
        at com.pinterest.ktlint.core.internal.VisitorProvider$sequentialVisitor$1$1$1$1.invoke(VisitorProvider.kt:123)
        at com.pinterest.ktlint.core.ast.PackageKt.visit(package.kt:236)
        at com.pinterest.ktlint.core.ast.PackageKt.visit(package.kt:237)
        at com.pinterest.ktlint.core.ast.PackageKt.visit(package.kt:237)
        at com.pinterest.ktlint.core.ast.PackageKt.visit(package.kt:237)
        at com.pinterest.ktlint.core.ast.PackageKt.visit(package.kt:237)
        at com.pinterest.ktlint.core.ast.PackageKt.visit(package.kt:237)
        at com.pinterest.ktlint.core.internal.VisitorProvider$sequentialVisitor$1.invoke(VisitorProvider.kt:123)
        at com.pinterest.ktlint.core.internal.VisitorProvider$sequentialVisitor$1.invoke(VisitorProvider.kt:115)
        at com.pinterest.ktlint.core.KtLint.format(KtLint.kt:244)
        at com.pinterest.ktlint.internal.FileUtilsKt.formatFile(FileUtils.kt:202)
        at com.pinterest.ktlint.internal.KtlintCommandLine.process(KtlintCommandLine.kt:355)
        at com.pinterest.ktlint.internal.KtlintCommandLine.access$process(KtlintCommandLine.kt:48)
        at com.pinterest.ktlint.internal.KtlintCommandLine$lintFiles$3.invoke$lambda-1(KtlintCommandLine.kt:274)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make field private transient java.lang.Object java.lang.Throwable.backtrace accessible: module java.base does not "opens java.lang" to unnamed module @a803f94
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
        at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:178)
        at java.base/java.lang.reflect.Field.setAccessible(Field.java:172)
        at org.jetbrains.kotlin.com.intellij.util.ReflectionUtil.findFieldInHierarchy(ReflectionUtil.java:154)
        at org.jetbrains.kotlin.com.intellij.util.ReflectionUtil.getDeclaredField(ReflectionUtil.java:279)
        at org.jetbrains.kotlin.com.intellij.openapi.util.objectTree.ThrowableInterner.<clinit>(ThrowableInterner.java:88)
        ... 33 more

FAILURE: Build failed with an exception.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
