### PR TITLE
Revamp errors in AWS runtime crates

### DIFF
--- a/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
+++ b/aws/rust-runtime/aws-config/src/meta/credentials/chain.rs
@@ -82,12 +82,12 @@ impl CredentialsProviderChain {
                     tracing::debug!(provider = %name, "loaded credentials");
                     return Ok(credentials);
                 }
-                Err(CredentialsError::CredentialsNotLoaded { context, .. }) => {
-                    tracing::debug!(provider = %name, context = %context, "provider in chain did not provide credentials");
+                Err(err @ CredentialsError::CredentialsNotLoaded(_)) => {
+                    tracing::debug!(provider = %name, context = %DisplayErrorContext(&err), "provider in chain did not provide credentials");
                 }
-                Err(e) => {
-                    tracing::warn!(provider = %name, error = %DisplayErrorContext(&e), "provider failed to provide credentials");
-                    return Err(e);
+                Err(err) => {
+                    tracing::warn!(provider = %name, error = %DisplayErrorContext(&err), "provider failed to provide credentials");
+                    return Err(err);
                 }
             }
         }

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -266,6 +266,7 @@ mod test {
     };
     use aws_sdk_sts::Region;
     use aws_smithy_async::rt::sleep::TokioSleep;
+    use aws_smithy_types::error::display::DisplayErrorContext;
     use aws_types::credentials::CredentialsError;
     use aws_types::os_shim_internal::{Env, Fs};
     use std::collections::HashMap;
@@ -308,7 +309,7 @@ mod test {
             .await
             .expect_err("should fail, provider not loaded");
         assert!(
-            format!("{}", err).contains("AWS_ROLE_ARN"),
+            format!("{}", DisplayErrorContext(&err)).contains("AWS_ROLE_ARN"),
             "`{}` did not contain expected string",
             err
         );

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_error/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_default_chain_error/test-case.json
@@ -2,6 +2,6 @@
   "name": "imds-default-chain",
   "docs": "IMDS isn't specifically configured but is loaded as part of the default chain. This has the exact same HTTP traffic as imds_no_iam_role, they are equivalent.",
   "result": {
-    "ErrorContains": "The credential provider was not enabled"
+    "ErrorContains": "the credential provider was not enabled"
   }
 }

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_disabled/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_disabled/test-case.json
@@ -2,6 +2,6 @@
   "name": "imds-disabled",
   "docs": "when IMDS is disabled by an environment variable, it shouldn't be used as part of the default chain",
   "result": {
-    "ErrorContains": "The credential provider was not enabled"
+    "ErrorContains": "the credential provider was not enabled"
   }
 }

--- a/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_no_iam_role/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/default-provider-chain/imds_no_iam_role/test-case.json
@@ -2,6 +2,6 @@
   "name": "imds-token-fail",
   "docs": "attempts to acquire an IMDS token, but the instance doesn't have a role configured",
   "result": {
-    "ErrorContains": "The credential provider was not enabled"
+    "ErrorContains": "the credential provider was not enabled"
   }
 }

--- a/aws/rust-runtime/aws-config/test-data/profile-provider/credential_process_failure/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/profile-provider/credential_process_failure/test-case.json
@@ -2,6 +2,6 @@
   "name": "credential_process_failure",
   "docs": "credential_process handles the external process exiting with a non-zero exit code",
   "result": {
-    "ErrorContains": "An error occurred while loading credentials: Error retrieving credentials: external process exited with code exit status: 1"
+    "ErrorContains": "an error occurred while loading credentials: Error retrieving credentials: external process exited with code exit status: 1"
   }
 }

--- a/aws/rust-runtime/aws-config/test-data/profile-provider/empty_config/test-case.json
+++ b/aws/rust-runtime/aws-config/test-data/profile-provider/empty_config/test-case.json
@@ -2,6 +2,6 @@
   "name": "empty-config",
   "docs": "no config was defined",
   "result": {
-    "ErrorContains": "The credential provider was not enabled"
+    "ErrorContains": "the credential provider was not enabled"
   }
 }

--- a/aws/rust-runtime/aws-http/src/auth.rs
+++ b/aws/rust-runtime/aws-http/src/auth.rs
@@ -54,7 +54,7 @@ impl CredentialsStage {
             }
             // if we get another error class, there is probably something actually wrong that the user will
             // want to know about
-            Err(other) => return Err(CredentialsStageError::CredentialsLoadingError(other)),
+            Err(other) => return Err(other.into()),
         }
         Ok(request)
     }
@@ -67,34 +67,28 @@ mod error {
 
     /// Failures that can occur in the credentials middleware.
     #[derive(Debug)]
-    pub enum CredentialsStageError {
-        /// No credentials provider was found in the property bag for the operation.
-        MissingCredentialsProvider,
-        /// Failed to load credentials with the credential provider in the property bag.
-        CredentialsLoadingError(CredentialsError),
+    pub struct CredentialsStageError {
+        source: CredentialsError,
     }
 
-    impl StdError for CredentialsStageError {}
+    impl StdError for CredentialsStageError {
+        fn source(&self) -> Option<&(dyn StdError + 'static)> {
+            Some(&self.source as _)
+        }
+    }
 
     impl fmt::Display for CredentialsStageError {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            use CredentialsStageError::*;
-            match self {
-                MissingCredentialsProvider => {
-                    write!(f, "No credentials provider in the property bag")
-                }
-                CredentialsLoadingError(err) => write!(
-                    f,
-                    "Failed to load credentials from the credentials provider: {}",
-                    err
-                ),
-            }
+            write!(
+                f,
+                "failed to load credentials from the credentials provider"
+            )
         }
     }
 
     impl From<CredentialsError> for CredentialsStageError {
-        fn from(err: CredentialsError) -> Self {
-            CredentialsStageError::CredentialsLoadingError(err)
+        fn from(source: CredentialsError) -> Self {
+            CredentialsStageError { source }
         }
     }
 }

--- a/aws/rust-runtime/aws-http/src/user_agent.rs
+++ b/aws/rust-runtime/aws-http/src/user_agent.rs
@@ -525,31 +525,53 @@ impl UserAgentStage {
     }
 }
 
-/// Failures that can arise from the user agent middleware
 #[derive(Debug)]
-pub enum UserAgentStageError {
+enum UserAgentStageErrorKind {
     /// There was no [`AwsUserAgent`] in the property bag.
     UserAgentMissing,
     /// The formatted user agent string is not a valid HTTP header value. This indicates a bug.
     InvalidHeader(InvalidHeaderValue),
 }
 
-impl Error for UserAgentStageError {}
+/// Failures that can arise from the user agent middleware
+#[derive(Debug)]
+pub struct UserAgentStageError {
+    kind: UserAgentStageErrorKind,
+}
+
+impl Error for UserAgentStageError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use UserAgentStageErrorKind::*;
+        match &self.kind {
+            InvalidHeader(source) => Some(source as _),
+            UserAgentMissing => None,
+        }
+    }
+}
 
 impl fmt::Display for UserAgentStageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UserAgentMissing => write!(f, "User agent missing from property bag"),
-            Self::InvalidHeader(_) => {
-                write!(f, "Provided user agent header was invalid. This is a bug.")
+        use UserAgentStageErrorKind::*;
+        match self.kind {
+            UserAgentMissing => write!(f, "user agent missing from property bag"),
+            InvalidHeader(_) => {
+                write!(f, "provided user agent header was invalid (this is a bug)")
             }
         }
     }
 }
 
+impl From<UserAgentStageErrorKind> for UserAgentStageError {
+    fn from(kind: UserAgentStageErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
 impl From<InvalidHeaderValue> for UserAgentStageError {
     fn from(value: InvalidHeaderValue) -> Self {
-        UserAgentStageError::InvalidHeader(value)
+        Self {
+            kind: UserAgentStageErrorKind::InvalidHeader(value),
+        }
     }
 }
 
@@ -564,7 +586,7 @@ impl MapRequest for UserAgentStage {
         request.augment(|mut req, conf| {
             let ua = conf
                 .get::<AwsUserAgent>()
-                .ok_or(UserAgentStageError::UserAgentMissing)?;
+                .ok_or(UserAgentStageErrorKind::UserAgentMissing)?;
             req.headers_mut()
                 .append(USER_AGENT, HeaderValue::try_from(ua.ua_header())?);
             req.headers_mut().append(

--- a/aws/rust-runtime/aws-inlineable/src/presigning.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning.rs
@@ -50,10 +50,8 @@ pub mod config {
         }
     }
 
-    /// `PresigningConfig` build errors.
-    #[non_exhaustive]
     #[derive(Debug)]
-    pub enum Error {
+    enum ErrorKind {
         /// Presigned requests cannot be valid for longer than one week.
         ExpiresInDurationTooLong,
 
@@ -61,16 +59,28 @@ pub mod config {
         ExpiresInRequired,
     }
 
+    /// `PresigningConfig` build errors.
+    #[derive(Debug)]
+    pub struct Error {
+        kind: ErrorKind,
+    }
+
     impl std::error::Error for Error {}
 
     impl fmt::Display for Error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            match self {
-                Error::ExpiresInDurationTooLong => {
+            match self.kind {
+                ErrorKind::ExpiresInDurationTooLong => {
                     write!(f, "`expires_in` must be no longer than one week")
                 }
-                Error::ExpiresInRequired => write!(f, "`expires_in` is required"),
+                ErrorKind::ExpiresInRequired => write!(f, "`expires_in` is required"),
             }
+        }
+    }
+
+    impl From<ErrorKind> for Error {
+        fn from(kind: ErrorKind) -> Self {
+            Self { kind }
         }
     }
 
@@ -134,9 +144,9 @@ pub mod config {
         /// Builds the `PresigningConfig`. This will error if `expires_in` is not
         /// given, or if it's longer than one week.
         pub fn build(self) -> Result<PresigningConfig, Error> {
-            let expires_in = self.expires_in.ok_or(Error::ExpiresInRequired)?;
+            let expires_in = self.expires_in.ok_or(ErrorKind::ExpiresInRequired)?;
             if expires_in > ONE_WEEK {
-                return Err(Error::ExpiresInDurationTooLong);
+                return Err(ErrorKind::ExpiresInDurationTooLong.into());
             }
             Ok(PresigningConfig {
                 start_time: self.start_time.unwrap_or_else(SystemTime::now),

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -61,50 +61,59 @@ impl SigV4SigningStage {
 }
 
 #[derive(Debug)]
-pub enum SigningStageError {
+enum SigningStageErrorKind {
     MissingCredentials,
     MissingSigningRegion,
     MissingSigningService,
     MissingSigningConfig,
-    InvalidBodyType,
     SigningFailure(SigningError),
+}
+
+#[derive(Debug)]
+pub struct SigningStageError {
+    kind: SigningStageErrorKind,
 }
 
 impl Display for SigningStageError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SigningStageError::MissingCredentials => {
-                write!(f, "No credentials in the property bag")
+        use SigningStageErrorKind::*;
+        match self.kind {
+            MissingCredentials => {
+                write!(f, "no credentials in the property bag")
             }
-            SigningStageError::MissingSigningRegion => {
-                write!(f, "No signing region in the property bag")
+            MissingSigningRegion => {
+                write!(f, "no signing region in the property bag")
             }
-            SigningStageError::MissingSigningService => {
-                write!(f, "No signing service in the property bag")
+            MissingSigningService => {
+                write!(f, "no signing service in the property bag")
             }
-            SigningStageError::MissingSigningConfig => {
-                write!(f, "No signing configuration in the property bag")
+            MissingSigningConfig => {
+                write!(f, "no signing configuration in the property bag")
             }
-            SigningStageError::InvalidBodyType => write!(
-                f,
-                "The request body could not be signed by this configuration"
-            ),
-            SigningStageError::SigningFailure(_) => write!(f, "Signing failed"),
+            SigningFailure(_) => write!(f, "signing failed"),
         }
-    }
-}
-
-impl From<SigningError> for SigningStageError {
-    fn from(error: SigningError) -> Self {
-        Self::SigningFailure(error)
     }
 }
 
 impl Error for SigningStageError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match &self {
-            SigningStageError::SigningFailure(err) => Some(err),
+        match &self.kind {
+            SigningStageErrorKind::SigningFailure(err) => Some(err),
             _ => None,
+        }
+    }
+}
+
+impl From<SigningStageErrorKind> for SigningStageError {
+    fn from(kind: SigningStageErrorKind) -> Self {
+        Self { kind }
+    }
+}
+
+impl From<SigningError> for SigningStageError {
+    fn from(error: SigningError) -> Self {
+        Self {
+            kind: SigningStageErrorKind::SigningFailure(error),
         }
     }
 }
@@ -115,17 +124,17 @@ fn signing_config(
 ) -> Result<(&OperationSigningConfig, RequestConfig, Credentials), SigningStageError> {
     let operation_config = config
         .get::<OperationSigningConfig>()
-        .ok_or(SigningStageError::MissingSigningConfig)?;
+        .ok_or(SigningStageErrorKind::MissingSigningConfig)?;
     let credentials = config
         .get::<Credentials>()
-        .ok_or(SigningStageError::MissingCredentials)?
+        .ok_or(SigningStageErrorKind::MissingCredentials)?
         .clone();
     let region = config
         .get::<SigningRegion>()
-        .ok_or(SigningStageError::MissingSigningRegion)?;
+        .ok_or(SigningStageErrorKind::MissingSigningRegion)?;
     let signing_service = config
         .get::<SigningService>()
-        .ok_or(SigningStageError::MissingSigningService)?;
+        .ok_or(SigningStageErrorKind::MissingSigningService)?;
     let payload_override = config.get::<SignableBody<'static>>();
     let request_config = RequestConfig {
         request_ts: config
@@ -146,7 +155,7 @@ impl MapRequest for SigV4SigningStage {
         req.augment(|mut req, config| {
             let operation_config = config
                 .get::<OperationSigningConfig>()
-                .ok_or(SigningStageError::MissingSigningConfig)?;
+                .ok_or(SigningStageErrorKind::MissingSigningConfig)?;
             let (operation_config, request_config, creds) =
                 match &operation_config.signing_requirements {
                     SigningRequirements::Disabled => return Ok(req),
@@ -160,7 +169,7 @@ impl MapRequest for SigV4SigningStage {
             let signature = self
                 .signer
                 .sign(operation_config, &request_config, &creds, &mut req)
-                .map_err(SigningStageError::SigningFailure)?;
+                .map_err(SigningStageErrorKind::SigningFailure)?;
             config.insert(signature);
             Ok(req)
         })
@@ -169,7 +178,9 @@ impl MapRequest for SigV4SigningStage {
 
 #[cfg(test)]
 mod test {
-    use crate::middleware::{SigV4SigningStage, Signature, SigningStageError};
+    use crate::middleware::{
+        SigV4SigningStage, Signature, SigningStageError, SigningStageErrorKind,
+    };
     use crate::signer::{OperationSigningConfig, SigV4Signer};
     use aws_endpoint::partition::endpoint::{Protocol, SignatureVersion};
     use aws_endpoint::{AwsEndpointStage, Params};
@@ -254,7 +265,10 @@ mod test {
         // make sure we got the correct error types in any order
         assert!(errs.iter().all(|el| matches!(
             el,
-            SigningStageError::MissingCredentials | SigningStageError::MissingSigningConfig
+            SigningStageError {
+                kind: SigningStageErrorKind::MissingCredentials
+                    | SigningStageErrorKind::MissingSigningConfig
+            }
         )));
 
         let (req, _) = req.into_parts();

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -97,9 +97,13 @@ impl Display for SigningStageError {
 
 impl Error for SigningStageError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
+        use SigningStageErrorKind as ErrorKind;
         match &self.kind {
-            SigningStageErrorKind::SigningFailure(err) => Some(err),
-            _ => None,
+            ErrorKind::SigningFailure(err) => Some(err),
+            ErrorKind::MissingCredentials
+            | ErrorKind::MissingSigningRegion
+            | ErrorKind::MissingSigningService
+            | ErrorKind::MissingSigningConfig => None,
         }
     }
 }

--- a/aws/rust-runtime/aws-types/src/credentials/mod.rs
+++ b/aws/rust-runtime/aws-types/src/credentials/mod.rs
@@ -71,8 +71,9 @@ mod credentials_impl;
 mod provider;
 
 pub use credentials_impl::Credentials;
+pub use provider::error;
+pub use provider::error::CredentialsError;
 pub use provider::future;
-pub use provider::CredentialsError;
 pub use provider::ProvideCredentials;
 pub use provider::Result;
 pub use provider::SharedCredentialsProvider;

--- a/aws/rust-runtime/aws-types/src/credentials/provider.rs
+++ b/aws/rust-runtime/aws-types/src/credentials/provider.rs
@@ -4,147 +4,173 @@
  */
 
 use crate::Credentials;
-use std::error::Error;
-use std::fmt::{self, Debug, Display, Formatter};
 use std::sync::Arc;
-use std::time::Duration;
 
-/// Error returned when credentials failed to load.
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum CredentialsError {
-    /// No credentials were available for this provider
-    #[non_exhaustive]
-    CredentialsNotLoaded {
-        /// Underlying cause of the error.
-        context: Box<dyn Error + Send + Sync + 'static>,
-    },
+/// Credentials provider errors
+pub mod error {
+    use std::error::Error;
+    use std::fmt;
+    use std::time::Duration;
 
-    /// Loading credentials from this provider exceeded the maximum allowed duration
-    #[non_exhaustive]
-    ProviderTimedOut(Duration),
+    /// Details for [`CredentialsError::CredentialsNotLoaded`]
+    #[derive(Debug)]
+    pub struct CredentialsNotLoaded {
+        source: Box<dyn Error + Send + Sync + 'static>,
+    }
 
-    /// The provider was given an invalid configuration
-    ///
-    /// For example:
-    /// - syntax error in ~/.aws/config
-    /// - assume role profile that forms an infinite loop
-    #[non_exhaustive]
-    InvalidConfiguration {
-        /// Underlying cause of the error.
-        cause: Box<dyn Error + Send + Sync + 'static>,
-    },
+    /// Details for [`CredentialsError::ProviderTimedOut`]
+    #[derive(Debug)]
+    pub struct ProviderTimedOut {
+        timeout_duration: Duration,
+    }
 
-    /// The provider experienced an error during credential resolution
-    ///
-    /// This may include errors like a 503 from STS or a file system error when attempting to
-    /// read a configuration file.
-    #[non_exhaustive]
-    ProviderError {
-        /// Underlying cause of the error.
-        cause: Box<dyn Error + Send + Sync + 'static>,
-    },
-
-    /// An unexpected error occurred during credential resolution
-    ///
-    /// If the error is something that can occur during expected usage of a provider, `ProviderError`
-    /// should be returned instead. Unhandled is reserved for exceptional cases, for example:
-    /// - Returned data not UTF-8
-    /// - A provider returns data that is missing required fields
-    #[non_exhaustive]
-    Unhandled {
-        /// Underlying cause of the error.
-        cause: Box<dyn Error + Send + Sync + 'static>,
-    },
-}
-
-impl CredentialsError {
-    /// The credentials provider did not provide credentials
-    ///
-    /// This error indicates the credentials provider was not enable or no configuration was set.
-    /// This contrasts with [`invalid_configuration`](CredentialsError::InvalidConfiguration), indicating
-    /// that the provider was configured in some way, but certain settings were invalid.
-    pub fn not_loaded(context: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
-        CredentialsError::CredentialsNotLoaded {
-            context: context.into(),
+    impl ProviderTimedOut {
+        /// Returns the maximum allowed timeout duration that was exceeded
+        pub fn timeout_duration(&self) -> Duration {
+            self.timeout_duration
         }
     }
 
-    /// An unexpected error occurred loading credentials from this provider
-    ///
-    /// Unhandled errors should not occur during normal operation and should be reserved for exceptional
-    /// cases, such as a JSON API returning an output that was not parseable as JSON.
-    pub fn unhandled(cause: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
-        Self::Unhandled {
-            cause: cause.into(),
+    /// Details for [`CredentialsError::InvalidConfiguration`]
+    #[derive(Debug)]
+    pub struct InvalidConfiguration {
+        source: Box<dyn Error + Send + Sync + 'static>,
+    }
+
+    /// Details for [`CredentialsError::ProviderError`]
+    #[derive(Debug)]
+    pub struct ProviderError {
+        source: Box<dyn Error + Send + Sync + 'static>,
+    }
+
+    /// Details for [`CredentialsError::Unhandled`]
+    #[derive(Debug)]
+    pub struct Unhandled {
+        source: Box<dyn Error + Send + Sync + 'static>,
+    }
+
+    /// Error returned when credentials failed to load.
+    #[derive(Debug)]
+    #[non_exhaustive]
+    pub enum CredentialsError {
+        /// No credentials were available for this provider
+        CredentialsNotLoaded(CredentialsNotLoaded),
+
+        /// Loading credentials from this provider exceeded the maximum allowed duration
+        ProviderTimedOut(ProviderTimedOut),
+
+        /// The provider was given an invalid configuration
+        ///
+        /// For example:
+        /// - syntax error in ~/.aws/config
+        /// - assume role profile that forms an infinite loop
+        InvalidConfiguration(InvalidConfiguration),
+
+        /// The provider experienced an error during credential resolution
+        ///
+        /// This may include errors like a 503 from STS or a file system error when attempting to
+        /// read a configuration file.
+        ProviderError(ProviderError),
+
+        /// An unexpected error occurred during credential resolution
+        ///
+        /// If the error is something that can occur during expected usage of a provider, `ProviderError`
+        /// should be returned instead. Unhandled is reserved for exceptional cases, for example:
+        /// - Returned data not UTF-8
+        /// - A provider returns data that is missing required fields
+        Unhandled(Unhandled),
+    }
+
+    impl CredentialsError {
+        /// The credentials provider did not provide credentials
+        ///
+        /// This error indicates the credentials provider was not enable or no configuration was set.
+        /// This contrasts with [`invalid_configuration`](CredentialsError::InvalidConfiguration), indicating
+        /// that the provider was configured in some way, but certain settings were invalid.
+        pub fn not_loaded(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+            CredentialsError::CredentialsNotLoaded(CredentialsNotLoaded {
+                source: source.into(),
+            })
+        }
+
+        /// An unexpected error occurred loading credentials from this provider
+        ///
+        /// Unhandled errors should not occur during normal operation and should be reserved for exceptional
+        /// cases, such as a JSON API returning an output that was not parseable as JSON.
+        pub fn unhandled(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+            Self::Unhandled(Unhandled {
+                source: source.into(),
+            })
+        }
+
+        /// The credentials provider returned an error
+        ///
+        /// Provider errors may occur during normal use of a credentials provider, e.g. a 503 when
+        /// retrieving credentials from IMDS.
+        pub fn provider_error(source: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
+            Self::ProviderError(ProviderError {
+                source: source.into(),
+            })
+        }
+
+        /// The provided configuration for a provider was invalid
+        pub fn invalid_configuration(
+            source: impl Into<Box<dyn Error + Send + Sync + 'static>>,
+        ) -> Self {
+            Self::InvalidConfiguration(InvalidConfiguration {
+                source: source.into(),
+            })
+        }
+
+        /// The credentials provider did not provide credentials within an allotted duration
+        pub fn provider_timed_out(timeout_duration: Duration) -> Self {
+            Self::ProviderTimedOut(ProviderTimedOut { timeout_duration })
         }
     }
 
-    /// The credentials provider returned an error
-    ///
-    /// Provider errors may occur during normal use of a credentials provider, e.g. a 503 when
-    /// retrieving credentials from IMDS.
-    pub fn provider_error(cause: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
-        Self::ProviderError {
-            cause: cause.into(),
-        }
-    }
-
-    /// The provided configuration for a provider was invalid
-    pub fn invalid_configuration(cause: impl Into<Box<dyn Error + Send + Sync + 'static>>) -> Self {
-        Self::InvalidConfiguration {
-            cause: cause.into(),
-        }
-    }
-
-    /// The credentials provider did not provide credentials within an allotted duration
-    pub fn provider_timed_out(context: Duration) -> Self {
-        Self::ProviderTimedOut(context)
-    }
-}
-
-impl Display for CredentialsError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            CredentialsError::CredentialsNotLoaded { context } => {
-                write!(f, "The credential provider was not enabled: {}", context)
-            }
-            CredentialsError::ProviderTimedOut(d) => write!(
-                f,
-                "Credentials provider timed out after {} seconds",
-                d.as_secs()
-            ),
-            CredentialsError::Unhandled { cause } => {
-                write!(f, "Unexpected credentials error: {}", cause)
-            }
-            CredentialsError::InvalidConfiguration { cause } => {
-                write!(
+    impl fmt::Display for CredentialsError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                CredentialsError::CredentialsNotLoaded(_) => {
+                    write!(f, "the credential provider was not enabled")
+                }
+                CredentialsError::ProviderTimedOut(details) => write!(
                     f,
-                    "The credentials provider was not properly configured: {}",
-                    cause
-                )
-            }
-            CredentialsError::ProviderError { cause } => {
-                write!(f, "An error occurred while loading credentials: {}", cause)
+                    "credentials provider timed out after {} seconds",
+                    details.timeout_duration.as_secs()
+                ),
+                CredentialsError::InvalidConfiguration(_) => {
+                    write!(f, "the credentials provider was not properly configured")
+                }
+                CredentialsError::ProviderError(_) => {
+                    write!(f, "an error occurred while loading credentials")
+                }
+                CredentialsError::Unhandled(_) => {
+                    write!(f, "unexpected credentials error")
+                }
             }
         }
     }
-}
 
-impl Error for CredentialsError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            CredentialsError::Unhandled { cause }
-            | CredentialsError::ProviderError { cause }
-            | CredentialsError::InvalidConfiguration { cause } => Some(cause.as_ref() as _),
-            CredentialsError::CredentialsNotLoaded { context } => Some(context.as_ref() as _),
-            _ => None,
+    impl Error for CredentialsError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            match self {
+                CredentialsError::CredentialsNotLoaded(details) => {
+                    Some(details.source.as_ref() as _)
+                }
+                CredentialsError::ProviderTimedOut(_) => None,
+                CredentialsError::InvalidConfiguration(details) => {
+                    Some(details.source.as_ref() as _)
+                }
+                CredentialsError::ProviderError(details) => Some(details.source.as_ref() as _),
+                CredentialsError::Unhandled(details) => Some(details.source.as_ref() as _),
+            }
         }
     }
 }
 
 /// Result type for credential providers.
-pub type Result = std::result::Result<Credentials, CredentialsError>;
+pub type Result = std::result::Result<Credentials, error::CredentialsError>;
 
 /// Convenience `ProvideCredentials` struct that implements the `ProvideCredentials` trait.
 pub mod future {
@@ -181,7 +207,7 @@ pub mod future {
 }
 
 /// Asynchronous Credentials Provider
-pub trait ProvideCredentials: Send + Sync + Debug {
+pub trait ProvideCredentials: Send + Sync + std::fmt::Debug {
     /// Returns a future that provides credentials.
     fn provide_credentials<'a>(&'a self) -> future::ProvideCredentials<'a>
     where


### PR DESCRIPTION
## Motivation and Context
This PR revamps errors in the AWS runtime crates (excluding `aws-config`) to adhere to [RFC-0022: Error Context and Compatibility](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0022_error_context_and_compatibility.md).

This PR is part of a series that will fully implement the RFC, tracked in #1926.

Changelog entries added in #1951.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
