### PR TITLE
Fix cargo audit issue on chrono

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -71,5 +71,5 @@ author = "Velfi"
 [[smithy-rs]]
 message = "Fix cargo audit issue on chrono."
 references = ["smithy-rs#1907"]
-meta = { "breaking" = false, "tada" = false, "bug" = false }
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
 author = "ysaito1001"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -52,3 +52,9 @@ message = "Fix bug that can cause panics in paginators"
 references = ["smithy-rs#1903", "smithy-rs#1902"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client"}
 author = "rcoh"
+
+[[smithy-rs]]
+message = "Fix cargo audit issue on chrono."
+references = ["smithy-rs#1907"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "ysaito1001"

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -22,7 +22,7 @@ bytes = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14.20", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = "0.7.0"
+lambda_http = "0.7.1"
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -22,7 +22,7 @@ bytes = "1.2"
 futures = "0.3"
 http = "0.2"
 hyper = { version = "0.14.20", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = "0.6.0"
+lambda_http = "0.7.0"
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = "0.7.0"
+lambda_http = "0.7.1"
 mime = "0.3"
 nom = "7"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -26,7 +26,7 @@ futures-util = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = "0.6.0"
+lambda_http = "0.7.0"
 mime = "0.3"
 nom = "7"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
@@ -37,7 +37,7 @@ rustls-pemfile = "1.0.1"
 futures-util = "0.3"
 
 # This dependency is only required for the `pokemon-service-lambda` program.
-lambda_http = "0.7.0"
+lambda_http = "0.7.1"
 
 # Local paths
 aws-smithy-http-server = { path = "../../" }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
@@ -37,7 +37,7 @@ rustls-pemfile = "1.0.1"
 futures-util = "0.3"
 
 # This dependency is only required for the `pokemon-service-lambda` program.
-lambda_http = "0.6.0"
+lambda_http = "0.7.0"
 
 # Local paths
 aws-smithy-http-server = { path = "../../" }

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -13,7 +13,7 @@ convert-time = ["aws-smithy-types", "time"]
 
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types", optional = true }
-chrono = { version = "0.4.19", optional = true }
+chrono = { version = "0.4.19", optional = true, default-features = false, features = ["std"] }
 time = { version = "0.3.4", optional = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Motivation and Context
This PR addresses a cargo audit issue described in https://github.com/awslabs/aws-sdk-rust/issues/643. ~~This will remain a draft until https://github.com/awslabs/aws-lambda-rust-runtime/pull/556 is resolved.~~

## Description
Within the top-level [rust-runtime](https://github.com/awslabs/smithy-rs/tree/b4f294c2770c58148c43411803330c26e369ec14/rust-runtime) workspace, we can see the following report generated when running `cargo audit`:
```
Crate:     time
Version:   0.1.44
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.44
└── chrono 0.4.22
    ├── aws_lambda_events 0.6.3
    │   └── lambda_http 0.6.2
    │       ├── aws-smithy-http-server-python 0.0.0-smithy-rs-head
    │       └── aws-smithy-http-server 0.0.0-smithy-rs-head
    │           ├── inlineable 0.0.0-smithy-rs-head
    │           └── aws-smithy-http-server-python 0.0.0-smithy-rs-head
    └── aws-smithy-types-convert 0.0.0-smithy-rs-head
```
To work around the issue, we follow [this](https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249) to avoid bringing in the `time` crate via the `chrono` crate. To that goal, this PR edits four `Cargo.toml` files.
- `Cargo.toml` in `aws-smithy-types-convert`
This implements the said workaround.
- `Cargo.toml`s in `aws-smithy-http-server-python` and `aws-smithy-http-server`
These crates indirectly stepped on the RustSec vulnerability in question from `aws_lambda_events` 0.6.3 (through `lambda_http` 0.6.2). `aws_lambda_events` addressed it as of 0.7.1 ([PR](https://github.com/LegNeato/aws-lambda-events/pull/110/files)) and `lambda_http` 0.7.1 ~~0.7.0~~, in turn, depended on a safe version of `aws_lambda_events` ([PR](https://github.com/awslabs/aws-lambda-rust-runtime/pull/541/files#diff-2fdc9da636cb156b470a06b7437c894efe621c03380a0e50ad19a1e1b47bce1e)). Thus, both `aws-smithy-http-server-python` and `aws-smithy-http-server` now depend on `lambda_http` 0.7.1 ~~0.7.0~~.
- `Cargo.toml` in `pokemon-service`
This is due to [b1cb5fa](https://github.com/awslabs/smithy-rs/pull/1907/commits/b1cb5fad024df27a6e62213d7ee2eeb3ddcef446).

## Testing
Ran `cargo audit` from within the top-level `rust-runtime` workspace:
```
$ rm Cargo.lock; cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 464 security advisories
    Updating crates.io index
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (249 crate dependencies)
```
This is the output as a result of running `cargo audit` in this branch. We can see no vulnerabilities detected.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
