### PR TITLE
Fix retry config doc comments and remove re-export

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -79,3 +79,9 @@ message = "Fix cargo audit issue on criterion."
 references = ["smithy-rs#1923"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "Removed re-export of `aws_smithy_client::retry::Config` from the `middleware` module."
+references = ["smithy-rs#1935"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"

--- a/aws/rust-runtime/aws-inlineable/src/middleware.rs
+++ b/aws/rust-runtime/aws-inlineable/src/middleware.rs
@@ -5,8 +5,6 @@
 
 //! Base Middleware Stack
 
-pub use aws_smithy_client::retry::Config as RetryConfig;
-
 use aws_endpoint::AwsEndpointStage;
 use aws_http::auth::CredentialsStage;
 use aws_http::recursion_detection::RecursionDetectionStage;

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -44,9 +44,11 @@ where
 
 /// Retry Policy Configuration
 ///
-/// Without specific use cases, users should generally rely on the default values set by `[Config::default]`(Config::default).`
+/// Without specific use cases, users should generally rely on the default values set
+/// by [`Config::default`](Config::default).
 ///
-/// Currently these fields are private and no setters provided. As needed, this configuration will become user-modifiable in the future..
+/// Currently these fields are private and no setters provided. As needed, this configuration
+/// will become user-modifiable in the future.
 #[derive(Clone, Debug)]
 pub struct Config {
     initial_retry_tokens: usize,


### PR DESCRIPTION
## Motivation and Context
The doc comments on `aws_smithy_client::retry::Config` weren't rendering properly, and I'm not sure why this struct was getting re-exported in the SDK's `middleware` module since it is only really useful in the retry implementation.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
