### PR TITLE
Add UNIFORM_NAME and Sealed for OperationShape

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationGenerator.kt
@@ -55,6 +55,7 @@ class ServerOperationGenerator(
 
             impl #{SmithyHttpServer}::operation::OperationShape for $operationName {
                 const NAME: &'static str = "${operationId.toString().replace("#", "##")}";
+                const UNIFORM_NAME: &'static str = "${operationId.toString().replace("#", ".")}";
 
                 type Input = crate::input::${operationName}Input;
                 type Output = crate::output::${operationName}Output;

--- a/rust-runtime/aws-smithy-http-server/src/operation/shape.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/shape.rs
@@ -8,9 +8,11 @@ use super::{Handler, IntoService, Normalize, Operation, OperationService};
 /// Models the [Smithy Operation shape].
 ///
 /// [Smithy Operation shape]: https://awslabs.github.io/smithy/1.0/spec/core/model.html#operation
-pub trait OperationShape {
+pub trait OperationShape: Sealed {
     /// The name of the operation.
     const NAME: &'static str;
+    /// The name of the operation, with `#` replaced by `.`.
+    const UNIFORM_NAME: &'static str;
 
     /// The operation input.
     type Input;
@@ -43,3 +45,6 @@ pub trait OperationShapeExt: OperationShape {
 }
 
 impl<S> OperationShapeExt for S where S: OperationShape {}
+
+#[doc(hidden)]
+pub trait Sealed {}


### PR DESCRIPTION


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
* `#` is forbidden in some implementations and `.` is what is used as a replacement.
* `OperationShape` should not be implemented by customers; we can't force them not to, but a hint to avoid it is helpful

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
