### PR TITLE
Fix `update-sdk-next` GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-sdk-next.yml
+++ b/.github/workflows/update-sdk-next.yml
@@ -30,7 +30,9 @@ jobs:
         java-version: 11
       # Rust is only used to `rustfmt` the generated code; doesn't need to match MSRV
     - name: Set up Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.62.1
     - name: Delete old SDK
       run: |
     - name: Generate a fresh SDK


### PR DESCRIPTION
## Motivation and Context
The version of Rust referenced by the workflow vs. what the `rust-toolchain.toml` file specifies were in disagreement, which led to the following error when running it:

```
:aws:sdk:requireCrateHasher (Thread[included builds,5,main]) started.
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the '1.62.1-x86_64-unknown-linux-gnu' toolchain
```

This PR should make the workflow pass once more.

Successful run: https://github.com/awslabs/smithy-rs/actions/runs/3448457209/jobs/5755493864

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
