### PR TITLE
Remove left behind trailing whitespace from instrumentation closure

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerHttpSensitivityGenerator.kt
@@ -192,7 +192,6 @@ sealed class HeaderSensitivity(
                 {
                     |name: &#{Http}::header::HeaderName| {
                         let name_match = #{NameMatch:W};
-
                         #{SuffixAndValue:W}
                         #{SmithyHttpServer}::instrumentation::sensitivity::headers::HeaderMarker { key_suffix, value }
                     }


### PR DESCRIPTION
## Motivation and Context

Running `./gradlew :codegen-server-test:smithyBuildJar --rerun-tasks` results in 

```
error[internal]: left behind trailing whitespace
   --> smithy-rs/codegen-server-test/build/smithyprojections/codegen-server-test/pokemon-service-server-sdk/rust-server-codegen/src/operation_registry.rs:434:434:1
    |
434 |                 
    | ^^^^^^^^^^^^^^^^
    |
warning: rustfmt has failed to format. See previous 1 errors.
)
```

in a few places.

## Description

Remove left behind trailing whitespace from instrumentation closure

## Tests

Observe the error described above does not occur in CI.
