### PR TITLE
Fix Canary

### DIFF
--- a/tools/ci-cdk/README.md
+++ b/tools/ci-cdk/README.md
@@ -21,10 +21,10 @@ From there, you can just point the `canary-runner` to the `cdk-outputs.json` to 
 
 ```bash
 cd canary-runner
-cargo run -- --sdk-version <version> --musl --cdk-outputs ../cdk-outputs.json
+cargo run -- run --sdk-release-tag <version> --musl --cdk-outputs ../cdk-outputs.json
 ```
 
-__NOTE:__ You may want to add a `--profile` to the deploy command to select a specific credential
+__NOTE:__ You may want to add a `--profile` to the `deploy` command to select a specific credential
 profile to deploy to if you don't want to use the default.
 
 Also, if this is a new test AWS account, be sure it CDK bootstrap it before attempting to deploy.

--- a/tools/ci-cdk/README.md
+++ b/tools/ci-cdk/README.md
@@ -7,7 +7,7 @@ The `cdk.json` file tells the CDK Toolkit how to synthesize the infrastructure.
 
 ## Canary local development
 
-Sometimes it's useful to only deploy the the canary resources to a test AWS account to iterate
+Sometimes it's useful to only deploy the canary resources to a test AWS account to iterate
 on the `canary-runner` and `canary-lambda`. To do this, run the following:
 
 ```bash

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use std::fmt::Write as FmtWrite;
+use std::fs;
+use std::io::Write as IoWrite;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::str::FromStr;
+
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use lazy_static::lazy_static;
@@ -11,12 +18,6 @@ use smithy_rs_tool_common::here;
 use smithy_rs_tool_common::release_tag::ReleaseTag;
 use smithy_rs_tool_common::shell::handle_failure;
 use smithy_rs_tool_common::versions_manifest::VersionsManifest;
-use std::fmt::Write as FmtWrite;
-use std::fs;
-use std::io::Write as IoWrite;
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::str::FromStr;
 
 const BASE_MANIFEST: &str = r#"
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -64,7 +65,6 @@ const REQUIRED_SDK_CRATES: &[&str] = &[
 lazy_static! {
     static ref NOTABLE_SDK_RELEASE_TAGS: Vec<ReleaseTag> = vec![
         ReleaseTag::from_str("v0.4.1").unwrap(), // first version to add support for paginators
-        ReleaseTag::from_str("release-2022-10-26").unwrap() // first version to add and use the `SdkError::into_service_error` method
     ];
 }
 
@@ -252,11 +252,13 @@ pub async fn build_bundle(opt: BuildBundleArgs) -> Result<Option<PathBuf>> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::Args;
     use clap::Parser;
     use smithy_rs_tool_common::package::PackageCategory;
     use smithy_rs_tool_common::versions_manifest::CrateVersion;
+
+    use crate::Args;
+
+    use super::*;
 
     #[test]
     fn test_arg_parsing() {

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -64,6 +64,7 @@ const REQUIRED_SDK_CRATES: &[&str] = &[
 lazy_static! {
     static ref NOTABLE_SDK_RELEASE_TAGS: Vec<ReleaseTag> = vec![
         ReleaseTag::from_str("v0.4.1").unwrap(), // first version to add support for paginators
+        ReleaseTag::from_str("release-2022-10-26").unwrap() // first version to add and use the `SdkError::into_service_error` method
     ];
 }
 

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -47,7 +47,7 @@ lazy_static::lazy_static! {
             // Versions <= 0.6.0 no longer compile against the canary after this commit in smithy-rs
             // due to the breaking change in https://github.com/awslabs/smithy-rs/pull/1085
             (ReleaseTag::from_str("v0.6.0").unwrap(), "d48c234796a16d518ca9e1dda5c7a1da4904318c"),
-            // Versions <= release-2022-10-26 no longer compiles against the canary after this commit in smithy-rs
+            // Versions <= release-2022-10-26 no longer compile against the canary after this commit in smithy-rs
             // due to the s3 canary update in https://github.com/awslabs/smithy-rs/pull/1974
             (ReleaseTag::from_str("release-2022-10-26").unwrap(), "3e24477ae7a0a2b3853962a064bc8333a016af54")
         ];

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -49,7 +49,7 @@ lazy_static::lazy_static! {
             (ReleaseTag::from_str("v0.6.0").unwrap(), "d48c234796a16d518ca9e1dda5c7a1da4904318c"),
             // Versions <= release-2022-10-26 no longer compiles against the canary after this commit in smithy-rs
             // due to the s3 canary update in https://github.com/awslabs/smithy-rs/pull/1974
-            (ReleaseTag::from_str("release-2022-10-26").unwrap(), "4563849dc7df8d5b11bce45bad32570cd5d41840")
+            (ReleaseTag::from_str("release-2022-10-26").unwrap(), "3e24477ae7a0a2b3853962a064bc8333a016af54")
         ];
         pinned.sort();
         pinned

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -44,12 +44,12 @@ lazy_static::lazy_static! {
     // This is a map of SDK release tag to smithy-rs commit hash
     static ref PINNED_SMITHY_RS_VERSIONS: Vec<(ReleaseTag, &'static str)> = {
         let mut pinned = vec![
-            // Versions <= 0.6.0 no longer compile against the canary after this commit in smithy-rs
+            // Versions <= 0.6.0 no longer compiles against the canary after this commit in smithy-rs
             // due to the breaking change in https://github.com/awslabs/smithy-rs/pull/1085
             (ReleaseTag::from_str("v0.6.0").unwrap(), "d48c234796a16d518ca9e1dda5c7a1da4904318c"),
-            // Versions <= release-2022-10-26 no longer compile against the canary after this commit in smithy-rs
+            // Versions <= release-2022-10-26 no longer compiles against the canary after this commit in smithy-rs
             // due to the s3 canary update in https://github.com/awslabs/smithy-rs/pull/1974
-            (ReleaseTag::from_str("release-2022-10-26").unwrap(), "9f0bc36fa7da0e7a60713040017a9b7503bdf354")
+            (ReleaseTag::from_str("release-2022-10-26").unwrap(), "4563849dc7df8d5b11bce45bad32570cd5d41840")
         ];
         pinned.sort();
         pinned

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -44,7 +44,7 @@ lazy_static::lazy_static! {
     // This is a map of SDK release tag to smithy-rs commit hash
     static ref PINNED_SMITHY_RS_VERSIONS: Vec<(ReleaseTag, &'static str)> = {
         let mut pinned = vec![
-            // Versions <= 0.6.0 no longer compiles against the canary after this commit in smithy-rs
+            // Versions <= 0.6.0 no longer compile against the canary after this commit in smithy-rs
             // due to the breaking change in https://github.com/awslabs/smithy-rs/pull/1085
             (ReleaseTag::from_str("v0.6.0").unwrap(), "d48c234796a16d518ca9e1dda5c7a1da4904318c"),
             // Versions <= release-2022-10-26 no longer compiles against the canary after this commit in smithy-rs

--- a/tools/ci-cdk/canary-runner/src/run.rs
+++ b/tools/ci-cdk/canary-runner/src/run.rs
@@ -14,11 +14,12 @@
 // CAUTION: This subcommand will `git reset --hard` in some cases. Don't ever run
 // it against a smithy-rs repo that you're actively working in.
 
-use crate::build_bundle::BuildBundleArgs;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime};
+use std::{env, path::Path};
+
 use anyhow::{bail, Context, Result};
-use aws_sdk_cloudwatch as cloudwatch;
-use aws_sdk_lambda as lambda;
-use aws_sdk_s3 as s3;
 use clap::Parser;
 use cloudwatch::model::StandardUnit;
 use s3::types::ByteStream;
@@ -26,12 +27,13 @@ use serde::Deserialize;
 use smithy_rs_tool_common::git::{find_git_repository_root, Git, GitCLI};
 use smithy_rs_tool_common::macros::here;
 use smithy_rs_tool_common::release_tag::ReleaseTag;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::time::{Duration, SystemTime};
-use std::{env, path::Path};
 use tracing::info;
 
+use crate::build_bundle::BuildBundleArgs;
+
+use aws_sdk_cloudwatch as cloudwatch;
+use aws_sdk_lambda as lambda;
+use aws_sdk_s3 as s3;
 lazy_static::lazy_static! {
     // Occasionally, a breaking change introduced in smithy-rs will cause the canary to fail
     // for older versions of the SDK since the canary is in the smithy-rs repository and will
@@ -45,6 +47,9 @@ lazy_static::lazy_static! {
             // Versions <= 0.6.0 no longer compile against the canary after this commit in smithy-rs
             // due to the breaking change in https://github.com/awslabs/smithy-rs/pull/1085
             (ReleaseTag::from_str("v0.6.0").unwrap(), "d48c234796a16d518ca9e1dda5c7a1da4904318c"),
+            // Versions <= release-2022-10-26 no longer compile against the canary after this commit in smithy-rs
+            // due to the s3 canary update in https://github.com/awslabs/smithy-rs/pull/1974
+            (ReleaseTag::from_str("release-2022-10-26").unwrap(), "9f0bc36fa7da0e7a60713040017a9b7503bdf354")
         ];
         pinned.sort();
         pinned


### PR DESCRIPTION
add: tag `release-2022-10-26` to NOTABLE_SDK_RELEASE_TAGS

John updated the canary to use the new `SdkError::into_service_error` method. This broke builds on older versions of the SDK.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
