### PR TITLE
Add Endpoint Resolver Implementation

### DIFF
--- a/aws/rust-runtime/aws-endpoint/src/lib.rs
+++ b/aws/rust-runtime/aws-endpoint/src/lib.rs
@@ -63,7 +63,7 @@ impl ResolveEndpoint<Params> for EndpointShim {
                     .ok_or_else(|| ResolveEndpointError::message("no region in params"))?,
             )
             .map_err(|err| {
-                ResolveEndpointError::message("failure resolving endpoint").with_source(err)
+                ResolveEndpointError::message("failure resolving endpoint").with_source(Some(err))
             })?;
         let uri = aws_endpoint.endpoint().uri();
         let mut auth_scheme =

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointsStdLib.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointsStdLib.kt
@@ -9,8 +9,8 @@ import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.CustomRuntimeFunction
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.CustomRuntimeFunction
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.awsStandardLib
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
@@ -32,12 +32,12 @@ class AwsEndpointsStdLib() : RustCodegenDecorator<ClientProtocolGenerator, Clien
         return clazz.isAssignableFrom(ClientCodegenContext::class.java)
     }
 
-    private fun partitionsDotjson(sdkSettings: SdkSettings): ObjectNode {
+    private fun partitionMetadata(sdkSettings: SdkSettings): ObjectNode {
         if (partitionsCache == null) {
-            val partitionsJson = when (val path = sdkSettings.partitionsDotJson) {
+            val partitionsJson = when (val path = sdkSettings.partitionsConfigPath) {
                 null -> (
                     javaClass.getResource("/default-partitions.json")
-                        ?: throw IllegalStateException("Failed to find default-default-partitions.json in the JAR")
+                        ?: throw IllegalStateException("Failed to find default-partitions.json in the JAR")
                     ).readText()
 
                 else -> path.readText()
@@ -52,7 +52,7 @@ class AwsEndpointsStdLib() : RustCodegenDecorator<ClientProtocolGenerator, Clien
             object : EndpointCustomization {
                 override fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> {
                     val sdkSettings = SdkSettings.from(codegenContext.settings)
-                    return awsStandardLib(codegenContext.runtimeConfig, partitionsDotjson(sdkSettings))
+                    return awsStandardLib(codegenContext.runtimeConfig, partitionMetadata(sdkSettings))
                 }
             },
         )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointsStdLib.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointsStdLib.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.model.node.ObjectNode
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.CustomRuntimeFunction
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.awsStandardLib
+import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import kotlin.io.path.readText
+
+/**
+ * Standard library functions for AWS-specific endpoint standard library functions.
+ *
+ * This decorator uses partitions.json to source a default partition map for the partition resolver (when used).
+ *
+ * For test purposes, [awsStandardLib] can be used directly with a manually supplied partitions.json
+ */
+class AwsEndpointsStdLib() : RustCodegenDecorator<ClientProtocolGenerator, ClientCodegenContext> {
+    private var partitionsCache: ObjectNode? = null
+    override val name: String = "AwsEndpointsStdLib"
+    override val order: Byte = 0
+
+    override fun supportsCodegenContext(clazz: Class<out CodegenContext>): Boolean {
+        return clazz.isAssignableFrom(ClientCodegenContext::class.java)
+    }
+
+    private fun partitionsDotjson(sdkSettings: SdkSettings): ObjectNode {
+        if (partitionsCache == null) {
+            val partitionsJson = when (val path = sdkSettings.partitionsDotJson) {
+                null -> (
+                    javaClass.getResource("/default-partitions.json")
+                        ?: throw IllegalStateException("Failed to find default-default-partitions.json in the JAR")
+                    ).readText()
+
+                else -> path.readText()
+            }
+            partitionsCache = Node.parse(partitionsJson).expectObjectNode()
+        }
+        return partitionsCache!!
+    }
+
+    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> {
+        return listOf<EndpointCustomization>(
+            object : EndpointCustomization {
+                override fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> {
+                    val sdkSettings = SdkSettings.from(codegenContext.settings)
+                    return awsStandardLib(codegenContext.runtimeConfig, partitionsDotjson(sdkSettings))
+                }
+            },
+        )
+    }
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -10,7 +10,8 @@ import software.amazon.smithy.rulesengine.language.syntax.parameters.Builtins
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.RulesEngineBuiltInResolver
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.CustomRuntimeFunction
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator
@@ -100,18 +101,18 @@ class RegionDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientCode
         return baseCustomizations + PubUseRegion(codegenContext.runtimeConfig)
     }
 
-    override fun builtInResolvers(codegenContext: ClientCodegenContext): List<RulesEngineBuiltInResolver> {
+    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> {
         return listOf(
-            object : RulesEngineBuiltInResolver {
-                override fun defaultFor(
-                    parameter: Parameter,
-                    configRef: String,
-                ): Writable? {
+            object : EndpointCustomization {
+                override fun builtInDefaultValue(parameter: Parameter, configRef: String): Writable? {
                     return when (parameter) {
-                        Builtins.REGION -> writable { rust("$configRef.region.as_ref().map(|r|r.as_ref())") }
+                        Builtins.REGION -> writable { rust("$configRef.region.as_ref().map(|r|r.as_ref().to_owned())") }
                         else -> null
                     }
                 }
+
+                override fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> =
+                    listOf()
             },
         )
     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -10,8 +10,8 @@ import software.amazon.smithy.rulesengine.language.syntax.parameters.Builtins
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.CustomRuntimeFunction
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.CustomRuntimeFunction
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
@@ -29,6 +29,11 @@ class SdkSettings private constructor(private val awsSdk: ObjectNode?) {
         get() =
             awsSdk?.getStringMember("endpointsConfigPath")?.orNull()?.value?.let { Paths.get(it) }
 
+    /** Path to the `default-partitions.json` configuration */
+    val partitionsDotJson: Path?
+        get() =
+            awsSdk?.getStringMember("partitionsConfigPath")?.orNull()?.value?.let { Paths.get(it) }
+
     /** Path to AWS SDK integration tests */
     val integrationTestPath: String
         get() =

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkSettings.kt
@@ -30,7 +30,7 @@ class SdkSettings private constructor(private val awsSdk: ObjectNode?) {
             awsSdk?.getStringMember("endpointsConfigPath")?.orNull()?.value?.let { Paths.get(it) }
 
     /** Path to the `default-partitions.json` configuration */
-    val partitionsDotJson: Path?
+    val partitionsConfigPath: Path?
         get() =
             awsSdk?.getStringMember("partitionsConfigPath")?.orNull()?.value?.let { Paths.get(it) }
 

--- a/aws/sdk-codegen/src/main/resources/default-partitions.json
+++ b/aws/sdk-codegen/src/main/resources/default-partitions.json
@@ -1,0 +1,105 @@
+{
+  "version": "1.1",
+  "partitions": [
+    {
+      "id": "aws",
+      "regionRegex": "^(us|eu|ap|sa|ca|me|af)-\\w+-\\d+$",
+      "regions": {
+        "af-south-1": {},
+        "ap-east-1": {},
+        "ap-northeast-1": {},
+        "ap-northeast-2": {},
+        "ap-northeast-3": {},
+        "ap-south-1": {},
+        "ap-southeast-1": {},
+        "ap-southeast-2": {},
+        "ap-southeast-3": {},
+        "ca-central-1": {},
+        "eu-central-1": {},
+        "eu-north-1": {},
+        "eu-south-1": {},
+        "eu-west-1": {},
+        "eu-west-2": {},
+        "eu-west-3": {},
+        "me-central-1": {},
+        "me-south-1": {},
+        "sa-east-1": {},
+        "us-east-1": {},
+        "us-east-2": {},
+        "us-west-1": {},
+        "us-west-2": {},
+        "aws-global": {}
+      },
+      "outputs": {
+        "name": "aws",
+        "dnsSuffix": "amazonaws.com",
+        "dualStackDnsSuffix": "api.aws",
+        "supportsFIPS": true,
+        "supportsDualStack": true
+      }
+    },
+    {
+      "id": "aws-us-gov",
+      "regionRegex": "^us\\-gov\\-\\w+\\-\\d+$",
+      "regions": {
+        "us-gov-west-1": {},
+        "us-gov-east-1": {},
+        "aws-us-gov-global": {}
+      },
+      "outputs": {
+        "name": "aws-us-gov",
+        "dnsSuffix": "amazonaws.com",
+        "dualStackDnsSuffix": "api.aws",
+        "supportsFIPS": true,
+        "supportsDualStack": true
+      }
+    },
+    {
+      "id": "aws-cn",
+      "regionRegex": "^cn\\-\\w+\\-\\d+$",
+      "regions": {
+        "cn-north-1": {},
+        "cn-northwest-1": {},
+        "aws-cn-global": {}
+      },
+      "outputs": {
+        "name": "aws-cn",
+        "dnsSuffix": "amazonaws.com.cn",
+        "dualStackDnsSuffix": "api.amazonwebservices.com.cn",
+        "supportsFIPS": true,
+        "supportsDualStack": true
+      }
+    },
+    {
+      "id": "aws-iso",
+      "regionRegex": "^us\\-iso\\-\\w+\\-\\d+$",
+      "outputs": {
+        "name": "aws-iso",
+        "dnsSuffix": "c2s.ic.gov",
+        "supportsFIPS": true,
+        "supportsDualStack": false,
+        "dualStackDnsSuffix": "c2s.ic.gov"
+      },
+      "regions": {
+        "us-iso-east-1":  {},
+        "us-iso-west-1": {},
+        "aws-iso-global": {}
+      }
+    },
+    {
+      "id": "aws-iso-b",
+      "regionRegex": "^us\\-isob\\-\\w+\\-\\d+$",
+      "outputs": {
+        "name": "aws-iso-b",
+        "dnsSuffix": "sc2s.sgov.gov",
+        "supportsFIPS": true,
+        "supportsDualStack": false,
+        "dualStackDnsSuffix": "sc2s.sgov.gov"
+      },
+      "regions": {
+        "us-isob-east-1": {},
+        "aws-iso-b-global": {}
+      }
+    }
+  ]
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/AllowLintsGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/AllowLintsGenerator.kt
@@ -32,7 +32,9 @@ val AllowedClippyLints = listOf(
     "should_implement_trait",
 
     // Protocol tests use silly names like `baz`, don't flag that.
+    // TODO(msrv_upgrade): switch
     "blacklisted_name",
+    // "disallowed_names",
 
     // Forcing use of `vec![]` can make codegen harder in some cases.
     "vec_init_then_push",
@@ -42,6 +44,14 @@ val AllowedClippyLints = listOf(
 
     // Determining if the expression is the last one (to remove return) can make codegen harder in some cases.
     "needless_return",
+
+    // For backwards compatibility, we often don't derive Eq
+    // TODO(msrv_upgrade): enable
+    // "derive_partial_eq_without_eq",
+
+    // Keeping errors small in a backwards compatible way is challenging
+    // TODO(msrv_upgrade): enable
+    // "result_large_err",
 )
 
 val AllowedRustdocLints = listOf(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RustCodegenDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RustCodegenDecorator.kt
@@ -10,7 +10,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.RulesEngineBuiltInResolver
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
@@ -70,7 +70,7 @@ interface RustCodegenDecorator<T, C : CodegenContext> {
 
     fun transformModel(service: ServiceShape, model: Model): Model = model
 
-    fun builtInResolvers(codegenContext: C): List<RulesEngineBuiltInResolver> = listOf()
+    fun endpointCustomizations(codegenContext: C): List<EndpointCustomization> = listOf()
 
     fun supportsCodegenContext(clazz: Class<out CodegenContext>): Boolean
 }
@@ -144,8 +144,8 @@ open class CombinedCodegenDecorator<T, C : CodegenContext>(decorators: List<Rust
         }
     }
 
-    override fun builtInResolvers(codegenContext: C): List<RulesEngineBuiltInResolver> {
-        return orderedDecorators.flatMap { it.builtInResolvers(codegenContext) }
+    override fun endpointCustomizations(codegenContext: C): List<EndpointCustomization> {
+        return orderedDecorators.flatMap { it.endpointCustomizations(codegenContext) }
     }
 
     override fun supportsCodegenContext(clazz: Class<out CodegenContext>): Boolean =

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextParamDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextParamDecorator.kt
@@ -89,7 +89,7 @@ internal class ClientContextDecorator(ctx: CodegenContext) : ConfigCustomization
                     docsOrFallback(param.docs)
                     rust(
                         """
-                        pub fn set_${param.name}(mut self, ${param.name}: Option<#T>) -> Self {
+                        pub fn set_${param.name}(&mut self, ${param.name}: Option<#T>) -> &mut Self {
                             self.${param.name} = ${param.name};
                             self
                         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextParamDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextParamDecorator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.generators.config.Servi
 import software.amazon.smithy.rust.codegen.core.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.docs
+import software.amazon.smithy.rust.codegen.core.rustlang.docsOrFallback
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
@@ -75,11 +76,21 @@ internal class ClientContextDecorator(ctx: CodegenContext) : ConfigCustomization
             }
             ServiceConfig.BuilderImpl -> writable {
                 contextParams.forEach { param ->
-                    param.docs?.also { docs(it) }
+                    docsOrFallback(param.docs)
                     rust(
                         """
                         pub fn ${param.name}(mut self, ${param.name}: impl Into<#T>) -> Self {
                             self.${param.name} = Some(${param.name}.into());
+                            self
+                        }""",
+                        param.type,
+                    )
+
+                    docsOrFallback(param.docs)
+                    rust(
+                        """
+                        pub fn set_${param.name}(mut self, ${param.name}: Option<#T>) -> Self {
+                            self.${param.name} = ${param.name};
                             self
                         }
                         """,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextParamDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextParamDecorator.kt
@@ -28,9 +28,10 @@ import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 /**
  * This decorator adds `ClientContextParams` to the service config.
  *
- * This handles injecting parameters like `s3::Accelerate` or `s3::ForcePathStyle`
+ * This handles injecting parameters like `s3::Accelerate` or `s3::ForcePathStyle`. The resulting parameters become
+ * setters on the config builder object.
  */
-class ClientContextDecorator(ctx: CodegenContext) : ConfigCustomization() {
+internal class ClientContextDecorator(ctx: CodegenContext) : ConfigCustomization() {
     private val contextParams = ctx.serviceShape.getTrait<ClientContextParamsTrait>()?.parameters.orEmpty().toList()
         .map { (key, value) -> ContextParam.fromClientParam(key, value, ctx.symbolProvider) }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
@@ -75,10 +75,10 @@ internal class EndpointConfigCustomization(
                         /// impl endpoint::ResolveEndpoint<EndpointParams> for PrefixResolver {
                         ///   fn resolve_endpoint(&self, params: &EndpointParams) -> endpoint::Result {
                         ///        self.base_resolver
-                        ///         .resolve_endpoint(params)
+                        ///              .resolve_endpoint(params)
                         ///              .map(|ep|{
-                        ///                 let url = ep.url().to_string();
-                        ///                 ep.into_builder().url(format!("{}.{}", &self.prefix, url)).build()
+                        ///                   let url = ep.url().to_string();
+                        ///                   ep.into_builder().url(format!("{}.{}", &self.prefix, url)).build()
                         ///               })
                         ///   }
                         /// }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+
+/**
+ * Customization which injects an Endpoints 2.0 Endpoint Resolver into the service config struct
+ */
+internal class EndpointConfigCustomization(
+    codegenContext: ClientCodegenContext,
+    private val typesGenerator: EndpointTypesGenerator,
+) :
+    ConfigCustomization() {
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val moduleUseName = codegenContext.moduleUseName()
+    private val types = Types(runtimeConfig)
+
+    override fun section(section: ServiceConfig): Writable {
+        return writable {
+            val resolverTrait = "#{SmithyResolver}<#{Params}>"
+            val codegenScope = arrayOf(
+                "SmithyResolver" to types.resolveEndpoint,
+                "Params" to typesGenerator.paramsStruct(),
+                "DefaultResolver" to typesGenerator.defaultResolver(),
+            )
+            when (section) {
+                is ServiceConfig.ConfigStruct -> rustTemplate(
+                    "pub (crate) endpoint_resolver: std::sync::Arc<dyn $resolverTrait>,",
+                    *codegenScope,
+                )
+
+                is ServiceConfig.ConfigImpl ->
+                    rustTemplate(
+                        """
+                        /// Returns the endpoint resolver.
+                        pub fn endpoint_resolver(&self) -> std::sync::Arc<dyn $resolverTrait> {
+                            self.endpoint_resolver.clone()
+                        }
+                        """,
+                        *codegenScope,
+                    )
+
+                is ServiceConfig.BuilderStruct ->
+                    rustTemplate(
+                        "endpoint_resolver: Option<std::sync::Arc<dyn $resolverTrait>>,",
+                        *codegenScope,
+                    )
+
+                ServiceConfig.BuilderImpl ->
+                    rustTemplate(
+                        """
+                        /// Sets the endpoint resolver to use when making requests.
+                        ///
+                        /// When unset, the client will used a generated endpoint resolver based on the endpoint resolution
+                        /// rules for `$moduleUseName`.
+                        ///
+                        /// ## Examples
+                        /// ```no_run
+                        /// use aws_smithy_http::endpoint;
+                        /// use $moduleUseName::endpoint::{Params as EndpointParams, DefaultResolver};
+                        /// /// Endpoint resolver which adds a prefix to the generated endpoint
+                        /// struct PrefixResolver {
+                        ///     base_resolver: DefaultResolver,
+                        ///     prefix: String
+                        /// }
+                        /// impl endpoint::ResolveEndpoint<EndpointParams> for PrefixResolver {
+                        ///   fn resolve_endpoint(&self, params: &EndpointParams) -> endpoint::Result {
+                        ///        self.base_resolver
+                        ///         .resolve_endpoint(params)
+                        ///              .map(|ep|{
+                        ///                 let url = ep.url().to_string();
+                        ///                 ep.into_builder().url(format!("{}.{}", &self.prefix, url)).build()
+                        ///               })
+                        ///   }
+                        /// }
+                        /// let prefix_resolver = PrefixResolver {
+                        ///     base_resolver: DefaultResolver::new(),
+                        ///     prefix: "subdomain".to_string()
+                        /// };
+                        /// let config = $moduleUseName::Config::builder().endpoint_resolver(prefix_resolver);
+                        /// ```
+                        pub fn endpoint_resolver(mut self, endpoint_resolver: impl $resolverTrait + 'static) -> Self {
+                            self.endpoint_resolver = Some(std::sync::Arc::new(endpoint_resolver) as _);
+                            self
+                        }
+
+                        /// Sets the endpoint resolver to use when making requests.
+                        ///
+                        /// When unset, the client will used a generated endpoint resolver based on the endpoint resolution
+                        /// rules for `$moduleUseName`.
+                        pub fn set_endpoint_resolver(&mut self, endpoint_resolver: Option<std::sync::Arc<dyn $resolverTrait>>) -> &mut Self {
+                            self.endpoint_resolver = endpoint_resolver;
+                            self
+                        }
+                        """,
+                        *codegenScope,
+                    )
+
+                ServiceConfig.BuilderBuild -> {
+                    rustTemplate(
+                        """
+                        endpoint_resolver: self.endpoint_resolver.unwrap_or_else(||
+                            std::sync::Arc::new(#{DefaultResolver}::new())
+                        ),
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                else -> emptySection
+            }
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointRulesetIndex.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointRulesetIndex.kt
@@ -10,6 +10,7 @@ import software.amazon.smithy.model.knowledge.KnowledgeIndex
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
+import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import java.util.concurrent.ConcurrentHashMap
 
@@ -23,6 +24,8 @@ internal class EndpointRulesetIndex : KnowledgeIndex {
     fun endpointRulesForService(serviceShape: ServiceShape) = ruleSets.computeIfAbsent(
         serviceShape,
     ) { serviceShape.getTrait<EndpointRuleSetTrait>()?.ruleSet?.let { EndpointRuleSet.fromNode(it) }?.also { it.typecheck() } }
+
+    fun endpointTests(serviceShape: ServiceShape) = serviceShape.getTrait<EndpointTestsTrait>()?.testCases ?: emptyList()
 
     companion object {
         fun of(model: Model): EndpointRulesetIndex {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointRulesetIndex.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointRulesetIndex.kt
@@ -13,17 +13,20 @@ import software.amazon.smithy.rulesengine.traits.EndpointRuleSetTrait
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import java.util.concurrent.ConcurrentHashMap
 
-class EndpointRulesetIndex(model: Model) : KnowledgeIndex {
+/**
+ * Index to ensure that endpoint rulesets are parsed only once
+ */
+internal class EndpointRulesetIndex : KnowledgeIndex {
 
-    private val rulesets: ConcurrentHashMap<ServiceShape, EndpointRuleSet?> = ConcurrentHashMap()
+    private val ruleSets: ConcurrentHashMap<ServiceShape, EndpointRuleSet?> = ConcurrentHashMap()
 
-    fun endpointRulesForService(serviceShape: ServiceShape) = rulesets.computeIfAbsent(
+    fun endpointRulesForService(serviceShape: ServiceShape) = ruleSets.computeIfAbsent(
         serviceShape,
-    ) { serviceShape.getTrait<EndpointRuleSetTrait>()?.ruleSet?.let { EndpointRuleSet.fromNode(it) } }
+    ) { serviceShape.getTrait<EndpointRuleSetTrait>()?.ruleSet?.let { EndpointRuleSet.fromNode(it) }?.also { it.typecheck() } }
 
     companion object {
         fun of(model: Model): EndpointRulesetIndex {
-            return model.getKnowledge(EndpointRulesetIndex::class.java) { EndpointRulesetIndex(it) }
+            return model.getKnowledge(EndpointRulesetIndex::class.java) { EndpointRulesetIndex() }
         }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointTypesGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointTypesGenerator.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint
+
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters
+import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointTestGenerator
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.util.getTrait
+
+/**
+ * Entrypoint for Endpoints 2.0 Code generation
+ *
+ * This exposes [RuntimeType]s for the individual components of endpoints 2.0
+ */
+class EndpointTypesGenerator(codegenContext: ClientCodegenContext, private val rules: EndpointRuleSet) {
+    val params: Parameters = rules.parameters
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val customizations = codegenContext.rootDecorator.endpointCustomizations(codegenContext)
+    private val stdlib = customizations
+        .flatMap { it.customRuntimeFunctions(codegenContext) }
+    private val tests = codegenContext.serviceShape.getTrait<EndpointTestsTrait>()?.testCases ?: emptyList()
+
+    companion object {
+        fun fromContext(codegenContext: ClientCodegenContext): EndpointTypesGenerator? {
+            val index = EndpointRulesetIndex.of(codegenContext.model)
+            val rules = index.endpointRulesForService(codegenContext.serviceShape) ?: return null
+            return EndpointTypesGenerator(codegenContext, rules)
+        }
+    }
+
+    fun paramsStruct(): RuntimeType = EndpointParamsGenerator(params).paramsStruct()
+    fun defaultResolver(): RuntimeType = EndpointResolverGenerator(stdlib, runtimeConfig).defaultEndpointResolver(rules)
+    fun testGenerator(): Writable = EndpointTestGenerator(tests, paramsStruct(), defaultResolver(), params, runtimeConfig).generate()
+    fun builtInFor(parameter: Parameter, config: String): Writable? {
+        val defaultProviders = customizations
+            .mapNotNull { it.builtInDefaultValue(parameter, config) }
+        if (defaultProviders.size > 1) {
+            error("Multiple providers provided a value for the builtin $parameter")
+        }
+        return defaultProviders.firstOrNull()
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointTypesGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointTypesGenerator.kt
@@ -8,38 +8,51 @@ package software.amazon.smithy.rust.codegen.client.smithy.endpoint
 import software.amazon.smithy.rulesengine.language.EndpointRuleSet
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters
-import software.amazon.smithy.rulesengine.traits.EndpointTestsTrait
+import software.amazon.smithy.rulesengine.traits.EndpointTestCase
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointResolverGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointTestGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.util.getTrait
 
 /**
  * Entrypoint for Endpoints 2.0 Code generation
  *
  * This exposes [RuntimeType]s for the individual components of endpoints 2.0
  */
-class EndpointTypesGenerator(codegenContext: ClientCodegenContext, private val rules: EndpointRuleSet) {
+class EndpointTypesGenerator(
+    codegenContext: ClientCodegenContext,
+    private val rules: EndpointRuleSet,
+    private val tests: List<EndpointTestCase>,
+) {
     val params: Parameters = rules.parameters
     private val runtimeConfig = codegenContext.runtimeConfig
     private val customizations = codegenContext.rootDecorator.endpointCustomizations(codegenContext)
     private val stdlib = customizations
         .flatMap { it.customRuntimeFunctions(codegenContext) }
-    private val tests = codegenContext.serviceShape.getTrait<EndpointTestsTrait>()?.testCases ?: emptyList()
 
     companion object {
         fun fromContext(codegenContext: ClientCodegenContext): EndpointTypesGenerator? {
             val index = EndpointRulesetIndex.of(codegenContext.model)
-            val rules = index.endpointRulesForService(codegenContext.serviceShape) ?: return null
-            return EndpointTypesGenerator(codegenContext, rules)
+            val rulesOrNull = index.endpointRulesForService(codegenContext.serviceShape)
+            return rulesOrNull?.let { rules ->
+                EndpointTypesGenerator(codegenContext, rules, index.endpointTests(codegenContext.serviceShape))
+            }
         }
     }
 
     fun paramsStruct(): RuntimeType = EndpointParamsGenerator(params).paramsStruct()
     fun defaultResolver(): RuntimeType = EndpointResolverGenerator(stdlib, runtimeConfig).defaultEndpointResolver(rules)
-    fun testGenerator(): Writable = EndpointTestGenerator(tests, paramsStruct(), defaultResolver(), params, runtimeConfig).generate()
+    fun testGenerator(): Writable =
+        EndpointTestGenerator(tests, paramsStruct(), defaultResolver(), params, runtimeConfig).generate()
+
+    /**
+     * Load the builtIn value for [parameter] from the endpoint customizations. If the built-in comes from service config,
+     * [config] refers to `&crate::config::Config`
+     *
+     * Exactly one endpoint customization must provide the value for this builtIn or null is returned.
+     */
     fun builtInFor(parameter: Parameter, config: String): Writable? {
         val defaultProviders = customizations
             .mapNotNull { it.builtInDefaultValue(parameter, config) }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -14,6 +14,9 @@ import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters
 import software.amazon.smithy.rulesengine.traits.ContextIndex
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointTests
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointsModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -21,6 +24,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.generators.operationBuildError
@@ -33,10 +37,19 @@ import software.amazon.smithy.rust.codegen.core.util.orNull
  *
  * If this resolver does not recognize the value, it MUST return `null`.
  */
-interface RulesEngineBuiltInResolver {
-    fun defaultFor(parameter: Parameter, configRef: String): Writable?
+interface EndpointCustomization {
+    fun builtInDefaultValue(parameter: Parameter, configRef: String): Writable? = null
+    fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> = listOf()
 }
 
+/**
+ * Decorator that injects endpoints 2.0 resolvers throughout the entire client.
+ *
+ * This _does not_ inject any standard library functions. For the standard library, ensure that
+ * [NativeSmithyEndpointsStdLib] is included as a decorator on the classpath.
+ *
+ * If the service _does not_ provide custom endpoint rules, this decorator is a no-op.
+ */
 class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientCodegenContext> {
     override val name: String = "Endpoints"
     override val order: Byte = 0
@@ -49,120 +62,128 @@ class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientC
         operation: OperationShape,
         baseCustomizations: List<OperationCustomization>,
     ): List<OperationCustomization> {
-        return baseCustomizations + CreateEndpointParams(
-            codegenContext,
-            operation,
-            codegenContext.rootDecorator.builtInResolvers(codegenContext),
-        )
+        return listOfNotNull(
+            EndpointTypesGenerator.fromContext(codegenContext)?.let { endpointTypes ->
+                InjectEndpointInMakeOperation(
+                    codegenContext,
+                    endpointTypes,
+                    operation,
+                )
+            },
+        ) + baseCustomizations
     }
 
     override fun configCustomizations(
         codegenContext: ClientCodegenContext,
         baseCustomizations: List<ConfigCustomization>,
     ): List<ConfigCustomization> {
-        return baseCustomizations + ClientContextDecorator(codegenContext)
-    }
-}
-
-/**
- * Creates an `<crate>::endpoint_resolver::Params` structure in make operation generator. This combines state from the
- * client, the operation, and the model to create parameters.
- *
- * Example generated code:
- * ```rust
- * let _endpoint_params = crate::endpoint_resolver::Params::builder()
- *     .set_region(Some("test-region"))
- *     .set_disable_everything(Some(true))
- *     .set_bucket(input.bucket.as_ref())
- *     .build();
- * ```
- */
-class CreateEndpointParams(
-    private val ctx: ClientCodegenContext,
-    private val operationShape: OperationShape,
-    private val rulesEngineBuiltInResolvers: List<RulesEngineBuiltInResolver>,
-) :
-    OperationCustomization() {
-
-    private val runtimeConfig = ctx.runtimeConfig
-    private val params =
-        EndpointRulesetIndex.of(ctx.model).endpointRulesForService(ctx.serviceShape)?.parameters
-    private val idx = ContextIndex.of(ctx.model)
-
-    override fun section(section: OperationSection): Writable {
-        // if we don't have any parameters, then we have no rules, don't bother
-        if (params == null) {
-            return emptySection
-        }
-        val codegenScope = arrayOf(
-            "Params" to EndpointParamsGenerator(params).paramsStruct(),
-            "BuildError" to runtimeConfig.operationBuildError(),
+        return baseCustomizations + ClientContextDecorator(codegenContext) + listOfNotNull(
+            EndpointTypesGenerator.fromContext(
+                codegenContext,
+            )?.let { EndpointConfigCustomization(codegenContext, it) },
         )
-        return when (section) {
-            is OperationSection.MutateInput -> writable {
-                rustTemplate(
-                    """
-                    let endpoint_params = #{Params}::builder()#{builderFields:W}.build();
-                    """,
-                    "builderFields" to builderFields(params, section),
-                    *codegenScope,
-                )
-            }
-
-            is OperationSection.MutateRequest -> writable {
-                // insert the endpoint resolution _result_ into the bag (note that this won't bail if endpoint
-                // resolution failed)
-                // this is temporary—in the long term, we will insert the endpoint into the bag directly, but this makes
-                // it testable
-                rustTemplate("${section.request}.properties_mut().insert(endpoint_params);")
-            }
-
-            else -> emptySection
-        }
     }
 
-    private fun builderFields(params: Parameters, section: OperationSection.MutateInput) = writable {
-        val memberParams = idx.getContextParams(operationShape)
-        val builtInParams = params.toList().filter { it.isBuiltIn }
-        // first load builtins and their defaults
-        builtInParams.forEach { param ->
-            val defaultProviders = rulesEngineBuiltInResolvers.mapNotNull { it.defaultFor(param, section.config) }
-            if (defaultProviders.size > 1) {
-                error("Multiple providers provided a value for the builtin $param")
-            }
-            defaultProviders.firstOrNull()?.also { defaultValue ->
-                rust(".set_${param.name.rustName()}(#W)", defaultValue)
-            }
-        }
-
-        idx.getClientContextParams(ctx.serviceShape).orNull()?.parameters?.forEach { (name, param) ->
-            val paramName = EndpointParamsGenerator.memberName(name)
-            val setterName = EndpointParamsGenerator.setterName(name)
-            if (param.type == ShapeType.BOOLEAN) {
-                rust(".$setterName(${section.config}.$paramName)")
-            } else {
-                rust(".$setterName(${section.config}.$paramName.clone())")
-            }
-        }
-
-        idx.getStaticContextParams(operationShape).orNull()?.parameters?.forEach { (name, param) ->
-            val setterName = EndpointParamsGenerator.setterName(name)
-            val value = writable {
-                when (val v = param.value) {
-                    is BooleanNode -> rust("Some(${v.value})")
-                    is StringNode -> rust("Some(${v.value.dq()}.to_string())")
-                    else -> TODO("Unexpected static value type: $v")
+    override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
+        EndpointTypesGenerator.fromContext(codegenContext)?.also { generator ->
+            rustCrate.withModule(EndpointsModule) {
+                withInlineModule(EndpointTests) {
+                    generator.testGenerator()(this)
                 }
             }
-            rust(".$setterName(#W)", value)
+        }
+    }
+
+    /**
+     * Creates an `<crate>::endpoint_resolver::Params` structure in make operation generator. This combines state from the
+     * client, the operation, and the model to create parameters.
+     *
+     * Example generated code:
+     * ```rust
+     * let _endpoint_params = crate::endpoint_resolver::Params::builder()
+     *     .set_region(Some("test-region"))
+     *     .set_disable_everything(Some(true))
+     *     .set_bucket(input.bucket.as_ref())
+     *     .build();
+     * ```
+     */
+    class InjectEndpointInMakeOperation(
+        private val ctx: ClientCodegenContext,
+        private val typesGenerator: EndpointTypesGenerator,
+        private val operationShape: OperationShape,
+    ) :
+        OperationCustomization() {
+
+        private val idx = ContextIndex.of(ctx.model)
+
+        override fun section(section: OperationSection): Writable {
+            val codegenScope = arrayOf(
+                "Params" to typesGenerator.paramsStruct(),
+                "BuildError" to ctx.runtimeConfig.operationBuildError(),
+            )
+            return when (section) {
+                is OperationSection.MutateInput -> writable {
+                    rustTemplate(
+                        """
+                        let endpoint_params = #{Params}::builder()#{builderFields:W}.build()
+                            .map_err(#{BuildError}::other)?;
+                        let endpoint_result = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params);
+                        """,
+                        "builderFields" to builderFields(typesGenerator.params, section),
+                        *codegenScope,
+                    )
+                }
+
+                is OperationSection.MutateRequest -> writable {
+                    // insert the endpoint resolution _result_ into the bag (note that this won't bail if endpoint
+                    // resolution failed)
+                    rustTemplate("${section.request}.properties_mut().insert(endpoint_params);")
+                    rustTemplate("${section.request}.properties_mut().insert(endpoint_result);")
+                }
+
+                else -> emptySection
+            }
         }
 
-        // lastly, allow these to be overridden by members
-        memberParams.forEach { (memberShape, param) ->
-            val memberName = ctx.symbolProvider.toMemberName(memberShape)
-            rust(
-                ".${EndpointParamsGenerator.setterName(param.name)}(${section.input}.$memberName.clone())",
-            )
+        private fun builderFields(params: Parameters, section: OperationSection.MutateInput) = writable {
+            val memberParams = idx.getContextParams(operationShape)
+            val builtInParams = params.toList().filter { it.isBuiltIn }
+            // first load builtins and their defaults
+            builtInParams.forEach { param ->
+                typesGenerator.builtInFor(param, section.config)?.also { defaultValue ->
+                    rust(".set_${param.name.rustName()}(#W)", defaultValue)
+                }
+            }
+
+            idx.getClientContextParams(ctx.serviceShape).orNull()?.parameters?.forEach { (name, param) ->
+                val paramName = EndpointParamsGenerator.memberName(name)
+                val setterName = EndpointParamsGenerator.setterName(name)
+                if (param.type == ShapeType.BOOLEAN) {
+                    rust(".$setterName(${section.config}.$paramName)")
+                } else {
+                    rust(".$setterName(${section.config}.$paramName.clone())")
+                }
+            }
+
+            idx.getStaticContextParams(operationShape).orNull()?.parameters?.forEach { (name, param) ->
+                val setterName = EndpointParamsGenerator.setterName(name)
+                val value = writable {
+                    when (val v = param.value) {
+                        is BooleanNode -> rust("Some(${v.value})")
+                        is StringNode -> rust("Some(${v.value.dq()}.to_string())")
+                        else -> TODO("Unexpected static value type: $v")
+                    }
+                }
+                rust(".$setterName(#W)", value)
+            }
+
+            // lastly, allow these to be overridden by members
+            memberParams.forEach { (memberShape, param) ->
+                val memberName = ctx.symbolProvider.toMemberName(memberShape)
+                rust(
+                    ".${EndpointParamsGenerator.setterName(param.name)}(${section.input}.$memberName.clone())",
+                )
+            }
         }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
@@ -11,6 +11,7 @@ import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointsStdLib
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.FunctionRegistry
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.InlineDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustDependency

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
@@ -10,18 +10,46 @@ import software.amazon.smithy.rulesengine.language.syntax.Identifier
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rulesengine.language.syntax.parameters.ParameterType
 import software.amazon.smithy.rulesengine.traits.ContextParamTrait
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointsStdLib
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.InlineDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.makeOptional
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
+
+data class Context(val functionRegistry: FunctionRegistry, val runtimeConfig: RuntimeConfig)
 
 /**
  * Utility function to convert an [Identifier] into a valid Rust identifier (snake case)
  */
 fun Identifier.rustName(): String {
     return this.toString().stringToRustName()
+}
+
+/**
+ * Endpoints standard library file
+ */
+internal fun endpointsLib(name: String, vararg additionalDependency: RustDependency) = InlineDependency.forRustFile(
+    RustModule.pubCrate(
+        name,
+        parent = EndpointsStdLib,
+    ),
+    "/inlineable/src/endpoint_lib/$name.rs",
+    *additionalDependency,
+)
+
+class Types(runtimeConfig: RuntimeConfig) {
+    private val smithyTypesEndpointModule = CargoDependency.smithyTypes(runtimeConfig).toType().member("endpoint")
+    val smithyHttpEndpointModule = CargoDependency.smithyHttp(runtimeConfig).toType().member("endpoint")
+    val resolveEndpoint = smithyHttpEndpointModule.member("ResolveEndpoint")
+    val smithyEndpoint = smithyTypesEndpointModule.member("Endpoint")
+    val resolveEndpointError = smithyHttpEndpointModule.member("ResolveEndpointError")
 }
 
 private fun String.stringToRustName(): String = RustReservedWords.escapeIfNeeded(this.toSnakeCase())

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointResolverGenerator.kt
@@ -1,0 +1,337 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint
+
+import software.amazon.smithy.rulesengine.language.Endpoint
+import software.amazon.smithy.rulesengine.language.EndpointRuleSet
+import software.amazon.smithy.rulesengine.language.eval.Type
+import software.amazon.smithy.rulesengine.language.syntax.Identifier
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
+import software.amazon.smithy.rulesengine.language.syntax.expr.Reference
+import software.amazon.smithy.rulesengine.language.syntax.fn.Function
+import software.amazon.smithy.rulesengine.language.syntax.fn.IsSet
+import software.amazon.smithy.rulesengine.language.syntax.rule.Condition
+import software.amazon.smithy.rulesengine.language.syntax.rule.Rule
+import software.amazon.smithy.rulesengine.language.visit.RuleValueVisitor
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointsImpl
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointsModule
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.ExpressionGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.Ownership
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.comment
+import software.amazon.smithy.rust.codegen.core.rustlang.escape
+import software.amazon.smithy.rust.codegen.core.rustlang.join
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.toType
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.orNull
+
+abstract class CustomRuntimeFunction {
+    abstract val id: String
+
+    /** Initialize the struct field to a default value */
+    abstract fun structFieldInit(): Writable?
+
+    /** The argument slot of the runtime function. MUST NOT include `,`
+     * e.g `partition_data: &PartitionData`
+     * */
+    abstract fun additionalArgsSignature(): Writable?
+
+    /**
+     * A writable that passes additional args from `self` into the function. Must match the order of additionalArgsSignature
+     */
+    abstract fun additionalArgsInvocation(self: String): Writable?
+
+    /**
+     * Any additional struct fields this runtime function adds to the resolver
+     */
+    abstract fun structField(): Writable?
+
+    /**
+     * Invoking the runtime function—(parens / args not needed) `$fn`
+     */
+    abstract fun usage(): Writable
+}
+
+class FunctionRegistry(private val functions: List<CustomRuntimeFunction>) {
+    private var usedFunctions = mutableSetOf<CustomRuntimeFunction>()
+    fun fnFor(id: String): CustomRuntimeFunction? =
+        functions.firstOrNull { it.id == id }?.also { usedFunctions.add(it) }
+
+    fun fnsUsed(): List<CustomRuntimeFunction> = usedFunctions.toList().sortedBy { it.id }
+}
+
+/**
+ * Generate an endpoint resolver struct. The struct may contain extras resulting from the usage of functions e.g. partition function
+ * 1. resolver configuration (e.g. a custom partitions.json)
+ * 2. extra function arguments in the resolver
+ * 3. the runtime type of the library function
+ *
+ * ```rust
+ * pub struct DefaultResolver {
+ *   partition: PartitionResolver
+ * }
+ *
+ * impl aws_smithy_http::endpoint::ResolveEndpoint<crate::endpoint::Params> for DefaultResolver {
+ *     fn resolve_endpoint(&self, params: &Params) -> aws_smithy_http::endpoint::Result {
+ *         let mut diagnostic_collector = crate::endpoint_lib::diagnostic::DiagnosticCollector::new();
+ *         crate::endpoint::internals::resolve_endpoint(params, &self.partition_resolver, &mut diagnostic_collector)
+ *             .map_err(|err| err.with_source(diagnostic_collector.take_last_error()))
+ *     }
+ * }
+ *
+ * mod internals {
+ *   fn resolve_endpoint(params: &crate::endpoint::Params,
+ *      // conditionally inserted, only when used
+ *      partition_resolver: &PartitionResolver, _diagnostics: &mut DiagnosticCollector) -> endpoint::Result {
+ *      // lots of generated code to actually resolve an endpoint
+ *   }
+ * }
+ * ```
+ *
+ */
+
+internal class EndpointResolverGenerator(stdlib: List<CustomRuntimeFunction>, runtimeConfig: RuntimeConfig) {
+    private val registry: FunctionRegistry = FunctionRegistry(stdlib)
+    // first, make a custom RustWriter and generate the interior of the resolver into it.
+    // next, since we've now captured what runtime functions are required, generate the container
+
+    private val types = Types(runtimeConfig)
+    private val codegenScope = arrayOf(
+        "endpoint" to types.smithyHttpEndpointModule,
+        "SmithyEndpoint" to types.smithyEndpoint,
+        "EndpointError" to types.resolveEndpointError,
+        "DiagnosticCollector" to endpointsLib("diagnostic").toType().member("DiagnosticCollector"),
+    )
+    private val context = Context(registry, runtimeConfig)
+
+    companion object {
+        const val DiagnosticCollector = "_diagnostic_collector"
+        private const val ParamsName = "_params"
+    }
+
+    /**
+     * Generates the endpoint resolver struct
+     *
+     * If the rules require a runtime function that has state (e.g., the partition resolver, the `[CustomRuntimeFunction.structField]`
+     * will insert the required fields into the resolver so that they can be used later.
+     */
+    fun defaultEndpointResolver(endpointRuleSet: EndpointRuleSet): RuntimeType {
+        check(endpointRuleSet.rules.isNotEmpty()) { "EndpointRuleset must contain at least one rule." }
+        // Here, we play a little trick: we run the resolver and actually render it into a writer. This allows the
+        // function registry to record what functions we actually need. We need to do this, because the functions we
+        // actually use impacts the function signature that we need to return
+        resolverFnBody(endpointRuleSet)(RustWriter.root())
+
+        // Now that we rendered the rules once (and then threw it away) we can see what functions we actually used!
+        val fnsUsed = registry.fnsUsed()
+        return RuntimeType.forInlineFun("DefaultResolver", EndpointsModule) {
+            rustTemplate(
+                """
+                /// The default endpoint resolver
+                ##[derive(Default)]
+                pub struct DefaultResolver {
+                    #{custom_fields:W}
+                }
+
+                impl DefaultResolver {
+                    /// Create a new endpoint resolver with default settings
+                    pub fn new() -> Self {
+                        Self { #{custom_fields_init:W} }
+                    }
+                }
+
+                impl #{endpoint}::ResolveEndpoint<#{Params}> for DefaultResolver {
+                    fn resolve_endpoint(&self, params: &Params) -> #{endpoint}::Result {
+                        let mut diagnostic_collector = #{DiagnosticCollector}::new();
+                        #{resolver_fn}(params, &mut diagnostic_collector, #{additional_args})
+                            .map_err(|err|err.with_source(diagnostic_collector.take_last_error()))
+                    }
+                }
+                """,
+                "custom_fields" to fnsUsed.mapNotNull { it.structField() }.join(","),
+                "custom_fields_init" to fnsUsed.mapNotNull { it.structFieldInit() }.join(","),
+                "Params" to EndpointParamsGenerator(endpointRuleSet.parameters).paramsStruct(),
+                "additional_args" to fnsUsed.mapNotNull { it.additionalArgsInvocation("self") }.join(","),
+                "resolver_fn" to resolverFn(endpointRuleSet, fnsUsed),
+                *codegenScope,
+            )
+        }
+    }
+
+    private fun resolverFn(
+        endpointRuleSet: EndpointRuleSet,
+        fnsUsed: List<CustomRuntimeFunction>,
+    ): RuntimeType {
+        return RuntimeType.forInlineFun("resolve_endpoint", EndpointsImpl) {
+            rustTemplate(
+                """
+                pub(super) fn resolve_endpoint($ParamsName: &#{Params}, $DiagnosticCollector: &mut #{DiagnosticCollector}, #{additional_args}) -> #{endpoint}::Result {
+                 #{body:W}
+                }
+
+                """,
+                *codegenScope,
+                "Params" to EndpointParamsGenerator(endpointRuleSet.parameters).paramsStruct(),
+                "additional_args" to fnsUsed.mapNotNull { it.additionalArgsSignature() }.join(","),
+                "body" to resolverFnBody(endpointRuleSet),
+            )
+        }
+    }
+
+    private fun resolverFnBody(endpointRuleSet: EndpointRuleSet) = writable {
+        endpointRuleSet.parameters.toList().forEach {
+            Attribute.AllowUnused.render(this)
+            rust("let ${it.memberName()} = &$ParamsName.${it.memberName()};")
+        }
+        generateRulesList(endpointRuleSet.rules)(this)
+    }
+
+    private fun generateRulesList(rules: List<Rule>) = writable {
+        rules.forEach { rule ->
+            rule.documentation.orNull()?.also { comment(escape(it)) }
+            generateRule(rule)(this)
+        }
+        if (!isExhaustive(rules.last())) {
+            // it's hard to figure out if these are always needed or not
+            Attribute.Custom("allow(unreachable_code)").render(this)
+            rustTemplate(
+                """return Err(#{EndpointError}::message(format!("No rules matched these parameters. This is a bug. {:?}", $ParamsName)));""",
+                *codegenScope,
+            )
+        }
+    }
+
+    private fun isExhaustive(rule: Rule): Boolean = rule.conditions.isEmpty() || rule.conditions.all {
+        when (it.fn.type()) {
+            is Type.Bool -> false
+            is Type.Option -> false
+            else -> true
+        }
+    }
+
+    private fun generateRule(rule: Rule): Writable {
+        return generateRuleInternal(rule, rule.conditions)
+    }
+
+    /**
+     * deal with the actual target of the condition but flattening through isSet
+     */
+    private fun Condition.targetFunction(): Expression {
+        return when (val fn = this.fn) {
+            is IsSet -> fn.target
+            else -> fn
+        }
+    }
+
+    /**
+     * Recursive function is generate a rule and its list of conditions.
+     *
+     * The resulting generated code is a series of nested-if statements, nesting each condition inside the previous.
+     */
+    private fun generateRuleInternal(rule: Rule, conditions: List<Condition>): Writable {
+        if (conditions.isEmpty()) {
+            return rule.accept(RuleVisitor())
+        } else {
+            val condition = conditions.first()
+            val rest = conditions.drop(1)
+            return {
+                val generator = ExpressionGenerator(Ownership.Borrowed, context)
+                val fn = condition.targetFunction()
+
+                // there are three patterns we need to handle:
+                // 1. the RHS returns an option which we need to guard as "Some(...)"
+                // 2. the RHS returns a boolean which we need to gate on
+                // 3. the RHS is infallible (e.g. uriEncode)
+                val resultName =
+                    (condition.result.orNull() ?: (fn as? Reference)?.name ?: Identifier.of("_")).rustName()
+                val target = generator.generate(fn)
+                val next = generateRuleInternal(rule, rest)
+                when {
+                    fn.type() is Type.Option ||
+                        // ReterminusCore bug: substring should return `Option<String>`: https://github.com/awslabs/smithy/pull/1504/files
+                        (fn as Function).name == "substring" -> {
+                        Attribute.AllowUnused.render(this)
+                        rustTemplate(
+                            "if let Some($resultName) = #{target:W} { #{next:W} }",
+                            "target" to target,
+                            "next" to next,
+                        )
+                    }
+
+                    fn.type() is Type.Bool -> {
+                        rustTemplate(
+                            """
+                            if #{target:W} {#{binding}
+                                #{next:W}
+                            }
+                            """,
+                            "target" to target,
+                            "next" to next,
+                            // handle the rare but possible case where we bound the name of a variable to a boolean condition
+                            "binding" to writable {
+                                if (resultName != "_") {
+                                    rust("let $resultName = true;")
+                                }
+                            },
+                        )
+                    }
+
+                    else -> {
+                        // the function is infallible: just create a binding
+                        rustTemplate(
+                            """
+                            let $resultName = #{target:W};
+                            #{next:W}
+                            """,
+                            "target" to generator.generate(fn),
+                            "next" to generateRuleInternal(rule, rest),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    inner class RuleVisitor : RuleValueVisitor<Writable> {
+        override fun visitTreeRule(rules: List<Rule>) = generateRulesList(rules)
+
+        override fun visitErrorRule(error: Expression) = writable {
+            rustTemplate(
+                "return Err(#{EndpointError}::message(#{message:W}));",
+                *codegenScope,
+                "message" to ExpressionGenerator(Ownership.Owned, context).generate(error),
+            )
+        }
+
+        override fun visitEndpointRule(endpoint: Endpoint): Writable = writable {
+            rust("return Ok(#W);", generateEndpoint(endpoint))
+        }
+    }
+
+    /**
+     * generate the rust code for `[endpoint]`
+     */
+    internal fun generateEndpoint(endpoint: Endpoint): Writable {
+        val generator = ExpressionGenerator(Ownership.Owned, context)
+        val url = generator.generate(endpoint.url)
+        val headers = endpoint.headers.mapValues { entry -> entry.value.map { generator.generate(it) } }
+        val properties = endpoint.properties.mapValues { entry -> generator.generate(entry.value) }
+        return writable {
+            rustTemplate("#{SmithyEndpoint}::builder().url(#{url:W})", *codegenScope, "url" to url)
+            headers.forEach { (name, values) -> values.forEach { rust(".header(${name.dq()}, #W)", it) } }
+            properties.forEach { (name, value) -> rust(".property(${name.asString().dq()}, #W)", value) }
+            rust(".build()")
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointTestGenerator.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators
+
+import software.amazon.smithy.rulesengine.language.eval.Value
+import software.amazon.smithy.rulesengine.language.syntax.Identifier
+import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameters
+import software.amazon.smithy.rulesengine.traits.EndpointTestCase
+import software.amazon.smithy.rulesengine.traits.ExpectedEndpoint
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Types
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
+import software.amazon.smithy.rust.codegen.core.rustlang.escape
+import software.amazon.smithy.rust.codegen.core.rustlang.join
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.orNull
+
+internal class EndpointTestGenerator(
+    private val testCases: List<EndpointTestCase>,
+    private val paramsType: RuntimeType,
+    private val resolverType: RuntimeType,
+    private val params: Parameters,
+    runtimeConfig: RuntimeConfig,
+) {
+    private val types = Types(runtimeConfig)
+    private val codegenScope = arrayOf(
+        "Endpoint" to types.smithyEndpoint,
+        "ResolveEndpoint" to types.resolveEndpoint,
+        "Error" to types.resolveEndpointError,
+        "Document" to CargoDependency.smithyTypes(runtimeConfig).toType().member("Document"),
+        "HashMap" to RustType.HashMap.RuntimeType,
+    )
+
+    fun generate(): Writable = writable {
+        var id = 0
+        testCases.forEach { testCase ->
+            id += 1
+
+            rustTemplate(
+                """
+                #{docs:W}
+                ##[test]
+                fn test_$id() {
+                    use #{ResolveEndpoint};
+                    let params = #{params:W};
+                    let resolver = #{resolver}::new();
+                    let endpoint = resolver.resolve_endpoint(&params);
+                    #{assertion:W}
+                }
+                """,
+                *codegenScope,
+                "docs" to writable { docs(testCase.documentation.orNull() ?: "no docs") },
+                "params" to params(testCase),
+                "resolver" to resolverType,
+                "assertion" to writable {
+                    testCase.expect.endpoint.ifPresent { endpoint ->
+                        rustTemplate(
+                            """
+                            let endpoint = endpoint.expect("Expected valid endpoint: ${escape(endpoint.url)}");
+                            assert_eq!(endpoint, #{expected:W});
+                            """,
+                            *codegenScope, "expected" to generateEndpoint(endpoint),
+                        )
+                    }
+                    testCase.expect.error.ifPresent { error ->
+                        val expectedError = escape("expected error: $error [${testCase.documentation.orNull() ?: "no docs"}]")
+                        rustTemplate(
+                            """
+                            let error = endpoint.expect_err(${expectedError.dq()});
+                            assert_eq!(format!("{}", error), ${escape(error).dq()})
+                            """,
+                            *codegenScope,
+                        )
+                    }
+                },
+            )
+        }
+    }
+
+    private fun params(testCase: EndpointTestCase) = writable {
+        rust("#T::builder()", paramsType)
+        testCase.params.members.forEach { (id, value) ->
+            if (params.get(Identifier.of(id)).isPresent) {
+                rust(".${Identifier.of(id).rustName()}(#W)", generateValue(Value.fromNode(value)))
+            }
+        }
+        rust(""".build().expect("invalid params")""")
+    }
+
+    private fun generateValue(value: Value): Writable {
+        return {
+            when (value) {
+                is Value.String -> rust(escape(value.value()).dq() + ".to_string()")
+                is Value.Bool -> rust(value.toString())
+                is Value.Array -> {
+                    rust(
+                        "vec![#W]",
+                        value.values.map { member ->
+                            writable {
+                                rustTemplate(
+                                    "#{Document}::from(#{value:W})",
+                                    *codegenScope,
+                                    "value" to generateValue(member),
+                                )
+                            }
+                        }.join(","),
+                    )
+                }
+
+                is Value.Record ->
+                    rustBlock("") {
+                        rustTemplate(
+                            "let mut out = #{HashMap}::<String, #{Document}>::new();",
+                            *codegenScope,
+                        )
+                        value.forEach { identifier, v ->
+                            rust(
+                                "out.insert(${identifier.toString().dq()}.to_string(), #W.into());",
+                                // When writing into the hashmap, it always needs to be an owned type
+                                generateValue(v),
+                            )
+                        }
+                        rustTemplate("out")
+                    }
+            }
+        }
+    }
+
+    private fun generateEndpoint(value: ExpectedEndpoint) = writable {
+        rustTemplate("#{Endpoint}::builder().url(${escape(value.url).dq()})", *codegenScope)
+        value.headers.forEach { (headerName, values) ->
+            values.forEach { headerValue ->
+                rust(".header(${headerName.dq()}, ${headerValue.dq()})")
+            }
+        }
+        value.properties.forEach { (name, value) ->
+            rust(
+                ".property(${name.dq()}, #W)",
+                generateValue(Value.fromNode(value)),
+            )
+        }
+        rust(".build()")
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGenerator.kt
@@ -1,0 +1,111 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+import org.jetbrains.annotations.Contract
+import software.amazon.smithy.rulesengine.language.eval.Type
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
+import software.amazon.smithy.rulesengine.language.syntax.expr.Literal
+import software.amazon.smithy.rulesengine.language.syntax.expr.Reference
+import software.amazon.smithy.rulesengine.language.syntax.fn.FunctionDefinition
+import software.amazon.smithy.rulesengine.language.syntax.fn.GetAttr
+import software.amazon.smithy.rulesengine.language.visit.ExpressionVisitor
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Context
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointResolverGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.join
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.util.PANIC
+
+/**
+ * Root expression generator.
+ */
+class ExpressionGenerator(
+    private val ownership: Ownership,
+    private val context: Context,
+) {
+
+    @Contract(pure = true)
+    fun generate(expr: Expression): Writable {
+        return expr.accept(ExprGeneratorVisitor(ownership))
+    }
+
+    /**
+     * Inner generator based on ExprVisitor
+     */
+    private inner class ExprGeneratorVisitor(
+        private val ownership: Ownership,
+    ) :
+        ExpressionVisitor<Writable> {
+
+        override fun visitLiteral(literal: Literal): Writable {
+            return literal.accept(LiteralGenerator(ownership, context))
+        }
+
+        override fun visitRef(ref: Reference) = writable {
+            rust(ref.name.rustName())
+            if (ownership == Ownership.Owned) {
+                rust(".to_owned()")
+            }
+        }
+
+        override fun visitGetAttr(getAttr: GetAttr): Writable {
+            val target = ExpressionGenerator(Ownership.Borrowed, context).generate(getAttr.target)
+            val path = writable {
+                getAttr.path.toList().forEach { part ->
+                    when (part) {
+                        is GetAttr.Part.Key -> rust(".${part.key().rustName()}()")
+                        is GetAttr.Part.Index -> rust(".get(${part.index()}).cloned()") // we end up with Option<&&T>, we need to get to Option<&T>
+                    }
+                }
+                if (ownership == Ownership.Owned) {
+                    if (getAttr.type() is Type.Option) {
+                        rust(".map(|t|t.to_owned())")
+                    } else {
+                        rust(".to_owned()")
+                    }
+                }
+            }
+            return writable { rust("#W#W", target, path) }
+        }
+
+        override fun visitIsSet(fn: Expression) = writable {
+            val expressionGenerator = ExpressionGenerator(Ownership.Borrowed, context)
+            rust("#W.is_some()", expressionGenerator.generate(fn))
+        }
+
+        override fun visitNot(not: Expression) = writable {
+            rust("!(#W)", ExpressionGenerator(Ownership.Borrowed, context).generate(not))
+        }
+
+        override fun visitBoolEquals(left: Expression, right: Expression) = writable {
+            val expressionGenerator = ExpressionGenerator(Ownership.Owned, context)
+            rust("(#W) == (#W)", expressionGenerator.generate(left), expressionGenerator.generate(right))
+        }
+
+        override fun visitStringEquals(left: Expression, right: Expression) = writable {
+            val expressionGenerator = ExpressionGenerator(Ownership.Borrowed, context)
+            rust("(#W) == (#W)", expressionGenerator.generate(left), expressionGenerator.generate(right))
+        }
+
+        override fun visitLibraryFunction(fn: FunctionDefinition, args: MutableList<Expression>): Writable = writable {
+            val fnDefinition = context.functionRegistry.fnFor(fn.id) ?: PANIC("no runtime function for ${fn.id}")
+            val expressionGenerator = ExpressionGenerator(Ownership.Borrowed, context)
+            val argWritables = args.map { expressionGenerator.generate(it) }
+            rustTemplate(
+                "#{fn}(#{args}, ${EndpointResolverGenerator.DiagnosticCollector})",
+                "fn" to fnDefinition.usage(),
+                "args" to argWritables.join(","),
+            )
+            if (ownership == Ownership.Owned) {
+                rust(".to_owned()")
+            }
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGenerator.kt
@@ -14,7 +14,7 @@ import software.amazon.smithy.rulesengine.language.syntax.fn.FunctionDefinition
 import software.amazon.smithy.rulesengine.language.syntax.fn.GetAttr
 import software.amazon.smithy.rulesengine.language.visit.ExpressionVisitor
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Context
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointResolverGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointResolverGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.join
@@ -95,7 +95,12 @@ class ExpressionGenerator(
         }
 
         override fun visitLibraryFunction(fn: FunctionDefinition, args: MutableList<Expression>): Writable = writable {
-            val fnDefinition = context.functionRegistry.fnFor(fn.id) ?: PANIC("no runtime function for ${fn.id}")
+            val fnDefinition = context.functionRegistry.fnFor(fn.id)
+                ?: PANIC(
+                    "no runtime function for ${fn.id} " +
+                        "(hint: if this is a custom or aws-specific runtime function, ensure the relevant standard library has been loaded " +
+                        "on the classpath)",
+                )
             val expressionGenerator = ExpressionGenerator(Ownership.Borrowed, context)
             val argWritables = args.map { expressionGenerator.generate(it) }
             rustTemplate(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/LiteralGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/LiteralGenerator.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+import software.amazon.smithy.rulesengine.language.syntax.Identifier
+import software.amazon.smithy.rulesengine.language.syntax.expr.Literal
+import software.amazon.smithy.rulesengine.language.syntax.expr.Template
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Context
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.util.dq
+import java.util.stream.Stream
+
+/**
+ * Generator for literals (strings, numbers, bools, lists and objects)
+ *
+ * The `Document` type is used to support generating JSON-like documents
+ */
+class LiteralGenerator(private val ownership: Ownership, private val context: Context) :
+    Literal.Vistor<Writable> {
+    private val runtimeConfig = context.runtimeConfig
+    private val document = CargoDependency.smithyTypes(runtimeConfig).toType().member("Document")
+    private val codegenScope = arrayOf("Document" to document, "HashMap" to RustType.HashMap.RuntimeType)
+    override fun visitBool(b: Boolean) = writable {
+        rust(b.toString())
+    }
+
+    override fun visitString(value: Template) = writable {
+        val parts: Stream<Writable> = value.accept(
+            TemplateGenerator(ownership) { expr, ownership ->
+                ExpressionGenerator(ownership, context).generate(expr)
+            },
+        )
+        parts.forEach { part -> part(this) }
+    }
+
+    override fun visitRecord(members: MutableMap<Identifier, Literal>) = writable {
+        rustBlock("") {
+            rustTemplate(
+                "let mut out = #{HashMap}::<String, #{Document}>::new();",
+                *codegenScope,
+            )
+            members.forEach { (identifier, literal) ->
+                rust(
+                    "out.insert(${identifier.toString().dq()}.to_string(), #W.into());",
+                    // When writing into the hashmap, it always needs to be an owned type
+                    ExpressionGenerator(Ownership.Owned, context).generate(literal),
+                )
+            }
+            rustTemplate("out")
+        }
+    }
+
+    override fun visitTuple(members: MutableList<Literal>) = writable {
+        rustTemplate(
+            "vec![#{inner:W}]", *codegenScope,
+            "inner" to writable {
+                members.forEach { literal ->
+                    rustTemplate(
+                        "#{Document}::from(#{literal:W}),",
+                        *codegenScope,
+                        "literal" to ExpressionGenerator(
+                            Ownership.Owned,
+                            context,
+                        ).generate(literal),
+                    )
+                }
+            },
+        )
+    }
+
+    override fun visitInteger(value: Int) = writable {
+        rust("$value")
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/Ownership.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/Ownership.kt
@@ -1,0 +1,20 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+sealed class Ownership {
+    object Borrowed : Ownership() {
+        override fun toString(): String {
+            return "Borrowed"
+        }
+    }
+
+    object Owned : Ownership() {
+        override fun toString(): String {
+            return "Owned"
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/StdLib.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/StdLib.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.RustCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.CustomRuntimeFunction
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.endpointsLib
+import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.toType
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.util.dq
+
+/**
+ * StandardLibrary functions for native-smithy implementations
+ *
+ * Note: this does not include any `aws.*` functions
+ */
+class NativeSmithyEndpointsStdLib : RustCodegenDecorator<ClientProtocolGenerator, ClientCodegenContext> {
+    override val name: String = "NativeSmithyStandardLib"
+    override val order: Byte = 0
+
+    override fun supportsCodegenContext(clazz: Class<out CodegenContext>): Boolean {
+        return clazz.isAssignableFrom(ClientCodegenContext::class.java)
+    }
+
+    override fun endpointCustomizations(codegenContext: ClientCodegenContext): List<EndpointCustomization> {
+        return listOf(
+            object : EndpointCustomization {
+                override fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> {
+                    return NativeSmithyFunctions
+                }
+            },
+        )
+    }
+}
+
+internal val NativeSmithyFunctions: List<CustomRuntimeFunction> = listOf(
+    PureRuntimeFunction("substring", endpointsLib("substring").toType().member("substring")),
+    PureRuntimeFunction("isValidHostLabel", endpointsLib("host").toType().member("is_valid_host_label")),
+    PureRuntimeFunction(
+        "parseURL",
+        endpointsLib("parse_url", CargoDependency.Http, CargoDependency.Url).toType().member("parse_url"),
+    ),
+    PureRuntimeFunction(
+        "uriEncode",
+        endpointsLib("uri_encode", CargoDependency.PercentEncoding).toType().member("uri_encode"),
+    ),
+)
+
+/**
+ * AWS Standard library functions
+ *
+ * This is defined in client-codegen to support running tests—it is not used when generating smithy-native services.
+ */
+fun awsStandardLib(runtimeConfig: RuntimeConfig, partitionsDotJson: Node) = listOf(
+    PureRuntimeFunction("aws.parseArn", endpointsLib("arn").toType().member("parse_arn")),
+    PureRuntimeFunction(
+        "aws.isVirtualHostableS3Bucket",
+        endpointsLib(
+            "s3",
+            endpointsLib("host"),
+            CargoDependency.OnceCell,
+            CargoDependency.Regex,
+        ).toType().member("is_virtual_hostable_s3_bucket"),
+    ),
+    AwsPartitionResolver(
+        runtimeConfig,
+        partitionsDotJson,
+    ),
+)
+
+/**
+ * Implementation of the `aws.partition` standard library function.
+ *
+ * A default `partitionsDotJson` node MUST be provided. The node MUST contain an AWS partition.
+ */
+class AwsPartitionResolver(runtimeConfig: RuntimeConfig, private val partitionsDotJson: Node) :
+    CustomRuntimeFunction() {
+    override val id: String = "aws.partition"
+    private val codegenScope = arrayOf(
+        "PartitionResolver" to endpointsLib(
+            "partition",
+            CargoDependency.smithyJson(runtimeConfig),
+            CargoDependency.Regex,
+        ).toType()
+            .member("PartitionResolver"),
+    )
+
+    override fun structFieldInit() = writable {
+        rustTemplate(
+            """partition_resolver: #{PartitionResolver}::new_from_json(b${
+            Node.printJson(partitionsDotJson).dq()
+            }).expect("valid JSON")""",
+            *codegenScope,
+        )
+    }
+
+    override fun additionalArgsSignature(): Writable = writable {
+        rustTemplate("partition_resolver: &#{PartitionResolver}", *codegenScope)
+    }
+
+    override fun additionalArgsInvocation(self: String) = writable {
+        rust("&$self.partition_resolver")
+    }
+
+    override fun structField(): Writable = writable {
+        rustTemplate("partition_resolver: #{PartitionResolver}", *codegenScope)
+    }
+
+    override fun usage() = writable {
+        rust("partition_resolver.resolve_partition")
+    }
+}
+
+/**
+ * A runtime function that doesn't need any support structures and can be invoked directly
+ */
+private class PureRuntimeFunction(override val id: String, private val runtimeType: RuntimeType) :
+    CustomRuntimeFunction() {
+    override fun structFieldInit(): Writable? = null
+
+    override fun additionalArgsSignature(): Writable? = null
+
+    override fun additionalArgsInvocation(self: String): Writable? = null
+
+    override fun structField(): Writable? = null
+
+    override fun usage() = writable { rust("#T", runtimeType) }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/TemplateGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/TemplateGenerator.kt
@@ -1,0 +1,69 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
+import software.amazon.smithy.rulesengine.language.visit.TemplateVisitor
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.util.dq
+
+/**
+ * Template Generator
+ *
+ * Templates can be in one of 3 possible formats:
+ * 1. Single static string: `https://staticurl.com`. In this case, we return a string literal.
+ * 2. Single dynamic string: `{Region}`. In this case we delegate directly to the underlying expression.
+ * 3. Compound string: `https://{Region}.example.com`. In this case, we use a string builder:
+ * ```rust
+ * {
+ *   let mut out = String::new();
+ *   out.push_str("https://");
+ *   out.push_str(region);
+ *   out.push_str(".example.com);
+ *   out
+ * }
+ * ```
+ */
+class TemplateGenerator(
+    private val ownership: Ownership,
+    private val exprGenerator: (Expression, Ownership) -> Writable,
+) : TemplateVisitor<Writable> {
+    override fun visitStaticTemplate(value: String) = writable {
+        // In the case of a static template, return the literal string, eg. `"foo"`.
+        rust(value.dq())
+        if (ownership == Ownership.Owned) {
+            rust(".to_string()")
+        }
+    }
+
+    override fun visitSingleDynamicTemplate(expr: Expression): Writable {
+        return exprGenerator(expr, ownership)
+    }
+
+    override fun visitStaticElement(str: String) = writable {
+        rust("out.push_str(${str.dq()});")
+    }
+
+    override fun visitDynamicElement(expr: Expression) = writable {
+        // we don't need to own the argument to push_str
+        Attribute.Custom("allow(clippy::needless_borrow)").render(this)
+        rust("out.push_str(&#W);", exprGenerator(expr, Ownership.Borrowed))
+    }
+
+    override fun startMultipartTemplate() = writable {
+        if (ownership == Ownership.Borrowed) {
+            rust("&")
+        }
+        rust("{ let mut out = String::new();")
+    }
+
+    override fun finishMultipartTemplate() = writable {
+        rust(" out }")
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/CodegenIntegrationTest.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/CodegenIntegrationTest.kt
@@ -34,6 +34,7 @@ fun clientIntegrationTest(
     service: String? = null,
     runtimeConfig: RuntimeConfig? = null,
     additionalSettings: ObjectNode = ObjectNode.builder().build(),
+    command: ((Path) -> Unit)? = null,
     test: (ClientCodegenContext, RustCrate) -> Unit,
 ): Path {
     return codegenIntegrationTest(
@@ -45,6 +46,7 @@ fun clientIntegrationTest(
         runtimeConfig = runtimeConfig,
         additionalSettings = additionalSettings,
         test = test,
+        command = command,
     )
 }
 
@@ -75,6 +77,7 @@ private fun <T, C : CodegenContext> codegenIntegrationTest(
     service: String? = null,
     runtimeConfig: RuntimeConfig? = null,
     overrideTestDir: File? = null, test: (C, RustCrate) -> Unit,
+    command: ((Path) -> Unit)? = null,
 ): Path {
     val (ctx, testDir) = generatePluginContext(
         model,
@@ -99,6 +102,6 @@ private fun <T, C : CodegenContext> codegenIntegrationTest(
     }
     buildPlugin.executeWithDecorator(ctx, codegenDecorator, *additionalDecorators.toTypedArray())
     ctx.fileManifest.printGeneratedFiles()
-    "cargo test".runCommand(testDir, environment = mapOf("RUSTFLAGS" to "-D warnings"))
+    command?.invoke(testDir) ?: "cargo test".runCommand(testDir, environment = mapOf("RUSTFLAGS" to "-D warnings"))
     return testDir
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointParamsGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointParamsGeneratorTest.kt
@@ -8,7 +8,7 @@ package software.amazon.smithy.rust.codegen.client.endpoint
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import software.amazon.smithy.rulesengine.testutil.TestDiscovery
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointResolverGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointResolverGeneratorTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.endpoint
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import software.amazon.smithy.codegen.core.CodegenException
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.rulesengine.language.Endpoint
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
+import software.amazon.smithy.rulesengine.language.syntax.expr.Literal
+import software.amazon.smithy.rulesengine.testutil.TestDiscovery
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointResolverGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointTestGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.NativeSmithyFunctions
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.awsStandardLib
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
+import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+import java.util.stream.Stream
+
+class EndpointResolverGeneratorTest {
+    companion object {
+        @JvmStatic
+        fun testSuites(): Stream<TestDiscovery.RulesTestSuite> = TestDiscovery().testSuites()
+    }
+
+    // for tests, load partitions.json from smithy—for real usage, this file will be inserted at codegen time
+    private val partitionsJson =
+        Node.parse(
+            this::class.java.getResource("/software/amazon/smithy/rulesengine/language/partitions.json")?.readText()
+                ?: throw CodegenException("partitions.json was not present in smithy bundle"),
+        )
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("testSuites")
+    fun `generate all rulesets`(suite: TestDiscovery.RulesTestSuite) {
+        // snippet to only run one ruleset during tests
+        if (!suite.toString().contains("hostable")) {
+            // return
+        }
+        val project = TestWorkspace.testProject()
+        suite.ruleSet().typecheck()
+        project.lib {
+            val ruleset = EndpointResolverGenerator(
+                NativeSmithyFunctions + awsStandardLib(TestRuntimeConfig, partitionsJson),
+                TestRuntimeConfig,
+            ).defaultEndpointResolver(suite.ruleSet())
+            val testGenerator = EndpointTestGenerator(
+                suite.testSuite().testCases,
+                paramsType = EndpointParamsGenerator(suite.ruleSet().parameters).paramsStruct(),
+                resolverType = ruleset,
+                suite.ruleSet().parameters,
+                TestRuntimeConfig,
+            )
+            testGenerator.generate()(this)
+        }
+        project.compileAndTest(runClippy = true)
+    }
+
+    @Test
+    fun `only include actually used functions in endpoints lib`() {
+        testSuites().map { it.ruleSet().sourceLocation.filename }.forEach { println(it) }
+        val suite =
+            testSuites().filter { it.ruleSet().sourceLocation.filename.endsWith("/uri-encode.json") }.findFirst()
+                .orElseThrow()
+        val project = TestWorkspace.testProject()
+        suite.ruleSet().typecheck()
+        project.lib {
+            val ruleset = EndpointResolverGenerator(
+                NativeSmithyFunctions + awsStandardLib(TestRuntimeConfig, partitionsJson),
+                TestRuntimeConfig,
+            ).defaultEndpointResolver(suite.ruleSet())
+            val testGenerator = EndpointTestGenerator(
+                suite.testSuite().testCases,
+                paramsType = EndpointParamsGenerator(suite.ruleSet().parameters).paramsStruct(),
+                resolverType = ruleset,
+                suite.ruleSet().parameters,
+                TestRuntimeConfig,
+            )
+            testGenerator.generate()(this)
+        }
+        project.compileAndTest()
+        project.generatedFiles()
+            .filter { it.toAbsolutePath().toString().contains("endpoint_lib/") }
+            .map { it.fileName.toString() }.sorted() shouldBe listOf(
+            "diagnostic.rs", "uri_encode.rs",
+        )
+    }
+
+    @Test
+    fun generateEndpoints() {
+        val endpoint = Endpoint.builder().url(Expression.of("https://{Region}.amazonaws.com"))
+            .addHeader("x-amz-test", listOf(Literal.of("header-value")))
+            .addAuthScheme(
+                "sigv4",
+                hashMapOf("signingName" to Literal.of("service"), "signingScope" to Literal.of("{Region}")),
+            )
+            .build()
+        val generator = EndpointResolverGenerator(listOf(), TestRuntimeConfig)
+        TestWorkspace.testProject().unitTest {
+            rustTemplate(
+                """
+                // create a local for region to generate against
+                let region = "us-east-1";
+                let endpoint = #{endpoint:W};
+
+                """,
+                "endpoint" to generator.generateEndpoint(endpoint),
+            )
+        }.compileAndTest()
+    }
+}

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointResolverGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointResolverGeneratorTest.kt
@@ -15,10 +15,10 @@ import software.amazon.smithy.rulesengine.language.Endpoint
 import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
 import software.amazon.smithy.rulesengine.language.syntax.expr.Literal
 import software.amazon.smithy.rulesengine.testutil.TestDiscovery
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointResolverGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointParamsGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointResolverGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointTestGenerator
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.NativeSmithyFunctions
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.SmithyEndpointsStdLib
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.awsStandardLib
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
@@ -51,7 +51,7 @@ class EndpointResolverGeneratorTest {
         suite.ruleSet().typecheck()
         project.lib {
             val ruleset = EndpointResolverGenerator(
-                NativeSmithyFunctions + awsStandardLib(TestRuntimeConfig, partitionsJson),
+                SmithyEndpointsStdLib + awsStandardLib(TestRuntimeConfig, partitionsJson),
                 TestRuntimeConfig,
             ).defaultEndpointResolver(suite.ruleSet())
             val testGenerator = EndpointTestGenerator(
@@ -76,7 +76,7 @@ class EndpointResolverGeneratorTest {
         suite.ruleSet().typecheck()
         project.lib {
             val ruleset = EndpointResolverGenerator(
-                NativeSmithyFunctions + awsStandardLib(TestRuntimeConfig, partitionsJson),
+                SmithyEndpointsStdLib + awsStandardLib(TestRuntimeConfig, partitionsJson),
                 TestRuntimeConfig,
             ).defaultEndpointResolver(suite.ruleSet())
             val testGenerator = EndpointTestGenerator(

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
@@ -9,7 +9,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointsDecorator
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.NativeSmithyEndpointsStdLib
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.testutil.TokioTest
@@ -95,7 +94,7 @@ class EndpointsDecoratorTest {
     fun `set an endpoint in the property bag`() {
         val testDir = clientIntegrationTest(
             model,
-            addtionalDecorators = listOf(EndpointsDecorator(), NativeSmithyEndpointsStdLib()),
+            addtionalDecorators = listOf(EndpointsDecorator()),
             command = { "cargo check".runWithWarnings(it) },
         ) { clientCodegenContext, rustCrate ->
             rustCrate.integrationTest("endpoint_params_test") {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
@@ -5,16 +5,23 @@
 
 package software.amazon.smithy.rust.codegen.client.endpoint
 
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointsDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.NativeSmithyEndpointsStdLib
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.testutil.TokioTest
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
+import software.amazon.smithy.rust.codegen.core.testutil.runWithWarnings
+import software.amazon.smithy.rust.codegen.core.util.CommandFailed
 
+/**
+ * End-to-end test of endpoint resolvers, attaching a real resolver to a fully generated service
+ */
 class EndpointsDecoratorTest {
-
     val model = """
         namespace test
 
@@ -29,7 +36,13 @@ class EndpointsDecoratorTest {
         @awsJson1_1
         @endpointRuleSet({
             "version": "1.0",
-            "rules": [],
+            "rules": [{
+                "conditions": [{"fn": "isSet", "argv": [{"ref":"Region"}]}],
+                "type": "endpoint",
+                "endpoint": {
+                    "url": "https://www.{Region}.example.com"
+                }
+            }],
             "parameters": {
                 "Bucket": { "required": false, "type": "String" },
                 "Region": { "required": false, "type": "String", "builtIn": "AWS::Region" },
@@ -37,13 +50,31 @@ class EndpointsDecoratorTest {
                 "ABoolParam": { "required": false, "type": "Boolean" }
             }
         })
-        @clientContextParams(AStringParam: {
-            documentation: "string docs",
-            type: "string"
-        },
-        aBoolParam: {
-            documentation: "bool docs",
-            type: "boolean"
+        @clientContextParams(
+            AStringParam: {
+                documentation: "string docs",
+                type: "string"
+            },
+            aBoolParam: {
+                documentation: "bool docs",
+                type: "boolean"
+            }
+        )
+        @endpointTests({
+          "version": "1.0",
+          "testCases": [
+            {
+              "documentation": "uriEncode when the string has nothing to encode returns the input",
+              "params": {
+                "Region": "test-region"
+              },
+              "expect": {
+                "endpoint": {
+                    "url": "https://failingtest.com"
+                }
+              }
+            }
+         ]
         })
         service TestService {
             operations: [TestOperation]
@@ -60,11 +91,13 @@ class EndpointsDecoratorTest {
         }
     """.asSmithyModel()
 
-    // NOTE: this test will fail once the endpoint starts being added directly (unless we preserve endpoint params in the
-    // property bag.
     @Test
-    fun `add endpoint params to the property bag`() {
-        clientIntegrationTest(model, addtionalDecorators = listOf(EndpointsDecorator())) { clientCodegenContext, rustCrate ->
+    fun `set an endpoint in the property bag`() {
+        val testDir = clientIntegrationTest(
+            model,
+            addtionalDecorators = listOf(EndpointsDecorator(), NativeSmithyEndpointsStdLib()),
+            command = { "cargo check".runWithWarnings(it) },
+        ) { clientCodegenContext, rustCrate ->
             rustCrate.integrationTest("endpoint_params_test") {
                 val moduleName = clientCodegenContext.moduleUseName()
                 TokioTest.render(this)
@@ -75,11 +108,14 @@ class EndpointsDecoratorTest {
                             let operation = $moduleName::operation::TestOperation::builder()
                                 .bucket("bucket-name").build().expect("input is valid")
                                 .make_operation(&conf).await.expect("valid operation");
-                            use $moduleName::endpoint::{Params, InvalidParams};
+                            use $moduleName::endpoint::{Params};
+                            use aws_smithy_http::endpoint::Result;
                             let props = operation.properties();
-                            let endpoint_params = props.get::<Result<Params, InvalidParams>>().unwrap();
+                            let endpoint_params = props.get::<Params>().unwrap();
+                            let endpoint_result = props.get::<Result>().unwrap();
+                            let endpoint = endpoint_result.as_ref().expect("endpoint resolved properly");
                             assert_eq!(
-                                endpoint_params.as_ref().expect("ok"),
+                                endpoint_params,
                                 &Params::builder()
                                     .bucket("bucket-name".to_string())
                                     .a_bool_param(false)
@@ -87,11 +123,17 @@ class EndpointsDecoratorTest {
                                     .region("us-east-2".to_string())
                                     .build().unwrap()
                             );
-                    }
 
+                            assert_eq!(endpoint.url(), "https://www.us-east-2.example.com");
+                    }
                     """,
                 )
             }
         }
+        // the model has an intentionally failing test—ensure it fails
+        val failure = shouldThrow<CommandFailed> { "cargo test".runWithWarnings(testDir) }
+        failure.output shouldContain "endpoint::test::test_1"
+        failure.output shouldContain "https://failingtest.com"
+        "cargo clippy".runWithWarnings(testDir)
     }
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGeneratorTest.kt
@@ -1,0 +1,95 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.model.node.ArrayNode
+import software.amazon.smithy.model.node.BooleanNode
+import software.amazon.smithy.model.node.Node
+import software.amazon.smithy.rulesengine.language.stdlib.BooleanEquals
+import software.amazon.smithy.rulesengine.language.syntax.Identifier
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
+import software.amazon.smithy.rulesengine.language.syntax.expr.Literal
+import software.amazon.smithy.rulesengine.language.syntax.expr.Template
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Context
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.FunctionRegistry
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
+import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+
+internal class ExprGeneratorTest {
+    fun Expression.shoop() = Expression.fromNode(this.toNode())
+    private val testContext = Context(FunctionRegistry(listOf()), TestRuntimeConfig)
+
+    @Test
+    fun generateExprs() {
+        val boolEq = Expression.of(true).equal(true).shoop()
+        val strEq = Expression.of("helloworld").equal("goodbyeworld").not().shoop()
+        val combined = BooleanEquals.ofExpressions(boolEq, strEq).shoop()
+        TestWorkspace.testProject().unitTest {
+            val generator = ExpressionGenerator(Ownership.Borrowed, testContext)
+            rust("assert_eq!(true, #W);", generator.generate(boolEq))
+            rust("assert_eq!(true, #W);", generator.generate(strEq))
+            rust("assert_eq!(true, #W);", generator.generate(combined))
+        }.compileAndTest(runClippy = true)
+    }
+
+    @Test
+    fun generateLiterals1() {
+        val literal = Literal.record(
+            mutableMapOf(
+                Identifier.of("this") to Literal.integer(5),
+                Identifier.of("that") to Literal.string(
+                    Template.fromString("static"),
+                ),
+            ),
+        )
+        TestWorkspace.testProject().unitTest {
+            val generator =
+                ExpressionGenerator(Ownership.Borrowed, testContext)
+            rust("""assert_eq!(Some(&(5.into())), #W.get("this"));""", generator.generate(literal))
+        }.compileAndTest(runClippy = true)
+    }
+
+    @Test
+    fun generateLiterals2() {
+        val project = TestWorkspace.testProject()
+        val gen = ExpressionGenerator(
+            Ownership.Borrowed,
+            Context(
+                FunctionRegistry(listOf()),
+                TestRuntimeConfig,
+            ),
+        )
+        project.unitTest {
+            rust("""let extra = "helloworld";""")
+            rust("assert_eq!(true, #W);", gen.generate(Expression.of(true)))
+            rust("assert_eq!(false, #W);", gen.generate(Expression.of(false)))
+            rust("""assert_eq!("blah", #W);""", gen.generate(Expression.of("blah")))
+            rust("""assert_eq!("helloworld: rust", #W);""", gen.generate(Expression.of("{ref}: rust")))
+            rustTemplate(
+                """
+                let mut expected = std::collections::HashMap::new();
+                expected.insert("a".to_string(), #{Document}::Bool(true));
+                expected.insert("b".to_string(), #{Document}::String("hello".to_string()));
+                expected.insert("c".to_string(), #{Document}::Array(vec![true.into()]));
+                assert_eq!(expected, #{actual:W});
+                """,
+                "Document" to CargoDependency.smithyTypes(TestRuntimeConfig).toType().member("Document"),
+                "actual" to gen.generate(
+                    Literal.fromNode(
+                        Node.objectNode().withMember("a", true).withMember("b", "hello")
+                            .withMember("c", ArrayNode.arrayNode(BooleanNode.from(true))),
+                    ),
+                ),
+            )
+        }
+    }
+}

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/ExpressionGeneratorTest.kt
@@ -14,8 +14,9 @@ import software.amazon.smithy.rulesengine.language.syntax.Identifier
 import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
 import software.amazon.smithy.rulesengine.language.syntax.expr.Literal
 import software.amazon.smithy.rulesengine.language.syntax.expr.Template
+import software.amazon.smithy.rulesengine.language.syntax.fn.LibraryFunction
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Context
-import software.amazon.smithy.rust.codegen.client.smithy.endpoint.FunctionRegistry
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.FunctionRegistry
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
@@ -25,8 +26,19 @@ import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
 
 internal class ExprGeneratorTest {
+    /**
+     * This works around a bug in smithy-endpoint-rules where the constructors on functions like `BooleanEquals`
+     * hit the wrong branch in the visitor (but when they get parsed, they hit the right branch).
+     */
     fun Expression.shoop() = Expression.fromNode(this.toNode())
     private val testContext = Context(FunctionRegistry(listOf()), TestRuntimeConfig)
+
+    @Test
+    fun `fail when smithy is fixed`() {
+        check(BooleanEquals.ofExpressions(Expression.of(true), Expression.of(true)) is LibraryFunction) {
+            "smithy has been fixed, shoop can be removed"
+        }
+    }
 
     @Test
     fun generateExprs() {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/TemplateGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/rulesgen/TemplateGeneratorTest.kt
@@ -1,0 +1,72 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen
+
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rulesengine.language.syntax.expr.Expression
+import software.amazon.smithy.rulesengine.language.syntax.expr.Template
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
+import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
+import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+import software.amazon.smithy.rust.codegen.core.util.dq
+
+internal class TemplateGeneratorTest {
+    /**
+     * helper to assert that a template string is templated to the expected result
+     */
+    private fun assertTemplateEquals(template: String, result: String) {
+        val literalTemplate = Template.fromString(template)
+        // For testing,
+        val exprFn = { expr: Expression, ownership: Ownership ->
+            writable {
+                rust(
+                    (expr.toString().uppercase() + ownership).dq(),
+                )
+                if (ownership == Ownership.Owned) {
+                    rust(".to_string()")
+                }
+            }
+        }
+        val borrowedGenerator = TemplateGenerator(Ownership.Borrowed, exprFn)
+        val ownedGenerator = TemplateGenerator(Ownership.Owned, exprFn)
+        val project = TestWorkspace.testProject()
+        project.unitTest {
+            rust(
+                "assert_eq!(${result.dq()}, #W);",
+                writable {
+                    literalTemplate.accept(borrowedGenerator).forEach { part -> part(this) }
+                },
+            )
+            rust(
+                "let _: String = #W;",
+                writable { literalTemplate.accept(ownedGenerator).forEach { part -> part(this) } },
+            )
+        }
+        project.compileAndTest()
+    }
+
+    @Test
+    fun testLiteralTemplate() {
+        assertTemplateEquals("https://example.com", "https://example.com")
+    }
+
+    @Test
+    fun testDynamicTemplate() {
+        assertTemplateEquals("https://{Region}.example.com", "https://REGIONBorrowed.example.com")
+    }
+
+    @Test
+    fun testSingleDynamicTemplate() {
+        assertTemplateEquals("{Region}", "REGIONBorrowed")
+    }
+
+    @Test
+    fun testMultipartTemplate() {
+        assertTemplateEquals("https://{Region}.{Bucket}.foo.com", "https://REGIONBorrowed.BUCKETBorrowed.foo.com")
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -112,7 +112,7 @@ class InlineDependency(
     }
 }
 
-fun InlineDependency.asType() = RuntimeType(name = null, dependency = this, namespace = module.fullyQualifiedPath())
+fun InlineDependency.toType() = RuntimeType(name = null, dependency = this, namespace = module.fullyQualifiedPath())
 
 data class Feature(val name: String, val default: Boolean, val deps: List<String>)
 
@@ -187,6 +187,8 @@ data class CargoDependency(
     }
 
     companion object {
+        val OnceCell: CargoDependency = CargoDependency("once_cell", CratesIo("1"))
+        val Url: CargoDependency = CargoDependency("url", CratesIo("2.3.1"))
         val Bytes: CargoDependency = CargoDependency("bytes", CratesIo("1.0.0"))
         val BytesUtils: CargoDependency = CargoDependency("bytes-utils", CratesIo("0.1.0"))
         val FastRand: CargoDependency = CargoDependency("fastrand", CratesIo("1.0.0"))

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -187,7 +187,7 @@ data class CargoDependency(
     }
 
     companion object {
-        val OnceCell: CargoDependency = CargoDependency("once_cell", CratesIo("1"))
+        val OnceCell: CargoDependency = CargoDependency("once_cell", CratesIo("1.16"))
         val Url: CargoDependency = CargoDependency("url", CratesIo("2.3.1"))
         val Bytes: CargoDependency = CargoDependency("bytes", CratesIo("1.0.0"))
         val BytesUtils: CargoDependency = CargoDependency("bytes-utils", CratesIo("0.1.0"))

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustModule.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustModule.kt
@@ -72,6 +72,9 @@ sealed class RustModule {
         fun private(name: String, documentation: String? = null, parent: RustModule = LibRs): LeafModule =
             new(name, visibility = Visibility.PRIVATE, documentation = documentation, inline = false, parent = parent)
 
+        fun pubCrate(name: String, documentation: String? = null, parent: RustModule): LeafModule =
+            new(name, visibility = Visibility.PUBCRATE, documentation = documentation, inline = false, parent = parent)
+
         /* Common modules used across client, server and tests */
         val Config = public("config", documentation = "Configuration for the service.")
         val Error = public("error", documentation = "All error types that operations can return.")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
@@ -382,6 +382,15 @@ data class RustMetadata(
         renderAttributes(writer)
         renderVisibility(writer)
     }
+
+    companion object {
+        val TestModule = RustMetadata(
+            visibility = Visibility.PRIVATE,
+            additionalAttributes = listOf(
+                Attribute.Cfg("test"),
+            ),
+        )
+    }
 }
 
 /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -23,8 +23,8 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
-import software.amazon.smithy.rust.codegen.core.rustlang.asType
 import software.amazon.smithy.rust.codegen.core.rustlang.rustInlineTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.toType
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import java.util.Optional
@@ -258,8 +258,8 @@ data class RuntimeType(val name: String?, val dependency: RustDependency?, val n
             )
         }
 
-        fun ConstrainedTrait() = constrained().asType().member("Constrained")
-        fun MaybeConstrained() = constrained().asType().member("MaybeConstrained")
+        fun ConstrainedTrait() = constrained().toType().member("Constrained")
+        fun MaybeConstrained() = constrained().toType().member("MaybeConstrained")
 
         fun ProtocolTestHelper(runtimeConfig: RuntimeConfig, func: String): RuntimeType =
             RuntimeType(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.raw
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.smithy.CoreCodegenConfig
 import software.amazon.smithy.rust.codegen.core.smithy.MaybeRenamed
@@ -109,11 +110,13 @@ object TestWorkspace {
                 PANIC("")
             }
         }
-        return TestWriterDelegator(
+        val writer = TestWriterDelegator(
             FileManifest.create(subprojectDir.toPath()),
             symbolProvider,
             CoreCodegenConfig(debugMode = debugMode),
         )
+        writer.lib { rust("// touch lib.rs") }
+        return writer
     }
 }
 
@@ -394,3 +397,5 @@ fun TestWriterDelegator.unitTest(test: Writable): TestWriterDelegator {
     }
     return this
 }
+
+fun String.runWithWarnings(crate: Path) = this.runCommand(crate, mapOf("RUSTFLAGS" to "-D warnings"))

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -87,7 +87,8 @@ object TestWorkspace {
             )
             newProject.resolve("rust-toolchain.toml").writeText(
                 // help rust select the right version when we run cargo test
-                // TODO(cleanup): load this from the msrv property using a method like we do for runtime crate versions
+                // TODO(https://github.com/awslabs/smithy-rs/issues/2048): load this from the msrv property using a
+                //  method as we do for runtime crate versions
                 "[toolchain]\nchannel = \"1.62.1\"\n",
             )
             // ensure there at least an empty lib.rs file to avoid broken crates

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Strings.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/Strings.kt
@@ -8,7 +8,9 @@ package software.amazon.smithy.rust.codegen.core.util
 import software.amazon.smithy.utils.CaseUtils
 import software.amazon.smithy.utils.StringUtils
 
-fun String.doubleQuote(): String = StringUtils.escapeJavaString(this, "")
+fun String.doubleQuote(): String = StringUtils.escapeJavaString(this, "").replace(Regex("""\\u([0-9a-f]{4})""")) { matchResult: MatchResult ->
+    "\\u{" + matchResult.groupValues[1] + "}" as CharSequence
+}
 
 /**
  * Double quote a string, e.g. "abc" -> "\"abc\""

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/InlineDependencyTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/InlineDependencyTest.kt
@@ -42,7 +42,7 @@ internal class InlineDependencyTest {
                 assert_eq!(res, "00000000-0000-4000-8000-000000000000");
 
                 """,
-                "idempotency" to dep.asType(),
+                "idempotency" to dep.toType(),
             )
         }
         testProject.compileAndTest()

--- a/rust-runtime/aws-smithy-http/src/endpoint.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint.rs
@@ -11,9 +11,9 @@ use std::result::Result as StdResult;
 use std::str::FromStr;
 
 pub mod error;
+pub use error::ResolveEndpointError;
 
-pub type Result =
-    std::result::Result<aws_smithy_types::endpoint::Endpoint, error::ResolveEndpointError>;
+pub type Result = std::result::Result<aws_smithy_types::endpoint::Endpoint, ResolveEndpointError>;
 
 pub trait ResolveEndpoint<Params>: Send + Sync {
     fn resolve_endpoint(&self, params: &Params) -> Result;

--- a/rust-runtime/aws-smithy-http/src/endpoint/error.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/error.rs
@@ -23,11 +23,8 @@ impl ResolveEndpointError {
     }
 
     /// Add a source to the error
-    pub fn with_source(self, source: impl Into<Box<dyn std::error::Error + Send + Sync>>) -> Self {
-        Self {
-            source: Some(source.into()),
-            ..self
-        }
+    pub fn with_source(self, source: Option<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+        Self { source, ..self }
     }
 }
 

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -103,6 +103,24 @@ impl From<HashMap<String, Document>> for Document {
     }
 }
 
+impl From<u64> for Document {
+    fn from(value: u64) -> Self {
+        Document::Number(Number::PosInt(value))
+    }
+}
+
+impl From<i64> for Document {
+    fn from(value: i64) -> Self {
+        Document::Number(Number::NegInt(value))
+    }
+}
+
+impl From<i32> for Document {
+    fn from(value: i32) -> Self {
+        Document::Number(Number::NegInt(value as i64))
+    }
+}
+
 /// A number type that implements Javascript / JSON semantics, modeled on serde_json:
 /// <https://docs.serde.rs/src/serde_json/number.rs.html#20-22>
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/rust-runtime/build.gradle.kts
+++ b/rust-runtime/build.gradle.kts
@@ -15,7 +15,7 @@ version = "0.0.3"
 
 tasks.jar {
     from("./") {
-        include("inlineable/src/*.rs")
+        include("inlineable/src/")
         include("inlineable/Cargo.toml")
     }
 }

--- a/rust-runtime/inlineable/Cargo.toml
+++ b/rust-runtime/inlineable/Cargo.toml
@@ -11,6 +11,12 @@ license = "Apache-2.0"
 publish = false
 repository = "https://github.com/awslabs/smithy-rs"
 
+[features]
+# this allows the tests to be excluded from downstream crates to keep dependencies / test times reasonable (e.g. no proptests)
+gated-tests = []
+default = ["gated-tests"]
+
+
 [dependencies]
 "bytes" = "1"
 "http" = "0.2.1"
@@ -23,8 +29,11 @@ repository = "https://github.com/awslabs/smithy-rs"
 "pin-project-lite" = "0.2"
 "tower" = { version = "0.4.11", default_features = false }
 "async-trait" = "0.1"
+percent-encoding = "2.2.0"
+once_cell = "1.16.0"
 regex = "1.5.5"
 "url" = "2.2.2"
+aws-smithy-http = { path = "../aws-smithy-http" }
 
 [dev-dependencies]
 proptest = "1"

--- a/rust-runtime/inlineable/src/endpoint_lib.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib.rs
@@ -8,4 +8,6 @@ mod diagnostic;
 mod host;
 mod parse_url;
 mod partition;
+mod s3;
 mod substring;
+mod uri_encode;

--- a/rust-runtime/inlineable/src/endpoint_lib/arn.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/arn.rs
@@ -96,7 +96,6 @@ pub(crate) fn parse_arn<'a, 'b>(input: &'a str, e: &'b mut DiagnosticCollector) 
 #[cfg(test)]
 mod test {
     use super::Arn;
-    use crate::endpoint_lib::diagnostic::DiagnosticCollector;
 
     #[test]
     fn arn_parser() {

--- a/rust-runtime/inlineable/src/endpoint_lib/diagnostic.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/diagnostic.rs
@@ -15,11 +15,13 @@ pub(crate) struct DiagnosticCollector {
 }
 
 impl DiagnosticCollector {
+    #[allow(unused)]
     /// Report an error to the collector
     pub(crate) fn report_error(&mut self, err: impl Into<Box<dyn Error + Send + Sync>>) {
         self.last_error = Some(err.into());
     }
 
+    #[allow(unused)]
     /// Capture a result, returning Some(t) when the input was `Ok` and `None` otherwise
     pub(crate) fn capture<T, E: Into<Box<dyn Error + Send + Sync>>>(
         &mut self,

--- a/rust-runtime/inlineable/src/endpoint_lib/host.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/host.rs
@@ -32,7 +32,7 @@ pub(crate) fn is_valid_host_label(
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gated-tests"))]
 mod test {
     use proptest::proptest;
 

--- a/rust-runtime/inlineable/src/endpoint_lib/parse_url.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/parse_url.rs
@@ -5,7 +5,6 @@
 
 use crate::endpoint_lib::diagnostic::DiagnosticCollector;
 use http::Uri;
-use std::error::Error;
 use url::{Host, Url as ParsedUrl};
 
 #[derive(PartialEq, Debug)]

--- a/rust-runtime/inlineable/src/endpoint_lib/partition.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/partition.rs
@@ -10,12 +10,14 @@
 //! If, at a future point, this interface stabilizes it is a good candidate for extraction into a
 //! shared crate.
 use crate::endpoint_lib::diagnostic::DiagnosticCollector;
+use crate::endpoint_lib::partition::deser::deserialize_partitions;
 use aws_smithy_json::deserialize::error::DeserializeError;
 use regex::Regex;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
 /// Determine the AWS partition metadata for a given region
+#[derive(Default)]
 pub(crate) struct PartitionResolver {
     partitions: Vec<PartitionMetadata>,
 }
@@ -30,17 +32,40 @@ impl PartitionResolver {
 pub(crate) struct Partition<'a> {
     name: &'a str,
     dns_suffix: &'a str,
-    dualstack_dns_suffix: &'a str,
+    dual_stack_dns_suffix: &'a str,
     supports_fips: bool,
-    supports_dualstack: bool,
+    supports_dual_stack: bool,
+}
+
+#[allow(unused)]
+impl<'a> Partition<'a> {
+    pub(crate) fn name(&self) -> &str {
+        self.name
+    }
+
+    pub(crate) fn dns_suffix(&self) -> &str {
+        self.dns_suffix
+    }
+
+    pub(crate) fn supports_fips(&self) -> bool {
+        self.supports_fips
+    }
+
+    pub(crate) fn dual_stack_dns_suffix(&self) -> &str {
+        self.dual_stack_dns_suffix
+    }
+
+    pub(crate) fn supports_dual_stack(&self) -> bool {
+        self.supports_dual_stack
+    }
 }
 
 static DEFAULT_OVERRIDE: &PartitionOutputOverride = &PartitionOutputOverride {
     name: None,
     dns_suffix: None,
-    dualstack_dns_suffix: None,
+    dual_stack_dns_suffix: None,
     supports_fips: None,
-    supports_dualstack: None,
+    supports_dual_stack: None,
 };
 
 /// Merge the base output and the override output, dealing with `Cow`s
@@ -55,11 +80,20 @@ macro_rules! merge {
 }
 
 impl PartitionResolver {
-    pub(crate) fn new() -> PartitionResolver {
+    #[allow(unused)]
+    pub(crate) fn empty() -> PartitionResolver {
         PartitionResolver { partitions: vec![] }
     }
+
+    #[allow(unused)]
     pub(crate) fn add_partition(&mut self, partition: PartitionMetadata) {
         self.partitions.push(partition);
+    }
+
+    pub(crate) fn new_from_json(
+        partition_dot_json: &[u8],
+    ) -> Result<PartitionResolver, DeserializeError> {
+        deserialize_partitions(partition_dot_json)
     }
 
     /// Resolve a partition for a given region
@@ -104,13 +138,13 @@ impl PartitionResolver {
         Some(Partition {
             name: merge!(base, region_override, name),
             dns_suffix: merge!(base, region_override, dns_suffix),
-            dualstack_dns_suffix: merge!(base, region_override, dualstack_dns_suffix),
+            dual_stack_dns_suffix: merge!(base, region_override, dual_stack_dns_suffix),
             supports_fips: region_override
                 .supports_fips
                 .unwrap_or(base.outputs.supports_fips),
-            supports_dualstack: region_override
-                .supports_dualstack
-                .unwrap_or(base.outputs.supports_dualstack),
+            supports_dual_stack: region_override
+                .supports_dual_stack
+                .unwrap_or(base.outputs.supports_dual_stack),
         })
     }
 }
@@ -172,18 +206,18 @@ impl PartitionMetadata {
 pub(crate) struct PartitionOutput {
     name: Str,
     dns_suffix: Str,
-    dualstack_dns_suffix: Str,
+    dual_stack_dns_suffix: Str,
     supports_fips: bool,
-    supports_dualstack: bool,
+    supports_dual_stack: bool,
 }
 
 #[derive(Default)]
 pub(crate) struct PartitionOutputOverride {
     name: Option<Str>,
     dns_suffix: Option<Str>,
-    dualstack_dns_suffix: Option<Str>,
+    dual_stack_dns_suffix: Option<Str>,
     supports_fips: Option<bool>,
-    supports_dualstack: Option<bool>,
+    supports_dual_stack: Option<bool>,
 }
 
 impl PartitionOutputOverride {
@@ -193,11 +227,13 @@ impl PartitionOutputOverride {
         Ok(PartitionOutput {
             name: self.name.ok_or("missing name")?,
             dns_suffix: self.dns_suffix.ok_or("missing dnsSuffix")?,
-            dualstack_dns_suffix: self
-                .dualstack_dns_suffix
-                .ok_or("missing dualstackDnsSuffix")?,
+            dual_stack_dns_suffix: self
+                .dual_stack_dns_suffix
+                .ok_or("missing dual_stackDnsSuffix")?,
             supports_fips: self.supports_fips.ok_or("missing supports fips")?,
-            supports_dualstack: self.supports_dualstack.ok_or("missing supportsDualstack")?,
+            supports_dual_stack: self
+                .supports_dual_stack
+                .ok_or("missing supportsDualstack")?,
         })
     }
 }
@@ -297,7 +333,7 @@ mod deser {
                                 builder.region_regex = token_to_str(tokens.next())?
                                     .map(|region_regex| Regex::new(&region_regex))
                                     .transpose()
-                                    .map_err(|e| DeserializeError::custom("invalid regex"))?;
+                                    .map_err(|_e| DeserializeError::custom("invalid regex"))?;
                             }
                             "regions" => {
                                 builder.regions = deser_explicit_regions(tokens)?;
@@ -386,13 +422,13 @@ mod deser {
                                 builder.dns_suffix = token_to_str(tokens.next())?;
                             }
                             "dualStackDnsSuffix" => {
-                                builder.dualstack_dns_suffix = token_to_str(tokens.next())?;
+                                builder.dual_stack_dns_suffix = token_to_str(tokens.next())?;
                             }
                             "supportsFIPS" => {
                                 builder.supports_fips = expect_bool_or_null(tokens.next())?;
                             }
                             "supportsDualStack" => {
-                                builder.supports_dualstack = expect_bool_or_null(tokens.next())?;
+                                builder.supports_dual_stack = expect_bool_or_null(tokens.next())?;
                             }
                             _ => skip_value(tokens)?,
                         },
@@ -537,7 +573,7 @@ mod test {
 
     #[test]
     fn resolve_partitions() {
-        let mut resolver = PartitionResolver::new();
+        let mut resolver = PartitionResolver::empty();
         let mut new_suffix = PartitionOutputOverride::default();
         new_suffix.dns_suffix = Some("mars.aws".into());
         resolver.add_partition(PartitionMetadata {
@@ -547,9 +583,9 @@ mod test {
             outputs: PartitionOutput {
                 name: "aws".into(),
                 dns_suffix: "amazonaws.com".into(),
-                dualstack_dns_suffix: "api.aws".into(),
+                dual_stack_dns_suffix: "api.aws".into(),
                 supports_fips: true,
-                supports_dualstack: true,
+                supports_dual_stack: true,
             },
         });
         resolver.add_partition(PartitionMetadata {
@@ -559,9 +595,9 @@ mod test {
             outputs: PartitionOutput {
                 name: "other".into(),
                 dns_suffix: "other.amazonaws.com".into(),
-                dualstack_dns_suffix: "other.aws".into(),
+                dual_stack_dns_suffix: "other.aws".into(),
                 supports_fips: false,
-                supports_dualstack: true,
+                supports_dual_stack: true,
             },
         });
         assert_eq!(resolve(&resolver, "us-east-1").name, "aws");

--- a/rust-runtime/inlineable/src/endpoint_lib/s3.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/s3.rs
@@ -1,0 +1,37 @@
+/*
+ *  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::endpoint_lib::diagnostic::DiagnosticCollector;
+use crate::endpoint_lib::host::is_valid_host_label;
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+static VIRTUAL_HOSTABLE_SEGMENT: Lazy<Regex> =
+    Lazy::new(|| Regex::new("^[a-z\\d][a-z\\d\\-.]{1,61}[a-z\\d]$").unwrap());
+
+static IPV4: Lazy<Regex> = Lazy::new(|| Regex::new("^(\\d+\\.){3}\\d+$").unwrap());
+
+static DOTS_AND_DASHES: Lazy<Regex> = Lazy::new(|| Regex::new("^.*[.-]{2}.*$").unwrap());
+
+/// Evaluates whether a string is a DNS-compatible bucket name that can be used with virtual hosted-style addressing.
+pub(crate) fn is_virtual_hostable_s3_bucket(
+    host_label: &str,
+    allow_subdomains: bool,
+    e: &mut DiagnosticCollector,
+) -> bool {
+    if !is_valid_host_label(host_label, allow_subdomains, e) {
+        false
+    } else if !allow_subdomains {
+        is_virtual_hostable_segment(host_label)
+    } else {
+        host_label.split('.').all(is_virtual_hostable_segment)
+    }
+}
+
+fn is_virtual_hostable_segment(host_label: &str) -> bool {
+    VIRTUAL_HOSTABLE_SEGMENT.is_match(host_label)
+        && !IPV4.is_match(host_label) // don't allow ip address
+        && !DOTS_AND_DASHES.is_match(host_label) // don't allow names like bucket-.name or bucket.-name
+}

--- a/rust-runtime/inlineable/src/endpoint_lib/substring.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/substring.rs
@@ -37,7 +37,7 @@ pub(crate) fn substring<'a, 'b>(
     Some(&input[effective_start..effective_stop])
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gated-tests"))]
 mod test {
     use super::*;
     use proptest::proptest;

--- a/rust-runtime/inlineable/src/endpoint_lib/uri_encode.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/uri_encode.rs
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::endpoint_lib::diagnostic::DiagnosticCollector;
+
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+
+pub(crate) const BASE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'/')
+    .add(b':')
+    .add(b',')
+    .add(b'?')
+    .add(b'#')
+    .add(b'[')
+    .add(b']')
+    .add(b'{')
+    .add(b'}')
+    .add(b'|')
+    .add(b'@')
+    .add(b'!')
+    .add(b'$')
+    .add(b'&')
+    .add(b'\'')
+    .add(b'(')
+    .add(b')')
+    .add(b'*')
+    .add(b'+')
+    .add(b';')
+    .add(b'=')
+    .add(b'%')
+    .add(b'<')
+    .add(b'>')
+    .add(b'"')
+    .add(b'^')
+    .add(b'`')
+    .add(b'\\');
+
+// Returns `Option` for forwards compatibility
+pub(crate) fn uri_encode<'a, 'b>(
+    s: &'a str,
+    _e: &'b mut DiagnosticCollector,
+) -> std::borrow::Cow<'a, str> {
+    utf8_percent_encode(s, BASE_SET).into()
+}


### PR DESCRIPTION
## Motivation and Context
- #1784 
- fixes #1927 

## Description
This commit adds `EndpointDecorator`, standard libary, tests, and endpoint resolver generator that can be used to add endpoints 2.0 to the AWS SDK.

It _does not_ actually wire these things up. We'll follow up with a PR that actually integrates everything.

## Testing
- [x] test against S3 model, test + real world usage (not included in PR)
- [x] many unit and integration tests

## Checklist
- no changelog (this change has no codegen impact because it is not enabled)
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
