### PR TITLE
Fix repeated options when creating an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,1 @@
-blank_issues_enabled: true
-contact_links:
-- name: Report a security vulnerability
-  url: https://github.com/awslabs/smithy-rs/security/policy
-  about: Please review our security policy for more details
+blank_issues_enabled: false


### PR DESCRIPTION
## Description
After https://github.com/awslabs/smithy-rs/pull/1913 our issue options look like this:

![image](https://user-images.githubusercontent.com/15112080/198339082-2bdaadac-378f-4857-b9fd-cb00318fb2cc.png)

Note the repeated option to view the security policy and the link on the bottom to create a blank issue (we already have that option).

The first happens because GH already links to the security policy if you have a `SECURITY.md` file.
The second is because we've added [this template](https://github.com/awslabs/smithy-rs/pull/1913/files#diff-5d7416ebfc56443c702e82a607f1ed7656f51a9138720a45d0781c84c4d53439), but kept `blank_issues_enable: true` in the config.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
