### PR TITLE
Improve error doc comments around logging errors

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/CombinedErrorGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/CombinedErrorGenerator.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.deprecatedShape
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
@@ -163,9 +164,9 @@ class CombinedErrorGenerator(
                 val errorVariantSymbol = symbolProvider.toSymbol(errorVariant)
                 write("${errorVariantSymbol.name}(#T),", errorVariantSymbol)
             }
+            docs(UNHANDLED_ERROR_DOCS)
             rust(
                 """
-                /// An unexpected error, e.g. invalid JSON returned by the service or an unknown error code
                 Unhandled(#T),
                 """,
                 unhandledError(),

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/TopLevelErrorGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/TopLevelErrorGenerator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.core.rustlang.asType
 import software.amazon.smithy.rust.codegen.core.rustlang.deprecatedShape
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
@@ -141,7 +142,7 @@ class TopLevelErrorGenerator(private val codegenContext: CodegenContext, private
                 val sym = symbolProvider.toSymbol(error)
                 rust("${sym.name}(#T),", sym)
             }
-            rust("/// An unhandled error occurred.")
+            docs(UNHANDLED_ERROR_DOCS)
             rust("Unhandled(#T)", unhandledError())
         }
     }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/UnhandledErrorGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/UnhandledErrorGenerator.kt
@@ -10,14 +10,18 @@ import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 
-internal fun unhandledError(): RuntimeType = RuntimeType.forInlineFun("Unhandled", RustModule.Error) {
-    docs(
-        """
-        An unexpected error occurred (e.g., invalid JSON returned by the service or an unknown error code)
+internal const val UNHANDLED_ERROR_DOCS =
+    """
+    An unexpected error occurred (e.g., invalid JSON returned by the service or an unknown error code).
 
-        Call [`Error::source`](std::error::Error::source) for more details about the underlying cause.
-        """,
-    )
+    When logging an error from the SDK, it is recommended that you either wrap the error in
+    [`DisplayErrorContext`](crate::types::DisplayErrorContext), use another
+    error reporter library that visits the error's cause/source chain, or call
+    [`Error::source`](std::error::Error::source) for more details about the underlying cause.
+    """
+
+internal fun unhandledError(): RuntimeType = RuntimeType.forInlineFun("Unhandled", RustModule.Error) {
+    docs(UNHANDLED_ERROR_DOCS)
     rustTemplate(
         """
         ##[derive(Debug)]

--- a/rust-runtime/aws-smithy-http/src/result.rs
+++ b/rust-runtime/aws-smithy-http/src/result.rs
@@ -123,6 +123,11 @@ impl<E, R> ServiceError<E, R> {
 }
 
 /// Failed SDK Result
+///
+/// When logging an error from the SDK, it is recommended that you either wrap the error in
+/// [`DisplayErrorContext`](aws_smithy_types::error::display::DisplayErrorContext), use another
+/// error reporter library that visits the error's cause/source chain, or call
+/// [`Error::source`](std::error::Error::source) for more details about the underlying cause.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum SdkError<E, R = operation::Response> {

--- a/rust-runtime/aws-smithy-types/src/error/display.rs
+++ b/rust-runtime/aws-smithy-types/src/error/display.rs
@@ -14,6 +14,14 @@ use std::fmt;
 /// in the chain separated by ": ". At the end of the chain, it outputs a debug view
 /// of the entire error chain.
 ///
+/// # Example
+///
+/// ```no_run
+/// # let err: &dyn std::error::Error = unimplemented!();
+/// # use aws_smithy_types::error::display::DisplayErrorContext;
+/// println!("There was an unhandled error: {}", DisplayErrorContext(&err));
+/// ```
+///
 // Internally in the SDK, this is useful for emitting errors with `tracing` in cases
 // where the error is not returned back to the customer.
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation and Context
This PR improves documentation around the use of `DisplayErrorContext`.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._