### PR TITLE
Slow down crate publish more

### DIFF
--- a/tools/publisher/src/subcommand/publish.rs
+++ b/tools/publisher/src/subcommand/publish.rs
@@ -66,15 +66,15 @@ pub async fn subcommand_publish(
             if !is_published(&package.handle).await? {
                 publish(&package.handle, &package.crate_path).await?;
 
+                // Keep things slow to avoid getting throttled by crates.io
+                tokio::time::sleep(Duration::from_secs(2)).await;
+
                 // Sometimes it takes a little bit of time for the new package version
                 // to become available after publish. If we proceed too quickly, then
                 // the next package publish can fail if it depends on this package.
                 wait_for_eventual_consistency(&package).await?;
                 info!("Successfully published `{}`", package.handle);
                 any_published = true;
-
-                // Keep things slow to avoid getting throttled by crates.io
-                tokio::time::sleep(Duration::from_secs(1)).await;
             } else {
                 info!("`{}` was already published", package.handle);
             }


### PR DESCRIPTION
## Motivation and Context
Throttling still occurs every 18 crates or so when publishing the SDK, although this doesn't cause anything to fail since it gets retried with a 30 second delay. This PR doubles the amount of time the publisher tool waits in between crates so that throttling occurs less frequently. Overall, this should reduce the total time since 18 seconds + 30 second retry timeout is greater than 36 seconds with no throttling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
