### PR TITLE
Endpoints 2.0 Integration pre-work

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -56,7 +56,7 @@ author = "david-perez"
 [[smithy-rs]]
 message = "Fix bug that can cause panics in paginators"
 references = ["smithy-rs#1903", "smithy-rs#1902"]
-meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client"}
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "rcoh"
 
 [[smithy-rs]]
@@ -65,13 +65,13 @@ Operation metadata is now added to the property bag before sending requests allo
 differently depending on the operation being sent.
 """
 references = ["smithy-rs#1919"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "Velfi"
 
 [[smithy-rs]]
 message = "Upgrade Smithy to v1.26"
 references = ["smithy-rs#1929"]
-meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all"}
+meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "all" }
 author = "Velfi"
 
 [[smithy-rs]]
@@ -392,7 +392,7 @@ match some_enum {
 This is forward-compatible because the execution will hit the second last match arm regardless of whether the enum defines `SomeEnum::NewVariant` or not.
 """
 references = ["smithy-rs#1945"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client"}
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "ysaito1001"
 
 [[aws-sdk-rust]]
@@ -635,5 +635,17 @@ author = "jdisanti"
 [[smithy-rs]]
 message = "`SdkBody` callbacks have been removed. If you were using these, please [file an issue](https://github.com/awslabs/smithy-rs/issues/new) so that we can better understand your use-case and provide the support you need."
 references = ["smithy-rs#2065"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client"}
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "`AwsEndpointStage`, a middleware which set endpoints and auth has been split into `AwsAuthStage` and `SmithyEndpointStage`. Related types have also been renamed."
+references = ["smithy-rs#2063"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "rcoh"
+
+[[smithy-rs]]
+message = "Added SmithyEndpointStage which can be used to set an endpoint for smithy-native clients"
+references = ["smithy-rs#2063"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "rcoh"

--- a/aws/rust-runtime/aws-inlineable/src/middleware.rs
+++ b/aws/rust-runtime/aws-inlineable/src/middleware.rs
@@ -5,30 +5,36 @@
 
 //! Base Middleware Stack
 
-use aws_endpoint::AwsEndpointStage;
+use aws_endpoint::AwsAuthStage;
 use aws_http::auth::CredentialsStage;
 use aws_http::recursion_detection::RecursionDetectionStage;
 use aws_http::user_agent::UserAgentStage;
 use aws_sig_auth::middleware::SigV4SigningStage;
 use aws_sig_auth::signer::SigV4Signer;
+use aws_smithy_http::endpoint::middleware::SmithyEndpointStage;
 use aws_smithy_http_tower::map_request::{AsyncMapRequestLayer, MapRequestLayer};
 use std::fmt::Debug;
-use tower::layer::util::{Identity, Stack};
 use tower::ServiceBuilder;
 
-type DefaultMiddlewareStack = Stack<
+/// Macro to generate the tower stack type. Arguments should be in reverse order
+macro_rules! stack_type {
+    ($first: ty, $($rest:ty),+) => {
+        tower::layer::util::Stack<$first, stack_type!($($rest),+)>
+    };
+    ($only: ty) => {
+        tower::layer::util::Stack<$only, tower::layer::util::Identity>
+    }
+}
+
+// Note: the layers here appear in reverse order
+type DefaultMiddlewareStack = stack_type!(
     MapRequestLayer<RecursionDetectionStage>,
-    Stack<
-        MapRequestLayer<SigV4SigningStage>,
-        Stack<
-            AsyncMapRequestLayer<CredentialsStage>,
-            Stack<
-                MapRequestLayer<UserAgentStage>,
-                Stack<MapRequestLayer<AwsEndpointStage>, Identity>,
-            >,
-        >,
-    >,
->;
+    MapRequestLayer<SigV4SigningStage>,
+    AsyncMapRequestLayer<CredentialsStage>,
+    MapRequestLayer<UserAgentStage>,
+    MapRequestLayer<AwsAuthStage>,
+    MapRequestLayer<SmithyEndpointStage>
+);
 
 /// AWS Middleware Stack
 ///
@@ -54,7 +60,8 @@ impl DefaultMiddleware {
 fn base() -> ServiceBuilder<DefaultMiddlewareStack> {
     let credential_provider = AsyncMapRequestLayer::for_mapper(CredentialsStage::new());
     let signer = MapRequestLayer::for_mapper(SigV4SigningStage::new(SigV4Signer::new()));
-    let endpoint_resolver = MapRequestLayer::for_mapper(AwsEndpointStage);
+    let endpoint_stage = MapRequestLayer::for_mapper(SmithyEndpointStage::new());
+    let auth_stage = MapRequestLayer::for_mapper(AwsAuthStage);
     let user_agent = MapRequestLayer::for_mapper(UserAgentStage::new());
     let recursion_detection = MapRequestLayer::for_mapper(RecursionDetectionStage::new());
     // These layers can be considered as occurring in order, that is:
@@ -64,7 +71,8 @@ fn base() -> ServiceBuilder<DefaultMiddlewareStack> {
     // 4. Sign with credentials
     // (5. Dispatch over the wire)
     ServiceBuilder::new()
-        .layer(endpoint_resolver)
+        .layer(endpoint_stage)
+        .layer(auth_stage)
         .layer(user_agent)
         .layer(credential_provider)
         .layer(signer)

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -237,14 +237,21 @@ mod test {
                 signature_versions: SignatureVersion::V4,
             },
         );
-        let req = http::Request::new(SdkBody::from(""));
+        let req = http::Request::builder()
+            .uri("https://kinesis.us-east-1.amazonaws.com")
+            .body(SdkBody::from(""))
+            .unwrap();
         let region = Region::new("us-east-1");
         let req = operation::Request::new(req)
             .augment(|req, conf| {
                 conf.insert(region.clone());
                 conf.insert(UNIX_EPOCH + Duration::new(1611160427, 0));
                 conf.insert(SigningService::from_static("kinesis"));
-                conf.insert(provider.resolve_endpoint(&Params::new(Some(region.clone()))));
+                conf.insert(
+                    provider
+                        .resolve_endpoint(&Params::new(Some(region.clone())))
+                        .unwrap(),
+                );
                 Result::<_, Infallible>::Ok(req)
             })
             .expect("succeeds");

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -187,7 +187,7 @@ mod test {
     };
     use crate::signer::{OperationSigningConfig, SigV4Signer};
     use aws_endpoint::partition::endpoint::{Protocol, SignatureVersion};
-    use aws_endpoint::{AwsEndpointStage, Params};
+    use aws_endpoint::{AwsAuthStage, Params};
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_http::endpoint::ResolveEndpoint;
     use aws_smithy_http::middleware::MapRequest;
@@ -249,7 +249,7 @@ mod test {
             })
             .expect("succeeds");
 
-        let endpoint = AwsEndpointStage;
+        let endpoint = AwsAuthStage;
         let signer = SigV4SigningStage::new(SigV4Signer::new());
         let mut req = endpoint.apply(req).expect("add endpoint should succeed");
         let mut errs = vec![signer

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -196,9 +196,9 @@ class EndpointResolverFeature(private val runtimeConfig: RuntimeConfig, private 
                     """
                     let endpoint_params = #{PlaceholderParams}::new(${section.config}.region.clone());
                     ${section.request}.properties_mut()
-                        .insert::<aws_smithy_http::endpoint::Result>(${section.config}
-                            .endpoint_resolver
-                            .resolve_endpoint(&endpoint_params));
+                        .insert::<aws_smithy_types::endpoint::Endpoint>(
+                            ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params)
+                                .map_err(#{BuildError}::other)?);
                     """,
                     *codegenScope,
                 )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -74,7 +74,7 @@ class AwsEndpointDecorator : RustCodegenDecorator<ClientProtocolGenerator, Clien
         operation: OperationShape,
         baseCustomizations: List<OperationCustomization>,
     ): List<OperationCustomization> {
-        return baseCustomizations + EndpointResolverFeature(codegenContext.runtimeConfig, operation)
+        return baseCustomizations + EndpointResolverFeature(codegenContext.runtimeConfig)
     }
 
     override fun libRsCustomizations(
@@ -179,9 +179,7 @@ class EndpointConfigCustomization(
     }
 }
 
-// This is an experiment in a slightly different way to create runtime types. All code MAY be refactored to use this pattern
-
-class EndpointResolverFeature(private val runtimeConfig: RuntimeConfig, private val operationShape: OperationShape) :
+class EndpointResolverFeature(runtimeConfig: RuntimeConfig) :
     OperationCustomization() {
     private val placeholderEndpointParams = runtimeConfig.awsEndpoint().toType().member("Params")
     private val codegenScope = arrayOf(
@@ -196,9 +194,9 @@ class EndpointResolverFeature(private val runtimeConfig: RuntimeConfig, private 
                     """
                     let endpoint_params = #{PlaceholderParams}::new(${section.config}.region.clone());
                     ${section.request}.properties_mut()
-                        .insert::<aws_smithy_types::endpoint::Endpoint>(
+                        .insert::<aws_smithy_http::endpoint::Result>(
                             ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params)
-                                .map_err(#{BuildError}::other)?);
+                        );
                     """,
                     *codegenScope,
                 )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -5,8 +5,10 @@
 
 package software.amazon.smithy.rustsdk
 
+import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Builtins
 import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
@@ -80,6 +82,10 @@ fn test_1() {
 class RegionDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientCodegenContext> {
     override val name: String = "Region"
     override val order: Byte = 0
+
+    override fun transformModel(service: ServiceShape, model: Model): Model {
+        return super.transformModel(service, model)
+    }
 
     override fun configCustomizations(
         codegenContext: ClientCodegenContext,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -119,14 +119,14 @@ class RegionDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientCode
                     }
                 }
 
-                override fun applyBuiltIn(name: String, value: Node, configRef: String): Writable? {
+                override fun setBuiltInOnConfig(name: String, value: Node, configBuilderRef: String): Writable? {
                     if (name != Builtins.REGION.builtIn.get()) {
                         println("not handling: $name")
                         return null
                     }
                     return writable {
                         rustTemplate(
-                            "let $configRef = $configRef.region(#{Region}::new(${value.expectStringNode().value.dq()}));",
+                            "let $configBuilderRef = $configBuilderRef.region(#{Region}::new(${value.expectStringNode().value.dq()}));",
                             "Region" to region(codegenContext.runtimeConfig).member("Region"),
                         )
                     }

--- a/aws/sdk/aws-models/glacier-tests.smithy
+++ b/aws/sdk/aws-models/glacier-tests.smithy
@@ -20,6 +20,13 @@ apply UploadArchive @httpRequestTests([
             accountId: "foo",
             vaultName: "bar",
         },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
     },
     {
         id: "GlacierChecksums",
@@ -38,6 +45,13 @@ apply UploadArchive @httpRequestTests([
             vaultName: "bar",
             body: "hello world"
         },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
         appliesTo: "client",
     },
     {
@@ -57,6 +71,13 @@ apply UploadArchive @httpRequestTests([
             accountId: "",
             vaultName: "bar",
         },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
         appliesTo: "client",
     },
     {
@@ -76,6 +97,13 @@ apply UploadArchive @httpRequestTests([
             vaultName: "bar",
             accountId: null
         },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
         appliesTo: "client",
     }
 ])
@@ -99,6 +127,13 @@ apply UploadMultipartPart @httpRequestTests([
             uploadId: "baz",
             body: "hello world"
         },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
         appliesTo: "client",
     }
 ])

--- a/aws/sdk/aws-models/route53-tests.smithy
+++ b/aws/sdk/aws-models/route53-tests.smithy
@@ -16,6 +16,13 @@ apply ListResourceRecordSets @httpRequestTests([
         params: {
             "HostedZoneId": "/hostedzone/IDOFMYHOSTEDZONE"
         }
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
     }
 ])
 
@@ -30,6 +37,13 @@ apply GetChange @httpRequestTests([
         params: {
             "Id": "/change/SOMECHANGEID"
         }
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
+        }
     },
 ])
 
@@ -43,6 +57,13 @@ apply GetReusableDelegationSet @httpRequestTests([
         bodyMediaType: "application/xml",
         params: {
             "Id": "/delegationset/DELEGATIONSETID"
+        }
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
         }
     },
 ])

--- a/aws/sdk/aws-models/s3-tests.smithy
+++ b/aws/sdk/aws-models/s3-tests.smithy
@@ -1,6 +1,7 @@
 $version: "1.0"
 
 namespace com.amazonaws.s3
+
 use smithy.test#httpResponseTests
 use smithy.test#httpRequestTests
 
@@ -84,20 +85,20 @@ apply ListObjects @httpResponseTests([
             Name: "bucketname",
             Prefix: "",
             Contents: [{
-                Key: "    ",
-                LastModified: 1626452453,
-                ETag: "\"etag123\"",
-                Size: 0,
-                Owner: { ID: "owner" },
-                StorageClass: "STANDARD"
-            }, {
-               Key: " a ",
-               LastModified: 1626451330,
-               ETag: "\"etag123\"",
-               Size: 0,
-               Owner: { ID: "owner" },
-               StorageClass: "STANDARD"
-           }]
+                           Key: "    ",
+                           LastModified: 1626452453,
+                           ETag: "\"etag123\"",
+                           Size: 0,
+                           Owner: { ID: "owner" },
+                           StorageClass: "STANDARD"
+                       }, {
+                           Key: " a ",
+                           LastModified: 1626451330,
+                           ETag: "\"etag123\"",
+                           Size: 0,
+                           Owner: { ID: "owner" },
+                           StorageClass: "STANDARD"
+                       }]
         }
     }
 ])
@@ -133,6 +134,13 @@ apply PutBucketLifecycleConfiguration @httpRequestTests([
                     {"Expiration": { "Days": 1 }, "Status": "Enabled", "ID": "Expire" },
                 ]
             }
+        },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
         }
     }
 ])
@@ -151,6 +159,13 @@ apply CreateMultipartUpload @httpRequestTests([
         params: {
             "Bucket": "test-bucket",
             "Key": "object.txt"
+        },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
         }
     }
 ])
@@ -167,6 +182,13 @@ apply PutObject @httpRequestTests([
             Bucket: "test-bucket",
             Key: "test-key",
             ContentType: "text/html"
+        },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
         }
     },
     {
@@ -181,6 +203,13 @@ apply PutObject @httpRequestTests([
             Key: "test-key",
             ContentLength: 2,
             Body: "ab"
+        },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
         }
     }
 ])
@@ -196,6 +225,13 @@ apply HeadObject @httpRequestTests([
         params: {
             Bucket: "test-bucket",
             Key: "<> `?🐱",
+        },
+        vendorParams: {
+            "endpointParams": {
+                "builtInParams": {
+                    "AWS::Region": "us-east-1"
+                }
+            }
         }
     }
 ])

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -12,7 +12,7 @@ aws-endpoint = { path = "../../build/aws-sdk/sdk/aws-endpoint"}
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
 aws-sdk-iam = { path = "../../build/aws-sdk/sdk/iam" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
-aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
+aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 bytes = "1.0.0"
 http = "0.2.0"
 tokio = { version = "1.8.4", features = ["full", "test-util"]}

--- a/aws/sdk/integration-tests/iam/tests/resolve-global-endpoint.rs
+++ b/aws/sdk/integration-tests/iam/tests/resolve-global-endpoint.rs
@@ -17,9 +17,8 @@ async fn correct_endpoint_resolver() {
         .await
         .expect("valid operation");
     let props = operation.properties();
-    let ep: &aws_smithy_http::endpoint::Result =
+    let ep: &aws_smithy_types::endpoint::Endpoint =
         props.get().expect("endpoint result was not present");
-    let ep = ep.as_ref().expect("ep resolved successfully");
     // test fips endpoint
     assert_eq!(ep.url(), "https://iam-fips.amazonaws.com/");
 }

--- a/aws/sdk/integration-tests/iam/tests/resolve-global-endpoint.rs
+++ b/aws/sdk/integration-tests/iam/tests/resolve-global-endpoint.rs
@@ -3,22 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_iam::Region;
+use aws_sdk_iam::{Credentials, Region};
+use aws_smithy_client::test_connection::capture_request;
 
 #[tokio::test]
 async fn correct_endpoint_resolver() {
+    let (conn, request) = capture_request(None);
     let conf = aws_sdk_iam::Config::builder()
         .region(Region::from_static("iam-fips"))
+        .credentials_provider(Credentials::new("asdf", "asdf", None, None, "tests"))
+        .http_connector(conn)
         .build();
-    let operation = aws_sdk_iam::operation::ListRoles::builder()
-        .build()
-        .unwrap()
-        .make_operation(&conf)
-        .await
-        .expect("valid operation");
-    let props = operation.properties();
-    let ep: &aws_smithy_types::endpoint::Endpoint =
-        props.get().expect("endpoint result was not present");
-    // test fips endpoint
-    assert_eq!(ep.url(), "https://iam-fips.amazonaws.com/");
+    let client = aws_sdk_iam::Client::from_conf(conf);
+    let _ = client.list_roles().send().await;
+    let req = request.expect_request();
+    assert_eq!(&req.uri().to_string(), "https://iam-fips.amazonaws.com/");
 }

--- a/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
+++ b/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
@@ -148,7 +148,7 @@ async fn retry_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std::
         .expect_err("call should fail");
     assert!(
         matches!(resp, SdkError::TimeoutError { .. }),
-        "expected a timeout error, got: {}",
+        "expected a timeout error, got: {:?}",
         resp
     );
     assert_eq!(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
@@ -30,7 +30,6 @@ internal class EndpointConfigCustomization(
             val codegenScope = arrayOf(
                 "SmithyResolver" to types.resolveEndpoint,
                 "Params" to typesGenerator.paramsStruct(),
-                "DefaultResolver" to typesGenerator.defaultResolver(),
             )
             when (section) {
                 is ServiceConfig.ConfigStruct -> rustTemplate(
@@ -55,10 +54,9 @@ internal class EndpointConfigCustomization(
                         *codegenScope,
                     )
 
-                ServiceConfig.BuilderImpl ->
-                    rustTemplate(
+                ServiceConfig.BuilderImpl -> {
+                    val extraDocs = if (typesGenerator.defaultResolver() != null) {
                         """
-                        /// Sets the endpoint resolver to use when making requests.
                         ///
                         /// When unset, the client will used a generated endpoint resolver based on the endpoint resolution
                         /// rules for `$moduleUseName`.
@@ -88,6 +86,12 @@ internal class EndpointConfigCustomization(
                         /// };
                         /// let config = $moduleUseName::Config::builder().endpoint_resolver(prefix_resolver);
                         /// ```
+                        """
+                    } else ""
+                    rustTemplate(
+                        """
+                        /// Sets the endpoint resolver to use when making requests.
+                        $extraDocs
                         pub fn endpoint_resolver(mut self, endpoint_resolver: impl $resolverTrait + 'static) -> Self {
                             self.endpoint_resolver = Some(std::sync::Arc::new(endpoint_resolver) as _);
                             self
@@ -104,16 +108,27 @@ internal class EndpointConfigCustomization(
                         """,
                         *codegenScope,
                     )
+                }
 
                 ServiceConfig.BuilderBuild -> {
-                    rustTemplate(
-                        """
-                        endpoint_resolver: self.endpoint_resolver.unwrap_or_else(||
-                            std::sync::Arc::new(#{DefaultResolver}::new())
-                        ),
-                        """,
-                        *codegenScope,
-                    )
+                    val defaultResolver = typesGenerator.defaultResolver()
+                    if (defaultResolver != null) {
+                        rustTemplate(
+                            """
+                            endpoint_resolver: self.endpoint_resolver.unwrap_or_else(||
+                                std::sync::Arc::new(#{DefaultResolver}::new())
+                            ),
+                            """,
+                            *codegenScope,
+                            "DefaultResolver" to defaultResolver,
+                        )
+                    } else {
+                        rustTemplate(
+                            """
+                            endpoint_resolver: self.endpoint_resolver.expect("an endpoint resolver must be provided")
+                            """,
+                        )
+                    }
                 }
 
                 else -> emptySection

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
@@ -55,7 +55,8 @@ internal class EndpointConfigCustomization(
                     )
 
                 ServiceConfig.BuilderImpl -> {
-                    val extraDocs = if (typesGenerator.defaultResolver() != null) {
+                    // if there are no rules, we don't generate a default resolver—we need to also suppress those docs.
+                    val defaultResolverDocs = if (typesGenerator.defaultResolver() != null) {
                         """
                         ///
                         /// When unset, the client will used a generated endpoint resolver based on the endpoint resolution
@@ -91,7 +92,7 @@ internal class EndpointConfigCustomization(
                     rustTemplate(
                         """
                         /// Sets the endpoint resolver to use when making requests.
-                        $extraDocs
+                        $defaultResolverDocs
                         pub fn endpoint_resolver(mut self, endpoint_resolver: impl $resolverTrait + 'static) -> Self {
                             self.endpoint_resolver = Some(std::sync::Arc::new(endpoint_resolver) as _);
                             self

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointTypesGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointTypesGenerator.kt
@@ -43,12 +43,9 @@ class EndpointTypesGenerator(
     }
 
     fun paramsStruct(): RuntimeType = EndpointParamsGenerator(params).paramsStruct()
-    fun defaultResolver(): RuntimeType? =
-        rules?.let { EndpointResolverGenerator(stdlib, runtimeConfig).defaultEndpointResolver(it) }
-
+    fun defaultResolver(): RuntimeType? = rules?.let { EndpointResolverGenerator(stdlib, runtimeConfig).defaultEndpointResolver(it) }
     fun testGenerator(): Writable =
-        defaultResolver()?.let { EndpointTestGenerator(tests, paramsStruct(), it, params, runtimeConfig).generate() }
-            ?: {}
+        defaultResolver()?.let { EndpointTestGenerator(tests, paramsStruct(), it, params, runtimeConfig).generate() } ?: {}
 
     /**
      * Load the builtIn value for [parameter] from the endpoint customizations. If the built-in comes from service config,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -139,7 +139,8 @@ class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientC
                         """
                         let endpoint_params = #{Params}::builder()#{builderFields:W}.build()
                             .map_err(#{BuildError}::other)?;
-                        let endpoint_result = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params);
+                        let endpoint = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params)
+                            .map_err(#{BuildError}::other)?;
                         """,
                         "builderFields" to builderFields(typesGenerator.params, section),
                         *codegenScope,
@@ -147,10 +148,9 @@ class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientC
                 }
 
                 is OperationSection.MutateRequest -> writable {
-                    // insert the endpoint resolution _result_ into the bag (note that this won't bail if endpoint
-                    // resolution failed)
+                    // insert the endpoint the bag
                     rustTemplate("${section.request}.properties_mut().insert(endpoint_params);")
-                    rustTemplate("${section.request}.properties_mut().insert(endpoint_result);")
+                    rustTemplate("${section.request}.properties_mut().insert(endpoint);")
                 }
 
                 else -> emptySection

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -41,14 +41,32 @@ import software.amazon.smithy.rust.codegen.core.util.orNull
  * If this resolver does not recognize the value, it MUST return `null`.
  */
 interface EndpointCustomization {
+    /**
+     * Provide the default value for [parameter] given a reference to the service config struct ([configRef])
+     *
+     * If this parameter is not recognized, return null.
+     */
     fun builtInDefaultValue(parameter: Parameter, configRef: String): Writable? = null
+
+    /**
+     * Provide a list of additional endpoints standard library functions that rules can use
+     */
     fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> = listOf()
 
-    fun applyBuiltIn(name: String, value: Node, configRef: String): Writable? = null
+    /**
+     * Set a given builtIn value on the service config builder. If this builtIn is not recognized, return null
+     */
+    fun setBuiltInOnConfig(name: String, value: Node, configBuilderRef: String): Writable? = null
 }
 
 /**
- * Decorator that injects endpoints 2.0 resolvers throughout the entire client.
+ * Decorator that injects endpoints 2.0 resolvers throughout the client.
+ *
+ * 1. Add ClientContext params to the config struct
+ * 2. Inject params / endpoint results into the operation properties
+ * 3. Set a default endpoint resolver (when available)
+ * 4. Create an endpoint params structure/builder
+ * 5. Generate endpoint tests (when available)
  *
  * This decorator installs the core standard library functions. It DOES NOT inject the AWS specific functions which
  * must be injected separately.

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -142,8 +142,8 @@ class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientC
                         """
                         let endpoint_params = #{Params}::builder()#{builderFields:W}.build()
                             .map_err(#{BuildError}::other)?;
-                        let endpoint = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params)
-                            .map_err(#{BuildError}::other)?;
+                        let endpoint_result = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params)
+                            .map_err(#{BuildError}::other);
                         """,
                         "builderFields" to builderFields(typesGenerator.params, section),
                         *codegenScope,
@@ -153,7 +153,7 @@ class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientC
                 is OperationSection.MutateRequest -> writable {
                     // insert the endpoint the bag
                     rustTemplate("${section.request}.properties_mut().insert(endpoint_params);")
-                    rustTemplate("${section.request}.properties_mut().insert(endpoint);")
+                    rustTemplate("${section.request}.properties_mut().insert(endpoint_result);")
                 }
 
                 else -> emptySection

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -142,8 +142,7 @@ class EndpointsDecorator : RustCodegenDecorator<ClientProtocolGenerator, ClientC
                         """
                         let endpoint_params = #{Params}::builder()#{builderFields:W}.build()
                             .map_err(#{BuildError}::other)?;
-                        let endpoint_result = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params)
-                            .map_err(#{BuildError}::other);
+                        let endpoint_result = ${section.config}.endpoint_resolver.resolve_endpoint(&endpoint_params);
                         """,
                         "builderFields" to builderFields(typesGenerator.params, section),
                         *codegenScope,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rust.codegen.client.smithy.endpoint
 
 import software.amazon.smithy.model.node.BooleanNode
+import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.node.StringNode
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeType
@@ -42,6 +43,8 @@ import software.amazon.smithy.rust.codegen.core.util.orNull
 interface EndpointCustomization {
     fun builtInDefaultValue(parameter: Parameter, configRef: String): Writable? = null
     fun customRuntimeFunctions(codegenContext: ClientCodegenContext): List<CustomRuntimeFunction> = listOf()
+
+    fun applyBuiltIn(name: String, value: Node, configRef: String): Writable? = null
 }
 
 /**

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -175,7 +175,7 @@ class ProtocolTestGenerator(
             writable {
                 val customizations = codegenContext.rootDecorator.endpointCustomizations(codegenContext)
                 params.getObjectMember("builtInParams").orNull()?.members?.forEach { (name, value) ->
-                    customizations.firstNotNullOf { it.applyBuiltIn(name.value, value, "builder") }(this)
+                    customizations.firstNotNullOf { it.setBuiltInOnConfig(name.value, value, "builder") }(this)
                 }
             }
         } ?: writable { }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.protocoltests.traits.HttpRequestTestCase
 import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.generators.clientInstantiator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
@@ -32,7 +33,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
-import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.error.errorSymbol
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
@@ -52,7 +53,7 @@ import java.util.logging.Logger
  * Generate protocol tests for an operation
  */
 class ProtocolTestGenerator(
-    private val codegenContext: CodegenContext,
+    private val codegenContext: ClientCodegenContext,
     private val protocolSupport: ProtocolSupport,
     private val operationShape: OperationShape,
     private val writer: RustWriter,
@@ -170,9 +171,23 @@ class ProtocolTestGenerator(
         val customToken = if (inputShape.findMemberWithTrait<IdempotencyTokenTrait>(codegenContext.model) != null) {
             """.make_token("00000000-0000-4000-8000-000000000000")"""
         } else ""
-        rust(
-            """let config = #T::Config::builder()$customToken.build();""",
-            RuntimeType.Config,
+        val customParams = httpRequestTestCase.vendorParams.getObjectMember("endpointParams").orNull()?.let { params ->
+            writable {
+                val customizations = codegenContext.rootDecorator.endpointCustomizations(codegenContext)
+                params.getObjectMember("builtInParams").orNull()?.members?.forEach { (name, value) ->
+                    customizations.firstNotNullOf { it.applyBuiltIn(name.value, value, "builder") }(this)
+                }
+            }
+        } ?: writable { }
+        rustTemplate(
+            """
+            let builder = #{Config}::Config::builder()$customToken;
+            #{customParams}
+            let config = builder.build();
+
+            """,
+            "Config" to RuntimeType.Config,
+            "customParams" to customParams,
         )
         writeInline("let input =")
         instantiator.render(this, inputShape, httpRequestTestCase.params)
@@ -199,7 +214,10 @@ class ProtocolTestGenerator(
                 *codegenScope,
             )
             resolvedHost.orNull()?.also { host ->
-                rustTemplate("""#{AssertEq}(http_request.uri().host().expect("host should be set"), ${host.dq()});""", *codegenScope)
+                rustTemplate(
+                    """#{AssertEq}(http_request.uri().host().expect("host should be set"), ${host.dq()});""",
+                    *codegenScope,
+                )
             }
         }
         checkQueryParams(this, httpRequestTestCase.queryParams)
@@ -285,7 +303,8 @@ class ProtocolTestGenerator(
                 .member("response::ParseHttpResponse"),
         )
         if (expectedShape.hasTrait<ErrorTrait>()) {
-            val errorSymbol = operationShape.errorSymbol(codegenContext.model, codegenContext.symbolProvider, codegenContext.target)
+            val errorSymbol =
+                operationShape.errorSymbol(codegenContext.model, codegenContext.symbolProvider, codegenContext.target)
             val errorVariant = codegenContext.symbolProvider.toSymbol(expectedShape).name
             rust("""let parsed = parsed.expect_err("should be error response");""")
             rustBlock("if let #TKind::$errorVariant(actual_error) = parsed.kind", errorSymbol) {
@@ -321,8 +340,12 @@ class ProtocolTestGenerator(
                                 """,
                             )
                         }
+
                         else ->
-                            rustTemplate("""#{AssertEq}(parsed.$memberName, expected_output.$memberName, "Unexpected value for `$memberName`");""", *codegenScope)
+                            rustTemplate(
+                                """#{AssertEq}(parsed.$memberName, expected_output.$memberName, "Unexpected value for `$memberName`");""",
+                                *codegenScope,
+                            )
                     }
                 }
             }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
@@ -95,7 +95,8 @@ class EndpointsDecoratorTest {
         val testDir = clientIntegrationTest(
             model,
             addtionalDecorators = listOf(EndpointsDecorator()),
-            command = { "cargo check".runWithWarnings(it) },
+            // just run integration tests
+            command = { "cargo test --test *".runWithWarnings(it) },
         ) { clientCodegenContext, rustCrate ->
             rustCrate.integrationTest("endpoint_params_test") {
                 val moduleName = clientCodegenContext.moduleUseName()
@@ -108,11 +109,10 @@ class EndpointsDecoratorTest {
                                 .bucket("bucket-name").build().expect("input is valid")
                                 .make_operation(&conf).await.expect("valid operation");
                             use $moduleName::endpoint::{Params};
-                            use aws_smithy_http::endpoint::Result;
+                            use aws_smithy_types::endpoint::Endpoint;
                             let props = operation.properties();
                             let endpoint_params = props.get::<Params>().unwrap();
-                            let endpoint_result = props.get::<Result>().unwrap();
-                            let endpoint = endpoint_result.as_ref().expect("endpoint resolved properly");
+                            let endpoint = props.get::<Endpoint>().unwrap();
                             assert_eq!(
                                 endpoint_params,
                                 &Params::builder()

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
@@ -109,10 +109,11 @@ class EndpointsDecoratorTest {
                                 .bucket("bucket-name").build().expect("input is valid")
                                 .make_operation(&conf).await.expect("valid operation");
                             use $moduleName::endpoint::{Params};
-                            use aws_smithy_types::endpoint::Endpoint;
+                            use aws_smithy_http::endpoint::Result;
                             let props = operation.properties();
-                            let endpoint_params = props.get::<Params>().unwrap();
-                            let endpoint = props.get::<Endpoint>().unwrap();
+                            let endpoint_params = props.get::<Params>().expect("endpoint params in the bag");
+                            let endpoint_result = props.get::<Result>().expect("endpoint result in the bag");
+                            let endpoint = endpoint_result.as_ref().expect("endpoint resolved properly");
                             assert_eq!(
                                 endpoint_params,
                                 &Params::builder()

--- a/design/src/rfcs/rfc0014_timeout_config.md
+++ b/design/src/rfcs/rfc0014_timeout_config.md
@@ -109,7 +109,7 @@ impl<S> tower::Layer<S> for AwsMiddleware {
   fn layer(&self, inner: S) -> Self::Service {
     let credential_provider = AsyncMapRequestLayer::for_mapper(CredentialsStage::new());
     let signer = MapRequestLayer::for_mapper(SigV4SigningStage::new(SigV4Signer::new()));
-    let endpoint_resolver = MapRequestLayer::for_mapper(AwsEndpointStage);
+    let endpoint_resolver = MapRequestLayer::for_mapper(AwsAuthStage);
     let user_agent = MapRequestLayer::for_mapper(UserAgentStage::new());
     ServiceBuilder::new()
             .layer(endpoint_resolver)

--- a/rust-runtime/aws-smithy-http/src/endpoint.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint.rs
@@ -11,6 +11,8 @@ use std::result::Result as StdResult;
 use std::str::FromStr;
 
 pub mod error;
+pub mod middleware;
+
 pub use error::ResolveEndpointError;
 
 pub type Result = std::result::Result<aws_smithy_types::endpoint::Endpoint, ResolveEndpointError>;

--- a/rust-runtime/aws-smithy-http/src/endpoint/error.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/error.rs
@@ -10,7 +10,7 @@ use std::fmt;
 #[derive(Debug)]
 pub struct ResolveEndpointError {
     message: String,
-    source: Option<Box<dyn std::error::Error + Send + Sync>>,
+    source: Option<Box<dyn Error + Send + Sync>>,
 }
 
 impl ResolveEndpointError {
@@ -23,10 +23,11 @@ impl ResolveEndpointError {
     }
 
     /// Add a source to the error
-    pub fn with_source(self, source: Option<Box<dyn std::error::Error + Send + Sync>>) -> Self {
+    pub fn with_source(self, source: Option<Box<dyn Error + Send + Sync>>) -> Self {
         Self { source, ..self }
     }
 
+    /// Create a [`ResolveEndpointError`] from a message and a source
     pub fn from_source(
         message: impl Into<String>,
         source: impl Into<Box<dyn Error + Send + Sync>>,

--- a/rust-runtime/aws-smithy-http/src/endpoint/error.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/error.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::error::{Error as StdError, Error};
+use std::error::Error;
 use std::fmt;
 
 /// Endpoint resolution failed
@@ -42,8 +42,8 @@ impl fmt::Display for ResolveEndpointError {
     }
 }
 
-impl StdError for ResolveEndpointError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+impl Error for ResolveEndpointError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         self.source.as_ref().map(|err| err.as_ref() as _)
     }
 }
@@ -52,10 +52,10 @@ impl StdError for ResolveEndpointError {
 pub(super) enum InvalidEndpointErrorKind {
     EndpointMustHaveScheme,
     FailedToConstructAuthority {
-        source: Box<dyn StdError + Send + Sync + 'static>,
+        source: Box<dyn Error + Send + Sync + 'static>,
     },
     FailedToConstructUri {
-        source: Box<dyn StdError + Send + Sync + 'static>,
+        source: Box<dyn Error + Send + Sync + 'static>,
     },
 }
 
@@ -72,7 +72,7 @@ impl InvalidEndpointError {
     }
 
     pub(super) fn failed_to_construct_authority(
-        source: impl Into<Box<dyn StdError + Send + Sync + 'static>>,
+        source: impl Into<Box<dyn Error + Send + Sync + 'static>>,
     ) -> Self {
         Self {
             kind: InvalidEndpointErrorKind::FailedToConstructAuthority {
@@ -82,7 +82,7 @@ impl InvalidEndpointError {
     }
 
     pub(super) fn failed_to_construct_uri(
-        source: impl Into<Box<dyn StdError + Send + Sync + 'static>>,
+        source: impl Into<Box<dyn Error + Send + Sync + 'static>>,
     ) -> Self {
         Self {
             kind: InvalidEndpointErrorKind::FailedToConstructUri {
@@ -112,8 +112,8 @@ impl fmt::Display for InvalidEndpointError {
     }
 }
 
-impl StdError for InvalidEndpointError {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+impl Error for InvalidEndpointError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         use InvalidEndpointErrorKind as ErrorKind;
         match &self.kind {
             ErrorKind::FailedToConstructUri { source }

--- a/rust-runtime/aws-smithy-http/src/endpoint/error.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/error.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::error::Error as StdError;
+use std::error::{Error as StdError, Error};
 use std::fmt;
 
 /// Endpoint resolution failed
@@ -25,6 +25,13 @@ impl ResolveEndpointError {
     /// Add a source to the error
     pub fn with_source(self, source: Option<Box<dyn std::error::Error + Send + Sync>>) -> Self {
         Self { source, ..self }
+    }
+
+    pub fn from_source(
+        message: impl Into<String>,
+        source: impl Into<Box<dyn Error + Send + Sync>>,
+    ) -> Self {
+        Self::message(message).with_source(Some(source.into()))
     }
 }
 

--- a/rust-runtime/aws-smithy-http/src/endpoint/middleware.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/middleware.rs
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::endpoint::{apply_endpoint, EndpointPrefix, ResolveEndpointError};
+use crate::middleware::MapRequest;
+use crate::operation::Request;
+use aws_smithy_types::endpoint::Endpoint;
+use http::header::HeaderName;
+use http::{HeaderValue, Uri};
+use std::str::FromStr;
+
+/// Middleware to apply an HTTP endpoint to the request
+///
+/// This middleware reads [`aws_smithy_types::endpoint::Endpoint`] out of the request properties and applies
+/// it to the HTTP request.
+#[non_exhaustive]
+#[derive(Default, Debug, Clone)]
+pub struct SmithyEndpointStage;
+impl SmithyEndpointStage {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MapRequest for SmithyEndpointStage {
+    type Error = ResolveEndpointError;
+
+    fn apply(&self, request: Request) -> Result<Request, Self::Error> {
+        request.augment(|mut http_req, props| {
+            let endpoint = props
+                .get::<Endpoint>()
+                .ok_or(ResolveEndpointError::message("no endpoint present"))?;
+            let uri: Uri = endpoint.url().parse().map_err(|err| {
+                ResolveEndpointError::from_source("endpoint did not have a valid uri", err)
+            })?;
+            apply_endpoint(http_req.uri_mut(), &uri, props.get::<EndpointPrefix>()).map_err(
+                |err| {
+                    ResolveEndpointError::message("failed to imply endpoint")
+                        .with_source(Some(err.into()))
+                },
+            )?;
+            for (header_name, header_values) in endpoint.headers() {
+                http_req.headers_mut().remove(header_name);
+                for value in header_values {
+                    http_req.headers_mut().insert(
+                        HeaderName::from_str(header_name).map_err(|err| {
+                            ResolveEndpointError::message("invalid header name")
+                                .with_source(Some(err.into()))
+                        })?,
+                        HeaderValue::from_str(value).map_err(|err| {
+                            ResolveEndpointError::message("invalid header value")
+                                .with_source(Some(err.into()))
+                        })?,
+                    );
+                }
+            }
+            Ok(http_req)
+        })
+    }
+}

--- a/rust-runtime/aws-smithy-http/src/endpoint/middleware.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/middleware.rs
@@ -37,8 +37,11 @@ impl MapRequest for SmithyEndpointStage {
             })?;
             apply_endpoint(http_req.uri_mut(), &uri, props.get::<EndpointPrefix>()).map_err(
                 |err| {
-                    ResolveEndpointError::message("failed to imply endpoint")
-                        .with_source(Some(err.into()))
+                    ResolveEndpointError::message(format!(
+                        "failed to apply endpoint `{:?}` to request `{:?}`",
+                        uri, http_req
+                    ))
+                    .with_source(Some(err.into()))
                 },
             )?;
             for (header_name, header_values) in endpoint.headers() {


### PR DESCRIPTION
## Motivation and Context
- #1784 

## Description
This PR does a 3 bits of pre-work ahead of ep2 integration:
1. Split endpoint resolution into two separate middlewares:
    1. A smithy native middleware that applies URI and headers
    2. An AWS middleware that applies the auth schemes
2. Add vendorParams support to the ProtocolTestGenerator so that protocol tests can insert a region.
~3. Simplify endpoint resolution logic by allowing `make_operation` to fail when an endpoint cannot be resolved.~

## Testing
- sdk works 
- it/ut

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
