### PR TITLE
Don't require `thiserror` 1.0.36

### DIFF
--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -35,8 +35,7 @@ once_cell = "1.13"
 regex = "1.5.5"
 serde_urlencoded = "0.7"
 strum_macros = "0.24"
-# TODO Investigate.
-thiserror = "<=1.0.36"
+thiserror = "1.0.0"
 tracing = "0.1.35"
 tokio = { version = "1.8.4", features = ["full"] }
 tower = { version = "0.4.11", features = ["util", "make"], default-features = false }


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
