### PR TITLE
Remove `fromCoreProtocol` in favour of `as` downcasting

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -161,7 +161,7 @@ class PythonServerCodegenVisitor(
             rustCrate,
             protocolGenerator,
             protocolGeneratorFactory.support(),
-            ServerProtocol.fromCoreProtocol(protocolGeneratorFactory.protocol(codegenContext)),
+            protocolGeneratorFactory.protocol(codegenContext) as ServerProtocol,
             codegenContext,
         )
             .render()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -438,7 +438,7 @@ open class ServerCodegenVisitor(
             rustCrate,
             protocolGenerator,
             protocolGeneratorFactory.support(),
-            ServerProtocol.fromCoreProtocol(protocolGeneratorFactory.protocol(codegenContext)),
+            protocolGeneratorFactory.protocol(codegenContext) as ServerProtocol,
             codegenContext,
         )
             .render()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/protocol/ServerProtocol.kt
@@ -78,16 +78,6 @@ interface ServerProtocol : Protocol {
      * Returns a boolean indicating whether to perform this check.
      */
     fun serverContentTypeCheckNoModeledInput(): Boolean = false
-
-    companion object {
-        /** Upgrades the core protocol to a `ServerProtocol`. */
-        fun fromCoreProtocol(protocol: Protocol): ServerProtocol = when (protocol) {
-            is AwsJson -> ServerAwsJsonProtocol.fromCoreProtocol(protocol)
-            is RestJson -> ServerRestJsonProtocol.fromCoreProtocol(protocol)
-            is RestXml -> ServerRestXmlProtocol.fromCoreProtocol(protocol)
-            else -> throw IllegalStateException("unsupported protocol")
-        }
-    }
 }
 
 class ServerAwsJsonProtocol(
@@ -119,11 +109,6 @@ class ServerAwsJsonProtocol(
 
     override fun structuredDataSerializer(operationShape: OperationShape): StructuredDataSerializerGenerator =
         ServerAwsJsonSerializerGenerator(serverCodegenContext, httpBindingResolver, awsJsonVersion)
-
-    companion object {
-        fun fromCoreProtocol(awsJson: AwsJson): ServerAwsJsonProtocol =
-            ServerAwsJsonProtocol(awsJson.codegenContext as ServerCodegenContext, awsJson.version)
-    }
 
     override fun markerStruct(): RuntimeType {
         return when (version) {
@@ -194,10 +179,6 @@ class ServerRestJsonProtocol(
     override fun structuredDataSerializer(operationShape: OperationShape): StructuredDataSerializerGenerator =
         ServerRestJsonSerializerGenerator(serverCodegenContext, httpBindingResolver)
 
-    companion object {
-        fun fromCoreProtocol(restJson: RestJson): ServerRestJsonProtocol = ServerRestJsonProtocol(restJson.codegenContext as ServerCodegenContext)
-    }
-
     override fun markerStruct() = ServerRuntimeType.Protocol("RestJson1", "rest_json_1", runtimeConfig)
 
     override fun routerType() = restRouterType(runtimeConfig)
@@ -221,12 +202,6 @@ class ServerRestXmlProtocol(
     codegenContext: CodegenContext,
 ) : RestXml(codegenContext), ServerProtocol {
     val runtimeConfig = codegenContext.runtimeConfig
-
-    companion object {
-        fun fromCoreProtocol(restXml: RestXml): ServerRestXmlProtocol {
-            return ServerRestXmlProtocol(restXml.codegenContext)
-        }
-    }
 
     override fun markerStruct() = ServerRuntimeType.Protocol("RestXml", "rest_xml", runtimeConfig)
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerRestXmlFactory.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerRestXmlFactory.kt
@@ -8,7 +8,6 @@ package software.amazon.smithy.rust.codegen.server.smithy.protocols
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolGeneratorFactory
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.RestXml
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerRestXmlProtocol
 
@@ -17,7 +16,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.Ser
  * with RestXml specific configurations.
  */
 class ServerRestXmlFactory : ProtocolGeneratorFactory<ServerHttpBoundProtocolGenerator, ServerCodegenContext> {
-    override fun protocol(codegenContext: ServerCodegenContext): Protocol = RestXml(codegenContext)
+    override fun protocol(codegenContext: ServerCodegenContext): Protocol = ServerRestXmlProtocol(codegenContext)
 
     override fun buildProtocolGenerator(codegenContext: ServerCodegenContext): ServerHttpBoundProtocolGenerator =
         ServerHttpBoundProtocolGenerator(codegenContext, ServerRestXmlProtocol(codegenContext))

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationRegistryGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationRegistryGeneratorTest.kt
@@ -68,7 +68,7 @@ class ServerOperationRegistryGeneratorTest {
 
         val index = TopDownIndex.of(serverCodegenContext.model)
         val operations = index.getContainedOperations(serverCodegenContext.serviceShape).sortedBy { it.id }
-        val protocol = ServerProtocol.fromCoreProtocol(protocolGeneratorFactory.protocol(serverCodegenContext))
+        val protocol = protocolGeneratorFactory.protocol(serverCodegenContext) as ServerProtocol
 
         val generator = ServerOperationRegistryGenerator(serverCodegenContext, protocol, operations)
         val writer = RustWriter.forModule("operation_registry")


### PR DESCRIPTION
## Motivation and Context

Having a `companion object` on `ServerProtocol` limits extensibility.

## Description

- Use `ProtocolGeneratorFactory` and `as` downcasting instead of `fromCoreProtocol`.
- Fix bug where `ServerRestXmlFactory.protocol` returned `RestXml` rather than `ServerRestXmlProtocol`.
