### PR TITLE
Bump `wrk-api-bench` to v0.0.8

### DIFF
--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/Cargo.toml
@@ -47,7 +47,7 @@ pokemon-service-server-sdk = { path = "../pokemon-service-server-sdk/" }
 assert_cmd = "2.0"
 home = "0.5"
 serial_test = "0.7.0"
-wrk-api-bench = "0.0.7"
+wrk-api-bench = "0.0.8"
 
 # This dependency is only required for testing the `pokemon-service-tls` program.
 hyper-rustls = { version = "0.23.0", features = ["http2"] }


### PR DESCRIPTION
The current version is vulnerable. See
https://github.com/crisidev/wrk-api-bench-rs/pull/1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
