### PR TITLE
Improve code generated documentation

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/DocHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/DocHandlerGenerator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import software.amazon.smithy.model.shapes.OperationShape

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/DocHandlerGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/DocHandlerGenerator.kt
@@ -1,0 +1,59 @@
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
+import software.amazon.smithy.rust.codegen.core.smithy.Errors
+import software.amazon.smithy.rust.codegen.core.smithy.Inputs
+import software.amazon.smithy.rust.codegen.core.smithy.Outputs
+import software.amazon.smithy.rust.codegen.core.smithy.generators.error.errorSymbol
+import software.amazon.smithy.rust.codegen.core.util.inputShape
+import software.amazon.smithy.rust.codegen.core.util.outputShape
+import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
+
+/**
+Generates a stub for use within documentation.
+ */
+class DocHandlerGenerator(private val operation: OperationShape, private val commentToken: String = "//", private val codegenContext: CodegenContext) {
+    private val model = codegenContext.model
+    private val symbolProvider = codegenContext.symbolProvider
+    private val crateName = codegenContext.settings.moduleName.toSnakeCase()
+
+    /**
+     * Returns the function signature for an operation handler implementation. Used in the documentation.
+     */
+    private fun OperationShape.docSignature(): Writable {
+        val inputSymbol = symbolProvider.toSymbol(inputShape(model))
+        val outputSymbol = symbolProvider.toSymbol(outputShape(model))
+        val errorSymbol = errorSymbol(model, symbolProvider, CodegenTarget.SERVER)
+
+        val outputT = if (errors.isEmpty()) {
+            outputSymbol.name
+        } else {
+            "Result<${outputSymbol.name}, ${errorSymbol.name}>"
+        }
+
+        return writable {
+            if (!errors.isEmpty()) {
+                rust("$commentToken ## use $crateName::${Errors.namespace}::${errorSymbol.name};")
+            }
+            rust(
+                """
+                $commentToken ## use $crateName::${Inputs.namespace}::${inputSymbol.name};
+                $commentToken ## use $crateName::${Outputs.namespace}::${outputSymbol.name};
+                $commentToken async fn handler(input: ${inputSymbol.name}) -> $outputT {
+                $commentToken     todo!()
+                $commentToken }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    fun render(writer: RustWriter) {
+        operation.docSignature()(writer)
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationShapeGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationShapeGenerator.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
+import software.amazon.smithy.rust.codegen.core.smithy.Errors
+import software.amazon.smithy.rust.codegen.core.smithy.Inputs
+import software.amazon.smithy.rust.codegen.core.smithy.Outputs
+import software.amazon.smithy.rust.codegen.core.smithy.generators.error.errorSymbol
+import software.amazon.smithy.rust.codegen.core.util.inputShape
+import software.amazon.smithy.rust.codegen.core.util.outputShape
+import software.amazon.smithy.rust.codegen.core.util.toPascalCase
+import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
+import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
+
+class ServerOperationShapeGenerator(
+    private val operations: List<OperationShape>,
+    private val codegenContext: CodegenContext,
+) {
+    private val model = codegenContext.model
+    private val symbolProvider = codegenContext.symbolProvider
+    private val firstOperation = codegenContext.symbolProvider.toSymbol(operations[0])
+    private val firstOperationName = firstOperation.name.toPascalCase()
+    private val crateName = codegenContext.settings.moduleName.toSnakeCase()
+
+    /**
+     * Returns the function signature for an operation handler implementation. Used in the documentation.
+     */
+    private fun OperationShape.docSignature(): Writable {
+        val inputSymbol = symbolProvider.toSymbol(inputShape(model))
+        val outputSymbol = symbolProvider.toSymbol(outputShape(model))
+        val errorSymbol = errorSymbol(model, symbolProvider, CodegenTarget.SERVER)
+
+        val outputT = if (errors.isEmpty()) {
+            outputSymbol.name
+        } else {
+            "Result<${outputSymbol.name}, ${errorSymbol.name}>"
+        }
+
+        return writable {
+            if (!errors.isEmpty()) {
+                rust("//! ## use $crateName::${Errors.namespace}::${errorSymbol.name};")
+            }
+            rust(
+                """
+                //! ## use $crateName::${Inputs.namespace}::${inputSymbol.name};
+                //! ## use $crateName::${Outputs.namespace}::${outputSymbol.name};
+                //! async fn handler(input: ${inputSymbol.name}) -> $outputT {
+                //!     todo!()
+                //! }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    fun render(writer: RustWriter) {
+        if (operations.isEmpty()) {
+            return
+        }
+
+        writer.rustTemplate(
+            """
+            //! A collection of zero-sized types (ZSTs) representing each operation defined in the service closure.
+            //!
+            //! ## Constructing an [`Operation`](#{SmithyHttpServer}::operation::OperationShapeExt)
+            //!
+            //! To apply middleware to specific operations the [`Operation`](#{SmithyHttpServer}::operation::Operation)
+            //! API must be used.
+            //!
+            //! Using the [`OperationShapeExt`](#{SmithyHttpServer}::operation::OperationShapeExt) trait
+            //! implemented on each ZST we can construct an [`Operation`](#{SmithyHttpServer}::operation::Operation)
+            //! with appropriate constraints given by Smithy.
+            //!
+            //! #### Example
+            //!
+            //! ```no_run
+            //! use $crateName::operation_shape::$firstOperationName;
+            //! use #{SmithyHttpServer}::operation::OperationShapeExt;
+            #{Handler:W}
+            //!
+            //! let operation = $firstOperationName::from_handler(handler)
+            //!     .layer(todo!("Provide a layer implementation"));
+            //! ```
+            //!
+            //! ## Use as Marker Structs
+            //!
+            //! The [plugin system](#{SmithyHttpServer}::plugin) also makes use of these ZSTs to parameterize
+            //! [`Plugin`](#{SmithyHttpServer}::plugin::Plugin) implementations. The traits, such as
+            //! [`OperationShape`](#{SmithyHttpServer}::operation::OperationShape) can be used to provide
+            //! operation specific information to the [`Layer`](#{Tower}::Layer) being applied.
+            """.trimIndent(),
+            "SmithyHttpServer" to
+                ServerCargoDependency.SmithyHttpServer(codegenContext.runtimeConfig).toType(),
+            "Tower" to ServerCargoDependency.Tower.toType(),
+            "Handler" to operations[0].docSignature(),
+        )
+        for (operation in operations) {
+            ServerOperationGenerator(codegenContext, operation).render(writer)
+        }
+    }
+}

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationShapeGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationShapeGenerator.kt
@@ -7,18 +7,9 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
-import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
-import software.amazon.smithy.rust.codegen.core.smithy.Errors
-import software.amazon.smithy.rust.codegen.core.smithy.Inputs
-import software.amazon.smithy.rust.codegen.core.smithy.Outputs
-import software.amazon.smithy.rust.codegen.core.smithy.generators.error.errorSymbol
-import software.amazon.smithy.rust.codegen.core.util.inputShape
-import software.amazon.smithy.rust.codegen.core.util.outputShape
 import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
@@ -27,46 +18,15 @@ class ServerOperationShapeGenerator(
     private val operations: List<OperationShape>,
     private val codegenContext: CodegenContext,
 ) {
-    private val model = codegenContext.model
-    private val symbolProvider = codegenContext.symbolProvider
-    private val firstOperation = codegenContext.symbolProvider.toSymbol(operations[0])
-    private val firstOperationName = firstOperation.name.toPascalCase()
-    private val crateName = codegenContext.settings.moduleName.toSnakeCase()
-
-    /**
-     * Returns the function signature for an operation handler implementation. Used in the documentation.
-     */
-    private fun OperationShape.docSignature(): Writable {
-        val inputSymbol = symbolProvider.toSymbol(inputShape(model))
-        val outputSymbol = symbolProvider.toSymbol(outputShape(model))
-        val errorSymbol = errorSymbol(model, symbolProvider, CodegenTarget.SERVER)
-
-        val outputT = if (errors.isEmpty()) {
-            outputSymbol.name
-        } else {
-            "Result<${outputSymbol.name}, ${errorSymbol.name}>"
-        }
-
-        return writable {
-            if (!errors.isEmpty()) {
-                rust("//! ## use $crateName::${Errors.namespace}::${errorSymbol.name};")
-            }
-            rust(
-                """
-                //! ## use $crateName::${Inputs.namespace}::${inputSymbol.name};
-                //! ## use $crateName::${Outputs.namespace}::${outputSymbol.name};
-                //! async fn handler(input: ${inputSymbol.name}) -> $outputT {
-                //!     todo!()
-                //! }
-                """.trimIndent(),
-            )
-        }
-    }
 
     fun render(writer: RustWriter) {
         if (operations.isEmpty()) {
             return
         }
+
+        val firstOperation = codegenContext.symbolProvider.toSymbol(operations[0])
+        val firstOperationName = firstOperation.name.toPascalCase()
+        val crateName = codegenContext.settings.moduleName.toSnakeCase()
 
         writer.rustTemplate(
             """
@@ -102,7 +62,7 @@ class ServerOperationShapeGenerator(
             "SmithyHttpServer" to
                 ServerCargoDependency.SmithyHttpServer(codegenContext.runtimeConfig).toType(),
             "Tower" to ServerCargoDependency.Tower.toType(),
-            "Handler" to operations[0].docSignature(),
+            "Handler" to DocHandlerGenerator(operations[0], "//!", codegenContext)::render,
         )
         for (operation in operations) {
             ServerOperationGenerator(codegenContext, operation).render(writer)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -35,6 +35,7 @@ open class ServerServiceGenerator(
 ) {
     private val index = TopDownIndex.of(codegenContext.model)
     protected val operations = index.getContainedOperations(codegenContext.serviceShape).sortedBy { it.id }
+    private val serviceName = codegenContext.serviceShape.id.name.toString()
 
     /**
      * Render Service Specific code. Code will end up in different files via [useShapeWriter]. See `SymbolVisitor.kt`
@@ -42,7 +43,6 @@ open class ServerServiceGenerator(
      */
     fun render() {
         rustCrate.lib {
-            val serviceName = codegenContext.serviceShape.id.name.toString()
             rust("##[doc(inline, hidden)]")
             rust("pub use crate::service::$serviceName;")
         }
@@ -85,9 +85,7 @@ open class ServerServiceGenerator(
                 ),
             ),
         ) {
-            for (operation in operations) {
-                ServerOperationGenerator(codegenContext, operation).render(this)
-            }
+            ServerOperationShapeGenerator(operations, codegenContext).render(this)
         }
 
         // TODO(https://github.com/awslabs/smithy-rs/issues/1707): Remove, this is temporary.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
@@ -343,7 +343,7 @@ class ServerServiceGeneratorV2(
 
                 /// Constructs a builder for [`$serviceName`].
                 ///
-                /// Use [`$serviceName::builder_without_plugins`] if you need to specify plugins.
+                /// Use [`$serviceName::builder_with_plugins`] if you need to specify plugins.
                 pub fn builder_without_plugins<Body>() -> $builderName<Body, #{SmithyHttpServer}::plugin::IdentityPlugin> {
                     Self::builder_with_plugins(#{SmithyHttpServer}::plugin::IdentityPlugin)
                 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
@@ -437,7 +437,7 @@ class ServerServiceGeneratorV2(
     private fun missingOperationsError(): Writable = writable {
         rust(
             """
-            /// The error encountered when calling the [`$builderName::build`] method while one or more operations are not
+            /// The error encountered when calling the [`$builderName::build`] method if one or more operation handlers are not
             /// specified.
             ##[derive(Debug)]
             pub struct MissingOperationsError {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
@@ -198,6 +198,9 @@ class ServerServiceGeneratorV2(
             /// Constructs a [`$serviceName`] from the arguments provided to the builder.
             ///
             /// Forgetting to register a handler for one or more operations will result in an error.
+            ///
+            /// Check out [`$builderName::build_unchecked`] if you'd prefer the service to return status code 500 when an
+            /// unspecified route requested.
             pub fn build(self) -> Result<$serviceName<#{SmithyHttpServer}::routing::Route<$builderBodyGenericTypeName>>, MissingOperationsError>
             {
                 let router = {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGeneratorV2.kt
@@ -434,6 +434,8 @@ class ServerServiceGeneratorV2(
     private fun missingOperationsError(): Writable = writable {
         rust(
             """
+            /// The error encountered when calling the [`$builderName::build`] method while one or more operations are not
+            /// specified.
             ##[derive(Debug)]
             pub struct MissingOperationsError {
                 operation_names2setter_methods: std::collections::HashMap<&'static str, &'static str>,


### PR DESCRIPTION
## Motivation and Context

There are a collection of papercuts among the generated documentation.

## Description

- Add module level documentation to `operation_shape.rs`, include doc test.
- Fix link in `builder_without_plugins` method
- Add doc test to setter.
- Add documentation to `MissingOperationsError`.
- Reference `build_unchecked` in `build` documentation.

