### PR TITLE
Fix examples check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
   # This job is split out from the rest since it is not required to pass for merge
   check-sdk-examples:
     name: Check SDK Examples
-    if: ${{ inputs.run_sdk_examples == 'true' }}
+    if: ${{ inputs.run_sdk_examples }}
     needs: generate
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Motivation and Context
The examples check condition added in #2088 seems to be broken since examples are always skipped now. This PR fixes the condition.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
