### PR TITLE
Fix some IntelliJ lints in Kotlin

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -897,14 +897,10 @@ class ServerProtocolTestGenerator(
         // These could be configured via runtime configuration, but since this won't be long-lasting,
         // it makes sense to do the simplest thing for now.
         // The test will _fail_ if these pass, so we will discover & remove if we fix them by accident
-        private val JsonRpc10 = "aws.protocoltests.json10#JsonRpc10"
-        private val AwsJson11 = "aws.protocoltests.json#JsonProtocol"
-        private val RestJson = "aws.protocoltests.restjson#RestJson"
-        private val RestJsonValidation = "aws.protocoltests.restjson.validation#RestJsonValidation"
-        private val RestXml = "aws.protocoltests.restxml#RestXml"
-        private val AwsQuery = "aws.protocoltests.query#AwsQuery"
-        private val Ec2Query = "aws.protocoltests.ec2#AwsEc2"
-        private val ExpectFail = setOf<FailingTest>(
+        private const val AwsJson11 = "aws.protocoltests.json#JsonProtocol"
+        private const val RestJson = "aws.protocoltests.restjson#RestJson"
+        private const val RestJsonValidation = "aws.protocoltests.restjson.validation#RestJsonValidation"
+        private val ExpectFail: Set<FailingTest> = setOf(
             // Pending merge from the Smithy team: see https://github.com/awslabs/smithy/pull/1477.
             FailingTest(RestJson, "RestJsonWithPayloadExpectsImpliedContentType", TestType.MalformedRequest),
             FailingTest(RestJson, "RestJsonBodyMalformedMapNullKey", TestType.MalformedRequest),
@@ -1073,6 +1069,7 @@ class ServerProtocolTestGenerator(
 
         private fun fixRestJsonSupportsNaNFloatQueryValues(
             testCase: HttpRequestTestCase,
+            @Suppress("UNUSED_PARAMETER")
             operationShape: OperationShape,
         ): HttpRequestTestCase {
             val params = Node.parse(
@@ -1093,6 +1090,7 @@ class ServerProtocolTestGenerator(
 
         private fun fixRestJsonSupportsInfinityFloatQueryValues(
             testCase: HttpRequestTestCase,
+            @Suppress("UNUSED_PARAMETER")
             operationShape: OperationShape,
         ): HttpRequestTestCase =
             testCase.toBuilder().params(
@@ -1112,6 +1110,7 @@ class ServerProtocolTestGenerator(
 
         private fun fixRestJsonSupportsNegativeInfinityFloatQueryValues(
             testCase: HttpRequestTestCase,
+            @Suppress("UNUSED_PARAMETER")
             operationShape: OperationShape,
         ): HttpRequestTestCase =
             testCase.toBuilder().params(
@@ -1131,6 +1130,7 @@ class ServerProtocolTestGenerator(
 
         private fun fixRestJsonAllQueryStringTypes(
             testCase: HttpRequestTestCase,
+            @Suppress("UNUSED_PARAMETER")
             operationShape: OperationShape,
         ): HttpRequestTestCase =
             testCase.toBuilder().params(
@@ -1182,6 +1182,7 @@ class ServerProtocolTestGenerator(
 
         private fun fixRestJsonQueryStringEscaping(
             testCase: HttpRequestTestCase,
+            @Suppress("UNUSED_PARAMETER")
             operationShape: OperationShape,
         ): HttpRequestTestCase =
             testCase.toBuilder().params(


### PR DESCRIPTION
## Description
Fixes some lints raised by IntelliJ:

- Remove unused bindings (`JsonRpc10`, etc)
- Mark test names as `const`
- Suppress warnings on unused parameters in test-fixing functions (they all have to have the same signature but some don't use the`operationShape` parameter)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
