### PR TITLE
Update changelog and use you task::spawn helper

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -46,3 +46,9 @@ message = "`aws_smithy_http_server::routing::Router` is exported from the crate 
 references = ["smithy-rs#1910"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server" }
 author = "david-perez"
+
+[[smithy-rs]]
+message = "Fix bug that can cause panics in paginators"
+references = ["smithy-rs#1903", "smithy-rs#1902"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client"}
+author = "rcoh"

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -18,6 +18,7 @@ futures-util = "0.3.16"
 
 [dev-dependencies]
 tokio = { version = "1.8.4", features = ["rt", "macros", "test-util"] }
+tokio-test = "0.4.2"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
## Motivation and Context
- cleanups from async-panic PR

## Description
The async panic PR was missing a changelog entry— @LucioFranco also turned me on to the new `tokio_test::task::spawn` which makes interacting with futures in a test context MUCH easier
## Testing
- [x] UTs

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
