### PR TITLE
Add error refactor changelog entries and re-export `DisplayErrorContext`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -103,3 +103,16 @@ message = "Upgrade to Smithy 1.26.2"
 references = ["smithy-rs#1972"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "rcoh"
+
+[[smithy-rs]]
+message = "Several breaking changes have been made to errors. See [the upgrade guide](https://github.com/awslabs/smithy-rs/issues/1950) for more information."
+references = ["smithy-rs#1926", "smithy-rs#1819"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Several breaking changes have been made to errors. See [the upgrade guide](https://github.com/awslabs/aws-sdk-rust/issues/657) for more information."
+references = ["smithy-rs#1926", "smithy-rs#1819"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "jdisanti"
+

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/SmithyTypesPubUseGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/SmithyTypesPubUseGenerator.kt
@@ -59,7 +59,9 @@ internal fun pubUseTypes(runtimeConfig: RuntimeConfig, model: Model): List<Runti
         listOf(
             PubUseType(RuntimeType.Blob(runtimeConfig), ::hasBlobs),
             PubUseType(RuntimeType.DateTime(runtimeConfig), ::hasDateTimes),
-        ) + CargoDependency.SmithyHttp(runtimeConfig).asType().let { http ->
+        ) + CargoDependency.SmithyTypes(runtimeConfig).asType().let { types ->
+            listOf(PubUseType(types.member("error::display::DisplayErrorContext")) { true })
+        } + CargoDependency.SmithyHttp(runtimeConfig).asType().let { http ->
             listOf(
                 PubUseType(http.member("result::SdkError")) { true },
                 PubUseType(http.member("byte_stream::ByteStream"), ::hasStreamingOperations),


### PR DESCRIPTION
## Motivation and Context
This PR finishes the series to fully implement the RFC, tracked in https://github.com/awslabs/smithy-rs/issues/1926 by re-exporting `DisplayErrorContext` and linking to the upgrade guidance from the changelog.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
