### PR TITLE
Smithy 1.26.2 upgrade / ensure that even empty lists are serialized

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -98,3 +98,8 @@ references = ["smithy-rs#1935"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "jdisanti"
 
+[[smithy-rs]]
+message = "Upgrade to Smithy 1.26.2"
+references = ["smithy-rs#1972"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocolTestGenerator.kt
@@ -903,7 +903,6 @@ class ServerProtocolTestGenerator(
         private val ExpectFail: Set<FailingTest> = setOf(
             // Pending merge from the Smithy team: see https://github.com/awslabs/smithy/pull/1477.
             FailingTest(RestJson, "RestJsonWithPayloadExpectsImpliedContentType", TestType.MalformedRequest),
-            FailingTest(RestJson, "RestJsonBodyMalformedMapNullKey", TestType.MalformedRequest),
 
             // Pending resolution from the Smithy team, see https://github.com/awslabs/smithy/issues/1068.
             FailingTest(RestJson, "RestJsonHttpWithHeadersButNoPayload", TestType.Request),

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ kotlin.code.style=official
 
 # codegen
 smithyGradlePluginVersion=0.6.0
-smithyVersion=1.26.0
+smithyVersion=1.26.2
 
 # kotlin
 kotlinVersion=1.6.21

--- a/rust-runtime/aws-smithy-query/src/lib.rs
+++ b/rust-runtime/aws-smithy-query/src/lib.rs
@@ -34,6 +34,7 @@ impl<'a> QueryWriter<'a> {
     }
 }
 
+#[must_use]
 pub struct QueryMapWriter<'a> {
     output: &'a mut String,
     prefix: Cow<'a, str>,
@@ -89,6 +90,7 @@ impl<'a> QueryMapWriter<'a> {
     }
 }
 
+#[must_use]
 pub struct QueryListWriter<'a> {
     output: &'a mut String,
     prefix: Cow<'a, str>,
@@ -140,6 +142,7 @@ impl<'a> QueryListWriter<'a> {
     }
 }
 
+#[must_use]
 pub struct QueryValueWriter<'a> {
     output: &'a mut String,
     prefix: Cow<'a, str>,
@@ -231,6 +234,15 @@ mod tests {
         let writer = QueryWriter::new(&mut out, "SomeAction", "1.0");
         writer.finish();
         assert_eq!("Action=SomeAction&Version=1.0", out);
+    }
+
+    #[test]
+    fn query_list_writer_empty_list() {
+        let mut out = String::new();
+        let mut writer = QueryWriter::new(&mut out, "SomeAction", "1.0");
+        writer.prefix("myList").start_list(false, None).finish();
+        writer.finish();
+        assert_eq!("Action=SomeAction&Version=1.0&myList=", out);
     }
 
     #[test]

--- a/rust-runtime/aws-smithy-query/src/lib.rs
+++ b/rust-runtime/aws-smithy-query/src/lib.rs
@@ -132,7 +132,11 @@ impl<'a> QueryListWriter<'a> {
     }
 
     pub fn finish(self) {
-        // Calling this drops self
+        // https://github.com/awslabs/smithy/commit/715b1d94ab14764ad43496b016b0c2e85bcf1d1f
+        // If the list was empty, just serialize the parameter name
+        if self.next_index == 1 {
+            QueryValueWriter::new(self.output, self.prefix).write_param_name();
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
- Smithy 1.26.2 upgrade: https://github.com/awslabs/smithy/commit/715b1d94ab14764ad43496b016b0c2e85bcf1d1f


## Description
@jdisanti, let me know your thoughts on this approach. The spec was altered to state that empty lists should be serialized—I decided to handle this at the runtime-level, but I'm open to other suggestions.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- [x] codegen integration tests
## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
