### PR TITLE
Improve extractor errors

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
@@ -24,7 +24,7 @@ use super::{internal_server_error, FromParts};
 #[non_exhaustive]
 #[derive(Debug, Error)]
 #[error(
-    "`ConnectInfo` is not present in the `http::Request` extensions - consider using `IntoMakeServiceWithConnectInfo`"
+    "`ConnectInfo` is not present in the `http::Request` extensions - consider using `aws_smithy_http_server::routing::IntoMakeServiceWithConnectInfo`"
 )]
 pub struct MissingConnectInfo;
 

--- a/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
@@ -27,7 +27,9 @@ use super::FromParts;
 
 #[non_exhaustive]
 #[derive(Debug, Error)]
-#[error("the `ConnectInfo` is not present in the `http::Request` - consider using `IntoMakeServiceWithConnectInfo`")]
+#[error(
+    "`ConnectInfo` is not present in the `http::Request` extensions - consider using `IntoMakeServiceWithConnectInfo`"
+)]
 pub struct MissingConnectInfo;
 
 impl<Protocol> IntoResponse<Protocol> for MissingConnectInfo {
@@ -40,7 +42,7 @@ impl<Protocol> IntoResponse<Protocol> for MissingConnectInfo {
 
 /// Extractor for getting connection information produced by a `Connected`.
 ///
-/// Note this extractor requires the existence of [`Extension<ConnectInfo<T>>`] in the [`http::Extensions`]. This is
+/// Note this extractor requires the existence of [`ConnectInfo<T>`] in the [`http::Extensions`]. This is
 /// automatically inserted by the [`IntoMakeServiceWithConnectInfo`](crate::routing::IntoMakeServiceWithConnectInfo)
 /// middleware, which can be applied using the `into_make_service_with_connect_info` method on your generated service.
 #[derive(Clone, Debug)]

--- a/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
@@ -11,15 +11,12 @@
 //! example illustrates the use of [`IntoMakeServiceWithConnectInfo`](crate::routing::IntoMakeServiceWithConnectInfo)
 //! and [`ConnectInfo`] with a service builder.
 
-use http::{request::Parts, StatusCode};
+use http::request::Parts;
 use thiserror::Error;
 
-use crate::{
-    body::{empty, BoxBody},
-    response::IntoResponse,
-};
+use crate::{body::BoxBody, response::IntoResponse};
 
-use super::FromParts;
+use super::{internal_server_error, FromParts};
 
 /// The [`ConnectInfo`] was not found in the [`http::Request`] extensions.
 ///
@@ -34,9 +31,7 @@ pub struct MissingConnectInfo;
 
 impl<Protocol> IntoResponse<Protocol> for MissingConnectInfo {
     fn into_response(self) -> http::Response<BoxBody> {
-        let mut response = http::Response::new(empty());
-        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        response
+        internal_server_error()
     }
 }
 

--- a/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
@@ -21,6 +21,10 @@ use crate::{
 
 use super::FromParts;
 
+/// The [`ConnectInfo`] was not found in the [`http::Request`] extensions.
+///
+/// Use [`IntoMakeServiceWithConnectInfo`](crate::routing::IntoMakeServiceWithConnectInfo) to ensure it's present.
+
 #[non_exhaustive]
 #[derive(Debug, Error)]
 #[error("the `ConnectInfo` is not present in the `http::Request` - consider using `IntoMakeServiceWithConnectInfo`")]

--- a/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/connect_info.rs
@@ -21,7 +21,6 @@ use super::{internal_server_error, FromParts};
 /// The [`ConnectInfo`] was not found in the [`http::Request`] extensions.
 ///
 /// Use [`IntoMakeServiceWithConnectInfo`](crate::routing::IntoMakeServiceWithConnectInfo) to ensure it's present.
-
 #[non_exhaustive]
 #[derive(Debug, Error)]
 #[error(

--- a/rust-runtime/aws-smithy-http-server/src/request/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/extension.rs
@@ -79,6 +79,7 @@ impl<T> Deref for Extension<T> {
 }
 
 /// The extension has not been added to the [`Request`](http::Request) or has been previously removed.
+#[non_exhaustive]
 #[derive(Debug, Error)]
 #[error("the `Extension` is not present in the `http::Request`")]
 pub struct MissingExtension;

--- a/rust-runtime/aws-smithy-http-server/src/request/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/extension.rs
@@ -50,14 +50,11 @@
 
 use std::ops::Deref;
 
-use http::StatusCode;
 use thiserror::Error;
 
-use crate::{
-    body::{empty, BoxBody},
-    request::FromParts,
-    response::IntoResponse,
-};
+use crate::{body::BoxBody, request::FromParts, response::IntoResponse};
+
+use super::internal_server_error;
 
 /// Generic extension type stored in and extracted from [request extensions].
 ///
@@ -86,9 +83,7 @@ pub struct MissingExtension;
 
 impl<Protocol> IntoResponse<Protocol> for MissingExtension {
     fn into_response(self) -> http::Response<BoxBody> {
-        let mut response = http::Response::new(empty());
-        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        response
+        internal_server_error()
     }
 }
 

--- a/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
@@ -50,7 +50,6 @@ enum MissingGatewayContextTypeV1 {
 /// The [`RequestContext::ApiGatewayV1`] was not found in the [`http::Request`] extensions.
 ///
 /// Use [`LambdaHandler`](crate::routing::LambdaHandler) to ensure it's present and ensure that you're using "ApiGatewayV1".
-#[non_exhaustive]
 #[derive(Debug, Error)]
 #[error("{inner}")]
 pub struct MissingGatewayContextV1 {
@@ -91,7 +90,6 @@ enum MissingGatewayContextTypeV2 {
 /// The [`RequestContext::ApiGatewayV2`] was not found in the [`http::Request`] extensions.
 ///
 /// Use [`LambdaHandler`](crate::routing::LambdaHandler) to ensure it's present and ensure that you're using "ApiGatewayV2".
-#[non_exhaustive]
 #[derive(Debug, Error)]
 #[error("{inner}")]
 pub struct MissingGatewayContextV2 {

--- a/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
@@ -22,7 +22,7 @@ use crate::{body::BoxBody, response::IntoResponse};
 /// Use [`LambdaHandler`](crate::routing::LambdaHandler) to ensure it's present.
 #[non_exhaustive]
 #[derive(Debug, Error)]
-#[error("`Context` is not present in the `http::Request` extensions - consider using `LambdaHandler`")]
+#[error("`Context` is not present in the `http::Request` extensions - consider using `aws_smithy_http_server::routing::LambdaHandler`")]
 pub struct MissingContext;
 
 impl<Protocol> IntoResponse<Protocol> for MissingContext {

--- a/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
@@ -6,47 +6,127 @@
 //! The [`lambda_http`] types included in [`http::Request`]s when [`LambdaHandler`](crate::routing::LambdaHandler) is
 //! used. Each are given a [`FromParts`] implementation for easy use within handlers.
 
+use http::StatusCode;
 use lambda_http::request::RequestContext;
 #[doc(inline)]
 pub use lambda_http::{
     aws_lambda_events::apigw::{ApiGatewayProxyRequestContext, ApiGatewayV2httpRequestContext},
     Context,
 };
+use thiserror::Error;
 
-use super::{extension::MissingExtension, FromParts};
-use crate::Extension;
+use super::FromParts;
+use crate::{
+    body::{empty, BoxBody},
+    response::IntoResponse,
+};
+
+/// The [`Context`] was not found in the [`http::Request`] extensions.
+///
+/// Use [`LambdaHandler`](crate::routing::LambdaHandler) to ensure it's present.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+#[error("`Context` is not present in the `http::Request` extensions - consider using `LambdaHandler`")]
+pub struct MissingContext;
+
+impl<Protocol> IntoResponse<Protocol> for MissingContext {
+    fn into_response(self) -> http::Response<BoxBody> {
+        let mut response = http::Response::new(empty());
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        response
+    }
+}
 
 impl<P> FromParts<P> for Context {
-    type Rejection = MissingExtension;
+    type Rejection = MissingContext;
 
     fn from_parts(parts: &mut http::request::Parts) -> Result<Self, Self::Rejection> {
-        let Extension(context) = <Extension<Self> as FromParts<P>>::from_parts(parts)?;
-        Ok(context)
+        parts.extensions.remove().ok_or(MissingContext)
+    }
+}
+
+#[derive(Debug, Error)]
+enum MissingGatewayContextTypeV1 {
+    #[error("`RequestContext` is not present in the `http::Request` extensions - consider using `LambdaHandler`")]
+    MissingRequestContext,
+    #[error("`RequestContext::ApiGatewayV2` is present in the `http::Request` extensions - consider using the `ApiGatewayV2httpRequestContext` extractor")]
+    VersionMismatch,
+}
+
+/// The [`RequestContext::ApiGatewayV1`] was not found in the [`http::Request`] extensions.
+///
+/// Use [`LambdaHandler`](crate::routing::LambdaHandler) to ensure it's present and ensure that you're using "ApiGatewayV1".
+#[non_exhaustive]
+#[derive(Debug, Error)]
+#[error("{inner}")]
+pub struct MissingGatewayContextV1 {
+    inner: MissingGatewayContextTypeV1,
+}
+
+impl<Protocol> IntoResponse<Protocol> for MissingGatewayContextV1 {
+    fn into_response(self) -> http::Response<BoxBody> {
+        let mut response = http::Response::new(empty());
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        response
     }
 }
 
 impl<P> FromParts<P> for ApiGatewayProxyRequestContext {
-    type Rejection = MissingExtension;
+    type Rejection = MissingGatewayContextV1;
 
     fn from_parts(parts: &mut http::request::Parts) -> Result<Self, Self::Rejection> {
-        let Extension(context) = <Extension<RequestContext> as FromParts<P>>::from_parts(parts)?;
+        let context = parts.extensions.remove().ok_or(MissingGatewayContextV1 {
+            inner: MissingGatewayContextTypeV1::MissingRequestContext,
+        })?;
         if let RequestContext::ApiGatewayV1(context) = context {
             Ok(context)
         } else {
-            Err(MissingExtension)
+            Err(MissingGatewayContextV1 {
+                inner: MissingGatewayContextTypeV1::VersionMismatch,
+            })
         }
     }
 }
 
+#[derive(Debug, Error)]
+enum MissingGatewayContextTypeV2 {
+    #[error("`RequestContext` is not present in the `http::Request` extensions - consider using `LambdaHandler`")]
+    MissingRequestContext,
+    #[error("`RequestContext::ApiGatewayV1` is present in the `http::Request` extensions - consider using the `ApiGatewayProxyRequestContext` extractor")]
+    VersionMismatch,
+}
+
+/// The [`RequestContext::ApiGatewayV2`] was not found in the [`http::Request`] extensions.
+///
+/// Use [`LambdaHandler`](crate::routing::LambdaHandler) to ensure it's present and ensure that you're using "ApiGatewayV2".
+#[non_exhaustive]
+#[derive(Debug, Error)]
+#[error("{inner}")]
+pub struct MissingGatewayContextV2 {
+    inner: MissingGatewayContextTypeV2,
+}
+
+impl<Protocol> IntoResponse<Protocol> for MissingGatewayContextV2 {
+    fn into_response(self) -> http::Response<BoxBody> {
+        let mut response = http::Response::new(empty());
+        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+        response
+    }
+}
+
 impl<P> FromParts<P> for ApiGatewayV2httpRequestContext {
-    type Rejection = MissingExtension;
+    type Rejection = MissingGatewayContextV2;
 
     fn from_parts(parts: &mut http::request::Parts) -> Result<Self, Self::Rejection> {
-        let Extension(context) = <Extension<RequestContext> as FromParts<P>>::from_parts(parts)?;
+        let context = parts.extensions.remove().ok_or(MissingGatewayContextV2 {
+            inner: MissingGatewayContextTypeV2::MissingRequestContext,
+        })?;
         if let RequestContext::ApiGatewayV2(context) = context {
             Ok(context)
         } else {
-            Err(MissingExtension)
+            Err(MissingGatewayContextV2 {
+                inner: MissingGatewayContextTypeV2::VersionMismatch,
+            })
         }
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
@@ -41,9 +41,9 @@ impl<P> FromParts<P> for Context {
 
 #[derive(Debug, Error)]
 enum MissingGatewayContextTypeV1 {
-    #[error("`RequestContext` is not present in the `http::Request` extensions - consider using `LambdaHandler`")]
+    #[error("`RequestContext` is not present in the `http::Request` extensions - consider using `aws_smithy_http_server::routing::LambdaHandler`")]
     MissingRequestContext,
-    #[error("`RequestContext::ApiGatewayV2` is present in the `http::Request` extensions - consider using the `ApiGatewayV2httpRequestContext` extractor")]
+    #[error("`RequestContext::ApiGatewayV2` is present in the `http::Request` extensions - consider using the `aws_smithy_http_server::request::lambda::ApiGatewayV2httpRequestContext` extractor")]
     VersionMismatch,
 }
 
@@ -81,9 +81,9 @@ impl<P> FromParts<P> for ApiGatewayProxyRequestContext {
 
 #[derive(Debug, Error)]
 enum MissingGatewayContextTypeV2 {
-    #[error("`RequestContext` is not present in the `http::Request` extensions - consider using `LambdaHandler`")]
+    #[error("`RequestContext` is not present in the `http::Request` extensions - consider using `aws_smithy_http_server::routing::LambdaHandler`")]
     MissingRequestContext,
-    #[error("`RequestContext::ApiGatewayV1` is present in the `http::Request` extensions - consider using the `ApiGatewayProxyRequestContext` extractor")]
+    #[error("`RequestContext::ApiGatewayV1` is present in the `http::Request` extensions - consider using the `aws_smithy_http_server::request::lambda::ApiGatewayProxyRequestContext` extractor")]
     VersionMismatch,
 }
 

--- a/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/lambda.rs
@@ -6,7 +6,6 @@
 //! The [`lambda_http`] types included in [`http::Request`]s when [`LambdaHandler`](crate::routing::LambdaHandler) is
 //! used. Each are given a [`FromParts`] implementation for easy use within handlers.
 
-use http::StatusCode;
 use lambda_http::request::RequestContext;
 #[doc(inline)]
 pub use lambda_http::{
@@ -15,11 +14,8 @@ pub use lambda_http::{
 };
 use thiserror::Error;
 
-use super::FromParts;
-use crate::{
-    body::{empty, BoxBody},
-    response::IntoResponse,
-};
+use super::{internal_server_error, FromParts};
+use crate::{body::BoxBody, response::IntoResponse};
 
 /// The [`Context`] was not found in the [`http::Request`] extensions.
 ///
@@ -31,9 +27,7 @@ pub struct MissingContext;
 
 impl<Protocol> IntoResponse<Protocol> for MissingContext {
     fn into_response(self) -> http::Response<BoxBody> {
-        let mut response = http::Response::new(empty());
-        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        response
+        internal_server_error()
     }
 }
 
@@ -65,9 +59,7 @@ pub struct MissingGatewayContextV1 {
 
 impl<Protocol> IntoResponse<Protocol> for MissingGatewayContextV1 {
     fn into_response(self) -> http::Response<BoxBody> {
-        let mut response = http::Response::new(empty());
-        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        response
+        internal_server_error()
     }
 }
 
@@ -108,9 +100,7 @@ pub struct MissingGatewayContextV2 {
 
 impl<Protocol> IntoResponse<Protocol> for MissingGatewayContextV2 {
     fn into_response(self) -> http::Response<BoxBody> {
-        let mut response = http::Response::new(empty());
-        *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
-        response
+        internal_server_error()
     }
 }
 

--- a/rust-runtime/aws-smithy-http-server/src/request/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/request/mod.rs
@@ -46,15 +46,25 @@ use futures_util::{
     future::{try_join, MapErr, MapOk, TryJoin},
     TryFutureExt,
 };
-use http::{request::Parts, Extensions, HeaderMap, Request, Uri};
+use http::{request::Parts, Extensions, HeaderMap, Request, StatusCode, Uri};
 
-use crate::{rejection::any_rejections, response::IntoResponse};
+use crate::{
+    body::{empty, BoxBody},
+    rejection::any_rejections,
+    response::IntoResponse,
+};
 
 pub mod connect_info;
 pub mod extension;
 #[cfg(feature = "aws-lambda")]
 #[cfg_attr(docsrs, doc(cfg(feature = "aws-lambda")))]
 pub mod lambda;
+
+fn internal_server_error() -> http::Response<BoxBody> {
+    let mut response = http::Response::new(empty());
+    *response.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+    response
+}
 
 #[doc(hidden)]
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation and Context

Extractor errors should be meaningful. Prior to this we were using a single blanket error for all extractors.

## Description

Add a separate extractor error for each extraction failure.
