### PR TITLE
Fix codegen doc link

### DIFF
--- a/design/src/smithy/overview.md
+++ b/design/src/smithy/overview.md
@@ -26,4 +26,4 @@ Smithy introduces a few concepts that are defined here:
 
 4. Generators: A Generator, e.g. `StructureGenerator`, `UnionGenerator` generates more complex Rust code from a Smithy model. Protocol generators pull these individual tools together to generate code for an entire service / protocol.
 
-A developer's view of code generation can be found in [this document](../docs/code_generation.md).
+A developer's view of code generation can be found in [this document](../server/code_generation.md).


### PR DESCRIPTION
## Motivation and Context
Fix broken link in design docs

## Description
Fix code generation link in Smithy overview doc page.

## Testing
Followed README in `/design/`:
```
cargo install mdbook
cargo install mdbook-mermaid
mdbook serve &
open http://localhost:3000
```
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
