### PR TITLE
Refactor build scripts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ buildscript {
 
 plugins {
     kotlin("jvm") version "1.3.72" apply false
-    id("org.jetbrains.dokka") version "1.7.10"
 }
 
 allprojects {

--- a/codegen-client/build.gradle.kts
+++ b/codegen-client/build.gradle.kts
@@ -7,7 +7,6 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.dokka")
     jacoco
     `maven-publish`
 }
@@ -82,13 +81,6 @@ if (isTestingEnabled.toBoolean()) {
             showStandardStreams = true
         }
     }
-
-    tasks.dokkaHtml.configure {
-        outputDirectory.set(buildDir.resolve("javadoc"))
-    }
-
-    // Always build documentation
-    tasks["build"].finalizedBy(tasks["dokkaHtml"])
 
     // Configure jacoco (code coverage) to generate an HTML report
     tasks.jacocoTestReport {

--- a/codegen-client/build.gradle.kts
+++ b/codegen-client/build.gradle.kts
@@ -20,7 +20,6 @@ group = "software.amazon.smithy.rust.codegen"
 version = "0.1.0"
 
 val smithyVersion: String by project
-val kotestVersion: String by project
 
 dependencies {
     implementation(project(":codegen-core"))
@@ -30,13 +29,6 @@ dependencies {
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
     implementation("software.amazon.smithy:smithy-rules-engine:$smithyVersion")
-    runtimeOnly(project(":rust-runtime"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
-}
-
-tasks.compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
 }
 
 tasks.compileKotlin {
@@ -65,36 +57,51 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.getByName("main").allSource)
 }
 
-tasks.test {
-    useJUnitPlatform()
-    testLogging {
-        events("passed", "skipped", "failed")
-        exceptionFormat = TestExceptionFormat.FULL
-        showCauses = true
-        showExceptions = true
-        showStackTraces = true
-        showStandardStreams = true
+val isTestingEnabled: String by project
+if (isTestingEnabled.toBoolean()) {
+    val kotestVersion: String by project
+
+    dependencies {
+        runtimeOnly(project(":rust-runtime"))
+        testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
+        testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
     }
-}
 
-tasks.dokkaHtml.configure {
-    outputDirectory.set(buildDir.resolve("javadoc"))
-}
-
-// Always build documentation
-tasks["build"].finalizedBy(tasks["dokkaHtml"])
-
-// Configure jacoco (code coverage) to generate an HTML report
-tasks.jacocoTestReport {
-    reports {
-        xml.required.set(false)
-        csv.required.set(false)
-        html.outputLocation.set(file("$buildDir/reports/jacoco"))
+    tasks.compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
     }
-}
 
-// Always run the jacoco test report after testing.
-tasks["test"].finalizedBy(tasks["jacocoTestReport"])
+    tasks.test {
+        useJUnitPlatform()
+        testLogging {
+            events("passed", "skipped", "failed")
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+            showStandardStreams = true
+        }
+    }
+
+    tasks.dokkaHtml.configure {
+        outputDirectory.set(buildDir.resolve("javadoc"))
+    }
+
+    // Always build documentation
+    tasks["build"].finalizedBy(tasks["dokkaHtml"])
+
+    // Configure jacoco (code coverage) to generate an HTML report
+    tasks.jacocoTestReport {
+        reports {
+            xml.required.set(false)
+            csv.required.set(false)
+            html.outputLocation.set(file("$buildDir/reports/jacoco"))
+        }
+    }
+
+    // Always run the jacoco test report after testing.
+    tasks["test"].finalizedBy(tasks["jacocoTestReport"])
+}
 
 publishing {
     publications {

--- a/codegen-core/build.gradle.kts
+++ b/codegen-core/build.gradle.kts
@@ -20,8 +20,9 @@ extra["moduleName"] = "software.amazon.smithy.rust.codegen.core"
 group = "software.amazon.smithy.rust.codegen"
 version = "0.1.0"
 
+val isTestingEnabled: String by project
+val shouldRunTests: Boolean = isTestingEnabled.toBoolean()
 val smithyVersion: String by project
-val kotestVersion: String by project
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
@@ -31,9 +32,19 @@ dependencies {
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-waiters:$smithyVersion")
-    runtimeOnly(project(":rust-runtime"))
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+}
+
+if (shouldRunTests) {
+    val kotestVersion: String by project
+
+    apply(plugin = "org.jetbrains.dokka")
+    apply(plugin = "jacoco")
+
+    dependencies {
+        runtimeOnly(project(":rust-runtime"))
+        testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
+        testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    }
 }
 
 fun gitCommitHash(): String {
@@ -78,10 +89,6 @@ tasks.compileKotlin {
     dependsOn(generateSmithyRuntimeCrateVersion)
 }
 
-tasks.compileTestKotlin {
-    kotlinOptions.jvmTarget = "1.8"
-}
-
 // Reusable license copySpec
 val licenseSpec = copySpec {
     from("${project.rootDir}/LICENSE")
@@ -104,36 +111,42 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.getByName("main").allSource)
 }
 
-tasks.test {
-    useJUnitPlatform()
-    testLogging {
-        events("passed", "skipped", "failed")
-        exceptionFormat = TestExceptionFormat.FULL
-        showCauses = true
-        showExceptions = true
-        showStackTraces = true
-        showStandardStreams = true
+if (shouldRunTests) {
+    tasks.compileTestKotlin {
+        kotlinOptions.jvmTarget = "1.8"
     }
-}
 
-tasks.dokkaHtml.configure {
-    outputDirectory.set(buildDir.resolve("javadoc"))
-}
-
-// Always build documentation
-tasks["build"].finalizedBy(tasks["dokkaHtml"])
-
-// Configure jacoco (code coverage) to generate an HTML report
-tasks.jacocoTestReport {
-    reports {
-        xml.required.set(false)
-        csv.required.set(false)
-        html.outputLocation.set(file("$buildDir/reports/jacoco"))
+    tasks.test {
+        useJUnitPlatform()
+        testLogging {
+            events("passed", "skipped", "failed")
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+            showStandardStreams = true
+        }
     }
-}
 
-// Always run the jacoco test report after testing.
-tasks["test"].finalizedBy(tasks["jacocoTestReport"])
+    tasks.dokkaHtml.configure {
+        outputDirectory.set(buildDir.resolve("javadoc"))
+    }
+
+    // Always build documentation
+    tasks["build"].finalizedBy(tasks["dokkaHtml"])
+
+    // Configure jacoco (code coverage) to generate an HTML report
+    tasks.jacocoTestReport {
+        reports {
+            xml.required.set(false)
+            csv.required.set(false)
+            html.outputLocation.set(file("$buildDir/reports/jacoco"))
+        }
+    }
+
+    // Always run the jacoco test report after testing.
+    tasks["test"].finalizedBy(tasks["jacocoTestReport"])
+}
 
 publishing {
     publications {

--- a/codegen-core/build.gradle.kts
+++ b/codegen-core/build.gradle.kts
@@ -4,12 +4,10 @@
  */
 
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.jetbrains.dokka.gradle.DokkaTask
 import java.io.ByteArrayOutputStream
 
 plugins {
     kotlin("jvm")
-    id("org.jetbrains.dokka") apply false
     jacoco
     `maven-publish`
 }
@@ -101,8 +99,6 @@ val isTestingEnabled: String by project
 if (isTestingEnabled.toBoolean()) {
     val kotestVersion: String by project
 
-    apply(plugin = "org.jetbrains.dokka")
-
     dependencies {
         runtimeOnly(project(":rust-runtime"))
         testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
@@ -124,13 +120,6 @@ if (isTestingEnabled.toBoolean()) {
             showStandardStreams = true
         }
     }
-
-    tasks.named<DokkaTask>("dokkaHtml") {
-        outputDirectory.set(buildDir.resolve("javadoc"))
-    }
-
-    // Always build documentation
-    tasks["build"].finalizedBy(tasks["dokkaHtml"])
 
     // Configure jacoco (code coverage) to generate an HTML report
     tasks.jacocoTestReport {

--- a/codegen-server/build.gradle.kts
+++ b/codegen-server/build.gradle.kts
@@ -21,19 +21,15 @@ group = "software.amazon.smithy.rust.codegen.server.smithy"
 version = "0.1.0"
 
 val smithyVersion: String by project
-val kotestVersion: String by project
 
 dependencies {
     implementation(project(":codegen-core"))
     implementation(project(":codegen-client"))
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
 }
 
 tasks.compileKotlin { kotlinOptions.jvmTarget = "1.8" }
-tasks.compileTestKotlin { kotlinOptions.jvmTarget = "1.8" }
 
 // Reusable license copySpec
 val licenseSpec = copySpec {
@@ -55,15 +51,27 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.getByName("main").allSource)
 }
 
-tasks.test {
-    useJUnitPlatform()
-    testLogging {
-        events("passed", "skipped", "failed")
-        exceptionFormat = TestExceptionFormat.FULL
-        showCauses = true
-        showExceptions = true
-        showStackTraces = true
-        showStandardStreams = true
+val isTestingEnabled: String by project
+if (isTestingEnabled.toBoolean()) {
+    val kotestVersion: String by project
+
+    dependencies {
+        testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
+        testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    }
+
+    tasks.compileTestKotlin { kotlinOptions.jvmTarget = "1.8" }
+
+    tasks.test {
+        useJUnitPlatform()
+        testLogging {
+            events("passed", "skipped", "failed")
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+            showStandardStreams = true
+        }
     }
 }
 

--- a/codegen-server/python/build.gradle.kts
+++ b/codegen-server/python/build.gradle.kts
@@ -21,7 +21,6 @@ group = "software.amazon.smithy.rust.codegen.server.python.smithy"
 version = "0.1.0"
 
 val smithyVersion: String by project
-val kotestVersion: String by project
 
 dependencies {
     implementation(project(":codegen-core"))
@@ -29,12 +28,9 @@ dependencies {
     implementation(project(":codegen-server"))
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
     implementation("software.amazon.smithy:smithy-protocol-test-traits:$smithyVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
-    testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
 }
 
 tasks.compileKotlin { kotlinOptions.jvmTarget = "1.8" }
-tasks.compileTestKotlin { kotlinOptions.jvmTarget = "1.8" }
 
 // Reusable license copySpec
 val licenseSpec = copySpec {
@@ -56,15 +52,27 @@ val sourcesJar by tasks.creating(Jar::class) {
     from(sourceSets.getByName("main").allSource)
 }
 
-tasks.test {
-    useJUnitPlatform()
-    testLogging {
-        events("passed", "skipped", "failed")
-        exceptionFormat = TestExceptionFormat.FULL
-        showCauses = true
-        showExceptions = true
-        showStackTraces = true
-        showStandardStreams = true
+val isTestingEnabled: String by project
+if (isTestingEnabled.toBoolean()) {
+    val kotestVersion: String by project
+
+    dependencies {
+        testImplementation("org.junit.jupiter:junit-jupiter:5.6.1")
+        testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion")
+    }
+
+    tasks.compileTestKotlin { kotlinOptions.jvmTarget = "1.8" }
+
+    tasks.test {
+        useJUnitPlatform()
+        testLogging {
+            events("passed", "skipped", "failed")
+            exceptionFormat = TestExceptionFormat.FULL
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+            showStandardStreams = true
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,8 @@ kotlinVersion=1.6.21
 # testing/utility
 ktlintVersion=0.46.1
 kotestVersion=5.2.3
+# Avoid registering dependencies/plugins/tasks that are only used for testing purposes
+isTestingEnabled=true
 
 # TODO(https://github.com/awslabs/smithy-rs/issues/1068): Once doc normalization
 # is completed, warnings can be prohibited in rustdoc.


### PR DESCRIPTION
Feature-flag all testing-related tasks.
Remove `dokka` in order to have no test-specific third-party dependency.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
