### PR TITLE
Export `Router` from `aws-smithy-http-server` crate root again --- `aws-smithy-http-server` v0.51.1

### DIFF
--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-lambda.rs
@@ -6,7 +6,7 @@
 // This program is exported as a binary named `pokemon-service-lambda`.
 use std::sync::Arc;
 
-use aws_smithy_http_server::{routing::LambdaHandler, routing::Router, AddExtensionLayer};
+use aws_smithy_http_server::{routing::LambdaHandler, AddExtensionLayer, Router};
 use pokemon_service::{
     capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics, get_storage, setup_tracing,
     State,

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
@@ -28,7 +28,7 @@ use std::io::BufReader;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aws_smithy_http_server::{routing::Router, AddExtensionLayer};
+use aws_smithy_http_server::{AddExtensionLayer, Router};
 use clap::Parser;
 use futures_util::stream::StreamExt;
 use pokemon_service::{

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service.rs
@@ -6,7 +6,7 @@
 // This program is exported as a binary named `pokemon-service`.
 use std::{net::SocketAddr, sync::Arc};
 
-use aws_smithy_http_server::{routing::Router, AddExtensionLayer};
+use aws_smithy_http_server::{AddExtensionLayer, Router};
 use clap::Parser;
 use pokemon_service::{
     capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics, get_storage, setup_tracing,

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -38,6 +38,8 @@ pub mod routers;
 pub(crate) use self::error::Error;
 pub use self::extension::Extension;
 #[doc(inline)]
+pub use self::routing::Router;
+#[doc(inline)]
 pub use tower_http::add_extension::{AddExtension, AddExtensionLayer};
 
 #[cfg(test)]


### PR DESCRIPTION
This reverts unintentional breakage introduced in
`aws-smithy-http-server` v0.51.0.

---

This is cherry-picking fb631b4f4cbe3f3a86137a2ed7835e747f9849fb on top of the
`release-2022-10-24` tag. This patch **will not** be merged into `main`; I'm
just submitting the PR so that it runs CI. We will _manually_ publish
`aws-smithy-http-server` v0.51.1 with this patch applied.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
