### PR TITLE
Configure the (in|ex)clusion of the Debug trait for containers per members' sensitive trait

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -487,13 +487,13 @@ meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "all" }
 author = "lsr0"
 
 [[aws-sdk-rust]]
-message = "Implementation of the Debug trait for enums can redact what is printed per the sensitive trait."
-references = ["smithy-rs#1983"]
+message = "Implementation of the Debug trait for container shapes can redact what is printed per the sensitive trait."
+references = ["smithy-rs#1983", "smithy-rs#2029"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "ysaito1001"
 
 [[smithy-rs]]
-message = "Implementation of the Debug trait for enums can redact what is printed per the sensitive trait."
-references = ["smithy-rs#1983"]
+message = "Implementation of the Debug trait for container shapes can redact what is printed per the sensitive trait."
+references = ["smithy-rs#1983", "smithy-rs#2029"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "all" }
 author = "ysaito1001"

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -119,7 +119,6 @@ class BuilderGenerator(
     fun render(writer: RustWriter) {
         val symbol = symbolProvider.toSymbol(shape)
         writer.docs("See #D.", symbol)
-        shape.builderSymbol(symbolProvider).namespace.split("::")
         writer.withInlineModule(shape.builderSymbol(symbolProvider).module()) {
             // Matching derives to the main structure + `Default` since we are a builder and everything is optional.
             renderBuilder(this)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
@@ -94,12 +94,7 @@ open class EnumGenerator(
 ) {
     protected val symbol: Symbol = symbolProvider.toSymbol(shape)
     protected val enumName: String = symbol.name
-    private val isSensitive = shape.shouldRedact(model)
-    protected val meta = if (isSensitive) {
-        symbol.expectRustMetadata().withoutDerives(RuntimeType.Debug)
-    } else {
-        symbol.expectRustMetadata()
-    }
+    protected val meta = symbol.expectRustMetadata()
     protected val sortedMembers: List<EnumMemberModel> =
         enumTrait.values.sortedBy { it.value }.map { EnumMemberModel(it, symbolProvider) }
     protected open var target: CodegenTarget = CodegenTarget.CLIENT
@@ -136,7 +131,7 @@ open class EnumGenerator(
             renderUnnamedEnum()
         }
 
-        if (isSensitive) {
+        if (shape.shouldRedact(model)) {
             renderDebugImplForSensitiveEnum()
         }
     }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
@@ -153,7 +153,9 @@ open class StructureGenerator(
         }
 
         renderStructureImpl()
-        renderDebugImpl()
+        if (!containerMeta.derives.derives.contains(RuntimeType.Debug)) {
+            renderDebugImpl()
+        }
     }
 
     protected fun RustWriter.forEachMember(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
@@ -144,8 +144,7 @@ open class StructureGenerator(
         val containerMeta = symbol.expectRustMetadata()
         writer.documentShape(shape, model)
         writer.deprecatedShape(shape)
-        val withoutDebug = containerMeta.derives.copy(derives = containerMeta.derives.derives - RuntimeType.Debug)
-        containerMeta.copy(derives = withoutDebug).render(writer)
+        containerMeta.render(writer)
 
         writer.rustBlock("struct $name ${lifetimeDeclaration()}") {
             writer.forEachMember(members) { member, memberName, memberSymbol ->

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
@@ -61,7 +61,7 @@ class UnionGenerator(
         renderImplBlock()
         if (!unionSymbol.expectRustMetadata().derives.derives.contains(RuntimeType.Debug)) {
             if (shape.hasTrait<SensitiveTrait>()) {
-                renderDebugImplForUnion()
+                renderFullyRedactedDebugImpl()
             } else {
                 renderDebugImplForUnionMemberWise()
             }
@@ -132,7 +132,7 @@ class UnionGenerator(
         }
     }
 
-    private fun renderDebugImplForUnion() {
+    private fun renderFullyRedactedDebugImpl() {
         writer.rustTemplate(
             """
             impl #{Debug} for ${unionSymbol.name} {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
@@ -63,7 +63,7 @@ class UnionGenerator(
             if (shape.hasTrait<SensitiveTrait>()) {
                 renderFullyRedactedDebugImpl()
             } else {
-                renderDebugImplForUnionMemberWise()
+                renderDebugImpl()
             }
         }
     }
@@ -146,7 +146,7 @@ class UnionGenerator(
         )
     }
 
-    private fun renderDebugImplForUnionMemberWise() {
+    private fun renderDebugImpl() {
         writer.rustBlock("impl #T for ${unionSymbol.name}", RuntimeType.Debug) {
             writer.rustBlock("fn fmt(&self, f: &mut #1T::Formatter<'_>) -> #1T::Result", RuntimeType.stdfmt) {
                 rustBlock("match self") {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
@@ -24,6 +24,7 @@ internal class BuilderGeneratorTest {
     private val model = StructureGeneratorTest.model
     private val inner = StructureGeneratorTest.inner
     private val struct = StructureGeneratorTest.struct
+    private val credentials = StructureGeneratorTest.credentials
 
     @Test
     fun `generate builders`() {
@@ -91,6 +92,29 @@ internal class BuilderGeneratorTest {
             let my_struct = MyStruct::builder().byte_value(4).foo("hello!").bar(0).build().expect("required field was not provided");
             assert_eq!(my_struct.foo.unwrap(), "hello!");
             assert_eq!(my_struct.bar, 0);
+            """,
+        )
+    }
+
+    @Test
+    fun `builder for a struct with sensitive fields should implement the debug trait as such`() {
+        val provider = testSymbolProvider(model)
+        val writer = RustWriter.forModule("model")
+        val credsGenerator = StructureGenerator(model, provider, writer, credentials)
+        val builderGenerator = BuilderGenerator(model, provider, credentials)
+        credsGenerator.render()
+        builderGenerator.render(writer)
+        writer.implBlock(credentials, provider) {
+            builderGenerator.renderConvenienceMethod(this)
+        }
+        writer.compileAndTest(
+            """
+            use super::*;
+            let builder = Credentials::builder()
+                .username("admin")
+                .password("pswd")
+                .secret_key("12345");
+                 assert_eq!(format!("{:?}", builder), "Builder { username: Some(\"admin\"), password: \"*** Sensitive Data Redacted ***\", secret_key: \"*** Sensitive Data Redacted ***\" }");
             """,
         )
     }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGeneratorTest.kt
@@ -165,6 +165,28 @@ class UnionGeneratorTest {
         )
     }
 
+    @Test
+    fun `impl debug for union should redact text for sensitive member target`() {
+        val writer = generateUnion(
+            """
+            @sensitive
+            string Bar
+
+            union MyUnion {
+                foo: PrimitiveInteger,
+                bar: Bar,
+            }
+            """,
+        )
+
+        writer.compileAndTest(
+            """
+            assert_eq!(format!("{:?}", MyUnion::Foo(3)), "Foo(3)");
+            assert_eq!(format!("{:?}", MyUnion::Bar("bar".to_owned())), $REDACTION);
+            """,
+        )
+    }
+
     private fun generateUnion(modelSmithy: String, unionName: String = "MyUnion", unknownVariant: Boolean = true): RustWriter {
         val model = "namespace test\n$modelSmithy".asSmithyModel()
         val provider: SymbolProvider = testSymbolProvider(model)

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGeneratorTest.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.core.util.REDACTION
 import software.amazon.smithy.rust.codegen.core.util.lookup
 
 class UnionGeneratorTest {
@@ -123,6 +124,45 @@ class UnionGeneratorTest {
         }
 
         project.compileAndTest()
+    }
+
+    @Test
+    fun `impl debug for non-sensitive union should implement the derived debug trait`() {
+        val writer = generateUnion(
+            """
+            union MyUnion {
+                foo: PrimitiveInteger
+                bar: String,
+            }
+            """,
+        )
+
+        writer.compileAndTest(
+            """
+            assert_eq!(format!("{:?}", MyUnion::Foo(3)), "Foo(3)");
+            assert_eq!(format!("{:?}", MyUnion::Bar("bar".to_owned())), "Bar(\"bar\")");
+            """,
+        )
+    }
+
+    @Test
+    fun `impl debug for sensitive union should redact text`() {
+        val writer = generateUnion(
+            """
+            @sensitive
+            union MyUnion {
+                foo: PrimitiveInteger,
+                bar: String,
+            }
+            """,
+        )
+
+        writer.compileAndTest(
+            """
+            assert_eq!(format!("{:?}", MyUnion::Foo(3)), $REDACTION);
+            assert_eq!(format!("{:?}", MyUnion::Bar("bar".to_owned())), $REDACTION);
+            """,
+        )
     }
 
     private fun generateUnion(modelSmithy: String, unionName: String = "MyUnion", unknownVariant: Boolean = true): RustWriter {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
@@ -168,8 +168,8 @@ class ServerBuilderGenerator(
         // Matching derives to the main structure, - `PartialEq` (see class documentation for why), + `Default`
         // since we are a builder and everything is optional.
         val baseDerives = structureSymbol.expectRustMetadata().derives
-        val derives = baseDerives.derives.intersect(setOf(RuntimeType.Clone)) + RuntimeType.Default
-        baseDerives.copy(derives = derives).render(writer)
+        val builderDerives = baseDerives.derives.intersect(setOf(RuntimeType.Debug, RuntimeType.Clone)) + RuntimeType.Default
+        baseDerives.copy(derives = builderDerives).render(writer)
         writer.rustBlock("pub${ if (visibility == Visibility.PUBCRATE) " (crate)" else "" } struct Builder") {
             members.forEach { renderBuilderMember(this, it) }
         }
@@ -187,7 +187,9 @@ class ServerBuilderGenerator(
             renderBuildFn(this)
         }
 
-        renderImplDebugForBuilder(writer)
+        if (!builderDerives.contains(RuntimeType.Debug)) {
+            renderImplDebugForBuilder(writer)
+        }
     }
 
     private fun renderImplFromConstraintViolationForRequestRejection(writer: RustWriter) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGenerator.kt
@@ -39,8 +39,10 @@ import software.amazon.smithy.rust.codegen.core.smithy.mapRustType
 import software.amazon.smithy.rust.codegen.core.smithy.module
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticInputTrait
+import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.letIf
+import software.amazon.smithy.rust.codegen.core.util.redactIfNecessary
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.ServerRuntimeType
@@ -166,7 +168,7 @@ class ServerBuilderGenerator(
         // Matching derives to the main structure, - `PartialEq` (see class documentation for why), + `Default`
         // since we are a builder and everything is optional.
         val baseDerives = structureSymbol.expectRustMetadata().derives
-        val derives = baseDerives.derives.intersect(setOf(RuntimeType.Debug, RuntimeType.Clone)) + RuntimeType.Default
+        val derives = baseDerives.derives.intersect(setOf(RuntimeType.Clone)) + RuntimeType.Default
         baseDerives.copy(derives = derives).render(writer)
         writer.rustBlock("pub${ if (visibility == Visibility.PUBCRATE) " (crate)" else "" } struct Builder") {
             members.forEach { renderBuilderMember(this, it) }
@@ -184,6 +186,8 @@ class ServerBuilderGenerator(
             }
             renderBuildFn(this)
         }
+
+        renderImplDebugForBuilder(writer)
     }
 
     private fun renderImplFromConstraintViolationForRequestRejection(writer: RustWriter) {
@@ -415,6 +419,23 @@ class ServerBuilderGenerator(
             """,
             *codegenScope,
         )
+    }
+
+    private fun renderImplDebugForBuilder(writer: RustWriter) {
+        writer.rustBlock("impl #T for Builder", RuntimeType.Debug) {
+            writer.rustBlock("fn fmt(&self, f: &mut #1T::Formatter<'_>) -> #1T::Result", RuntimeType.stdfmt) {
+                rust("""let mut formatter = f.debug_struct("Builder");""")
+                members.forEach { member ->
+                    val memberName = symbolProvider.toMemberName(member)
+                    val fieldValue = member.redactIfNecessary(model, "self.$memberName")
+
+                    rust(
+                        "formatter.field(${memberName.dq()}, &$fieldValue);",
+                    )
+                }
+                rust("formatter.finish()")
+            }
+        }
     }
 
     /**

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package software.amazon.smithy.rust.codegen.server.smithy.generators
 
 import org.junit.jupiter.api.Test

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorTest.kt
@@ -1,0 +1,52 @@
+package software.amazon.smithy.rust.codegen.server.smithy.generators
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
+import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.implBlock
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.util.lookup
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverTestCodegenContext
+
+class ServerBuilderGeneratorTest {
+    @Test
+    fun `it respects the sensitive trait in Debug impl`() {
+        val model = """
+            namespace test
+            @sensitive
+            string SecretKey
+
+            @sensitive
+            string Password
+
+            structure Credentials {
+                username: String,
+                password: Password,
+                secretKey: SecretKey
+            }
+        """.asSmithyModel()
+
+        val codegenContext = serverTestCodegenContext(model)
+        val writer = RustWriter.forModule("model")
+        val shape = model.lookup<StructureShape>("test#Credentials")
+        StructureGenerator(model, codegenContext.symbolProvider, writer, shape).render(CodegenTarget.SERVER)
+        val builderGenerator = ServerBuilderGenerator(codegenContext, shape)
+        builderGenerator.render(writer)
+        writer.implBlock(shape, codegenContext.symbolProvider) {
+            builderGenerator.renderConvenienceMethod(this)
+        }
+        writer.compileAndTest(
+            """
+            use super::*;
+            let builder = Credentials::builder()
+                .username(Some("admin".to_owned()))
+                .password(Some("pswd".to_owned()))
+                .secret_key(Some("12345".to_owned()));
+                 assert_eq!(format!("{:?}", builder), "Builder { username: Some(\"admin\"), password: \"*** Sensitive Data Redacted ***\", secret_key: \"*** Sensitive Data Redacted ***\" }");
+            """,
+        )
+    }
+}


### PR DESCRIPTION
~~**Currently a draft PR to wash out test failures in CI.**~~

## Motivation and Context
Addresses https://github.com/awslabs/smithy-rs/pull/1983#discussion_r1022613055.

## Description
This PR is a follow-up on #1983 and configures the inclusion & exclusion of the Rust `Debug` trait in a central place rather than each shape figuring it out locally. To do so, `BaseSymbolMetadataProvider.containerDefault` looks at the passed-in container shape and if the shape has the sensitive trait it excludes the `Debug` trait, otherwise it will keep it. Based on `containerDefault`, `structureMeta`, `unionMeta`, and `enumMeta` further configures their `RustMetadata` as they see fit.

As a result of this change, we have newly added a custom implementation of the `Debug` trait within `BuilderGeneratorTest`, `UnionGeneratorTest`, and `ServerBuilderGeneratorTest`.

Note that this PR will be merged into the branch `ysaito/respect-sensitive-trait-for-enum`.

## Testing
- [x] Added unit tests in `BuilderGeneratorTest`, `UnionGeneratorTest`, and `ServerBuilderGeneratorTest`
- [x] All tests passed in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
