### PR TITLE
Fix clippy lints and run formatter

### DIFF
--- a/aws/rust-runtime/aws-config/src/credential_process.rs
+++ b/aws/rust-runtime/aws-config/src/credential_process.rs
@@ -115,11 +115,11 @@ impl CredentialProcessProvider {
 
         let mut command = if cfg!(windows) {
             let mut command = Command::new("cmd.exe");
-            command.args(&["/C", self.command.unredacted()]);
+            command.args(["/C", self.command.unredacted()]);
             command
         } else {
             let mut command = Command::new("sh");
-            command.args(&["-c", self.command.unredacted()]);
+            command.args(["-c", self.command.unredacted()]);
             command
         };
 

--- a/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
@@ -123,9 +123,9 @@ pub(super) fn resolve_chain<'a>(
     // - There is not default profile
     // Then:
     // - Treat this situation as if no profiles were defined
-    if profile_override == None
+    if profile_override.is_none()
         && profile_set.selected_profile() == "default"
-        && profile_set.get_profile("default") == None
+        && profile_set.get_profile("default").is_none()
     {
         tracing::debug!("No default profile defined");
         return Err(ProfileFileError::NoProfilesDefined);

--- a/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
@@ -140,7 +140,7 @@ fn validate_identifier(input: &str) -> Result<&str, ()> {
                     .iter()
                     .any(|c| *c == ch)
         })
-        .then(|| input)
+        .then_some(input)
         .ok_or(())
 }
 

--- a/aws/sdk/integration-tests/glacier/tests/custom-headers.rs
+++ b/aws/sdk/integration-tests/glacier/tests/custom-headers.rs
@@ -26,7 +26,7 @@ async fn set_correct_headers() {
         .await;
     let req = handler.expect_request();
     assert_ok(validate_headers(
-        &req.headers(),
+        req.headers(),
         [
             (
                 "x-amz-sha256-tree-hash",

--- a/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
+++ b/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
@@ -55,7 +55,12 @@ async fn client_is_debug() {
 async fn client_is_clone() {
     let conf = kms::Config::builder().build();
     let client = kms::Client::from_conf(conf);
-    let _ = client.clone();
+
+    fn is_clone(it: impl Clone) {
+        drop(it)
+    }
+
+    is_clone(client);
 }
 
 #[test]

--- a/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
+++ b/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
@@ -74,7 +74,7 @@ async fn test_s3_signer_with_naughty_string_metadata() {
     for (idx, line) in NAUGHTY_STRINGS.split('\n').enumerate() {
         // add lines to metadata unless they're a comment or empty
         // Some naughty strings aren't valid HeaderValues so we skip those too
-        if !line.starts_with("#") && !line.is_empty() && HeaderValue::from_str(line).is_ok() {
+        if !line.starts_with('#') && !line.is_empty() && HeaderValue::from_str(line).is_ok() {
             let key = format!("line-{}", idx);
 
             builder = builder.metadata(key, line);

--- a/aws/sdk/integration-tests/s3/tests/streaming-response.rs
+++ b/aws/sdk/integration-tests/s3/tests/streaming-response.rs
@@ -111,15 +111,13 @@ Hello"#;
                 }
             }
 
-            if socket.writable().await.is_ok() {
-                if time_to_respond {
-                    // The content length is 12 but we'll only write 5 bytes
-                    socket.try_write(&response).unwrap();
-                    // We break from the R/W loop after sending a partial response in order to
-                    // close the connection early.
-                    debug!("faulty server has written partial response, now closing connection");
-                    break;
-                }
+            if socket.writable().await.is_ok() && time_to_respond {
+                // The content length is 12 but we'll only write 5 bytes
+                socket.try_write(response).unwrap();
+                // We break from the R/W loop after sending a partial response in order to
+                // close the connection early.
+                debug!("faulty server has written partial response, now closing connection");
+                break;
             }
         }
     }

--- a/aws/sdk/integration-tests/s3/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/s3/tests/timeouts.rs
@@ -81,11 +81,10 @@ async fn test_read_timeout() {
         (
             async move {
                 while shutdown_receiver.try_recv().is_err() {
-                    if let Ok(result) = timeout(Duration::from_millis(100), listener.accept()).await
+                    if let Ok(Ok((_socket, _))) =
+                        timeout(Duration::from_millis(100), listener.accept()).await
                     {
-                        if let Ok((_socket, _)) = result {
-                            tokio::time::sleep(Duration::from_millis(1000)).await;
-                        }
+                        tokio::time::sleep(Duration::from_millis(1000)).await;
                     }
                 }
             },

--- a/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
+++ b/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
@@ -38,7 +38,7 @@ async fn test_success() {
         match event {
             TranscriptResultStream::TranscriptEvent(transcript_event) => {
                 let transcript = transcript_event.transcript.unwrap();
-                for result in transcript.results.unwrap_or_else(Vec::new) {
+                for result in transcript.results.unwrap_or_default() {
                     if !result.is_partial {
                         let first_alternative = &result.alternatives.as_ref().unwrap()[0];
                         full_message += first_alternative.transcript.as_ref().unwrap();

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -239,8 +239,8 @@ where
         );
         let (mut req, parts) = op.into_request_response();
         if let Some(metadata) = &parts.metadata {
-            span.record("operation", &metadata.name());
-            span.record("service", &metadata.service());
+            span.record("operation", metadata.name());
+            span.record("service", metadata.service());
             // This will clone two `Cow::<&'static str>::Borrow`s in the vast majority of cases
             req.properties_mut().insert(metadata.clone());
         }
@@ -251,12 +251,12 @@ where
             .await;
         match &result {
             Ok(_) => {
-                span.record("status", &"ok");
+                span.record("status", "ok");
             }
             Err(err) => {
                 span.record(
                     "status",
-                    &match err {
+                    match err {
                         SdkError::ConstructionFailure(_) => "construction_failure",
                         SdkError::DispatchFailure(_) => "dispatch_failure",
                         SdkError::ResponseError(_) => "response_error",

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -239,8 +239,8 @@ where
         );
         let (mut req, parts) = op.into_request_response();
         if let Some(metadata) = &parts.metadata {
-            span.record("operation", metadata.name());
-            span.record("service", metadata.service());
+            span.record("operation", &metadata.name());
+            span.record("service", &metadata.service());
             // This will clone two `Cow::<&'static str>::Borrow`s in the vast majority of cases
             req.properties_mut().insert(metadata.clone());
         }
@@ -251,12 +251,12 @@ where
             .await;
         match &result {
             Ok(_) => {
-                span.record("status", "ok");
+                span.record("status", &"ok");
             }
             Err(err) => {
                 span.record(
                     "status",
-                    match err {
+                    &match err {
                         SdkError::ConstructionFailure(_) => "construction_failure",
                         SdkError::DispatchFailure(_) => "dispatch_failure",
                         SdkError::ResponseError(_) => "response_error",

--- a/rust-runtime/aws-smithy-http-server-python/src/server.rs
+++ b/rust-runtime/aws-smithy-http-server-python/src/server.rs
@@ -140,7 +140,7 @@ pub trait PyApp: Clone + pyo3::IntoPy<PyObject> {
     /// Other signals are NOOP.
     fn block_on_rust_signals(&self) {
         let mut signals =
-            Signals::new(&[SIGINT, SIGHUP, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2, SIGWINCH])
+            Signals::new([SIGINT, SIGHUP, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2, SIGWINCH])
                 .expect("Unable to register signals");
         for sig in signals.forever() {
             match sig {
@@ -226,7 +226,7 @@ event_loop.add_signal_handler(signal.SIGINT,
     ) -> PyResult<()> {
         // Clone the socket.
         let borrow = socket.try_borrow_mut()?;
-        let held_socket: &PySocket = &*borrow;
+        let held_socket: &PySocket = &borrow;
         let raw_socket = held_socket.get_socket()?;
         // Register signals on the Python event loop.
         self.register_python_signals(py, event_loop.to_object(py))?;

--- a/rust-runtime/aws-smithy-protocol-test/src/lib.rs
+++ b/rust-runtime/aws-smithy-protocol-test/src/lib.rs
@@ -244,7 +244,7 @@ pub fn forbid_headers(
 ) -> Result<(), ProtocolTestFailure> {
     for key in forbidden_headers {
         // Protocol tests store header lists as comma-delimited
-        if let Some(value) = normalized_header(headers, *key) {
+        if let Some(value) = normalized_header(headers, key) {
             return Err(ProtocolTestFailure::ForbiddenHeader {
                 forbidden: key.to_string(),
                 found: format!("{}: {}", key, value),
@@ -260,7 +260,7 @@ pub fn require_headers(
 ) -> Result<(), ProtocolTestFailure> {
     for key in required_headers {
         // Protocol tests store header lists as comma-delimited
-        if normalized_header(headers, *key).is_none() {
+        if normalized_header(headers, key).is_none() {
             return Err(ProtocolTestFailure::MissingHeader {
                 expected: key.to_string(),
             });

--- a/tools/changelogger/src/render.rs
+++ b/tools/changelogger/src/render.rs
@@ -404,7 +404,7 @@ mod test {
 
     fn render_full(entries: &[ChangelogEntry], release_header: &str) -> String {
         let (header, body) = render(entries, release_header);
-        return format!("{}{}", header, body);
+        format!("{header}{body}")
     }
 
     #[test]

--- a/tools/changelogger/tests/e2e_test.rs
+++ b/tools/changelogger/tests/e2e_test.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 use tempfile::TempDir;
 use time::OffsetDateTime;
 
-const SOURCE_TOML: &'static str = r#"
+const SOURCE_TOML: &str = r#"
     [[aws-sdk-rust]]
     message = "Some change"
     references = ["aws-sdk-rust#123", "smithy-rs#456"]
@@ -37,7 +37,7 @@ const SOURCE_TOML: &'static str = r#"
     author = "another-dev"
     "#;
 
-const SDK_MODEL_SOURCE_TOML: &'static str = r#"
+const SDK_MODEL_SOURCE_TOML: &str = r#"
     [[aws-sdk-model]]
     module = "aws-sdk-ec2"
     version = "0.12.0"
@@ -390,7 +390,7 @@ Old entry contents
 /// set, which should result in the default
 #[test]
 fn render_smithy_entries() {
-    const NEXT_CHANGELOG: &'static str = r#"
+    const NEXT_CHANGELOG: &str = r#"
 # Example changelog entries
 # [[aws-sdk-rust]]
 # message = "Fix typos in module documentation for generated crates"
@@ -499,7 +499,7 @@ Old entry contents
 /// aws_sdk_rust should not be allowed to have target entries
 #[test]
 fn aws_sdk_cannot_have_target() {
-    const NEXT_CHANGELOG: &'static str = r#"
+    const NEXT_CHANGELOG: &str = r#"
 # Example changelog entries
 # [[aws-sdk-rust]]
 # message = "Fix typos in module documentation for generated crates"
@@ -565,8 +565,8 @@ author = "rcoh"
         change_set: ChangeSet::SmithyRs,
         independent_versioning: true,
         source: vec![source_path.clone()],
-        source_to_truncate: source_path.clone(),
-        changelog_output: dest_path.clone(),
+        source_to_truncate: source_path,
+        changelog_output: dest_path,
         release_manifest_output: Some(tmp_dir.path().into()),
         date_override: Some(OffsetDateTime::UNIX_EPOCH),
         previous_release_versions_manifest: None,
@@ -579,9 +579,6 @@ author = "rcoh"
             .find("aws-sdk-rust changelog entry cannot have an affected target");
         assert!(index.is_some());
     } else {
-        assert!(
-            false,
-            "This should have been error that aws-sdk-rust has a target entry"
-        );
+        panic!("This should have been error that aws-sdk-rust has a target entry");
     }
 }


### PR DESCRIPTION
I noticed while working on the concurrency tests that we had neglected to run clippy in a few places. I also ran `cargo fmt` for good measure. This change doesn't change any behavior.

---

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
