### PR TITLE
update: increase alternative-async-runtime.rs grace period to 150ms from 100ms

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
+++ b/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
@@ -117,8 +117,8 @@ async fn timeout_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std
         .unwrap_err();
 
     assert_eq!("TimeoutError(TimeoutError { source: RequestTimeoutError { kind: \"operation timeout (all attempts including retries)\", duration: 500ms } })", format!("{:?}", err));
-    // Assert 500ms have passed with a 10ms margin of error
-    assert_elapsed!(now, Duration::from_millis(500), Duration::from_millis(100));
+    // Assert 500ms have passed with a 150ms margin of error
+    assert_elapsed!(now, Duration::from_millis(500), Duration::from_millis(150));
 
     Ok(())
 }


### PR DESCRIPTION
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
