### PR TITLE
Prepare 0.52.0 release of smithy-rs

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -13,7 +13,7 @@
 
 [[smithy-rs]]
 message = "Upgrade Rust MSRV to 1.62.1"
-references = ["smithy-rs#0"]
+references = ["smithy-rs#1938"]
 meta = { "breaking" = true, "tada" = true, "bug" = false, "target" = "all" }
 author = "jjantdev"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ rust.msrv=1.62.1
 org.gradle.jvmargs=-Xmx1024M
 
 # Version number to use for the generated runtime crates
-smithy.rs.runtime.crate.version=0.51.0
+smithy.rs.runtime.crate.version=0.52.0
 
 kotlin.code.style=official
 


### PR DESCRIPTION
Bumping the version of `smithy-rs` in `gradle.properties` to cut the 0.52.0 release.
This PR must be merged in after #2069 

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
