### PR TITLE
Fix canary Lambda invoke success check

### DIFF
--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -375,13 +375,13 @@ async fn invoke_lambda(lambda_client: lambda::Client, bundle_name: &str) -> Resu
         .await
         .context(here!("failed to invoke the canary Lambda"))?;
 
-    if let Some(log_result) = response.log_result {
+    if let Some(log_result) = response.log_result() {
         info!(
             "Last 4 KB of canary logs:\n----\n{}\n----\n",
-            std::str::from_utf8(&base64::decode(&log_result)?)?
+            std::str::from_utf8(&base64::decode(log_result)?)?
         );
     }
-    if response.status_code != 200 {
+    if response.status_code() != 200 || response.function_error().is_some() {
         bail!(
             "Canary failed: {}",
             response


### PR DESCRIPTION
## Motivation and Context
It seems Lambda's `Invoke` returns a status 200 even when the function fails with exit status 1, but at the same time, it responds with `function_error` set. I tested this by uploading a trivial Rust binary that just exits with status 1 to Lambda and invoking it, which resulted in:

```
[src/main.rs:18] result = Ok(
    InvokeOutput {
        status_code: 200,
        function_error: Some(
            "Unhandled",
        ),
        // -- snip --
    },
)
```

This PR fixes the check in `canary-runner`.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._