### PR TITLE
Detect if the `uniqueItems` trait is used

### DIFF
--- a/codegen-core/common-test-models/constraints.smithy
+++ b/codegen-core/common-test-models/constraints.smithy
@@ -154,8 +154,10 @@ structure ConstrainedHttpBoundShapesOperationInputOutput {
     // @httpHeader("X-Length-MediaType")
     // lengthStringHeaderWithMediaType: MediaTypeLengthString,
 
-    @httpHeader("X-Length-Set")
-    lengthStringSetHeader: SetOfLengthString,
+    // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+    //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+    // @httpHeader("X-Length-Set")
+    // lengthStringSetHeader: SetOfLengthString,
 
     @httpHeader("X-Length-List")
     lengthStringListHeader: ListOfLengthString,
@@ -176,8 +178,10 @@ structure ConstrainedHttpBoundShapesOperationInputOutput {
     @httpQuery("lengthStringList")
     lengthStringListQuery: ListOfLengthString,
 
-    @httpQuery("lengthStringSet")
-    lengthStringSetQuery: SetOfLengthString,
+    // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+    //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+    // @httpQuery("lengthStringSet")
+    // lengthStringSetQuery: SetOfLengthString,
 
     @httpQuery("enumStringList")
     enumStringListQuery: ListOfEnumString,
@@ -277,7 +281,9 @@ structure ConA {
     conBList: ConBList,
     conBList2: ConBList2,
 
-    conBSet: ConBSet,
+    // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+    //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+    // conBSet: ConBSet,
 
     conBMap: ConBMap,
 
@@ -287,7 +293,9 @@ structure ConA {
     enumString: EnumString,
 
     listOfLengthString: ListOfLengthString,
-    setOfLengthString: SetOfLengthString,
+    // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+    //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+    // setOfLengthString: SetOfLengthString,
     mapOfLengthString: MapOfLengthString,
 
     nonStreamingBlob: NonStreamingBlob
@@ -315,7 +323,10 @@ map MapOfListOfEnumString {
 
 map MapOfSetOfLengthString {
     key: LengthString,
-    value: SetOfLengthString,
+    // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+    //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+    // value: SetOfLengthString,
+    value: ListOfLengthString
 }
 
 @length(min: 2, max: 8)
@@ -346,7 +357,9 @@ union ConstrainedUnion {
 
     constrainedStructure: ConB,
     conBList: ConBList,
-    conBSet: ConBSet,
+    // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+    //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+    // conBSet: ConBSet,
     conBMap: ConBMap,
 }
 
@@ -420,13 +433,15 @@ list NestedList {
     member: ConB
 }
 
-set ConBSet {
-    member: NestedSet
-}
-
-set NestedSet {
-    member: String
-}
+// TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
+//  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
+// set ConBSet {
+//     member: NestedSet
+// }
+//
+// set NestedSet {
+//     member: String
+// }
 
 @length(min: 1, max: 69)
 map ConBMap {

--- a/codegen-core/common-test-models/misc.smithy
+++ b/codegen-core/common-test-models/misc.smithy
@@ -255,6 +255,7 @@ list HeaderList {
     member: String
 }
 
-set HeaderSet {
+@uniqueItems
+list HeaderSet {
     member: String
 }

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -54,7 +54,12 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
             "constraints",
             imports = listOf("$commonModels/constraints.smithy"),
         ),
-        CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
+        CodegenTest(
+            "aws.protocoltests.restjson#RestJson",
+            "rest_json",
+            // TODO(https://github.com/awslabs/smithy-rs/issues/1401) `@uniqueItems` is used.
+            extraConfig = """, "codegen": { "ignoreUnsupportedConstraints": true } """,
+        ),
         CodegenTest(
             "aws.protocoltests.restjson#RestJsonExtras",
             "rest_json_extras",
@@ -70,7 +75,13 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
             "json_rpc11",
             extraConfig = """, "codegen": { "ignoreUnsupportedConstraints": true } """,
         ),
-        CodegenTest("aws.protocoltests.misc#MiscService", "misc", imports = listOf("$commonModels/misc.smithy")),
+        CodegenTest(
+            "aws.protocoltests.misc#MiscService",
+            "misc",
+            imports = listOf("$commonModels/misc.smithy"),
+            // TODO(https://github.com/awslabs/smithy-rs/issues/1401) `@uniqueItems` is used.
+            extraConfig = """, "codegen": { "ignoreUnsupportedConstraints": true } """,
+        ),
         CodegenTest(
             "com.amazonaws.ebs#Ebs", "ebs",
             imports = listOf("$commonModels/ebs.json"),

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -65,7 +65,11 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
             extraConfig = """, "codegen": { "ignoreUnsupportedConstraints": true } """,
         ),
         CodegenTest("aws.protocoltests.json10#JsonRpc10", "json_rpc10"),
-        CodegenTest("aws.protocoltests.json#JsonProtocol", "json_rpc11"),
+        CodegenTest(
+            "aws.protocoltests.json#JsonProtocol",
+            "json_rpc11",
+            extraConfig = """, "codegen": { "ignoreUnsupportedConstraints": true } """,
+        ),
         CodegenTest("aws.protocoltests.misc#MiscService", "misc", imports = listOf("$commonModels/misc.smithy")),
         CodegenTest(
             "com.amazonaws.ebs#Ebs", "ebs",

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraintsAreNotUsedTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraintsAreNotUsedTest.kt
@@ -215,6 +215,27 @@ internal class ValidateUnsupportedConstraintsAreNotUsedTest {
     }
 
     @Test
+    fun `it should detect when the unique items trait is used`() {
+        val model =
+            """
+            $baseModel
+            
+            structure TestInputOutput {
+                uniqueItemsList: UniqueItemsList
+            }
+            
+            @uniqueItems
+            list UniqueItemsList {
+                member: String
+            }
+            """.asSmithyModel()
+        val validationResult = validateModel(model)
+
+        validationResult.messages shouldHaveSize 1
+        validationResult.messages[0].message shouldContain "The list shape `test#UniqueItemsList` has the constraint trait `smithy.api#uniqueItems` attached"
+    }
+
+    @Test
     fun `it should abort when ignoreUnsupportedConstraints is false and unsupported constraints are used`() {
         val validationResult = validateModel(constraintTraitOnStreamingBlobShapeModel, ServerCodegenConfig())
 


### PR DESCRIPTION
And act like in the rest of the unsupported constraint traits cases.

I missed this in the implementation of #1342.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
