### PR TITLE
Multiple FromParts in handlers

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -431,3 +431,9 @@ message = "`Endpoint::immutable` now takes `impl AsRef<str>` instead of `Uri`. F
 references = ["smithy-rs#1984", "smithy-rs#1496"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Business logic handlers can have up to 8 extensions in input"
+references = ["smithy-rs#1999"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server" }
+author = "82marbag"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -433,7 +433,7 @@ meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
 
 [[smithy-rs]]
-message = "Business logic handlers can have up to 8 extensions in input"
+message = "Operation handlers can now have up to 8 extensions as input parameters. They were previously limited to 1 extension input parameter."
 references = ["smithy-rs#1999"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server" }
 author = "82marbag"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -431,9 +431,3 @@ message = "`Endpoint::immutable` now takes `impl AsRef<str>` instead of `Uri`. F
 references = ["smithy-rs#1984", "smithy-rs#1496"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
-
-[[smithy-rs]]
-message = "Operation handlers can now have up to 8 extensions as input parameters. They were previously limited to 1 extension input parameter."
-references = ["smithy-rs#1999"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server" }
-author = "82marbag"

--- a/rust-runtime/aws-smithy-http-server/src/operation/handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/handler.rs
@@ -62,24 +62,10 @@ where
     }
 }
 
-impl<Op, F, Fut, Ext0> Handler<Op, (Ext0,)> for F
-where
-    Op: OperationShape,
-    F: Fn(Op::Input, Ext0) -> Fut,
-    Fut: Future,
-    Fut::Output: IntoResult<Op::Output, Op::Error>,
-{
-    type Future = Map<Fut, fn(Fut::Output) -> Result<Op::Output, Op::Error>>;
-
-    fn call(&mut self, input: Op::Input, exts: (Ext0,)) -> Self::Future {
-        (self)(input, exts.0).map(IntoResult::into_result)
-    }
-}
-
 // fn(Input, Ext_i) -> Output
 macro_rules! impl_handler {
     ($($var:ident),+) => (
-        impl<Op, F, Fut, $($var,)*> Handler<Op, ($($var),*)> for F
+        impl<Op, F, Fut, $($var,)*> Handler<Op, ($($var,)*)> for F
         where
             Op: OperationShape,
             F: Fn(Op::Input, $($var,)*) -> Fut,
@@ -97,6 +83,7 @@ macro_rules! impl_handler {
     )
 }
 
+impl_handler!(Exts0);
 impl_handler!(Exts0, Exts1);
 impl_handler!(Exts0, Exts1, Exts2);
 impl_handler!(Exts0, Exts1, Exts2, Exts3);

--- a/rust-runtime/aws-smithy-http-server/src/operation/handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/handler.rs
@@ -62,7 +62,6 @@ where
     }
 }
 
-// fn(Input, Ext0) -> Output
 impl<Op, F, Fut, Ext0> Handler<Op, (Ext0,)> for F
 where
     Op: OperationShape,
@@ -77,20 +76,35 @@ where
     }
 }
 
-// fn(Input, Ext0, Ext1) -> Output
-impl<Op, F, Fut, Ext0, Ext1> Handler<Op, (Ext0, Ext1)> for F
-where
-    Op: OperationShape,
-    F: Fn(Op::Input, Ext0, Ext1) -> Fut,
-    Fut: Future,
-    Fut::Output: IntoResult<Op::Output, Op::Error>,
-{
-    type Future = Map<Fut, fn(Fut::Output) -> Result<Op::Output, Op::Error>>;
+// fn(Input, Ext_i) -> Output
+macro_rules! impl_handler {
+    ($($var:ident),+) => (
+        impl<Op, F, Fut, $($var,)*> Handler<Op, ($($var),*)> for F
+        where
+            Op: OperationShape,
+            F: Fn(Op::Input, $($var,)*) -> Fut,
+            Fut: Future,
+            Fut::Output: IntoResult<Op::Output, Op::Error>,
+        {
+            type Future = Map<Fut, fn(Fut::Output) -> Result<Op::Output, Op::Error>>;
 
-    fn call(&mut self, input: Op::Input, exts: (Ext0, Ext1)) -> Self::Future {
-        (self)(input, exts.0, exts.1).map(IntoResult::into_result)
-    }
+            fn call(&mut self, input: Op::Input, exts: ($($var,)*)) -> Self::Future {
+                #[allow(non_snake_case)]
+                let ($($var,)*) = exts;
+                (self)(input, $($var,)*).map(IntoResult::into_result)
+            }
+        }
+    )
 }
+
+impl_handler!(Exts0, Exts1);
+impl_handler!(Exts0, Exts1, Exts2);
+impl_handler!(Exts0, Exts1, Exts2, Exts3);
+impl_handler!(Exts0, Exts1, Exts2, Exts3, Exts4);
+impl_handler!(Exts0, Exts1, Exts2, Exts3, Exts4, Exts5);
+impl_handler!(Exts0, Exts1, Exts2, Exts3, Exts4, Exts5, Exts6);
+impl_handler!(Exts0, Exts1, Exts2, Exts3, Exts4, Exts5, Exts6, Exts7);
+impl_handler!(Exts0, Exts1, Exts2, Exts3, Exts4, Exts5, Exts6, Exts7, Exts8);
 
 /// An extension trait for [`Handler`].
 pub trait HandlerExt<Op, Exts>: Handler<Op, Exts>

--- a/rust-runtime/aws-smithy-http-server/src/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/rejection.rs
@@ -264,31 +264,31 @@ convert_to_request_rejection!(hyper::Error, HttpBody);
 // Required in order to accept Lambda HTTP requests using `Router<lambda_http::Body>`.
 convert_to_request_rejection!(lambda_http::Error, HttpBody);
 
-macro_rules! any_rejection {
-    ($name:ident, $($var:ident),+) => (
-        pub enum $name<$($var),*> {
-            $($var ($var),)*
-        }
-
-        impl<P, $($var,)*> IntoResponse<P> for $name<$($var),*>
-        where
-            $($var: IntoResponse<P>,)*
-        {
-            #[allow(non_snake_case)]
-            fn into_response(self) -> http::Response<crate::body::BoxBody> {
-                match self {
-                    $($name::$var ($var) => $var.into_response(),)*
-                }
-            }
-        }
-    )
-}
-
 pub mod any_rejections {
     //! This module hosts enums, up to size 8, which implement [`IntoResponse`] when their variants implement
     //! [`IntoResponse`].
 
     use super::IntoResponse;
+
+    macro_rules! any_rejection {
+        ($name:ident, $($var:ident),+) => (
+            pub enum $name<$($var),*> {
+                $($var ($var),)*
+            }
+
+            impl<P, $($var,)*> IntoResponse<P> for $name<$($var),*>
+            where
+                $($var: IntoResponse<P>,)*
+            {
+                #[allow(non_snake_case)]
+                fn into_response(self) -> http::Response<crate::body::BoxBody> {
+                    match self {
+                        $($name::$var ($var) => $var.into_response(),)*
+                    }
+                }
+            }
+        )
+    }
 
     // any_rejection!(One, A);
     any_rejection!(Two, A, B);

--- a/rust-runtime/aws-smithy-http-server/src/request.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request.rs
@@ -43,7 +43,7 @@ use futures_util::{
 };
 use http::{request::Parts, Extensions, HeaderMap, Request, Uri};
 
-use crate::{rejection::EitherRejection, response::IntoResponse};
+use crate::{rejection::any_rejections, response::IntoResponse};
 
 #[doc(hidden)]
 #[derive(Debug)]
@@ -139,19 +139,31 @@ where
     }
 }
 
-impl<P, T1, T2> FromParts<P> for (T1, T2)
-where
-    T1: FromParts<P>,
-    T2: FromParts<P>,
-{
-    type Rejection = EitherRejection<T1::Rejection, T2::Rejection>;
+macro_rules! impl_from_parts {
+    ($error_name:ident, $($var:ident),+) => (
+        impl<P, $($var,)*> FromParts<P> for ($($var),*)
+        where
+            $($var: FromParts<P>,)*
+        {
+            type Rejection = any_rejections::$error_name<$($var::Rejection),*>;
 
-    fn from_parts(parts: &mut Parts) -> Result<Self, Self::Rejection> {
-        let t1 = T1::from_parts(parts).map_err(EitherRejection::Left)?;
-        let t2 = T2::from_parts(parts).map_err(EitherRejection::Right)?;
-        Ok((t1, t2))
-    }
+            fn from_parts(parts: &mut Parts) -> Result<Self, Self::Rejection> {
+                let tuple = (
+                    $($var::from_parts(parts).map_err(any_rejections::$error_name::$var)?,)*
+                );
+                Ok(tuple)
+            }
+        }
+    )
 }
+
+impl_from_parts!(Two, A, B);
+impl_from_parts!(Three, A, B, C);
+impl_from_parts!(Four, A, B, C, D);
+impl_from_parts!(Five, A, B, C, D, E);
+impl_from_parts!(Six, A, B, C, D, E, F);
+impl_from_parts!(Seven, A, B, C, D, E, F, G);
+impl_from_parts!(Eight, A, B, C, D, E, F, G, H);
 
 /// Provides a protocol aware extraction from a [`Request`]. This consumes the
 /// [`Request`], in contrast to [`FromParts`].
@@ -180,14 +192,14 @@ where
     T1: FromRequest<P, B>,
     T2: FromParts<P>,
 {
-    type Rejection = EitherRejection<T1::Rejection, T2::Rejection>;
+    type Rejection = any_rejections::Two<T1::Rejection, T2::Rejection>;
     type Future = TryJoin<MapErr<T1::Future, fn(T1::Rejection) -> Self::Rejection>, Ready<Result<T2, Self::Rejection>>>;
 
     fn from_request(request: Request<B>) -> Self::Future {
         let (mut parts, body) = request.into_parts();
-        let t2_result = T2::from_parts(&mut parts).map_err(EitherRejection::Right);
+        let t2_result = T2::from_parts(&mut parts).map_err(any_rejections::Two::B);
         try_join(
-            T1::from_request(Request::from_parts(parts, body)).map_err(EitherRejection::Left),
+            T1::from_request(Request::from_parts(parts, body)).map_err(any_rejections::Two::A),
             ready(t2_result),
         )
     }


### PR DESCRIPTION
## Motivation and Context
Handlers are restricted in the number of parameters implementing FromParts; their workaround is to use tuples.

## Description
To aid developers and have better ergonomics, handlers can have up to 8 extensions (FromParts):
```
pub async fn handler(
    input: input::Input,
    ext0: Extension<...>,
    ext1: Extension<...>,
    ext2: Extension<...>,
    ext3: Extension<...>,
    ext4: Extension<...>,
    ext5: Extension<...>,
    ext6: Extension<...>,
    ext7: Extension<...>,
) -> Result<output::Output, error::Error> { ... }
```

## Testing
Tested on PokemonService

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
