### PR TITLE
Add const to generated enum values()

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -478,3 +478,9 @@ x-amzn-errortype: com.example.service#InvalidRequestException
 references = ["smithy-rs#1982"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
 author = "david-perez"
+
+[[smithy-rs]]
+message = "Make generated enum `values()` functions callable in const contexts."
+references = []
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+author = "lsr0"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -482,5 +482,5 @@ author = "david-perez"
 [[smithy-rs]]
 message = "Make generated enum `values()` functions callable in const contexts."
 references = ["smithy-rs#2011"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
 author = "lsr0"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -481,6 +481,6 @@ author = "david-perez"
 
 [[smithy-rs]]
 message = "Make generated enum `values()` functions callable in const contexts."
-references = []
+references = ["smithy-rs#2011"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "lsr0"

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
@@ -141,7 +141,7 @@ open class EnumGenerator(
             }
 
             docs("Returns all the `&str` representations of the enum members.")
-            rustBlock("pub fn $Values() -> &'static [&'static str]") {
+            rustBlock("pub const fn $Values() -> &'static [&'static str]") {
                 withBlock("&[", "]") {
                     val memberList = sortedMembers.joinToString(", ") { it.value.dq() }
                     rust(memberList)
@@ -198,7 +198,7 @@ open class EnumGenerator(
             }
 
             rust("/// Returns all the `&str` values of the enum members.")
-            rustBlock("pub fn $Values() -> &'static [&'static str]") {
+            rustBlock("pub const fn $Values() -> &'static [&'static str]") {
                 withBlock("&[", "]") {
                     val memberList = sortedMembers.joinToString(", ") { it.value.doubleQuote() }
                     write(memberList)


### PR DESCRIPTION
## Motivation and Context
Generated enum `values()` functions return their options as static arrays of static strings, perfect for compile time processing. Some motivating uses are CLIs/GUIs for things like completion and option lists or validation functions.

## Description
Simply adds `const` to the existing `values()` function definitions.

## Testing
Ran gradle tests up to and including `:aws:sdk:build`/`:aws:sdk:cargoClippy`.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
