### PR TITLE
Re-export service from root of the generated crate

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
@@ -40,6 +41,12 @@ open class ServerServiceGenerator(
      * which assigns a symbol location to each shape.
      */
     fun render() {
+        rustCrate.lib {
+            val serviceName = codegenContext.serviceShape.id.name.toString()
+            rust("##[doc(inline, hidden)]")
+            rust("pub use crate::service::$serviceName;")
+        }
+
         rustCrate.withModule(RustModule.operation(Visibility.PRIVATE)) {
             ServerProtocolTestGenerator(codegenContext, protocolSupport, protocolGenerator).render(this)
         }


### PR DESCRIPTION
## Motivation and Context

As the central API for the `smithy-rs` it should be exported from the root of the generated crate.

## Description

- Re-export the service from the root of the generated crate.

## Notes

It's `doc(hidden)` for now.
