### PR TITLE
allow parse_url functions to be unused

### DIFF
--- a/rust-runtime/inlineable/src/endpoint_lib/parse_url.rs
+++ b/rust-runtime/inlineable/src/endpoint_lib/parse_url.rs
@@ -14,6 +14,9 @@ pub(crate) struct Url<'a> {
     raw: &'a str,
 }
 
+// individual methods on parse_url might not be used (although the [`parse_url`] itself _MUST_ be used
+// since stdlib functions are pulled into crate lazily)
+#[allow(unused)]
 impl<'a> Url<'a> {
     pub(crate) fn is_ip(&self) -> bool {
         matches!(self.url.host(), Some(Host::Ipv4(_) | Host::Ipv6(_)))


### PR DESCRIPTION
## Motivation and Context
- compile warnings for ep2

## Description
allow members of parse_url struct to be unused

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
