### PR TITLE
Extract SdkConfig parts into decorators

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -38,6 +38,7 @@ val DECORATORS: List<ClientCodegenDecorator> = listOf(
     HttpConnectorDecorator(),
     AwsEndpointsStdLib(),
     AddFIPSDualStackDecorator(),
+    GenericSmithySdkConfigSettings(),
 
     // Service specific decorators
     ApiGatewayDecorator(),

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -16,7 +16,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.customize.DetachedSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
@@ -49,7 +49,7 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
         return baseCustomizations + PubUseCredentials(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
         listOf(
             SdkConfigSection.create { section ->
                 writable {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -16,8 +16,10 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.customize.DetachedSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 
@@ -46,6 +48,15 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
     ): List<LibRsCustomization> {
         return baseCustomizations + PubUseCredentials(codegenContext.runtimeConfig)
     }
+
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> =
+        listOf(
+            SdkConfigSection.create { section ->
+                writable {
+                    rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")
+                }
+            },
+        )
 }
 
 /**
@@ -64,6 +75,7 @@ class CredentialProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomizati
                 """pub(crate) credentials_provider: #{provider}::SharedCredentialsProvider,""",
                 *codegenScope,
             )
+
             ServiceConfig.ConfigImpl -> rustTemplate(
                 """
                 /// Returns the credentials provider.
@@ -73,8 +85,10 @@ class CredentialProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomizati
                 """,
                 *codegenScope,
             )
+
             ServiceConfig.BuilderStruct ->
                 rustTemplate("credentials_provider: Option<#{provider}::SharedCredentialsProvider>,", *codegenScope)
+
             ServiceConfig.BuilderImpl -> {
                 rustTemplate(
                     """

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -21,7 +21,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.DetachedSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
@@ -109,15 +109,15 @@ class RegionDecorator : ClientCodegenDecorator {
         return baseCustomizations.extendIf(usesRegion(codegenContext)) { PubUseRegion(codegenContext.runtimeConfig) }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> {
         return usesRegion(codegenContext).thenSingletonListOf {
             SdkConfigSection.create { section ->
                 {
                     rust(
                         """
-                        ${section.serviceConfigBuilder} = 
+                        ${section.serviceConfigBuilder} =
                              ${section.serviceConfigBuilder}.region(${section.sdkConfig}.region().cloned());
-                             """,
+                        """,
                     )
                 }
             }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -5,28 +5,25 @@
 
 package software.amazon.smithy.rustsdk
 
-import software.amazon.smithy.rulesengine.language.syntax.parameters.Builtins
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
-
 import software.amazon.smithy.rust.codegen.core.rustlang.join
-
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.DetachedSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 
 /**
  * Section enabling linkage between `SdkConfig` and <service>::Config
  */
-object SdkConfigSection : DetachedSection<SdkConfigSection.CopySdkConfigToClientConfig>("SdkConfig") {
+object SdkConfigSection : AdHocSection<SdkConfigSection.CopySdkConfigToClientConfig>("SdkConfig") {
     /**
      * [sdkConfig]: A reference to the SDK config struct
      * [serviceConfigBuilder]: A reference (owned) to the `<service>::config::Builder` struct.
@@ -47,7 +44,7 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
     override val name: String = "GenericSmithySdkConfigSettings"
     override val order: Byte = 0
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
         listOf(
             SdkConfigSection.create { section ->
                 writable {
@@ -85,7 +82,6 @@ class SdkConfigDecorator : ClientCodegenDecorator {
             "SdkConfig" to AwsRuntimeType.awsTypes(codegenContext.runtimeConfig).resolve("sdk_config::SdkConfig"),
         )
         rustCrate.withModule(RustModule.Config) {
-            // !!NOTE!! As more items are added to aws_types::SdkConfig, use them here to configure the config builder
             rustTemplate(
                 """
                 impl From<&#{SdkConfig}> for Builder {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -50,9 +50,13 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
                 writable {
                     rust(
                         """
+                        // resiliency
                         ${section.serviceConfigBuilder}.set_retry_config(${section.sdkConfig}.retry_config().cloned());
                         ${section.serviceConfigBuilder}.set_timeout_config(${section.sdkConfig}.timeout_config().cloned());
                         ${section.serviceConfigBuilder}.set_sleep_impl(${section.sdkConfig}.sleep_impl());
+
+                        ${section.serviceConfigBuilder}.set_http_connector(${section.sdkConfig}.http_connector().cloned());
+
                         """,
                     )
                 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -16,8 +16,10 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.customize.DetachedSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -53,105 +55,123 @@ class UserAgentDecorator : ClientCodegenDecorator {
     ): List<OperationCustomization> {
         return baseCustomizations + UserAgentFeature(codegenContext.runtimeConfig)
     }
-}
 
-/**
- * Adds a static `API_METADATA` variable to the crate root containing the serviceId & the version of the crate for this individual service
- */
-private class ApiVersionAndPubUse(private val runtimeConfig: RuntimeConfig, serviceTrait: ServiceTrait) :
-    LibRsCustomization() {
-    private val serviceId = serviceTrait.sdkId.lowercase().replace(" ", "")
-    override fun section(section: LibRsSection): Writable = when (section) {
-        is LibRsSection.Body -> writable {
-            // PKG_VERSION comes from CrateVersionGenerator
-            rust(
-                "static API_METADATA: #1T::ApiMetadata = #1T::ApiMetadata::new(${serviceId.dq()}, PKG_VERSION);",
-                AwsRuntimeType.awsHttp(runtimeConfig).resolve("user_agent"),
-            )
-
-            // Re-export the app name so that it can be specified in config programmatically without an explicit dependency
-            rustTemplate("pub use #{AppName};", "AppName" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("app_name::AppName"))
-        }
-        else -> emptySection
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> {
+        return listOf(
+            SdkConfigSection.create { section ->
+                writable { rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());") }
+            },
+        )
     }
-}
 
-private class UserAgentFeature(private val runtimeConfig: RuntimeConfig) : OperationCustomization() {
-    override fun section(section: OperationSection): Writable = when (section) {
-        is OperationSection.MutateRequest -> writable {
-            rustTemplate(
-                """
-                let mut user_agent = #{ua_module}::AwsUserAgent::new_from_environment(
-                    #{Env}::real(),
-                    crate::API_METADATA.clone(),
-                );
-                if let Some(app_name) = _config.app_name() {
-                    user_agent = user_agent.with_app_name(app_name.clone());
-                }
-                ${section.request}.properties_mut().insert(user_agent);
-                """,
-                "ua_module" to AwsRuntimeType.awsHttp(runtimeConfig).resolve("user_agent"),
-                "Env" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("os_shim_internal::Env"),
-            )
-        }
-        else -> emptySection
-    }
-}
+    /**
+     * Adds a static `API_METADATA` variable to the crate root containing the serviceId & the version of the crate for this individual service
+     */
+    private class ApiVersionAndPubUse(private val runtimeConfig: RuntimeConfig, serviceTrait: ServiceTrait) :
+        LibRsCustomization() {
+        private val serviceId = serviceTrait.sdkId.lowercase().replace(" ", "")
+        override fun section(section: LibRsSection): Writable = when (section) {
+            is LibRsSection.Body -> writable {
+                // PKG_VERSION comes from CrateVersionGenerator
+                rust(
+                    "static API_METADATA: #1T::ApiMetadata = #1T::ApiMetadata::new(${serviceId.dq()}, PKG_VERSION);",
+                    AwsRuntimeType.awsHttp(runtimeConfig).resolve("user_agent"),
+                )
 
-private class AppNameCustomization(runtimeConfig: RuntimeConfig) : ConfigCustomization() {
-    private val codegenScope = arrayOf(
-        "AppName" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("app_name::AppName"),
-    )
-
-    override fun section(section: ServiceConfig): Writable =
-        when (section) {
-            is ServiceConfig.BuilderStruct -> writable {
-                rustTemplate("app_name: Option<#{AppName}>,", *codegenScope)
-            }
-            is ServiceConfig.BuilderImpl -> writable {
+                // Re-export the app name so that it can be specified in config programmatically without an explicit dependency
                 rustTemplate(
-                    """
-                    /// Sets the name of the app that is using the client.
-                    ///
-                    /// This _optional_ name is used to identify the application in the user agent that
-                    /// gets sent along with requests.
-                    pub fn app_name(mut self, app_name: #{AppName}) -> Self {
-                        self.set_app_name(Some(app_name));
-                        self
-                    }
-
-                    /// Sets the name of the app that is using the client.
-                    ///
-                    /// This _optional_ name is used to identify the application in the user agent that
-                    /// gets sent along with requests.
-                    pub fn set_app_name(&mut self, app_name: Option<#{AppName}>) -> &mut Self {
-                        self.app_name = app_name;
-                        self
-                    }
-                    """,
-                    *codegenScope,
+                    "pub use #{AppName};",
+                    "AppName" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("app_name::AppName"),
                 )
             }
-            is ServiceConfig.BuilderBuild -> writable {
-                rust("app_name: self.app_name,")
-            }
-            is ServiceConfig.ConfigStruct -> writable {
-                rustTemplate("app_name: Option<#{AppName}>,", *codegenScope)
-            }
-            is ServiceConfig.ConfigImpl -> writable {
-                rustTemplate(
-                    """
-                    /// Returns the name of the app that is using the client, if it was provided.
-                    ///
-                    /// This _optional_ name is used to identify the application in the user agent that
-                    /// gets sent along with requests.
-                    pub fn app_name(&self) -> Option<&#{AppName}> {
-                        self.app_name.as_ref()
-                    }
-                    """,
-                    *codegenScope,
-                )
-            }
+
             else -> emptySection
         }
+    }
+
+    private class UserAgentFeature(private val runtimeConfig: RuntimeConfig) : OperationCustomization() {
+        override fun section(section: OperationSection): Writable = when (section) {
+            is OperationSection.MutateRequest -> writable {
+                rustTemplate(
+                    """
+                    let mut user_agent = #{ua_module}::AwsUserAgent::new_from_environment(
+                        #{Env}::real(),
+                        crate::API_METADATA.clone(),
+                    );
+                    if let Some(app_name) = _config.app_name() {
+                        user_agent = user_agent.with_app_name(app_name.clone());
+                    }
+                    ${section.request}.properties_mut().insert(user_agent);
+                    """,
+                    "ua_module" to AwsRuntimeType.awsHttp(runtimeConfig).resolve("user_agent"),
+                    "Env" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("os_shim_internal::Env"),
+                )
+            }
+
+            else -> emptySection
+        }
+    }
+
+    private class AppNameCustomization(runtimeConfig: RuntimeConfig) : ConfigCustomization() {
+        private val codegenScope = arrayOf(
+            "AppName" to AwsRuntimeType.awsTypes(runtimeConfig).resolve("app_name::AppName"),
+        )
+
+        override fun section(section: ServiceConfig): Writable =
+            when (section) {
+                is ServiceConfig.BuilderStruct -> writable {
+                    rustTemplate("app_name: Option<#{AppName}>,", *codegenScope)
+                }
+
+                is ServiceConfig.BuilderImpl -> writable {
+                    rustTemplate(
+                        """
+                        /// Sets the name of the app that is using the client.
+                        ///
+                        /// This _optional_ name is used to identify the application in the user agent that
+                        /// gets sent along with requests.
+                        pub fn app_name(mut self, app_name: #{AppName}) -> Self {
+                            self.set_app_name(Some(app_name));
+                            self
+                        }
+
+                        /// Sets the name of the app that is using the client.
+                        ///
+                        /// This _optional_ name is used to identify the application in the user agent that
+                        /// gets sent along with requests.
+                        pub fn set_app_name(&mut self, app_name: Option<#{AppName}>) -> &mut Self {
+                            self.app_name = app_name;
+                            self
+                        }
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                is ServiceConfig.BuilderBuild -> writable {
+                    rust("app_name: self.app_name,")
+                }
+
+                is ServiceConfig.ConfigStruct -> writable {
+                    rustTemplate("app_name: Option<#{AppName}>,", *codegenScope)
+                }
+
+                is ServiceConfig.ConfigImpl -> writable {
+                    rustTemplate(
+                        """
+                        /// Returns the name of the app that is using the client, if it was provided.
+                        ///
+                        /// This _optional_ name is used to identify the application in the user agent that
+                        /// gets sent along with requests.
+                        pub fn app_name(&self) -> Option<&#{AppName}> {
+                            self.app_name.as_ref()
+                        }
+                        """,
+                        *codegenScope,
+                    )
+                }
+
+                else -> emptySection
+            }
+    }
 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -16,7 +16,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.DetachedSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
@@ -56,7 +56,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
         return baseCustomizations + UserAgentFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> {
         return listOf(
             SdkConfigSection.create { section ->
                 writable { rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());") }

--- a/aws/sdk/integration-tests/dynamodb/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/endpoints.rs
@@ -19,7 +19,8 @@ async fn endpoints_can_be_overridden_globally() {
         .credentials_provider(Credentials::new("asdf", "asdf", None, None, "test"))
         .build();
     let svc = aws_sdk_dynamodb::Client::from_conf(conf);
-    let _ = svc.list_tables().send().await;
+    // dbg to see why the request failed if this test is failing
+    let _ = dbg!(svc.list_tables().send().await);
     assert_eq!(
         request.expect_request().uri(),
         &Uri::from_static("http://localhost:8000")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -66,7 +66,7 @@ interface CoreCodegenDecorator<CodegenContext> {
     /**
      * Extra sections allow one decorator to influence another. This is intended to be used by querying the `rootDecorator`
      */
-    fun extraSections(codegenContext: CodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> = listOf()
+    fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> = listOf()
 }
 
 /**
@@ -99,7 +99,7 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
             decorator.transformModel(otherModel.expectShape(service.id, ServiceShape::class.java), otherModel)
         }
 
-    final override fun extraSections(codegenContext: CodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> =
+    final override fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.core.smithy.customize
 import software.amazon.smithy.build.PluginContext
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.ManifestCustomizations
@@ -61,6 +62,11 @@ interface CoreCodegenDecorator<CodegenContext> {
         codegenContext: CodegenContext,
         baseCustomizations: List<LibRsCustomization>,
     ): List<LibRsCustomization> = baseCustomizations
+
+    /**
+     * Extra sections allow one decorator to influence another. This is intended to be used by querying the `rootDecorator`
+     */
+    fun extraSections(codegenContext: CodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> = listOf()
 }
 
 /**
@@ -92,6 +98,9 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
         combineCustomizations(model) { decorator, otherModel ->
             decorator.transformModel(otherModel.expectShape(service.id, ServiceShape::class.java), otherModel)
         }
+
+    final override fun extraSections(codegenContext: CodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> =
+        addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
     /**
      * Combines customizations from multiple ordered codegen decorators.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
@@ -24,6 +24,19 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 abstract class Section(val name: String)
 
 /**
+ * Detatched section abstraction to allow adhoc sections to be created. By using the `.writer` method, a instantiation
+ * of this section can be easily created.
+ */
+abstract class DetachedSection<T : Section>(val name: String) {
+    /**
+     * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
+     */
+    fun create(w: (T) -> Writable): Pair<DetachedSection<*>, (Section) -> Writable> = this to { s: Section ->
+        w((s as T))
+    }
+}
+
+/**
  * A named section generator allows customization via a predefined set of named sections.
  *
  * Implementors MUST override section and use a `when` clause to handle each section individually

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
@@ -27,11 +27,11 @@ abstract class Section(val name: String)
  * Detatched section abstraction to allow adhoc sections to be created. By using the `.writer` method, a instantiation
  * of this section can be easily created.
  */
-abstract class DetachedSection<T : Section>(val name: String) {
+abstract class AdHocSection<T : Section>(val name: String) {
     /**
      * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
      */
-    fun create(w: (T) -> Writable): Pair<DetachedSection<*>, (Section) -> Writable> = this to { s: Section ->
+    fun create(w: (T) -> Writable): Pair<AdHocSection<*>, (Section) -> Writable> = this to { s: Section ->
         w((s as T))
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/LetIf.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/util/LetIf.kt
@@ -18,3 +18,9 @@ fun <T> List<T>.extendIf(condition: Boolean, f: () -> T) = if (condition) {
 } else {
     this
 }
+
+fun <T> Boolean.thenSingletonListOf(f: () -> T): List<T> = if (this) {
+    listOf(f())
+} else {
+    listOf()
+}


### PR DESCRIPTION
## Motivation and Context
The code currently has this awkward comment:
```
// !!NOTE!! As more items are added to aws_types::SdkConfig, use them here to configure the config builder
```
this gets more problematic as things can be conditionally included—we don't want to keep all that logic in SdkConfigDecorator.

## Description
<!--- Describe your changes in detail -->
Create `extraSections` as a customization option to allow open-ended customization sections to be defined.

This works in two parts:
1. A `DetachedSection` sets up the "type" of the customization. This is parameterized in terms of the interior section that will be used.
```kotlin
/**
 * Section enabling linkage between `SdkConfig` and <service>::Config
 */
object SdkConfigSection : DetachedSection<SdkConfigSection.CopySdkConfigToClientConfig>("SdkConfig") {
    /**
     * [sdkConfig]: A reference to the SDK config struct
     * [serviceConfigBuilder]: A reference (owned) to the `<service>::config::Builder` struct.
     *
     * Each invocation of this section MUST be a complete statement (ending with a semicolon), e.g:
     * ```
     * rust("${section.serviceConfigBuilder}.set_foo(${section.sdkConfig}.foo());")
     * ```
     */
    data class CopySdkConfigToClientConfig(val sdkConfig: String, val serviceConfigBuilder: String) :
        Section("CopyConfig")
}
```
2. Customizations define `DetachedSection<T> -> T -> Writable` — there is a helper method to set up the signature properly:

```kotlin
    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<DetachedSection<*>, (Section) -> Writable>> =
        listOf(
            SdkConfigSection.create { section ->
                writable {
                    rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")
                }
            },
        )
}
```

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
