### PR TITLE
formatting: run code cleanup on entire project

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsReadmeDecorator.kt
@@ -218,7 +218,7 @@ internal class AwsSdkReadmeGenerator {
     private fun Element.normalizeLists() {
         (getElementsByTag("ul") + getElementsByTag("ol"))
             // Only operate on lists that are top-level (are not nested within other lists)
-            .filter { list -> list.parents().none() { it.isList() } }
+            .filter { list -> list.parents().none { it.isList() } }
             .forEach { list -> list.normalizeList() }
     }
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
@@ -19,10 +19,6 @@ class SdkSettings private constructor(private val awsSdk: ObjectNode?) {
             SdkSettings(coreRustSettings.customizationConfig?.getObjectMember("awsSdk")?.orNull())
     }
 
-    /** Path to the `sdk-default-configuration.json` config file */
-    val defaultsConfigPath: Path? get() =
-        awsSdk?.getStringMember("defaultConfigPath")?.orNull()?.value.let { Paths.get(it) }
-
     /** Path to the `sdk-endpoints.json` configuration */
     val endpointsConfigPath: Path? get() =
         awsSdk?.getStringMember("endpointsConfigPath")?.orNull()?.value?.let { Paths.get(it) }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
@@ -19,13 +19,20 @@ class SdkSettings private constructor(private val awsSdk: ObjectNode?) {
             SdkSettings(coreRustSettings.customizationConfig?.getObjectMember("awsSdk")?.orNull())
     }
 
+    /** Path to the `sdk-default-configuration.json` config file */
+    val defaultsConfigPath: Path?
+        get() =
+            awsSdk?.getStringMember("defaultConfigPath")?.orNull()?.value.let { Paths.get(it) }
+
     /** Path to the `sdk-endpoints.json` configuration */
-    val endpointsConfigPath: Path? get() =
-        awsSdk?.getStringMember("endpointsConfigPath")?.orNull()?.value?.let { Paths.get(it) }
+    val endpointsConfigPath: Path?
+        get() =
+            awsSdk?.getStringMember("endpointsConfigPath")?.orNull()?.value?.let { Paths.get(it) }
 
     /** Path to AWS SDK integration tests */
-    val integrationTestPath: String get() =
-        awsSdk?.getStringMember("integrationTestPath")?.orNull()?.value ?: "aws/sdk/integration-tests"
+    val integrationTestPath: String
+        get() =
+            awsSdk?.getStringMember("integrationTestPath")?.orNull()?.value ?: "aws/sdk/integration-tests"
 
     /** Version number of the `aws-config` crate */
     val awsConfigVersion: String? get() =

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/AccountIdAutofill.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/AccountIdAutofill.kt
@@ -14,7 +14,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustom
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 
-class AccountIdAutofill() : OperationCustomization() {
+class AccountIdAutofill : OperationCustomization() {
     override fun mutSelf(): Boolean = true
     override fun consumesSelf(): Boolean = false
     override fun section(section: OperationSection): Writable {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -138,12 +138,12 @@ class ProtocolTestGenerator(
         testModuleWriter: RustWriter,
         block: Writable,
     ) {
-        testModuleWriter.setNewlinePrefix("/// ")
+        testModuleWriter.newlinePrefix = "/// "
         testCase.documentation.map {
             testModuleWriter.writeWithNoFormatting(it)
         }
         testModuleWriter.write("Test ID: ${testCase.id}")
-        testModuleWriter.setNewlinePrefix("")
+        testModuleWriter.newlinePrefix = ""
         TokioTest.render(testModuleWriter)
         val action = when (testCase) {
             is HttpResponseTestCase -> Action.Response

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
@@ -66,7 +66,7 @@ val SimpleShapes: Map<KClass<out Shape>, RustType> = mapOf(
 data class SymbolVisitorConfig(
     val runtimeConfig: RuntimeConfig,
     val renameExceptions: Boolean,
-    val nullabilityCheckMode: NullableIndex.CheckMode,
+    val nullabilityCheckMode: CheckMode,
 )
 
 /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/HttpBoundProtocolPayloadGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/HttpBoundProtocolPayloadGenerator.kt
@@ -193,7 +193,7 @@ class HttpBoundProtocolPayloadGenerator(
             symbolProvider,
             unionShape,
             serializerGenerator,
-            contentType ?: throw CodegenException("event streams must set a content type"),
+            contentType,
         ).render()
 
         // TODO(EventStream): [RPC] RPC protocols need to send an initial message with the

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerModuleGenerator.kt
@@ -65,7 +65,7 @@ class PythonServerModuleGenerator(
             """,
             *codegenScope,
         )
-        serviceShapes.forEach() { shape ->
+        serviceShapes.forEach { shape ->
             val moduleType = moduleType(shape)
             if (moduleType != null) {
                 rustTemplate(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/traits/ShapeReachableFromOperationInputTagTrait.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/traits/ShapeReachableFromOperationInputTagTrait.kt
@@ -23,7 +23,7 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
  *
  * See the [ShapesReachableFromOperationInputTagger] model transform for how it's used.
  */
-class ShapeReachableFromOperationInputTagTrait() : AnnotationTrait(ID, Node.objectNode()) {
+class ShapeReachableFromOperationInputTagTrait : AnnotationTrait(ID, Node.objectNode()) {
     companion object {
         val ID = ShapeId.from("smithy.api.internal#syntheticStructureReachableFromOperationInputTag")
     }


### PR DESCRIPTION
This is a small formatting PR. I ran IntelliJ's code cleanup on the entire project and it changed a few things.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
