### PR TITLE
Add a test helper for creating a dummy Credentials

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -55,6 +55,7 @@ arbitrary = "=1.1.3" # 1.1.4 requires Rust 1.63 to compile
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
+aws-credential-types = { path = "../../sdk/build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-smithy-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
 
 # used for a usage example

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -206,7 +206,7 @@ mod test {
         let mut base = HashMap::new();
         base.insert(
             "Environment".into(),
-            Arc::new(Credentials::new("key", "secret", None, None, "test")) as _,
+            Arc::new(Credentials::for_tests()) as _,
         );
         let provider = NamedProviderFactory::new(base);
         assert!(provider.provider("environment").is_some());

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -321,13 +321,7 @@ mod test {
             .configure(&provider_conf)
             .region(Region::new("us-east-1"))
             .session_length(Duration::from_secs(1234567))
-            .build(SharedCredentialsProvider::new(Credentials::new(
-                "base",
-                "basesecret",
-                Some("token".to_string()),
-                None,
-                "inner",
-            )));
+            .build(SharedCredentialsProvider::new(Credentials::for_tests()));
         let _ = provider.provide_credentials().await;
         let req = request.expect_request();
         let str_body = std::str::from_utf8(req.body().bytes().unwrap()).unwrap();
@@ -349,13 +343,7 @@ mod test {
         let provider = AssumeRoleProvider::builder("myrole")
             .configure(&provider_conf)
             .region(Region::new("us-east-1"))
-            .build(SharedCredentialsProvider::new(Credentials::new(
-                "base",
-                "basesecret",
-                Some("token".to_string()),
-                None,
-                "inner",
-            )));
+            .build(SharedCredentialsProvider::new(Credentials::for_tests()));
         let creds_first = provider
             .provide_credentials()
             .await

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
 hardcoded-credentials = []
+test-util = []
 
 [dependencies]
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }

--- a/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
+++ b/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
@@ -140,6 +140,21 @@ impl Credentials {
         )
     }
 
+    /// Creates a test `Credentials`.
+    ///
+    /// Marked as `#[doc(hidden)]` due to the usage limited to testing.
+    /// TODO(https://github.com/rust-lang/cargo/issues/2911): Consider using an auto-activated feature for testing
+    #[doc(hidden)]
+    pub fn for_tests() -> Self {
+        Self::new(
+            "ANOTREAL",
+            "notrealrnrELgWzOk3IfjzDKtFBhDby",
+            Some("notarealsessiontoken".to_string()),
+            None,
+            "test",
+        )
+    }
+
     /// Returns the access key ID.
     pub fn access_key_id(&self) -> &str {
         &self.0.access_key_id

--- a/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
+++ b/aws/rust-runtime/aws-credential-types/src/credentials_impl.rs
@@ -141,10 +141,7 @@ impl Credentials {
     }
 
     /// Creates a test `Credentials`.
-    ///
-    /// Marked as `#[doc(hidden)]` due to the usage limited to testing.
-    /// TODO(https://github.com/rust-lang/cargo/issues/2911): Consider using an auto-activated feature for testing
-    #[doc(hidden)]
+    #[cfg(feature = "test-util")]
     pub fn for_tests() -> Self {
         Self::new(
             "ANOTREAL",

--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -22,6 +22,7 @@ pin-project-lite = "0.2.9"
 
 [dev-dependencies]
 async-trait = "0.1.50"
+aws-credential-types = { path = "../aws-credential-types", features = ["test-util"] }
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features = ["rt-tokio"] }
 aws-smithy-checksums = { path = "../../../rust-runtime/aws-smithy-checksums" }
 aws-smithy-protocol-test = { path = "../../../rust-runtime/aws-smithy-protocol-test" }

--- a/aws/rust-runtime/aws-http/src/auth.rs
+++ b/aws/rust-runtime/aws-http/src/auth.rs
@@ -188,7 +188,7 @@ mod tests {
         let mut req = operation::Request::new(http::Request::new(SdkBody::from("some body")));
         set_provider(
             &mut req.properties_mut(),
-            SharedCredentialsProvider::new(Credentials::new("test", "test", None, None, "test")),
+            SharedCredentialsProvider::new(Credentials::for_tests()),
         );
         let req = CredentialsStage::new()
             .apply(req)

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -35,6 +35,7 @@ tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
+aws-credential-types = { path = "../aws-credential-types", features = ["test-util"] }
 aws-smithy-client = { path = "../../../rust-runtime/aws-smithy-client", features = ["test-util"] }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http", features = ["rt-tokio"] }
 tempfile = "3.2.0"

--- a/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
+++ b/aws/rust-runtime/aws-inlineable/tests/middleware_e2e_test.rs
@@ -87,13 +87,7 @@ fn test_operation() -> Operation<TestOperationParser, AwsResponseRetryClassifier
         ));
         aws_http::auth::set_provider(
             conf,
-            SharedCredentialsProvider::new(Credentials::new(
-                "access_key",
-                "secret_key",
-                None,
-                None,
-                "test",
-            )),
+            SharedCredentialsProvider::new(Credentials::for_tests()),
         );
         conf.insert(SigningRegion::from_static("test-region"));
         conf.insert(OperationSigningConfig::default_config());
@@ -123,8 +117,9 @@ async fn e2e_test() {
     let expected_req = http::Request::builder()
         .header(USER_AGENT, "aws-sdk-rust/0.123.test os/windows/XPSP3 lang/rust/1.50.0")
         .header("x-amz-user-agent", "aws-sdk-rust/0.123.test api/test-service/0.123 os/windows/XPSP3 lang/rust/1.50.0")
-        .header(AUTHORIZATION, "AWS4-HMAC-SHA256 Credential=access_key/20210215/test-region/test-service-signing/aws4_request, SignedHeaders=host;x-amz-date;x-amz-user-agent, Signature=da249491d7fe3da22c2e09cbf910f37aa5b079a3cedceff8403d0b18a7bfab75")
+        .header(AUTHORIZATION, "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210215/test-region/test-service-signing/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=6d477055738c4e634c2451b9fc378b6ff2f967d37657c3dd50a1b6a735576960")
         .header("x-amz-date", "20210215T184017Z")
+        .header("x-amz-security-token", "notarealsessiontoken")
         .uri(Uri::from_static("https://test-service.test-region.amazonaws.com/"))
         .body(SdkBody::from("request body")).unwrap();
     let events = vec![(
@@ -149,8 +144,9 @@ async fn test_operation_metadata_is_available_to_middlewares() {
         http::Request::builder()
             .header(USER_AGENT, "aws-sdk-rust/0.123.test os/windows/XPSP3 lang/rust/1.50.0")
             .header("x-amz-user-agent", "aws-sdk-rust/0.123.test api/test-service/0.123 os/windows/XPSP3 lang/rust/1.50.0")
-            .header(AUTHORIZATION, "AWS4-HMAC-SHA256 Credential=access_key/20210215/test-region/test-service-signing/aws4_request, SignedHeaders=host;x-amz-date;x-amz-user-agent, Signature=da249491d7fe3da22c2e09cbf910f37aa5b079a3cedceff8403d0b18a7bfab75")
+            .header(AUTHORIZATION, "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210215/test-region/test-service-signing/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=6d477055738c4e634c2451b9fc378b6ff2f967d37657c3dd50a1b6a735576960")
             .header("x-amz-date", "20210215T184017Z")
+            .header("x-amz-security-token", "notarealsessiontoken")
             .uri(Uri::from_static("https://test-service.test-region.amazonaws.com/"))
             .body(SdkBody::from("request body")).unwrap(),
         http::Response::builder()

--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -20,6 +20,7 @@ http = "0.2.2"
 tracing = "0.1"
 
 [dev-dependencies]
+aws-credential-types = { path = "../aws-credential-types", features = ["test-util"] }
 aws-endpoint = { path = "../aws-endpoint" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types"}
 tracing-test = "0.2.1"

--- a/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
@@ -106,7 +106,7 @@ mod tests {
         properties.insert(region.clone());
         properties.insert(UNIX_EPOCH + Duration::new(1611160427, 0));
         properties.insert(SigningService::from_static("transcribe"));
-        properties.insert(Credentials::new("AKIAfoo", "bar", None, None, "test"));
+        properties.insert(Credentials::for_tests());
         properties.insert(SigningRegion::from(region));
         properties.insert(Signature::new("initial-signature".into()));
 

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -220,7 +220,7 @@ mod test {
                 properties.insert(UNIX_EPOCH + Duration::new(1611160427, 0));
                 properties.insert(SigningService::from_static("kinesis"));
                 properties.insert(OperationSigningConfig::default_config());
-                properties.insert(Credentials::new("AKIAfoo", "bar", None, None, "test"));
+                properties.insert(Credentials::for_tests());
                 properties.insert(SigningRegion::from(region));
                 Result::<_, Infallible>::Ok(req)
             })
@@ -270,6 +270,7 @@ mod test {
                 .apply(req.try_clone().expect("can clone"))
                 .expect_err("no cred provider"),
         );
+        // use `new` instead of `for_tests` because the presence of a session_token will render `auth_header` below `Sensitive`.
         req.properties_mut()
             .insert(Credentials::new("AKIAfoo", "bar", None, None, "test"));
         let req = signer.apply(req).expect("signing succeeded");

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -270,9 +270,7 @@ mod test {
                 .apply(req.try_clone().expect("can clone"))
                 .expect_err("no cred provider"),
         );
-        // use `new` instead of `for_tests` because the presence of a session_token will render `auth_header` below `Sensitive`.
-        req.properties_mut()
-            .insert(Credentials::new("AKIAfoo", "bar", None, None, "test"));
+        req.properties_mut().insert(Credentials::for_tests());
         let req = signer.apply(req).expect("signing succeeded");
         // make sure we got the correct error types in any order
         assert!(errs.iter().all(|el| matches!(
@@ -293,7 +291,9 @@ mod test {
         let auth_header = req
             .headers()
             .get(AUTHORIZATION)
-            .expect("auth header must be present");
-        assert_eq!(auth_header, "AWS4-HMAC-SHA256 Credential=AKIAfoo/20210120/us-east-1/kinesis/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=af71a409f0229dfd6e88409cd1b11f5c2803868d6869888e53bbf9ee12a97ea0");
+            .expect("auth header must be present")
+            .to_str()
+            .unwrap();
+        assert_eq!(auth_header, "AWS4-HMAC-SHA256 Credential=ANOTREAL/20210120/us-east-1/kinesis/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=228edaefb06378ac8d050252ea18a219da66117dd72759f4d1d60f02ebc3db64");
     }
 }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointsCredentialsTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointsCredentialsTest.kt
@@ -88,7 +88,7 @@ class EndpointsCredentialsTest {
                         let conf = $moduleName::Config::builder()
                             .http_connector(conn)
                             .region(#{Region}::new("us-west-2"))
-                            .credentials_provider($moduleName::Credentials::new("example", "example", None, None, "example"))
+                            .credentials_provider($moduleName::Credentials::for_tests())
                             .build();
                         let client = $moduleName::Client::from_conf(conf);
                         let _ = client.default_auth().send().await;
@@ -110,7 +110,7 @@ class EndpointsCredentialsTest {
                         let conf = $moduleName::Config::builder()
                             .http_connector(conn)
                             .region(#{Region}::new("us-west-2"))
-                            .credentials_provider($moduleName::Credentials::new("example", "example", None, None, "example"))
+                            .credentials_provider($moduleName::Credentials::for_tests())
                             .build();
                         let client = $moduleName::Client::from_conf(conf);
                         let _ = client.custom_auth().send().await;

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointsCredentialsTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/EndpointsCredentialsTest.kt
@@ -88,7 +88,7 @@ class EndpointsCredentialsTest {
                         let conf = $moduleName::Config::builder()
                             .http_connector(conn)
                             .region(#{Region}::new("us-west-2"))
-                            .credentials_provider($moduleName::Credentials::for_tests())
+                            .credentials_provider(#{Credentials}::for_tests())
                             .build();
                         let client = $moduleName::Client::from_conf(conf);
                         let _ = client.default_auth().send().await;
@@ -98,6 +98,8 @@ class EndpointsCredentialsTest {
                         """,
                         "capture_request" to CargoDependency.smithyClient(context.runtimeConfig)
                             .withFeature("test-util").toType().resolve("test_connection::capture_request"),
+                        "Credentials" to AwsCargoDependency.awsCredentialTypes(context.runtimeConfig)
+                            .withFeature("test-util").toType().resolve("Credentials"),
                         "Region" to AwsRuntimeType.awsTypes(context.runtimeConfig).resolve("region::Region"),
                     )
                 }
@@ -110,7 +112,7 @@ class EndpointsCredentialsTest {
                         let conf = $moduleName::Config::builder()
                             .http_connector(conn)
                             .region(#{Region}::new("us-west-2"))
-                            .credentials_provider($moduleName::Credentials::for_tests())
+                            .credentials_provider(#{Credentials}::for_tests())
                             .build();
                         let client = $moduleName::Client::from_conf(conf);
                         let _ = client.custom_auth().send().await;
@@ -120,6 +122,8 @@ class EndpointsCredentialsTest {
                         """,
                         "capture_request" to CargoDependency.smithyClient(context.runtimeConfig)
                             .withFeature("test-util").toType().resolve("test_connection::capture_request"),
+                        "Credentials" to AwsCargoDependency.awsCredentialTypes(context.runtimeConfig)
+                            .withFeature("test-util").toType().resolve("Credentials"),
                         "Region" to AwsRuntimeType.awsTypes(context.runtimeConfig).resolve("region::Region"),
                     )
                 }

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types" }
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
 aws-sdk-dynamodb = { path = "../../build/aws-sdk/sdk/dynamodb" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/dynamodb/tests/cloning.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/cloning.rs
@@ -12,9 +12,7 @@ use aws_types::region::Region;
 async fn ensure_builders_clone() {
     let shared_config = aws_types::SdkConfig::builder()
         .region(Region::new("us-east-4"))
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "asdf", "asdf", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .build();
     let client = aws_sdk_dynamodb::Client::new(&shared_config);
     let base_query = client.list_tables();

--- a/aws/sdk/integration-tests/dynamodb/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/endpoints.rs
@@ -16,7 +16,7 @@ async fn endpoints_can_be_overridden_globally() {
         .endpoint_url("http://localhost:8000")
         .build();
     let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)
-        .credentials_provider(Credentials::new("asdf", "asdf", None, None, "test"))
+        .credentials_provider(Credentials::for_tests())
         .build();
     let svc = aws_sdk_dynamodb::Client::from_conf(conf);
     let _ = svc.list_tables().send().await;
@@ -34,7 +34,7 @@ async fn endpoints_can_be_overridden_locally() {
         .http_connector(conn)
         .build();
     let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)
-        .credentials_provider(Credentials::new("asdf", "asdf", None, None, "test"))
+        .credentials_provider(Credentials::for_tests())
         .endpoint_url("http://localhost:8000")
         .build();
     let svc = aws_sdk_dynamodb::Client::from_conf(conf);

--- a/aws/sdk/integration-tests/dynamodb/tests/movies.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/movies.rs
@@ -149,13 +149,7 @@ async fn movies_it() {
     let conf = dynamodb::Config::builder()
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
-        .credentials_provider(Credentials::new(
-            "AKNOTREAL",
-            "NOT_A_SECRET",
-            None,
-            None,
-            "test",
-        ))
+        .credentials_provider(Credentials::for_tests())
         .build();
     let client = Client::from_conf(conf);
 

--- a/aws/sdk/integration-tests/dynamodb/tests/paginators.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/paginators.rs
@@ -20,7 +20,7 @@ use aws_types::region::Region;
 fn stub_config(conn: impl Into<HttpConnector>) -> Config {
     Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(Credentials::new("akid", "secret", None, None, "test"))
+        .credentials_provider(Credentials::for_tests())
         .http_connector(conn)
         .build()
 }

--- a/aws/sdk/integration-tests/dynamodb/tests/shared-config.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/shared-config.rs
@@ -14,7 +14,7 @@ async fn shared_config_testbed() {
         .build();
     let (conn, request) = aws_smithy_client::test_connection::capture_request(None);
     let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)
-        .credentials_provider(Credentials::new("asdf", "asdf", None, None, "test"))
+        .credentials_provider(Credentials::for_tests())
         .http_connector(conn)
         .endpoint_url("http://localhost:8000")
         .build();

--- a/aws/sdk/integration-tests/dynamodb/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/timeouts.rs
@@ -30,9 +30,7 @@ async fn api_call_timeout_retries() {
     let conf = SdkConfig::builder()
         .region(Region::new("us-east-2"))
         .http_connector(conn.clone())
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "stub", "stub", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .timeout_config(
             TimeoutConfig::builder()
                 .operation_attempt_timeout(Duration::new(123, 0))
@@ -65,9 +63,7 @@ async fn no_retries_on_operation_timeout() {
     let conf = SdkConfig::builder()
         .region(Region::new("us-east-2"))
         .http_connector(conn.clone())
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "stub", "stub", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .timeout_config(
             TimeoutConfig::builder()
                 .operation_timeout(Duration::new(123, 0))

--- a/aws/sdk/integration-tests/ec2/Cargo.toml
+++ b/aws/sdk/integration-tests/ec2/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-sdk-ec2 = { path = "../../build/aws-sdk/sdk/ec2" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"]}
 tokio = { version = "1.8.4", features = ["full"]}

--- a/aws/sdk/integration-tests/ec2/tests/paginators.rs
+++ b/aws/sdk/integration-tests/ec2/tests/paginators.rs
@@ -12,7 +12,7 @@ use aws_smithy_client::test_connection::TestConnection;
 fn stub_config(conn: impl Into<HttpConnector>) -> Config {
     Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(Credentials::new("akid", "secret", None, None, "test"))
+        .credentials_provider(Credentials::for_tests())
         .http_connector(conn)
         .build()
 }

--- a/aws/sdk/integration-tests/glacier/Cargo.toml
+++ b/aws/sdk/integration-tests/glacier/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
 aws-sdk-glacier = { path = "../../build/aws-sdk/sdk/glacier" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/glacier/tests/custom-headers.rs
+++ b/aws/sdk/integration-tests/glacier/tests/custom-headers.rs
@@ -13,7 +13,7 @@ async fn set_correct_headers() {
     let (conn, handler) = capture_request(None);
     let conf = aws_sdk_glacier::Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(Credentials::new("key", "secret", None, None, "test"))
+        .credentials_provider(Credentials::for_tests())
         .http_connector(conn)
         .build();
 

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-endpoint = { path = "../../build/aws-sdk/sdk/aws-endpoint"}
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
 aws-sdk-iam = { path = "../../build/aws-sdk/sdk/iam" }

--- a/aws/sdk/integration-tests/iam/tests/resolve-global-endpoint.rs
+++ b/aws/sdk/integration-tests/iam/tests/resolve-global-endpoint.rs
@@ -14,7 +14,7 @@ async fn correct_endpoint_resolver() {
     let (conn, request) = capture_request(None);
     let conf = aws_sdk_iam::Config::builder()
         .region(Region::from_static("iam-fips"))
-        .credentials_provider(Credentials::new("asdf", "asdf", None, None, "tests"))
+        .credentials_provider(Credentials::for_tests())
         .http_connector(conn)
         .build();
     let client = aws_sdk_iam::Client::from_conf(conf);

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
 aws-sdk-kms = { path = "../../build/aws-sdk/sdk/kms" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/kms/tests/integration.rs
+++ b/aws/sdk/integration-tests/kms/tests/integration.rs
@@ -25,13 +25,6 @@ type Client<C> = CoreClient<C, DefaultMiddleware>;
 /// Validate that for CN regions we set the URI correctly
 #[tokio::test]
 async fn generate_random_cn() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
     let conn = TestConnection::new(vec![(
         http::Request::builder()
             .uri(Uri::from_static("https://kms.cn-north-1.amazonaws.com.cn/"))
@@ -42,7 +35,7 @@ async fn generate_random_cn() {
     ]);
     let conf = Config::builder()
         .region(Region::new("cn-north-1"))
-        .credentials_provider(creds)
+        .credentials_provider(Credentials::for_tests())
         .http_connector(conn.clone())
         .build();
     let client = kms::Client::from_conf(conf);
@@ -59,13 +52,6 @@ async fn generate_random_cn() {
 
 #[tokio::test]
 async fn generate_random() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
     let conn = TestConnection::new(vec![(
         http::Request::builder()
             .header("content-type", "application/x-amz-json-1.1")
@@ -85,7 +71,7 @@ async fn generate_random() {
     let client = Client::new(conn.clone());
     let conf = Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(creds)
+        .credentials_provider(Credentials::for_tests())
         .build();
     let mut op = GenerateRandom::builder()
         .number_of_bytes(64)
@@ -113,13 +99,6 @@ async fn generate_random() {
 
 #[tokio::test]
 async fn generate_random_malformed_response() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
     let conn = TestConnection::new(vec![(
         http::Request::builder().body(SdkBody::from(r#"{"NumberOfBytes":64}"#)).unwrap(),
         http::Response::builder()
@@ -130,7 +109,7 @@ async fn generate_random_malformed_response() {
     let client = Client::new(conn.clone());
     let conf = Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(creds)
+        .credentials_provider(Credentials::for_tests())
         .build();
     let op = GenerateRandom::builder()
         .number_of_bytes(64)
@@ -144,16 +123,9 @@ async fn generate_random_malformed_response() {
 
 #[tokio::test]
 async fn generate_random_keystore_not_found() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
     let conf = Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(creds)
+        .credentials_provider(Credentials::for_tests())
         .build();
     let conn = TestConnection::new(vec![(
         http::Request::builder()

--- a/aws/sdk/integration-tests/polly/Cargo.toml
+++ b/aws/sdk/integration-tests/polly/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http"}
 aws-sdk-polly = { path = "../../build/aws-sdk/sdk/polly" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/polly/tests/presigning.rs
+++ b/aws/sdk/integration-tests/polly/tests/presigning.rs
@@ -11,15 +11,8 @@ use std::time::{Duration, SystemTime};
 
 #[tokio::test]
 async fn test_presigning() -> Result<(), Box<dyn Error>> {
-    let creds = polly::Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
     let config = polly::Config::builder()
-        .credentials_provider(creds)
+        .credentials_provider(polly::Credentials::for_tests())
         .region(polly::Region::new("us-east-1"))
         .build();
 

--- a/aws/sdk/integration-tests/qldbsession/Cargo.toml
+++ b/aws/sdk/integration-tests/qldbsession/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
 aws-sdk-qldbsession = { path = "../../build/aws-sdk/sdk/qldbsession" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/qldbsession/tests/integration.rs
+++ b/aws/sdk/integration-tests/qldbsession/tests/integration.rs
@@ -23,13 +23,7 @@ pub type Client<C> = CoreClient<C, DefaultMiddleware>;
 
 #[tokio::test]
 async fn signv4_use_correct_service_name() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
+    let creds = Credentials::for_tests();
     let conn = TestConnection::new(vec![(
         http::Request::builder()
             .header("content-type", "application/x-amz-json-1.0")

--- a/aws/sdk/integration-tests/qldbsession/tests/integration.rs
+++ b/aws/sdk/integration-tests/qldbsession/tests/integration.rs
@@ -23,7 +23,6 @@ pub type Client<C> = CoreClient<C, DefaultMiddleware>;
 
 #[tokio::test]
 async fn signv4_use_correct_service_name() {
-    let creds = Credentials::for_tests();
     let conn = TestConnection::new(vec![(
         http::Request::builder()
             .header("content-type", "application/x-amz-json-1.0")
@@ -44,7 +43,7 @@ async fn signv4_use_correct_service_name() {
     let client = Client::new(conn.clone());
     let conf = Config::builder()
         .region(Region::new("us-east-1"))
-        .credentials_provider(creds)
+        .credentials_provider(Credentials::for_tests())
         .build();
 
     let mut op = SendCommand::builder()

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 
 [dev-dependencies]
 async-std = "1.12.0"
-aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types" }
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }

--- a/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
+++ b/aws/sdk/integration-tests/s3/tests/alternative-async-runtime.rs
@@ -76,14 +76,13 @@ fn test_async_std_runtime_retry() {
 async fn timeout_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std::error::Error>> {
     let conn = NeverConnector::new();
     let region = Region::from_static("us-east-2");
-    let credentials = Credentials::new("test", "test", None, None, "test");
     let timeout_config = TimeoutConfig::builder()
         .operation_timeout(Duration::from_secs_f32(0.5))
         .build();
     let config = Config::builder()
         .region(region)
         .http_connector(conn.clone())
-        .credentials_provider(credentials)
+        .credentials_provider(Credentials::for_tests())
         .timeout_config(timeout_config)
         .sleep_impl(sleep_impl)
         .build();
@@ -125,21 +124,23 @@ async fn timeout_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std
 
 async fn retry_test(sleep_impl: Arc<dyn AsyncSleep>) -> Result<(), Box<dyn std::error::Error>> {
     let conn = NeverConnector::new();
-    let credentials = Credentials::new("test", "test", None, None, "test");
-    let conf = aws_types::SdkConfig::builder()
-        .region(Region::new("us-east-2"))
-        .http_connector(conn.clone())
-        .credentials_provider(
-            aws_credential_types::provider::SharedCredentialsProvider::new(credentials),
-        )
-        .retry_config(RetryConfig::standard())
-        .timeout_config(
-            TimeoutConfig::builder()
-                .operation_attempt_timeout(Duration::from_secs_f64(0.1))
-                .build(),
-        )
-        .sleep_impl(sleep_impl)
-        .build();
+    let conf =
+        aws_types::SdkConfig::builder()
+            .region(Region::new("us-east-2"))
+            .http_connector(conn.clone())
+            .credentials_provider(
+                aws_credential_types::provider::SharedCredentialsProvider::new(
+                    Credentials::for_tests(),
+                ),
+            )
+            .retry_config(RetryConfig::standard())
+            .timeout_config(
+                TimeoutConfig::builder()
+                    .operation_attempt_timeout(Duration::from_secs_f64(0.1))
+                    .build(),
+            )
+            .sleep_impl(sleep_impl)
+            .build();
     let client = Client::new(&conf);
     let resp = client
         .list_buckets()

--- a/aws/sdk/integration-tests/s3/tests/checksums.rs
+++ b/aws/sdk/integration-tests/s3/tests/checksums.rs
@@ -58,13 +58,7 @@ async fn test_checksum_on_streaming_response(
         checksum_header_value,
     );
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();
@@ -163,13 +157,7 @@ async fn test_checksum_on_streaming_request<'a>(
 ) {
     let (conn, rcvr) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/concurrency.rs
+++ b/aws/sdk/integration-tests/s3/tests/concurrency.rs
@@ -43,13 +43,7 @@ async fn test_concurrency_on_multi_thread_against_dummy_server() {
     let (server, server_addr) = start_agreeable_server().await;
     let _ = tokio::spawn(server);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .endpoint_url(format!("http://{server_addr}"))
         .build();
@@ -62,13 +56,7 @@ async fn test_concurrency_on_single_thread_against_dummy_server() {
     let (server, server_addr) = start_agreeable_server().await;
     let _ = tokio::spawn(server);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .endpoint_url(format!("http://{server_addr}"))
         .build();

--- a/aws/sdk/integration-tests/s3/tests/customizable-operation.rs
+++ b/aws/sdk/integration-tests/s3/tests/customizable-operation.rs
@@ -16,13 +16,7 @@ use std::time::{Duration, UNIX_EPOCH};
 async fn test_s3_ops_are_customizable() {
     let (conn, rcvr) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/s3/tests/endpoints.rs
@@ -14,13 +14,7 @@ use std::time::{Duration, UNIX_EPOCH};
 fn test_client(update_builder: fn(Builder) -> Builder) -> (CaptureRequestReceiver, Client) {
     let (conn, captured_request) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-west-4"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
+++ b/aws/sdk/integration-tests/s3/tests/ignore-invalid-xml-body-root.rs
@@ -46,13 +46,7 @@ async fn ignore_invalid_xml_body_root() {
     ]);
 
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
+++ b/aws/sdk/integration-tests/s3/tests/naughty-string-metadata.rs
@@ -54,13 +54,7 @@ const NAUGHTY_STRINGS: &str = include_str!("blns/blns.txt");
 async fn test_s3_signer_with_naughty_string_metadata() {
     let (conn, rcvr) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/normalize-uri-path.rs
+++ b/aws/sdk/integration-tests/s3/tests/normalize-uri-path.rs
@@ -16,13 +16,7 @@ use std::time::{Duration, UNIX_EPOCH};
 async fn test_operation_should_not_normalize_uri_path() {
     let (conn, rx) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_owned()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -15,13 +15,7 @@ use std::time::{Duration, SystemTime};
 /// Assumes that that input has a `presigned` method on it.
 macro_rules! presign_input {
     ($input:expr) => {{
-        let creds = s3::Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        );
+        let creds = s3::Credentials::for_tests();
         let config = s3::Config::builder()
             .credentials_provider(creds)
             .region(s3::Region::new("us-east-1"))

--- a/aws/sdk/integration-tests/s3/tests/query-strings-are-correctly-encoded.rs
+++ b/aws/sdk/integration-tests/s3/tests/query-strings-are-correctly-encoded.rs
@@ -15,13 +15,7 @@ use std::time::{Duration, UNIX_EPOCH};
 async fn test_s3_signer_query_string_with_all_valid_chars() {
     let (conn, rcvr) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/recursion-detection.rs
+++ b/aws/sdk/integration-tests/s3/tests/recursion-detection.rs
@@ -15,13 +15,7 @@ async fn recursion_detection_applied() {
     std::env::set_var("_X_AMZN_TRACE_ID", "traceid");
     let (conn, captured_request) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/select-object-content.rs
+++ b/aws/sdk/integration-tests/s3/tests/select-object-content.rs
@@ -21,9 +21,7 @@ async fn test_success() {
     let replayer = ReplayingConnection::new(events);
     let sdk_config = SdkConfig::builder()
         .region(Region::from_static("us-east-2"))
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "test", "test", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .http_connector(replayer.clone())
         .build();
     let client = Client::new(&sdk_config);

--- a/aws/sdk/integration-tests/s3/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3/tests/signing-it.rs
@@ -23,13 +23,7 @@ async fn test_signer() {
         http::Response::builder().status(200).body("").unwrap(),
     )]);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();

--- a/aws/sdk/integration-tests/s3/tests/streaming-response.rs
+++ b/aws/sdk/integration-tests/s3/tests/streaming-response.rs
@@ -22,13 +22,7 @@ async fn test_streaming_response_fails_when_eof_comes_before_content_length_reac
     let _ = tokio::spawn(server);
 
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .endpoint_url(format!("http://{server_addr}"))
         .build();

--- a/aws/sdk/integration-tests/s3/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/s3/tests/timeouts.rs
@@ -26,9 +26,7 @@ use tokio::time::timeout;
 async fn test_timeout_service_ends_request_that_never_completes() {
     let sdk_config = SdkConfig::builder()
         .region(Region::from_static("us-east-2"))
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "test", "test", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .http_connector(NeverConnector::new())
         .timeout_config(
             TimeoutConfig::builder()
@@ -105,9 +103,7 @@ async fn test_read_timeout() {
         )
         .endpoint_url(format!("http://{server_addr}"))
         .region(Some(Region::from_static("us-east-1")))
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "test", "test", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .build();
     let client = Client::new(&config);
 
@@ -150,9 +146,7 @@ async fn test_connect_timeout() {
             "http://172.255.255.0:18104",
         )
         .region(Some(Region::from_static("us-east-1")))
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "test", "test", None, None, "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .build();
     let client = Client::new(&config);
 

--- a/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
+++ b/aws/sdk/integration-tests/s3/tests/user-agent-app-name.rs
@@ -12,13 +12,7 @@ use aws_smithy_client::test_connection::capture_request;
 async fn user_agent_app_name() {
     let (conn, rcvr) = capture_request(None);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .region(Region::new("us-east-1"))
         .http_connector(conn.clone())
         .app_name(AppName::new("test-app-name").expect("valid app name")) // set app name in config

--- a/aws/sdk/integration-tests/s3control/Cargo.toml
+++ b/aws/sdk/integration-tests/s3control/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types" }
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
 aws-sdk-s3control = { path = "../../build/aws-sdk/sdk/s3control" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/s3control/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/s3control/tests/signing-it.rs
@@ -26,13 +26,7 @@ async fn test_signer() {
         http::Response::builder().status(200).body("").unwrap(),
     )]);
     let sdk_config = SdkConfig::builder()
-        .credentials_provider(SharedCredentialsProvider::new(Credentials::new(
-            "ANOTREAL",
-            "notrealrnrELgWzOk3IfjzDKtFBhDby",
-            Some("notarealsessiontoken".to_string()),
-            None,
-            "test",
-        )))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
         .http_connector(conn.clone())
         .region(Region::new("us-east-1"))
         .build();

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }

--- a/aws/sdk/integration-tests/sts/tests/signing-it.rs
+++ b/aws/sdk/integration-tests/sts/tests/signing-it.rs
@@ -8,13 +8,7 @@ use aws_smithy_client::test_connection::capture_request;
 
 #[tokio::test]
 async fn assume_role_signed() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
+    let creds = Credentials::for_tests();
     let (server, request) = capture_request(None);
     let conf = aws_sdk_sts::Config::builder()
         .credentials_provider(creds)
@@ -32,13 +26,7 @@ async fn assume_role_signed() {
 
 #[tokio::test]
 async fn web_identity_unsigned() {
-    let creds = Credentials::new(
-        "ANOTREAL",
-        "notrealrnrELgWzOk3IfjzDKtFBhDby",
-        Some("notarealsessiontoken".to_string()),
-        None,
-        "test",
-    );
+    let creds = Credentials::for_tests();
     let (server, request) = capture_request(None);
     let conf = aws_sdk_sts::Config::builder()
         .credentials_provider(creds)

--- a/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
+++ b/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dev-dependencies]
 async-stream = "0.3.0"
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
 aws-sdk-transcribestreaming = { path = "../../build/aws-sdk/sdk/transcribestreaming" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }

--- a/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
+++ b/aws/sdk/integration-tests/transcribestreaming/tests/test.rs
@@ -106,11 +106,10 @@ async fn start_request(
     let replayer = ReplayingConnection::new(events);
 
     let region = Region::from_static(region);
-    let credentials = Credentials::new("test", "test", None, None, "test");
     let config = Config::builder()
         .region(region)
         .http_connector(replayer.clone())
-        .credentials_provider(credentials)
+        .credentials_provider(Credentials::for_tests())
         .build();
     let client = Client::from_conf(config);
 


### PR DESCRIPTION
## Motivation and Context
This is a refactoring PR affecting only tests, in response to https://github.com/awslabs/smithy-rs/pull/2122#discussion_r1056499862.

## Description
We have various places in testing that create dummy `Credentials` such as
- `Credentials::new("ANOTREAL", "notrealrnrELgWzOk3IfjzDKtFBhDby", Some("notarealsessiontoken".to_string()), None, "test")`
- `Credentials::new("akid", "secret", None, None, "test")`
- `Credentials::new("example", "example", None, None, "example")`

These essentially mean "it does not matter". To consolidate all of these instances, a test helper `aws_credential_types::Credentials::for_tests` has been introduced whose implementation is taken from the first bullet point above.

We intentionally did not replace certain occurrences of dummy `Credentials::new` with `Credentials::for_tests`:
- Those that appear in code examples in rustdoc (it makes more sense for the customers to see `new` rather than `for_tests`)
- Those that need to configure the expiration time

## Testing
- [x] Passed all tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
