### PR TITLE
Add a test ensuring streamed response will error if `EOF` is received early

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -198,3 +198,9 @@ message = "Add test to exercise excluded headers in aws-sigv4."
 references = ["smithy-rs#1890"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "Add test ensuring that a response will error if the response body returns an EOF before the entire body has been read."
+references = ["smithy-rs#1801"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "Velfi"

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2021"
 async-std = "1.12.0"
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
-aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
 aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts" }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["rt-tokio"] }
@@ -19,14 +18,15 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol-test" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 bytes = "1"
 bytes-utils = "0.1.2"
 http = "0.2.3"
 http-body = "0.4.5"
 hyper = "0.14.12"
 serde_json = "1"
-tempfile = "3"
 smol = "1.2"
+tempfile = "3"
 tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
-tracing = "0.1.0"

--- a/aws/sdk/integration-tests/s3/tests/streaming-response.rs
+++ b/aws/sdk/integration-tests/s3/tests/streaming-response.rs
@@ -1,0 +1,143 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::net::SocketAddr;
+use std::time::Duration;
+use aws_sdk_s3::{
+    Credentials, Region,
+    Endpoint
+};
+use bytes::BytesMut;
+use tracing::debug;
+
+// static INIT_LOGGER: std::sync::Once = std::sync::Once::new();
+//
+// fn init_logger() {
+//     INIT_LOGGER.call_once(|| {
+//         tracing_subscriber::fmt::init();
+//     });
+// }
+
+// test will hang forever with the default (single-threaded) test executor
+#[tokio::test(flavor = "multi_thread")]
+#[should_panic(expected = "error reading a body from connection: end of file before message length reached")]
+async fn test_streaming_response_fails_when_eof_comes_before_content_length_reached() {
+    // init_logger();
+
+    let addr = SocketAddr::from(([0,0,0,0], 3000));
+    // We spawn a faulty server that will close the connection after
+    // writing half of the response body.
+    let _server = tokio::spawn(start_faulty_server(addr));
+
+    let creds = Credentials::new(
+        "ANOTREAL",
+        "notrealrnrELgWzOk3IfjzDKtFBhDby",
+        Some("notarealsessiontoken".to_string()),
+        None,
+        "test",
+    );
+
+    let conf = aws_sdk_s3::Config::builder()
+        .credentials_provider(creds)
+        .region(Region::new("us-east-1"))
+        .endpoint_resolver(
+            Endpoint::immutable("http://localhost:3000".parse().expect("valid URI"))
+        )
+        .build();
+
+    let client = aws_sdk_s3::client::Client::from_conf(conf);
+
+    // This will succeed b/c the head of the response is fine.
+    let res = client
+        .get_object()
+        .bucket("some-test-bucket")
+        .key("test.txt")
+        .send()
+        .await
+        .unwrap();
+
+    // Should panic here when the body is read with an "UnexpectedEof" error
+    if let Err(e) = res.body.collect().await {
+        panic!("{e}")
+    }
+}
+
+async fn start_faulty_server(addr: SocketAddr) {
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::time::sleep;
+
+    let listener = TcpListener::bind(addr).await.expect("socket is free");
+
+    async fn process_socket(socket: TcpStream) {
+        let mut buf = BytesMut::new();
+        let response: &[u8] = br#"HTTP/1.1 200 OK
+x-amz-request-id: 4B4NGF0EAWN0GE63
+content-length: 12
+etag: 3e25960a79dbc69b674cd4ec67a72c62
+content-type: application/octet-stream
+server: AmazonS3
+content-encoding:
+last-modified: Tue, 21 Jun 2022 16:29:14 GMT
+date: Tue, 21 Jun 2022 16:29:23 GMT
+x-amz-id-2: kPl+IVVZAwsN8ePUyQJZ40WD9dzaqtr4eNESArqE68GSKtVvuvCTDe+SxhTT+JTUqXB1HL4OxNM=
+accept-ranges: bytes
+
+Hello"#;
+        let mut nothing_more_to_read = false;
+        let mut time_to_respond = false;
+
+        loop {
+            match socket.try_read_buf(&mut buf) {
+                Ok(0) => {
+                    debug!("stream read has been closed, breaking from loop");
+                    nothing_more_to_read = true;
+                }
+                Ok(n) => {
+                    debug!("read {n} bytes from the socket reader");
+                    if let Ok(s) = std::str::from_utf8(&buf) {
+                        debug!("buf currently looks like:\n{s:?}");
+                    }
+
+                    if buf.ends_with(b"\r\n\r\n") {
+                        time_to_respond = true;
+                    }
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    debug!("would block, looping again after small 1ms nap");
+                    sleep(Duration::from_millis(1)).await;
+                }
+                Err(e) => {
+                    panic!("{e}")
+                }
+            }
+
+            if nothing_more_to_read {
+                let s = std::str::from_utf8(&buf).unwrap();
+                debug!("nothing_more_to_read, server received {s}");
+                break;
+            }
+
+            if socket.writable().await.is_ok() {
+                if time_to_respond {
+                    // The content length is 12 but we'll only write 5 bytes
+                    socket.try_write(&response).unwrap();
+                    // We break from the R/W loop after sending a partial response in order to
+                    // close the connection early.
+                    debug!("faulty server has written partial response, now closing connection");
+                    break;
+                }
+            }
+        }
+    }
+
+    loop {
+        let (socket, addr) = listener.accept().await.expect("listener can accept new connections");
+        debug!("server received new connection from {addr:?}");
+        let start = std::time::Instant::now();
+        process_socket(socket).await;
+        debug!("connection to {addr:?} closed after {:.02?}", start.elapsed());
+    }
+}
+


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
#1801 

## Description
<!--- Describe your changes in detail -->
The SDK depends on our HTTP client (`hyper`) to return an error in the event that a connection is closed early and only a portion of the response body is received. This PR adds a test that exercises that error.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The PR adds a test.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
