### PR TITLE
Add `smithy-rules-engine` dependency to add endpoint traits

### DIFF
--- a/aws/sdk-codegen/build.gradle.kts
+++ b/aws/sdk-codegen/build.gradle.kts
@@ -26,8 +26,9 @@ dependencies {
     implementation(project(":codegen-client"))
     runtimeOnly(project(":aws:rust-runtime"))
     implementation("org.jsoup:jsoup:1.14.3")
-    implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
+    implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
 }


### PR DESCRIPTION
## Motivation and Context
This PR will unblock #1932 since it adds the endpoint traits to the classpath, which enables the AWS SDK models to be updated to the latest.

## Testing
- [x] Verified the latest SDK models successfully code generate with this change

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
