### PR TITLE
Improve RustDocs for constrained types

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstraintViolationSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstraintViolationSymbolProvider.kt
@@ -77,13 +77,21 @@ class ConstraintViolationSymbolProvider(
         false -> Visibility.PUBCRATE
     }
 
-    private fun Shape.shapeModule() = RustModule.new(
-        // need to use the context name so we get the correct name for maps
-        name = RustReservedWords.escapeIfNeeded(this.contextName(serviceShape)).toSnakeCase(),
-        visibility = visibility,
-        parent = ModelsModule,
-        inline = true,
-    )
+    private fun Shape.shapeModule(): RustModule.LeafModule {
+        val documentation = if (publicConstrainedTypes && this.isDirectlyConstrained(base)) {
+            "See [`${this.contextName(serviceShape)}`]."
+        } else {
+            null
+        }
+        return RustModule.new(
+            // Need to use the context name so we get the correct name for maps.
+            name = RustReservedWords.escapeIfNeeded(this.contextName(serviceShape)).toSnakeCase(),
+            visibility = visibility,
+            parent = ModelsModule,
+            inline = true,
+            documentation = documentation,
+        )
+    }
 
     private fun constraintViolationSymbolForCollectionOrMapOrUnionShape(shape: Shape): Symbol {
         check(shape is CollectionShape || shape is MapShape || shape is UnionShape)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
@@ -85,7 +85,8 @@ class ConstrainedCollectionGenerator(
             "ConstraintViolation" to constraintViolation,
         )
 
-        writer.documentShape(shape, model, note = rustDocsNote(name))
+        writer.documentShape(shape, model)
+        writer.docs(rustDocsConstrainedTypeEpilogue(name))
         constrainedTypeMetadata.render(writer)
         writer.rustTemplate(
             """

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedMapGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedMapGenerator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
+import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
@@ -74,7 +75,8 @@ class ConstrainedMapGenerator(
             "ConstraintViolation" to constraintViolation,
         )
 
-        writer.documentShape(shape, model, note = rustDocsNote(name))
+        writer.documentShape(shape, model)
+        writer.docs(rustDocsConstrainedTypeEpilogue(name))
         constrainedTypeMetadata.render(writer)
         writer.rustTemplate("struct $name(pub(crate) $inner);", *codegenScope)
         if (constrainedTypeVisibility == Visibility.PUBCRATE) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedShapeGeneratorCommon.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedShapeGeneratorCommon.kt
@@ -9,10 +9,12 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
  * Functions shared amongst the constrained shape generators, to keep them DRY and consistent.
  */
 
-fun rustDocsNote(typeName: String) =
-    "this is a constrained type because its corresponding modeled Smithy shape has one or more " +
-        "[constraint traits]. Use [`parse`] or [`$typeName::TryFrom`] to construct values of this type." +
-        "[constraint traits]: https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html"
+fun rustDocsConstrainedTypeEpilogue(typeName: String) = """
+This is a constrained type because its corresponding modeled Smithy shape has one or more 
+[constraint traits]. Use [`$typeName::try_from`] to construct values of this type.
+
+[constraint traits]: https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html
+"""
 
 fun rustDocsTryFromMethod(typeName: String, inner: String) =
     "Constructs a `$typeName` from an [`$inner`], failing when the provided value does not satisfy the modeled constraints."

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedStringGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedStringGenerator.kt
@@ -81,7 +81,8 @@ class ConstrainedStringGenerator(
         // Note that we're using the linear time check `chars().count()` instead of `len()` on the input value, since the
         // Smithy specification says the `length` trait counts the number of Unicode code points when applied to string shapes.
         // https://awslabs.github.io/smithy/1.0/spec/core/constraint-traits.html#length-trait
-        writer.documentShape(shape, model, note = rustDocsNote(name))
+        writer.documentShape(shape, model)
+        writer.docs(rustDocsConstrainedTypeEpilogue(name))
         constrainedTypeMetadata.render(writer)
         writer.rust("struct $name(pub(crate) $inner);")
         if (constrainedTypeVisibility == Visibility.PUBCRATE) {


### PR DESCRIPTION
* We decided not to generate `parse` method in #1342.
* Fix link to `try_from` constructor.
* Always mention the type is the result of a constrained shape, even if the shape has no documentation.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
