### PR TITLE
Refactor configuration loading to parse profile files only once

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -87,3 +87,46 @@ message = "The constraint `@length` on non-streaming blob shapes is supported."
 references = ["smithy-rs#2131"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server"}
 author = "82marbag"
+
+[[aws-sdk-rust]]
+references = ["smithy-rs#2152"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"
+message = """Add support for overriding profile name and profile file location across all providers. Prior to this change, each provider needed to be updated individually.
+
+### Before
+```rust
+use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
+use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
+
+let profile_files = ProfileFiles::builder()
+    .with_file(ProfileFileKind::Credentials, "some/path/to/credentials-file")
+    .build();
+let credentials_provider = ProfileFileCredentialsProvider::builder()
+    .profile_files(profile_files.clone())
+    .build();
+let region_provider = ProfileFileRegionProvider::builder()
+    .profile_files(profile_files)
+    .build();
+
+let sdk_config = aws_config::from_env()
+    .credentials_provider(credentials_provider)
+    .region(region_provider)
+    .load()
+    .await;
+```
+
+### After
+```rust
+use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
+use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
+
+let profile_files = ProfileFiles::builder()
+    .with_file(ProfileFileKind::Credentials, "some/path/to/credentials-file")
+    .build();
+let sdk_config = aws_config::from_env()
+    .profile_files(profile_files)
+    .load()
+    .await;
+/// ```
+"""

--- a/aws/rust-runtime/aws-config/src/imds/client/error.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/error.rs
@@ -5,7 +5,6 @@
 
 //! Error types for [`ImdsClient`](crate::imds::client::Client)
 
-use crate::profile::credentials::ProfileFileError;
 use aws_smithy_client::SdkError;
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::endpoint::error::InvalidEndpointError;
@@ -178,9 +177,6 @@ enum BuildErrorKind {
     /// The endpoint mode was invalid
     InvalidEndpointMode(InvalidEndpointMode),
 
-    /// The AWS Profile (e.g. `~/.aws/config`) was invalid
-    InvalidProfile(ProfileFileError),
-
     /// The specified endpoint was not a valid URI
     InvalidEndpointUri(Box<dyn Error + Send + Sync + 'static>),
 }
@@ -195,12 +191,6 @@ impl BuildError {
     pub(super) fn invalid_endpoint_mode(source: InvalidEndpointMode) -> Self {
         Self {
             kind: BuildErrorKind::InvalidEndpointMode(source),
-        }
-    }
-
-    pub(super) fn invalid_profile(source: ProfileFileError) -> Self {
-        Self {
-            kind: BuildErrorKind::InvalidProfile(source),
         }
     }
 
@@ -219,7 +209,6 @@ impl fmt::Display for BuildError {
         write!(f, "failed to build IMDS client: ")?;
         match self.kind {
             InvalidEndpointMode(_) => write!(f, "invalid endpoint mode"),
-            InvalidProfile(_) => write!(f, "profile file error"),
             InvalidEndpointUri(_) => write!(f, "invalid URI"),
         }
     }
@@ -230,7 +219,6 @@ impl Error for BuildError {
         use BuildErrorKind::*;
         match &self.kind {
             InvalidEndpointMode(e) => Some(e),
-            InvalidProfile(e) => Some(e),
             InvalidEndpointUri(e) => Some(e.as_ref()),
         }
     }

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -353,9 +353,8 @@ mod loader {
         /// `~/.aws/config` and `~/.aws/credentials` respectively.
         ///
         /// Any number of config and credential files may be added to the `ProfileFiles` file set, with the
-        /// only requirement being that there is at least one of them. Custom file locations that are added
-        /// will produce errors if they don't exist, while the default config/credentials files paths are
-        /// allowed to not exist even if they're included.
+        /// only requirement being that there is at least one of each. Profile file locations will produce an
+        /// error if they don't exist, but the default config/credentials files paths are exempt from this validation.
         ///
         /// # Example: Using a custom profile file path
         ///

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -161,6 +161,7 @@ mod loader {
     use crate::connector::default_connector;
     use crate::default_provider::{app_name, credentials, region, retry_config, timeout_config};
     use crate::meta::region::ProvideRegion;
+    use crate::profile::profile_file::ProfileFiles;
     use crate::provider_config::ProviderConfig;
 
     /// Load a cross-service [`SdkConfig`](aws_types::SdkConfig) from the environment
@@ -181,6 +182,8 @@ mod loader {
         timeout_config: Option<TimeoutConfig>,
         provider_config: Option<ProviderConfig>,
         http_connector: Option<HttpConnector>,
+        profile_name_override: Option<String>,
+        profile_files_override: Option<ProfileFiles>,
     }
 
     impl ConfigLoader {
@@ -344,6 +347,73 @@ mod loader {
             self
         }
 
+        /// Provides the ability to programmatically override the profile files that get loaded by the SDK.
+        ///
+        /// The [`Default`] for `ProfileFiles` includes the default SDK config and credential files located in
+        /// `~/.aws/config` and `~/.aws/credentials` respectively.
+        ///
+        /// Any number of config and credential files may be added to the `ProfileFiles` file set, with the
+        /// only requirement being that there is at least one of them. Custom file locations that are added
+        /// will produce errors if they don't exist, while the default config/credentials files paths are
+        /// allowed to not exist even if they're included.
+        ///
+        /// # Example: Using a custom profile file path
+        ///
+        /// ```
+        /// use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
+        /// use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
+        ///
+        /// # async fn example() {
+        /// let profile_files = ProfileFiles::builder()
+        ///     .with_file(ProfileFileKind::Credentials, "some/path/to/credentials-file")
+        ///     .build();
+        /// let sdk_config = aws_config::from_env()
+        ///     .profile_files(profile_files)
+        ///     .load()
+        ///     .await;
+        /// # }
+        pub fn profile_files(mut self, profile_files: ProfileFiles) -> Self {
+            self.profile_files_override = Some(profile_files);
+            self
+        }
+
+        /// Override the profile name used by configuration providers
+        ///
+        /// Profile name is selected from an ordered list of sources:
+        /// 1. This override.
+        /// 2. The value of the `AWS_PROFILE` environment variable.
+        /// 3. `default`
+        ///
+        /// Each AWS profile has a name. For example, in the file below, the profiles are named
+        /// `dev`, `prod` and `staging`:
+        /// ```ini
+        /// [dev]
+        /// ec2_metadata_service_endpoint = http://my-custom-endpoint:444
+        ///
+        /// [staging]
+        /// ec2_metadata_service_endpoint = http://my-custom-endpoint:444
+        ///
+        /// [prod]
+        /// ec2_metadata_service_endpoint = http://my-custom-endpoint:444
+        /// ```
+        ///
+        /// # Example: Using a custom profile name
+        ///
+        /// ```
+        /// use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
+        /// use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
+        ///
+        /// # async fn example() {
+        /// let sdk_config = aws_config::from_env()
+        ///     .profile_name("prod")
+        ///     .load()
+        ///     .await;
+        /// # }
+        pub fn profile_name(mut self, profile_name: impl Into<String>) -> Self {
+            self.profile_name_override = Some(profile_name.into());
+            self
+        }
+
         /// Override the endpoint URL used for **all** AWS services.
         ///
         /// This method will override the endpoint URL used for **all** AWS services. This primarily
@@ -372,16 +442,14 @@ mod loader {
         ///
         /// Update the `ProviderConfig` used for all nested loaders. This can be used to override
         /// the HTTPs connector used by providers or to stub in an in memory `Env` or `Fs` for testing.
-        /// This **does not set** the HTTP connector used when sending operations. To change that
-        /// connector, use [ConfigLoader::http_connector].
         ///
         /// # Examples
         /// ```no_run
         /// # #[cfg(feature = "hyper-client")]
         /// # async fn create_config() {
         /// use aws_config::provider_config::ProviderConfig;
-        /// let custom_https_connector = hyper_rustls::HttpsConnectorBuilder::new().
-        ///     with_webpki_roots()
+        /// let custom_https_connector = hyper_rustls::HttpsConnectorBuilder::new()
+        ///     .with_webpki_roots()
         ///     .https_only()
         ///     .enable_http1()
         ///     .build();
@@ -404,7 +472,10 @@ mod loader {
         /// This means that if you provide a region provider that does not return a region, no region will
         /// be set in the resulting [`SdkConfig`](aws_types::SdkConfig)
         pub async fn load(self) -> SdkConfig {
-            let conf = self.provider_config.unwrap_or_default();
+            let conf = self
+                .provider_config
+                .unwrap_or_default()
+                .with_profile_config(self.profile_files_override, self.profile_name_override);
             let region = if let Some(provider) = self.region {
                 provider.region().await
             } else {

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -397,6 +397,9 @@ mod loader {
         /// ec2_metadata_service_endpoint = http://my-custom-endpoint:444
         /// ```
         ///
+        /// See [Named profiles](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+        /// for more information about naming profiles.
+        ///
         /// # Example: Using a custom profile name
         ///
         /// ```

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -568,12 +568,16 @@ mod loader {
         use aws_smithy_async::rt::sleep::TokioSleep;
         use aws_smithy_client::erase::DynConnector;
         use aws_smithy_client::never::NeverConnector;
-        use aws_types::os_shim_internal::Env;
+        use aws_types::app_name::AppName;
+        use aws_types::os_shim_internal::{Env, Fs};
+        use tracing_test::traced_test;
 
         use crate::from_env;
+        use crate::profile::profile_file::{ProfileFileKind, ProfileFiles};
         use crate::provider_config::ProviderConfig;
 
         #[tokio::test]
+        #[traced_test]
         async fn provider_config_used() {
             let env = Env::from_slice(&[
                 ("AWS_MAX_ATTEMPTS", "10"),
@@ -581,12 +585,21 @@ mod loader {
                 ("AWS_ACCESS_KEY_ID", "akid"),
                 ("AWS_SECRET_ACCESS_KEY", "secret"),
             ]);
+            let fs =
+                Fs::from_slice(&[("test_config", "[profile custom]\nsdk-ua-app-id = correct")]);
             let loader = from_env()
                 .configure(
                     ProviderConfig::empty()
                         .with_sleep(TokioSleep::new())
                         .with_env(env)
+                        .with_fs(fs)
                         .with_http_connector(DynConnector::new(NeverConnector::new())),
+                )
+                .profile_name("custom")
+                .profile_files(
+                    ProfileFiles::builder()
+                        .with_file(ProfileFileKind::Config, "test_config")
+                        .build(),
                 )
                 .load()
                 .await;
@@ -602,6 +615,22 @@ mod loader {
                     .access_key_id(),
                 "akid"
             );
+            assert_eq!(loader.app_name(), Some(&AppName::new("correct").unwrap()));
+            logs_assert(|lines| {
+                let num_config_loader_logs = lines
+                    .iter()
+                    .filter(|l| l.contains("provider_config_used"))
+                    .filter(|l| l.contains("config file loaded"))
+                    .count();
+                match num_config_loader_logs {
+                    0 => Err("no config file logs found!".to_string()),
+                    1 => Ok(()),
+                    more => Err(format!(
+                        "the config file was parsed more than once! (parsed {})",
+                        more
+                    )),
+                }
+            });
         }
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -24,7 +24,7 @@
 
 use crate::profile::credentials::exec::named::NamedProviderFactory;
 use crate::profile::credentials::exec::{ClientConfiguration, ProviderChain};
-use crate::profile::parser::ProfileParseError;
+use crate::profile::parser::ProfileFileLoadError;
 use crate::profile::profile_file::ProfileFiles;
 use crate::profile::Profile;
 use crate::provider_config::ProviderConfig;
@@ -34,7 +34,6 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::Instrument;
 
@@ -145,8 +144,6 @@ pub struct ProfileFileCredentialsProvider {
     factory: NamedProviderFactory,
     client_config: ClientConfiguration,
     provider_config: ProviderConfig,
-    profile_override: Option<String>,
-    profile_files: ProfileFiles,
 }
 
 impl ProfileFileCredentialsProvider {
@@ -156,23 +153,18 @@ impl ProfileFileCredentialsProvider {
     }
 
     async fn load_credentials(&self) -> provider::Result {
-        let inner_provider = build_provider_chain(
-            &self.provider_config,
-            &self.factory,
-            self.profile_override.as_deref(),
-            &self.profile_files,
-        )
-        .await
-        .map_err(|err| match err {
-            ProfileFileError::NoProfilesDefined
-            | ProfileFileError::ProfileDidNotContainCredentials { .. } => {
-                CredentialsError::not_loaded(err)
-            }
-            _ => CredentialsError::invalid_configuration(format!(
-                "ProfileFile provider could not be built: {}",
-                &err
-            )),
-        })?;
+        let inner_provider = build_provider_chain(&self.provider_config, &self.factory)
+            .await
+            .map_err(|err| match err {
+                ProfileFileError::NoProfilesDefined
+                | ProfileFileError::ProfileDidNotContainCredentials { .. } => {
+                    CredentialsError::not_loaded(err)
+                }
+                _ => CredentialsError::invalid_configuration(format!(
+                    "ProfileFile provider could not be built: {}",
+                    &err
+                )),
+            })?;
         let mut creds = match inner_provider
             .base()
             .provide_credentials()
@@ -208,20 +200,13 @@ impl ProfileFileCredentialsProvider {
     }
 }
 
-#[doc(hidden)]
-#[derive(Debug)]
-pub struct CouldNotReadProfileFile {
-    pub(crate) path: PathBuf,
-    pub(crate) cause: std::io::Error,
-}
-
 /// An Error building a Credential source from an AWS Profile
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum ProfileFileError {
     /// The profile was not a valid AWS profile
     #[non_exhaustive]
-    CouldNotParseProfile(ProfileParseError),
+    InvalidProfile(ProfileFileLoadError),
 
     /// No profiles existed (the profile was empty)
     #[non_exhaustive]
@@ -273,10 +258,6 @@ pub enum ProfileFileError {
         /// The name of the provider
         name: String,
     },
-
-    /// A custom profile file location didn't exist or could not be read
-    #[non_exhaustive]
-    CouldNotReadProfileFile(CouldNotReadProfileFile),
 }
 
 impl ProfileFileError {
@@ -288,11 +269,20 @@ impl ProfileFileError {
     }
 }
 
+impl Error for ProfileFileError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ProfileFileError::InvalidProfile(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 impl Display for ProfileFileError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ProfileFileError::CouldNotParseProfile(err) => {
-                write!(f, "could not parse profile file: {}", err)
+            ProfileFileError::InvalidProfile(err) => {
+                write!(f, "invalid profile: {}", err)
             }
             ProfileFileError::CredentialLoop { profiles, next } => write!(
                 f,
@@ -320,30 +310,7 @@ impl Display for ProfileFileError {
                 "profile `{}` did not contain credential information",
                 profile
             ),
-            ProfileFileError::CouldNotReadProfileFile(details) => {
-                write!(
-                    f,
-                    "Failed to read custom profile file at {:?}",
-                    details.path
-                )
-            }
         }
-    }
-}
-
-impl Error for ProfileFileError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            ProfileFileError::CouldNotParseProfile(err) => Some(err),
-            ProfileFileError::CouldNotReadProfileFile(details) => Some(&details.cause),
-            _ => None,
-        }
-    }
-}
-
-impl From<ProfileParseError> for ProfileFileError {
-    fn from(err: ProfileParseError) -> Self {
-        ProfileFileError::CouldNotParseProfile(err)
     }
 }
 
@@ -428,7 +395,10 @@ impl Builder {
     pub fn build(self) -> ProfileFileCredentialsProvider {
         let build_span = tracing::debug_span!("build_profile_provider");
         let _enter = build_span.enter();
-        let conf = self.provider_config.unwrap_or_default();
+        let conf = self
+            .provider_config
+            .unwrap_or_default()
+            .with_profile_config(self.profile_files, self.profile_override);
         let mut named_providers = self.custom_providers.clone();
         named_providers
             .entry("Environment".into())
@@ -467,8 +437,6 @@ impl Builder {
                 region: conf.region(),
             },
             provider_config: conf,
-            profile_override: self.profile_override,
-            profile_files: self.profile_files.unwrap_or_default(),
         }
     }
 }
@@ -476,12 +444,12 @@ impl Builder {
 async fn build_provider_chain(
     provider_config: &ProviderConfig,
     factory: &NamedProviderFactory,
-    profile_override: Option<&str>,
-    profile_files: &ProfileFiles,
 ) -> Result<ProviderChain, ProfileFileError> {
-    let profile_set =
-        super::parser::load(&provider_config.fs(), &provider_config.env(), profile_files).await?;
-    let repr = repr::resolve_chain(&profile_set, profile_override)?;
+    let profile_set = provider_config
+        .try_profile()
+        .await
+        .map_err(|parse_err| ProfileFileError::InvalidProfile(parse_err.clone()))?;
+    let repr = repr::resolve_chain(profile_set)?;
     tracing::info!(chain = ?repr, "constructed abstract provider from config file");
     exec::ProviderChain::from_repr(provider_config, repr, factory)
 }

--- a/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
@@ -108,10 +108,9 @@ pub(super) struct RoleArn<'a> {
 }
 
 /// Resolve a ProfileChain from a ProfileSet or return an error
-pub(super) fn resolve_chain<'a>(
-    profile_set: &'a ProfileSet,
-    profile_override: Option<&str>,
-) -> Result<ProfileChain<'a>, ProfileFileError> {
+pub(super) fn resolve_chain(
+    profile_set: &ProfileSet,
+) -> Result<ProfileChain<'_>, ProfileFileError> {
     // If there are no profiles, allow flowing into the next provider
     if profile_set.is_empty() {
         return Err(ProfileFileError::NoProfilesDefined);
@@ -123,15 +122,11 @@ pub(super) fn resolve_chain<'a>(
     // - There is not default profile
     // Then:
     // - Treat this situation as if no profiles were defined
-    if profile_override.is_none()
-        && profile_set.selected_profile() == "default"
-        && profile_set.get_profile("default").is_none()
-    {
+    if profile_set.selected_profile() == "default" && profile_set.get_profile("default").is_none() {
         tracing::debug!("No default profile defined");
         return Err(ProfileFileError::NoProfilesDefined);
     }
-    let mut source_profile_name =
-        profile_override.unwrap_or_else(|| profile_set.selected_profile());
+    let mut source_profile_name = profile_set.selected_profile();
     let mut visited_profiles = vec![];
     let mut chain = vec![];
     let base = loop {
@@ -435,7 +430,7 @@ mod tests {
 
     fn check(test_case: TestCase) {
         let source = ProfileSet::new(test_case.input.profile, test_case.input.selected_profile);
-        let actual = resolve_chain(&source, None);
+        let actual = resolve_chain(&source);
         let expected = test_case.output;
         match (expected, actual) {
             (TestOutput::Error(s), Err(e)) => assert!(

--- a/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/repr.rs
@@ -119,7 +119,7 @@ pub(super) fn resolve_chain(
     // If:
     // - There is no explicit profile override
     // - We're looking for the default profile (no configuration)
-    // - There is not default profile
+    // - There is no default profile
     // Then:
     // - Treat this situation as if no profiles were defined
     if profile_set.selected_profile() == "default" && profile_set.get_profile("default").is_none() {

--- a/aws/rust-runtime/aws-config/src/profile/mod.rs
+++ b/aws/rust-runtime/aws-config/src/profile/mod.rs
@@ -16,7 +16,7 @@ mod parser;
 #[doc(inline)]
 pub use parser::ProfileParseError;
 #[doc(inline)]
-pub use parser::{load, Profile, ProfileSet, Property};
+pub use parser::{load, Profile, ProfileFileLoadError, ProfileSet, Property};
 
 pub mod app_name;
 pub mod credentials;

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -9,9 +9,12 @@ use crate::profile::profile_file::ProfileFiles;
 use aws_types::os_shim_internal::{Env, Fs};
 use std::borrow::Cow;
 use std::collections::HashMap;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+use std::sync::Arc;
 
 pub use self::parse::ProfileParseError;
-use super::credentials::ProfileFileError;
 
 mod normalize;
 mod parse;
@@ -56,8 +59,12 @@ pub async fn load(
     fs: &Fs,
     env: &Env,
     profile_files: &ProfileFiles,
-) -> Result<ProfileSet, ProfileFileError> {
-    let source = source::load(env, fs, profile_files).await?;
+    selected_profile_override: Option<Cow<'static, str>>,
+) -> Result<ProfileSet, ProfileFileLoadError> {
+    let mut source = source::load(env, fs, profile_files).await?;
+    if let Some(profile) = selected_profile_override {
+        source.profile = profile;
+    }
     Ok(ProfileSet::parse(source)?)
 }
 
@@ -69,17 +76,11 @@ pub struct ProfileSet {
 }
 
 impl ProfileSet {
-    #[doc(hidden)]
     /// Create a new Profile set directly from a HashMap
     ///
-    /// This method creates a ProfileSet directly from a hashmap with no normalization.
-    ///
-    /// ## Warning
-    ///
-    /// This is probably not what you want! In general, [`load`](load) should be used instead
-    /// because it will perform input normalization. However, for tests which operate on the
-    /// normalized profile, this method exists to facilitate easy construction of a ProfileSet
-    pub fn new(
+    /// This method creates a ProfileSet directly from a hashmap with no normalization for test purposes.
+    #[cfg(test)]
+    pub(crate) fn new(
         profiles: HashMap<String, HashMap<String, String>>,
         selected_profile: impl Into<Cow<'static, str>>,
     ) -> Self {
@@ -193,6 +194,53 @@ impl Property {
     pub fn new(key: String, value: String) -> Self {
         Property { key, value }
     }
+}
+
+/// Failed to read or parse the profile file(s)
+#[derive(Debug, Clone)]
+pub enum ProfileFileLoadError {
+    /// The profile could not be parsed
+    #[non_exhaustive]
+    ParseError(ProfileParseError),
+
+    /// The profile file (e.g. `~/.aws/config`) encountered an error reading from the filesystem
+    #[non_exhaustive]
+    CouldNotReadFile(CouldNotReadProfileFile),
+}
+
+impl Display for ProfileFileLoadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProfileFileLoadError::ParseError(_err) => {
+                write!(f, "could not parse profile file")
+            }
+            ProfileFileLoadError::CouldNotReadFile(err) => {
+                write!(f, "could not read file `{}`", err.path.display())
+            }
+        }
+    }
+}
+
+impl Error for ProfileFileLoadError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ProfileFileLoadError::ParseError(err) => Some(err),
+            ProfileFileLoadError::CouldNotReadFile(details) => Some(&details.cause),
+        }
+    }
+}
+
+impl From<ProfileParseError> for ProfileFileLoadError {
+    fn from(err: ProfileParseError) -> Self {
+        ProfileFileLoadError::ParseError(err)
+    }
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct CouldNotReadProfileFile {
+    pub(crate) path: PathBuf,
+    pub(crate) cause: Arc<std::io::Error>,
 }
 
 #[cfg(test)]

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -204,7 +204,7 @@ pub enum ProfileFileLoadError {
     #[non_exhaustive]
     ParseError(ProfileParseError),
 
-    /// The profile file (e.g. `~/.aws/config`) encountered an error reading from the filesystem
+    /// Attempt to read the AWS config file (`~/.aws/config` by default) failed with a filesystem error.
     #[non_exhaustive]
     CouldNotReadFile(CouldNotReadProfileFile),
 }

--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -65,6 +65,7 @@ pub async fn load(
     if let Some(profile) = selected_profile_override {
         source.profile = profile;
     }
+
     Ok(ProfileSet::parse(source)?)
 }
 

--- a/aws/rust-runtime/aws-config/src/profile/parser/parse.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/parse.rs
@@ -36,7 +36,7 @@ struct Location {
 }
 
 /// An error encountered while parsing a profile
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ProfileParseError {
     /// Location where this error occurred
     location: Location,

--- a/aws/rust-runtime/aws-config/src/profile/parser/source.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/source.rs
@@ -4,13 +4,16 @@
  */
 
 use crate::fs_util::{home_dir, Os};
-use crate::profile::credentials::{CouldNotReadProfileFile, ProfileFileError};
+
+use crate::profile::parser::{CouldNotReadProfileFile, ProfileFileLoadError};
 use crate::profile::profile_file::{ProfileFile, ProfileFileKind, ProfileFiles};
+
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal;
 use std::borrow::Cow;
 use std::io::ErrorKind;
 use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 use tracing::{warn, Instrument};
 
 const HOME_EXPANSION_FAILURE_WARNING: &str =
@@ -40,7 +43,7 @@ pub(super) async fn load(
     proc_env: &os_shim_internal::Env,
     fs: &os_shim_internal::Fs,
     profile_files: &ProfileFiles,
-) -> Result<Source, ProfileFileError> {
+) -> Result<Source, ProfileFileLoadError> {
     let home = home_dir(proc_env, Os::real());
 
     let mut files = Vec::new();
@@ -86,7 +89,7 @@ async fn load_config_file(
     home_directory: &Option<String>,
     fs: &os_shim_internal::Fs,
     environment: &os_shim_internal::Env,
-) -> Result<File, ProfileFileError> {
+) -> Result<File, ProfileFileLoadError> {
     let (path, kind, contents) = match source {
         ProfileFile::Default(kind) => {
             let (path_is_default, path) = environment
@@ -127,10 +130,10 @@ async fn load_config_file(
             let data = match fs.read_to_end(&path).await {
                 Ok(data) => data,
                 Err(e) => {
-                    return Err(ProfileFileError::CouldNotReadProfileFile(
+                    return Err(ProfileFileLoadError::CouldNotReadFile(
                         CouldNotReadProfileFile {
                             path: path.clone(),
-                            cause: e,
+                            cause: Arc::new(e),
                         },
                     ))
                 }
@@ -195,10 +198,10 @@ fn expand_home(
 
 #[cfg(test)]
 mod tests {
-    use crate::profile::credentials::ProfileFileError;
     use crate::profile::parser::source::{
         expand_home, load, load_config_file, HOME_EXPANSION_FAILURE_WARNING,
     };
+    use crate::profile::parser::ProfileFileLoadError;
     use crate::profile::profile_file::{ProfileFile, ProfileFileKind, ProfileFiles};
     use aws_types::os_shim_internal::{Env, Fs};
     use futures_util::FutureExt;
@@ -477,7 +480,7 @@ mod tests {
             .build();
         assert!(matches!(
             load(&env, &fs, &profile_files).await,
-            Err(ProfileFileError::CouldNotReadProfileFile(_))
+            Err(ProfileFileLoadError::CouldNotReadFile(_))
         ));
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/profile_file.rs
+++ b/aws/rust-runtime/aws-config/src/profile/profile_file.rs
@@ -18,7 +18,7 @@ use std::path::PathBuf;
 /// will produce errors if they don't exist, while the default config/credentials files paths are
 /// allowed to not exist even if they're included.
 ///
-/// # Example: Using a custom profile file path for credentials and region
+/// # Example: Using a custom profile file path
 ///
 /// ```
 /// use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
@@ -28,16 +28,8 @@ use std::path::PathBuf;
 /// let profile_files = ProfileFiles::builder()
 ///     .with_file(ProfileFileKind::Credentials, "some/path/to/credentials-file")
 ///     .build();
-/// let credentials_provider = ProfileFileCredentialsProvider::builder()
-///     .profile_files(profile_files.clone())
-///     .build();
-/// let region_provider = ProfileFileRegionProvider::builder()
-///     .profile_files(profile_files)
-///     .build();
-///
 /// let sdk_config = aws_config::from_env()
-///     .credentials_provider(credentials_provider)
-///     .region(region_provider)
+///     .profile_files(profile_files)
 ///     .load()
 ///     .await;
 /// # }

--- a/aws/rust-runtime/aws-config/src/profile/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/retry_config.rs
@@ -84,9 +84,7 @@ impl ProfileFileRetryConfigProvider {
     ///
     /// To override the selected profile, set the `AWS_PROFILE` environment variable or use the [Builder].
     pub fn new() -> Self {
-        Self {
-            provider_config: Default::default(),
-        }
+        Self::default()
     }
 
     /// [Builder] to construct a [ProfileFileRetryConfigProvider]

--- a/aws/rust-runtime/aws-config/src/profile/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/profile/retry_config.rs
@@ -10,8 +10,6 @@ use crate::provider_config::ProviderConfig;
 use crate::retry::{
     error::RetryConfigError, error::RetryConfigErrorKind, RetryConfigBuilder, RetryMode,
 };
-use aws_smithy_types::error::display::DisplayErrorContext;
-use aws_types::os_shim_internal::{Env, Fs};
 use std::str::FromStr;
 
 /// Load retry configuration properties from a profile file
@@ -39,10 +37,7 @@ use std::str::FromStr;
 /// This provider is part of the [default retry_config provider chain](crate::default_provider::retry_config).
 #[derive(Debug, Default)]
 pub struct ProfileFileRetryConfigProvider {
-    fs: Fs,
-    env: Env,
-    profile_override: Option<String>,
-    profile_files: ProfileFiles,
+    provider_config: ProviderConfig,
 }
 
 /// Builder for [ProfileFileRetryConfigProvider]
@@ -74,12 +69,12 @@ impl Builder {
 
     /// Build a [ProfileFileRetryConfigProvider] from this builder
     pub fn build(self) -> ProfileFileRetryConfigProvider {
-        let conf = self.config.unwrap_or_default();
+        let conf = self
+            .config
+            .unwrap_or_default()
+            .with_profile_config(self.profile_files, self.profile_override);
         ProfileFileRetryConfigProvider {
-            env: conf.env(),
-            fs: conf.fs(),
-            profile_override: self.profile_override,
-            profile_files: self.profile_files.unwrap_or_default(),
+            provider_config: conf,
         }
     }
 }
@@ -90,10 +85,7 @@ impl ProfileFileRetryConfigProvider {
     /// To override the selected profile, set the `AWS_PROFILE` environment variable or use the [Builder].
     pub fn new() -> Self {
         Self {
-            fs: Fs::real(),
-            env: Env::real(),
-            profile_override: None,
-            profile_files: Default::default(),
+            provider_config: Default::default(),
         }
     }
 
@@ -104,32 +96,14 @@ impl ProfileFileRetryConfigProvider {
 
     /// Attempt to create a new RetryConfigBuilder from a profile file.
     pub async fn retry_config_builder(&self) -> Result<RetryConfigBuilder, RetryConfigError> {
-        let profile = match super::parser::load(&self.fs, &self.env, &self.profile_files).await {
-            Ok(profile) => profile,
-            Err(err) => {
-                tracing::warn!(err = %DisplayErrorContext(&err), "failed to parse profile");
-                // return an empty builder
-                return Ok(RetryConfigBuilder::new());
-            }
-        };
-
-        let selected_profile = self
-            .profile_override
-            .as_deref()
-            .unwrap_or_else(|| profile.selected_profile());
-        let selected_profile = match profile.get_profile(selected_profile) {
+        let profile = match self.provider_config.profile().await {
             Some(profile) => profile,
             None => {
-                // Only warn if the user specified a profile name to use.
-                if self.profile_override.is_some() {
-                    tracing::warn!("failed to get selected '{}' profile", selected_profile);
-                }
-                // return an empty builder
+                // if there is no profile or the profile is invalid, don't update retry config
                 return Ok(RetryConfigBuilder::new());
             }
         };
-
-        let max_attempts = match selected_profile.get("max_attempts") {
+        let max_attempts = match profile.get("max_attempts") {
             Some(max_attempts) => match max_attempts.parse::<u32>() {
                 Ok(max_attempts) if max_attempts == 0 => {
                     return Err(RetryConfigErrorKind::MaxAttemptsMustNotBeZero {
@@ -149,7 +123,7 @@ impl ProfileFileRetryConfigProvider {
             None => None,
         };
 
-        let retry_mode = match selected_profile.get("retry_mode") {
+        let retry_mode = match profile.get("retry_mode") {
             Some(retry_mode) => match RetryMode::from_str(retry_mode) {
                 Ok(retry_mode) => Some(retry_mode),
                 Err(retry_mode_err) => {

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -42,8 +42,11 @@ pub struct ProviderConfig {
     connector: HttpConnector,
     sleep: Option<Arc<dyn AsyncSleep>>,
     region: Option<Region>,
-    parsed_profile: Arc<OnceCell<Result<ProfileSet, ProfileFileLoadError>>>,
+    // An AWS profile created from `ProfileFiles` and a `profile_name`
+    profile: Arc<OnceCell<Result<ProfileSet, ProfileFileLoadError>>>,
+    // A list of [std::path::Path]s to profile files
     profile_files: ProfileFiles,
+    // An override to use when constructing a `ProfileSet`
     profile_name_override: Option<Cow<'static, str>>,
 }
 
@@ -231,7 +234,7 @@ impl ProviderConfig {
         self
     }
 
-    /// Override profile-file (`~/.aws/config` et al) configuration
+    /// Override the profile file paths (`~/.aws/config` by default) and name (`default` by default)
     pub(crate) fn with_profile_config(
         self,
         profile_files: Option<ProfileFiles>,

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -8,16 +8,23 @@
 use aws_credential_types::time_source::TimeSource;
 use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep};
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal::{Env, Fs};
 use aws_types::{
     http_connector::{ConnectorSettings, HttpConnector},
     region::Region,
 };
+use std::borrow::Cow;
 
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
+use tokio::sync::OnceCell;
 
 use crate::connector::default_connector;
+use crate::profile;
+
+use crate::profile::profile_file::ProfileFiles;
+use crate::profile::{ProfileFileLoadError, ProfileSet};
 
 /// Configuration options for Credential Providers
 ///
@@ -35,6 +42,9 @@ pub struct ProviderConfig {
     connector: HttpConnector,
     sleep: Option<Arc<dyn AsyncSleep>>,
     region: Option<Region>,
+    profile: Arc<OnceCell<Result<ProfileSet, ProfileFileLoadError>>>,
+    profile_files: ProfileFiles,
+    profile_name_override: Option<Cow<'static, str>>,
 }
 
 impl Debug for ProviderConfig {
@@ -63,6 +73,9 @@ impl Default for ProviderConfig {
             connector,
             sleep: default_async_sleep(),
             region: None,
+            profile: Default::default(),
+            profile_files: ProfileFiles::default(),
+            profile_name_override: None,
         }
     }
 }
@@ -77,13 +90,18 @@ impl ProviderConfig {
         use aws_credential_types::time_source::TestingTimeSource;
         use std::collections::HashMap;
         use std::time::UNIX_EPOCH;
+        let fs = Fs::from_raw_map(HashMap::new());
+        let env = Env::from_slice(&[]);
         Self {
-            env: Env::from_slice(&[]),
-            fs: Fs::from_raw_map(HashMap::new()),
+            profile: Default::default(),
+            profile_files: ProfileFiles::default(),
+            env,
+            fs,
             time_source: TimeSource::testing(&TestingTimeSource::new(UNIX_EPOCH)),
             connector: HttpConnector::Prebuilt(None),
             sleep: None,
             region: None,
+            profile_name_override: None,
         }
     }
 }
@@ -123,6 +141,9 @@ impl ProviderConfig {
             connector: HttpConnector::Prebuilt(None),
             sleep: None,
             region: None,
+            profile: Default::default(),
+            profile_files: ProfileFiles::default(),
+            profile_name_override: None,
         }
     }
 
@@ -180,10 +201,58 @@ impl ProviderConfig {
         self.region.clone()
     }
 
+    pub(crate) async fn try_profile(&self) -> Result<&ProfileSet, &ProfileFileLoadError> {
+        let parsed_profile = self
+            .profile
+            .get_or_init(|| async {
+                let profile = profile::load(
+                    &self.fs,
+                    &self.env,
+                    &self.profile_files,
+                    self.profile_name_override.clone(),
+                )
+                .await;
+                if let Err(err) = profile.as_ref() {
+                    tracing::warn!(err = %DisplayErrorContext(&err), "failed to parse profile")
+                }
+                profile
+            })
+            .await;
+        parsed_profile.as_ref()
+    }
+
+    pub(crate) async fn profile(&self) -> Option<&ProfileSet> {
+        self.try_profile().await.ok()
+    }
+
     /// Override the region for the configuration
     pub fn with_region(mut self, region: Option<Region>) -> Self {
         self.region = region;
         self
+    }
+
+    /// Override the profile files for the configuration
+    pub fn with_profile_files(self, profile_files: ProfileFiles) -> Self {
+        ProviderConfig {
+            profile: Default::default(),
+            profile_files,
+            ..self
+        }
+    }
+
+    pub(crate) fn with_profile_config(
+        self,
+        profile_files: Option<ProfileFiles>,
+        profile_name_override: Option<String>,
+    ) -> Self {
+        ProviderConfig {
+            profile: Default::default(),
+            profile_files: profile_files.unwrap_or(self.profile_files),
+            profile_name_override: profile_name_override
+                .map(Cow::Owned)
+                .or(self.profile_name_override),
+            ..self
+        }
     }
 
     /// Use the [default region chain](crate::default_provider::region) to set the
@@ -200,12 +269,20 @@ impl ProviderConfig {
 
     #[doc(hidden)]
     pub fn with_fs(self, fs: Fs) -> Self {
-        ProviderConfig { fs, ..self }
+        ProviderConfig {
+            profile: Default::default(),
+            fs,
+            ..self
+        }
     }
 
     #[doc(hidden)]
     pub fn with_env(self, env: Env) -> Self {
-        ProviderConfig { env, ..self }
+        ProviderConfig {
+            profile: Default::default(),
+            env,
+            ..self
+        }
     }
 
     #[doc(hidden)]

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -43,7 +43,7 @@ pub struct ProviderConfig {
     sleep: Option<Arc<dyn AsyncSleep>>,
     region: Option<Region>,
     // An AWS profile created from `ProfileFiles` and a `profile_name`
-    profile: Arc<OnceCell<Result<ProfileSet, ProfileFileLoadError>>>,
+    parsed_profile: Arc<OnceCell<Result<ProfileSet, ProfileFileLoadError>>>,
     // A list of [std::path::Path]s to profile files
     profile_files: ProfileFiles,
     // An override to use when constructing a `ProfileSet`

--- a/aws/rust-runtime/aws-config/src/provider_config.rs
+++ b/aws/rust-runtime/aws-config/src/provider_config.rs
@@ -231,11 +231,16 @@ impl ProviderConfig {
         self
     }
 
+    /// Override profile-file (`~/.aws/config` et al) configuration
     pub(crate) fn with_profile_config(
         self,
         profile_files: Option<ProfileFiles>,
         profile_name_override: Option<String>,
     ) -> Self {
+        // if there is no override, then don't clear out `parsed_profile`.
+        if profile_files.is_none() && profile_name_override.is_none() {
+            return self;
+        }
         ProviderConfig {
             // clear out the profile since we need to reparse it
             parsed_profile: Default::default(),

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -78,7 +78,7 @@ pub(crate) fn no_traffic_connector() -> DynConnector {
 }
 
 #[derive(Debug)]
-struct InstantSleep;
+pub(crate) struct InstantSleep;
 impl AsyncSleep for InstantSleep {
     fn sleep(&self, _duration: Duration) -> Sleep {
         Sleep::new(std::future::ready(()))

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -95,6 +95,7 @@ impl<T> GenericTestResult<T>
 where
     T: PartialEq + Debug,
 {
+    #[track_caller]
     pub(crate) fn assert_matches(&self, result: Result<impl Into<T>, impl Error>) {
         match (result, &self) {
             (Ok(actual), GenericTestResult::Ok(expected)) => {
@@ -247,6 +248,7 @@ impl TestEnvironment {
         }
     }
 
+    #[track_caller]
     fn check_results(&self, result: provider::Result) {
         self.metadata.result.assert_matches(result);
     }


### PR DESCRIPTION
## Motivation and Context
- https://github.com/awslabs/aws-sdk-rust/issues/237
- parsing profile files each time produces noisy logs
- parsing profile files multiple times is inefficient
- parsing profile files multiple times makes it difficult to unify profile parsing settings
- fixes #2142 
## Description
1. Refactor to only parse profile files once in a lazy async cell
2. Support setting the profile name and profile file at a SdkConfig level instead of for each provider.


## Testing
- [x] UT

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
