### PR TITLE
Make `SdkError::into_service_error` infallible

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/CombinedErrorGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/CombinedErrorGenerator.kt
@@ -13,11 +13,13 @@ import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.model.traits.RetryableTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.asType
 import software.amazon.smithy.rust.codegen.core.rustlang.deprecatedShape
 import software.amazon.smithy.rust.codegen.core.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
@@ -124,6 +126,7 @@ class CombinedErrorGenerator(
 ) {
     private val runtimeConfig = symbolProvider.config().runtimeConfig
     private val genericError = RuntimeType.GenericError(symbolProvider.config().runtimeConfig)
+    private val createUnhandledError = CargoDependency.SmithyHttp(runtimeConfig).asType().member("result::CreateUnhandledError")
 
     fun render(writer: RustWriter) {
         val errorSymbol = RuntimeType("${operationSymbol.name}Error", null, "crate::error")
@@ -154,6 +157,15 @@ class CombinedErrorGenerator(
                 RuntimeType.GenericError(runtimeConfig),
             )
         }
+        writer.rustBlock("impl #T for ${errorSymbol.name}", createUnhandledError) {
+            rustBlock("fn create_unhandled_error(source: Box<dyn std::error::Error + Send + Sync + 'static>) -> Self") {
+                rustBlock("Self") {
+                    rust("kind: ${errorSymbol.name}Kind::Unhandled(#T::new(source)),", unhandledError())
+                    rust("meta: Default::default()")
+                }
+            }
+        }
+
         writer.rust("/// Types of errors that can occur for the `${operationSymbol.name}` operation.")
         meta.render(writer)
         writer.rustBlock("enum ${errorSymbol.name}Kind") {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/TopLevelErrorGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/TopLevelErrorGenerator.kt
@@ -95,6 +95,7 @@ class TopLevelErrorGenerator(private val codegenContext: CodegenContext, private
 
     private fun RustWriter.renderImplFrom(errorSymbol: RuntimeType, errors: List<ShapeId>) {
         if (errors.isNotEmpty() || CodegenTarget.CLIENT == codegenContext.target) {
+            val operationErrors = errors.map { model.expectShape(it) }
             rustBlock(
                 "impl<R> From<#T<#T, R>> for Error where R: Send + Sync + std::fmt::Debug + 'static",
                 sdkError,
@@ -106,22 +107,27 @@ class TopLevelErrorGenerator(private val codegenContext: CodegenContext, private
                     "OpError" to errorSymbol,
                 ) {
                     rustBlock("match err") {
-                        val operationErrors = errors.map { model.expectShape(it) }
-                        rustBlock("#T::ServiceError(context) => match context.into_err().kind", sdkError) {
-                            operationErrors.forEach { errorShape ->
-                                val errSymbol = symbolProvider.toSymbol(errorShape)
-                                rust(
-                                    "#TKind::${errSymbol.name}(inner) => Error::${errSymbol.name}(inner),",
-                                    errorSymbol,
-                                )
-                            }
-                            rustTemplate(
-                                "#{errorSymbol}Kind::Unhandled(inner) => Error::Unhandled(#{unhandled}::new(inner.into())),",
-                                "errorSymbol" to errorSymbol,
-                                "unhandled" to unhandledError(),
+                        rust("#T::ServiceError(context) => Self::from(context.into_err()),", sdkError)
+                        rust("_ => Error::Unhandled(#T::new(err.into())),", unhandledError())
+                    }
+                }
+            }
+
+            rustBlock("impl From<#T> for Error", errorSymbol) {
+                rustBlock("fn from(err: #T) -> Self", errorSymbol) {
+                    rustBlock("match err.kind") {
+                        operationErrors.forEach { errorShape ->
+                            val errSymbol = symbolProvider.toSymbol(errorShape)
+                            rust(
+                                "#TKind::${errSymbol.name}(inner) => Error::${errSymbol.name}(inner),",
+                                errorSymbol,
                             )
                         }
-                        rust("_ => Error::Unhandled(#T::new(err.into())),", unhandledError())
+                        rustTemplate(
+                            "#{errorSymbol}Kind::Unhandled(inner) => Error::Unhandled(#{unhandled}::new(inner.into())),",
+                            "errorSymbol" to errorSymbol,
+                            "unhandled" to unhandledError(),
+                        )
                     }
                 }
             }

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -34,10 +34,7 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
                 CanaryError(format!("Expected object {} to not exist in S3", test_key)).into(),
             );
         }
-        Err(err) => match err
-            .into_service_error()
-            .context("unexpected s3::GetObject failure")?
-        {
+        Err(err) => match err.into_service_error() {
             GetObjectError {
                 kind: GetObjectErrorKind::NoSuchKey(..),
                 ..


### PR DESCRIPTION
## Motivation and Context
Originally, `into_service_error` returned a `Result<E, Self>`. The intent was that the `ServiceError` could easily be extracted while bubbling up other error types, but as it turns out, this makes it harder to bubble up service errors that don't need to be handled in a match block. Making `into_service_error` makes both use cases easy.

Credit goes to @rcoh for the suggestion.

This PR is part of a series that will fully implement the RFC, tracked in #1926.

Changelog entries added in #1951.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
