### PR TITLE
fix: missing Tokio feature in S3 integration test

### DIFF
--- a/aws/sdk/integration-tests/README.md
+++ b/aws/sdk/integration-tests/README.md
@@ -1,6 +1,6 @@
 # Handwritten Integration Test Root
 
-This folder contains hand-written integration tests that are specific to
+This folder contains handwritten integration tests that are specific to
 individual services. In order for your test to be merged into the final artifact:
 
 - The crate name must match the generated crate name, e.g. `kms`, `dynamodb`
@@ -13,8 +13,8 @@ tests & inserted into the `tests` folder of the final generated service crate.
 
 Some integration test roots have a `benches/` directory. In these, `cargo bench` can be
 invoked to run the benchmarks against the current version of smithy-rs. To compare
-across smithy-rs versions, you can use git to checkout the version to compare against,
-run the benchmark, and then checkout the other version and run it again:
+across smithy-rs versions, you can `git checkout` the version to compare against,
+run the benchmark, and then `git checkout` the other version and run it again:
 
 ```bash
 # For example, this was the very first commit that had a benchmark
@@ -42,3 +42,11 @@ cargo bench
 
 # Compare!
 ```
+
+## Adding dependencies to tests
+
+When adding new dependencies or adding new features to old dependencies, don't forget to update the
+[`IntegrationTestDependencies` file][IntegrationTestDependencies]. Otherwise, after your tests have been copied into
+their respective SDK crates may fail when run due to a dependency resolution error.
+
+[IntegrationTestDependencies]: ../../sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -27,6 +27,6 @@ hyper = "0.14.12"
 serde_json = "1"
 smol = "1.2"
 tempfile = "3"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.8.4", features = ["macros", "test-util", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -221,7 +221,7 @@ data class CargoDependency(
         val Smol: CargoDependency = CargoDependency("smol", CratesIo("1.2.0"), DependencyScope.Dev)
         val TempFile: CargoDependency = CargoDependency("tempfile", CratesIo("3.2.0"), DependencyScope.Dev)
         val Tokio: CargoDependency =
-            CargoDependency("tokio", CratesIo("1.8.4"), DependencyScope.Dev, features = setOf("macros", "test-util"))
+            CargoDependency("tokio", CratesIo("1.8.4"), DependencyScope.Dev, features = setOf("macros", "test-util", "rt-multi-thread"))
         val TracingSubscriber: CargoDependency = CargoDependency(
             "tracing-subscriber",
             CratesIo("0.3.15"),

--- a/tools/ci-cdk/README.md
+++ b/tools/ci-cdk/README.md
@@ -7,7 +7,7 @@ The `cdk.json` file tells the CDK Toolkit how to synthesize the infrastructure.
 
 ## Canary local development
 
-Sometimes it's useful to only deploy the the canary resources to a test AWS account to iterate
+Sometimes it's useful to only deploy the canary resources to a test AWS account to iterate
 on the `canary-runner` and `canary-lambda`. To do this, run the following:
 
 ```bash
@@ -24,7 +24,7 @@ cd canary-runner
 cargo run -- --sdk-version <version> --musl --cdk-outputs ../cdk-outputs.json
 ```
 
-__NOTE:__ You may want to add a `--profile` to the deploy command to select a specific credential
+__NOTE:__ You may want to add a `--profile` to the `deploy` command to select a specific credential
 profile to deploy to if you don't want to use the default.
 
 Also, if this is a new test AWS account, be sure it CDK bootstrap it before attempting to deploy.


### PR DESCRIPTION
fix: remove extra "the" in CDK readme

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
