### PR TITLE
Enable FIPS and dual-stack from SDK config

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -148,3 +148,17 @@ references = ["smithy-rs#2170", "aws-sdk-rust#706"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 message = "Remove the webpki-roots feature from `hyper-rustls`"
 author = "rcoh"
+
+[[aws-sdk-rust]]
+references = ["smithy-rs#2168"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+message = """Add support for resolving FIPS and dual-stack endpoints.
+
+FIPS and dual-stack endpoints can each be configured in multiple ways:
+1. Automatically from the environment and AWS profile
+2. Across all clients loaded from the same `SdkConfig` via `from_env().use_dual_stack(true).load().await`
+3. At a client level when constructing the configuration for an individual client.
+
+Note: Not all services support FIPS and dual-stack.
+"""
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/src/default_provider.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider.rs
@@ -41,3 +41,9 @@ pub mod timeout_config;
 /// Typically, this module is used via [`load_from_env`](crate::load_from_env) or [`from_env`](crate::from_env). It should only be used directly
 /// if you need to set custom configuration options like [`region`](credentials::Builder::region) or [`profile_name`](credentials::Builder::profile_name).
 pub mod credentials;
+
+/// Default FIPS provider chain
+pub mod use_fips;
+
+/// Default dual-stack provider chain
+pub mod use_dual_stack;

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -269,7 +269,6 @@ mod test {
 
     use crate::default_provider::credentials::DefaultCredentialsChain;
 
-    use crate::provider_config::ProviderConfig;
     use crate::test_case::TestEnvironment;
 
     /// Test generation macro
@@ -371,6 +370,7 @@ mod test {
     #[traced_test]
     #[cfg(feature = "client-hyper")]
     async fn no_providers_configured_err() {
+        use crate::provider_config::ProviderConfig;
         use aws_credential_types::provider::error::CredentialsError;
         use aws_credential_types::time_source::TimeSource;
         use aws_smithy_async::rt::sleep::TokioSleep;

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -266,11 +266,9 @@ mod test {
     use tracing_test::traced_test;
 
     use aws_credential_types::provider::ProvideCredentials;
-    use aws_smithy_types::retry::{RetryConfig, RetryMode};
-    use aws_types::os_shim_internal::{Env, Fs};
 
     use crate::default_provider::credentials::DefaultCredentialsChain;
-    use crate::default_provider::retry_config;
+
     use crate::provider_config::ProviderConfig;
     use crate::test_case::TestEnvironment;
 
@@ -397,121 +395,5 @@ mod test {
             "should be NotLoaded: {:?}",
             creds
         )
-    }
-
-    #[tokio::test]
-    async fn test_returns_default_retry_config_from_empty_profile() {
-        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
-        let fs = Fs::from_slice(&[("config", "[default]\n")]);
-
-        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
-
-        let actual_retry_config = retry_config::default_provider()
-            .configure(&provider_config)
-            .retry_config()
-            .await;
-
-        let expected_retry_config = RetryConfig::standard();
-
-        assert_eq!(actual_retry_config, expected_retry_config);
-        // This is redundant but it's really important to make sure that
-        // we're setting these exact values by default so we check twice
-        assert_eq!(actual_retry_config.max_attempts(), 3);
-        assert_eq!(actual_retry_config.mode(), RetryMode::Standard);
-    }
-
-    #[tokio::test]
-    async fn test_no_retry_config_in_empty_profile() {
-        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
-        let fs = Fs::from_slice(&[("config", "[default]\n")]);
-
-        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
-
-        let actual_retry_config = retry_config::default_provider()
-            .configure(&provider_config)
-            .retry_config()
-            .await;
-
-        let expected_retry_config = RetryConfig::standard();
-
-        assert_eq!(actual_retry_config, expected_retry_config)
-    }
-
-    #[tokio::test]
-    async fn test_creation_of_retry_config_from_profile() {
-        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
-        // TODO(https://github.com/awslabs/aws-sdk-rust/issues/247): standard is the default mode;
-        // this test would be better if it was setting it to adaptive mode
-        // adaptive mode is currently unsupported so that would panic
-        let fs = Fs::from_slice(&[(
-            "config",
-            // If the lines with the vars have preceding spaces, they don't get read
-            r#"[default]
-max_attempts = 1
-retry_mode = standard
-            "#,
-        )]);
-
-        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
-
-        let actual_retry_config = retry_config::default_provider()
-            .configure(&provider_config)
-            .retry_config()
-            .await;
-
-        let expected_retry_config = RetryConfig::standard().with_max_attempts(1);
-
-        assert_eq!(actual_retry_config, expected_retry_config)
-    }
-
-    #[tokio::test]
-    async fn test_env_retry_config_takes_precedence_over_profile_retry_config() {
-        let env = Env::from_slice(&[
-            ("AWS_CONFIG_FILE", "config"),
-            ("AWS_MAX_ATTEMPTS", "42"),
-            ("AWS_RETRY_MODE", "standard"),
-        ]);
-        // TODO(https://github.com/awslabs/aws-sdk-rust/issues/247) standard is the default mode;
-        // this test would be better if it was setting it to adaptive mode
-        // adaptive mode is currently unsupported so that would panic
-        let fs = Fs::from_slice(&[(
-            "config",
-            // If the lines with the vars have preceding spaces, they don't get read
-            r#"[default]
-max_attempts = 88
-retry_mode = standard
-            "#,
-        )]);
-
-        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
-
-        let actual_retry_config = retry_config::default_provider()
-            .configure(&provider_config)
-            .retry_config()
-            .await;
-
-        let expected_retry_config = RetryConfig::standard().with_max_attempts(42);
-
-        assert_eq!(actual_retry_config, expected_retry_config)
-    }
-
-    #[tokio::test]
-    #[should_panic = "failed to parse max attempts. source: profile `default`, key: `max_attempts`: invalid digit found in string"]
-    async fn test_invalid_profile_retry_config_panics() {
-        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
-        let fs = Fs::from_slice(&[(
-            "config",
-            // If the lines with the vars have preceding spaces, they don't get read
-            r#"[default]
-max_attempts = potato
-            "#,
-        )]);
-
-        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
-
-        let _ = retry_config::default_provider()
-            .configure(&provider_config)
-            .retry_config()
-            .await;
     }
 }

--- a/aws/rust-runtime/aws-config/src/default_provider/retry_config.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/retry_config.rs
@@ -149,7 +149,7 @@ mod test {
         error::RetryConfigError, error::RetryConfigErrorKind, RetryConfig, RetryMode,
     };
     use crate::standard_property::PropertyResolutionError;
-    use aws_types::os_shim_internal::Env;
+    use aws_types::os_shim_internal::{Env, Fs};
 
     async fn test_provider(
         vars: &[(&str, &str)],
@@ -158,6 +158,122 @@ mod test {
             .configure(&ProviderConfig::no_configuration().with_env(Env::from_slice(vars)))
             .try_retry_config()
             .await
+    }
+
+    #[tokio::test]
+    async fn test_returns_default_retry_config_from_empty_profile() {
+        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
+        let fs = Fs::from_slice(&[("config", "[default]\n")]);
+
+        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
+
+        let actual_retry_config = super::default_provider()
+            .configure(&provider_config)
+            .retry_config()
+            .await;
+
+        let expected_retry_config = RetryConfig::standard();
+
+        assert_eq!(actual_retry_config, expected_retry_config);
+        // This is redundant but it's really important to make sure that
+        // we're setting these exact values by default so we check twice
+        assert_eq!(actual_retry_config.max_attempts(), 3);
+        assert_eq!(actual_retry_config.mode(), RetryMode::Standard);
+    }
+
+    #[tokio::test]
+    async fn test_no_retry_config_in_empty_profile() {
+        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
+        let fs = Fs::from_slice(&[("config", "[default]\n")]);
+
+        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
+
+        let actual_retry_config = super::default_provider()
+            .configure(&provider_config)
+            .retry_config()
+            .await;
+
+        let expected_retry_config = RetryConfig::standard();
+
+        assert_eq!(actual_retry_config, expected_retry_config)
+    }
+
+    #[tokio::test]
+    async fn test_creation_of_retry_config_from_profile() {
+        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
+        // TODO(https://github.com/awslabs/aws-sdk-rust/issues/247): standard is the default mode;
+        // this test would be better if it was setting it to adaptive mode
+        // adaptive mode is currently unsupported so that would panic
+        let fs = Fs::from_slice(&[(
+            "config",
+            // If the lines with the vars have preceding spaces, they don't get read
+            r#"[default]
+max_attempts = 1
+retry_mode = standard
+            "#,
+        )]);
+
+        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
+
+        let actual_retry_config = super::default_provider()
+            .configure(&provider_config)
+            .retry_config()
+            .await;
+
+        let expected_retry_config = RetryConfig::standard().with_max_attempts(1);
+
+        assert_eq!(actual_retry_config, expected_retry_config)
+    }
+
+    #[tokio::test]
+    async fn test_env_retry_config_takes_precedence_over_profile_retry_config() {
+        let env = Env::from_slice(&[
+            ("AWS_CONFIG_FILE", "config"),
+            ("AWS_MAX_ATTEMPTS", "42"),
+            ("AWS_RETRY_MODE", "standard"),
+        ]);
+        // TODO(https://github.com/awslabs/aws-sdk-rust/issues/247) standard is the default mode;
+        // this test would be better if it was setting it to adaptive mode
+        // adaptive mode is currently unsupported so that would panic
+        let fs = Fs::from_slice(&[(
+            "config",
+            // If the lines with the vars have preceding spaces, they don't get read
+            r#"[default]
+max_attempts = 88
+retry_mode = standard
+            "#,
+        )]);
+
+        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
+
+        let actual_retry_config = super::default_provider()
+            .configure(&provider_config)
+            .retry_config()
+            .await;
+
+        let expected_retry_config = RetryConfig::standard().with_max_attempts(42);
+
+        assert_eq!(actual_retry_config, expected_retry_config)
+    }
+
+    #[tokio::test]
+    #[should_panic = "failed to parse max attempts. source: profile `default`, key: `max_attempts`: invalid digit found in string"]
+    async fn test_invalid_profile_retry_config_panics() {
+        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "config")]);
+        let fs = Fs::from_slice(&[(
+            "config",
+            // If the lines with the vars have preceding spaces, they don't get read
+            r#"[default]
+max_attempts = potato
+            "#,
+        )]);
+
+        let provider_config = ProviderConfig::no_configuration().with_env(env).with_fs(fs);
+
+        let _ = super::default_provider()
+            .configure(&provider_config)
+            .retry_config()
+            .await;
     }
 
     #[tokio::test]

--- a/aws/rust-runtime/aws-config/src/default_provider/use_dual_stack.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/use_dual_stack.rs
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::environment::parse_bool;
+use crate::provider_config::ProviderConfig;
+use crate::standard_property::StandardProperty;
+use aws_smithy_types::error::display::DisplayErrorContext;
+
+mod env {
+    pub(super) const USE_DUAL_STACK: &'static str = "AWS_USE_DUALSTACK_ENDPOINT";
+}
+
+mod profile_key {
+    pub(super) const USE_DUAL_STACK: &'static str = "use_dualstack_endpoint";
+}
+
+pub(crate) async fn use_dual_stack_provider(provider_config: &ProviderConfig) -> Option<bool> {
+    StandardProperty::new()
+        .env(env::USE_DUAL_STACK)
+        .profile(profile_key::USE_DUAL_STACK)
+        .validate(provider_config, parse_bool)
+        .await
+        .map_err(
+            |err| tracing::warn!(err = %DisplayErrorContext(err), "invalid value for dual-stack setting"),
+        )
+        .unwrap_or(None)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::default_provider::use_dual_stack::use_dual_stack_provider;
+    use crate::profile::profile_file::{ProfileFileKind, ProfileFiles};
+    use crate::provider_config::ProviderConfig;
+    use aws_types::os_shim_internal::{Env, Fs};
+    use tracing_test::traced_test;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn log_error_on_invalid_value() {
+        let conf = ProviderConfig::empty().with_env(Env::from_slice(&[(
+            "AWS_USE_DUALSTACK_ENDPOINT",
+            "not-a-boolean",
+        )]));
+        assert_eq!(use_dual_stack_provider(&conf).await, None);
+        assert!(logs_contain("invalid value for dual-stack setting"));
+        assert!(logs_contain("AWS_USE_DUALSTACK_ENDPOINT"));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn environment_priority() {
+        let conf = ProviderConfig::empty()
+            .with_env(Env::from_slice(&[("AWS_USE_DUALSTACK_ENDPOINT", "TRUE")]))
+            .with_profile_config(
+                Some(
+                    ProfileFiles::builder()
+                        .with_file(ProfileFileKind::Config, "conf")
+                        .build(),
+                ),
+                None,
+            )
+            .with_fs(Fs::from_slice(&[(
+                "conf",
+                "[default]\nuse_dualstack_endpoint = false",
+            )]));
+        assert_eq!(use_dual_stack_provider(&conf).await, Some(true));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn profile_works() {
+        let conf = ProviderConfig::empty()
+            .with_profile_config(
+                Some(
+                    ProfileFiles::builder()
+                        .with_file(ProfileFileKind::Config, "conf")
+                        .build(),
+                ),
+                None,
+            )
+            .with_fs(Fs::from_slice(&[(
+                "conf",
+                "[default]\nuse_dualstack_endpoint = false",
+            )]));
+        assert_eq!(use_dual_stack_provider(&conf).await, Some(false));
+    }
+}

--- a/aws/rust-runtime/aws-config/src/default_provider/use_dual_stack.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/use_dual_stack.rs
@@ -23,7 +23,7 @@ pub(crate) async fn use_dual_stack_provider(provider_config: &ProviderConfig) ->
         .validate(provider_config, parse_bool)
         .await
         .map_err(
-            |err| tracing::warn!(err = %DisplayErrorContext(err), "invalid value for dual-stack setting"),
+            |err| tracing::warn!(err = %DisplayErrorContext(&err), "invalid value for dual-stack setting"),
         )
         .unwrap_or(None)
 }

--- a/aws/rust-runtime/aws-config/src/default_provider/use_dual_stack.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/use_dual_stack.rs
@@ -9,11 +9,11 @@ use crate::standard_property::StandardProperty;
 use aws_smithy_types::error::display::DisplayErrorContext;
 
 mod env {
-    pub(super) const USE_DUAL_STACK: &'static str = "AWS_USE_DUALSTACK_ENDPOINT";
+    pub(super) const USE_DUAL_STACK: &str = "AWS_USE_DUALSTACK_ENDPOINT";
 }
 
 mod profile_key {
-    pub(super) const USE_DUAL_STACK: &'static str = "use_dualstack_endpoint";
+    pub(super) const USE_DUAL_STACK: &str = "use_dualstack_endpoint";
 }
 
 pub(crate) async fn use_dual_stack_provider(provider_config: &ProviderConfig) -> Option<bool> {

--- a/aws/rust-runtime/aws-config/src/default_provider/use_fips.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/use_fips.rs
@@ -30,7 +30,7 @@ pub async fn use_fips_provider(provider_config: &ProviderConfig) -> Option<bool>
         .validate(provider_config, parse_bool)
         .await
         .map_err(
-            |err| tracing::warn!(err = %DisplayErrorContext(err), "invalid value for FIPS setting"),
+            |err| tracing::warn!(err = %DisplayErrorContext(&err), "invalid value for FIPS setting"),
         )
         .unwrap_or(None)
 }

--- a/aws/rust-runtime/aws-config/src/default_provider/use_fips.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/use_fips.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::environment::parse_bool;
+use crate::provider_config::ProviderConfig;
+use crate::standard_property::StandardProperty;
+use aws_smithy_types::error::display::DisplayErrorContext;
+
+mod env {
+    pub(super) const USE_FIPS: &'static str = "AWS_USE_FIPS_ENDPOINT";
+}
+
+mod profile_key {
+    pub(super) const USE_FIPS: &'static str = "use_fips_endpoint";
+}
+
+/// Load the value for "use FIPS"
+///
+/// This checks the following sources:
+/// 1. The environment variable `AWS_USE_FIPS_ENDPOINT=true/false`
+/// 2. The profile key `use_fips_endpoint=true/false`
+///
+/// If invalid values are found, the provider will return None and an error will be logged.
+pub async fn use_fips_provider(provider_config: &ProviderConfig) -> Option<bool> {
+    StandardProperty::new()
+        .env(env::USE_FIPS)
+        .profile(profile_key::USE_FIPS)
+        .validate(provider_config, parse_bool)
+        .await
+        .map_err(
+            |err| tracing::warn!(err = %DisplayErrorContext(err), "invalid value for FIPS setting"),
+        )
+        .unwrap_or(None)
+}
+
+#[cfg(test)]
+mod test {
+    use crate::default_provider::use_fips::use_fips_provider;
+    use crate::profile::profile_file::{ProfileFileKind, ProfileFiles};
+    use crate::provider_config::ProviderConfig;
+    use aws_types::os_shim_internal::{Env, Fs};
+    use tracing_test::traced_test;
+
+    #[tokio::test]
+    #[traced_test]
+    async fn log_error_on_invalid_value() {
+        let conf = ProviderConfig::empty().with_env(Env::from_slice(&[(
+            "AWS_USE_FIPS_ENDPOINT",
+            "not-a-boolean",
+        )]));
+        assert_eq!(use_fips_provider(&conf).await, None);
+        assert!(logs_contain("invalid value for FIPS setting"));
+        assert!(logs_contain("AWS_USE_FIPS_ENDPOINT"));
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn environment_priority() {
+        let conf = ProviderConfig::empty()
+            .with_env(Env::from_slice(&[("AWS_USE_FIPS_ENDPOINT", "TRUE")]))
+            .with_profile_config(
+                Some(
+                    ProfileFiles::builder()
+                        .with_file(ProfileFileKind::Config, "conf")
+                        .build(),
+                ),
+                None,
+            )
+            .with_fs(Fs::from_slice(&[(
+                "conf",
+                "[default]\nuse_fips_endpoint = false",
+            )]));
+        assert_eq!(use_fips_provider(&conf).await, Some(true));
+    }
+}

--- a/aws/rust-runtime/aws-config/src/default_provider/use_fips.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/use_fips.rs
@@ -9,11 +9,11 @@ use crate::standard_property::StandardProperty;
 use aws_smithy_types::error::display::DisplayErrorContext;
 
 mod env {
-    pub(super) const USE_FIPS: &'static str = "AWS_USE_FIPS_ENDPOINT";
+    pub(super) const USE_FIPS: &str = "AWS_USE_FIPS_ENDPOINT";
 }
 
 mod profile_key {
-    pub(super) const USE_FIPS: &'static str = "use_fips_endpoint";
+    pub(super) const USE_FIPS: &str = "use_fips_endpoint";
 }
 
 /// Load the value for "use FIPS"

--- a/aws/rust-runtime/aws-config/src/environment/mod.rs
+++ b/aws/rust-runtime/aws-config/src/environment/mod.rs
@@ -7,7 +7,10 @@
 
 /// Load app name from the environment
 pub mod app_name;
+
 pub use app_name::EnvironmentVariableAppNameProvider;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
 
 /// Load credentials from the environment
 pub mod credentials;
@@ -16,3 +19,28 @@ pub use credentials::EnvironmentVariableCredentialsProvider;
 /// Load regions from the environment
 pub mod region;
 pub use region::EnvironmentVariableRegionProvider;
+
+#[derive(Debug)]
+pub(crate) struct InvalidBooleanValue {
+    value: String,
+}
+
+impl Display for InvalidBooleanValue {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} was not a valid boolean", self.value)
+    }
+}
+
+impl Error for InvalidBooleanValue {}
+
+pub(crate) fn parse_bool(value: &str) -> Result<bool, InvalidBooleanValue> {
+    if value.eq_ignore_ascii_case("false") {
+        Ok(false)
+    } else if value.eq_ignore_ascii_case("true") {
+        Ok(true)
+    } else {
+        Err(InvalidBooleanValue {
+            value: value.to_string(),
+        })
+    }
+}

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -156,6 +156,7 @@ mod loader {
     use aws_smithy_types::retry::RetryConfig;
     use aws_smithy_types::timeout::TimeoutConfig;
     use aws_types::app_name::AppName;
+    use aws_types::docs_for;
     use aws_types::endpoint::ResolveAwsEndpoint;
     use aws_types::SdkConfig;
 
@@ -445,24 +446,13 @@ mod loader {
             self
         }
 
-        /// When true, send this request to the FIPS-compliant regional endpoint.
-        ///
-        /// If the configured endpoint does not have a FIPS compliant endpoint, dispatching
-        /// the request will return an error.
-        ///
-        /// **Note**: Not all services and regions support FIPS. If a service does not support FIPS,
-        /// this setting will have no effect.
+        #[doc = docs_for!(use_fips)]
         pub fn use_fips(mut self, use_fips: bool) -> Self {
             self.use_fips = Some(use_fips);
             self
         }
 
-        /// When true, send this request to the dual-stack endpoint.
-        ///
-        /// If the configured endpoint does not support dual-stack, the request MAY return an error.
-        ///
-        /// **Note**: Not all services and regions support dual-stack. If a service does not support
-        /// dual-stack, this setting will have no effect.
+        #[doc = docs_for!(use_dual_stack)]
         pub fn use_dual_stack(mut self, use_dual_stack: bool) -> Self {
             self.use_dual_stack = Some(use_dual_stack);
             self

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -606,9 +606,10 @@ mod loader {
         use aws_types::os_shim_internal::{Env, Fs};
         use tracing_test::traced_test;
 
-        use crate::from_env;
         use crate::profile::profile_file::{ProfileFileKind, ProfileFiles};
         use crate::provider_config::ProviderConfig;
+        use crate::test_case::{no_traffic_connector, InstantSleep};
+        use crate::{from_env, ConfigLoader};
 
         #[tokio::test]
         #[traced_test]
@@ -667,18 +668,26 @@ mod loader {
             });
         }
 
+        fn base_conf() -> ConfigLoader {
+            from_env().configure(
+                ProviderConfig::empty()
+                    .with_sleep(InstantSleep)
+                    .with_http_connector(no_traffic_connector()),
+            )
+        }
+
         #[tokio::test]
         async fn load_fips() {
-            let conf = from_env().use_fips(true).load().await;
+            let conf = base_conf().use_fips(true).load().await;
             assert_eq!(conf.use_fips(), Some(true));
         }
 
         #[tokio::test]
         async fn load_dual_stack() {
-            let conf = from_env().use_dual_stack(false).load().await;
+            let conf = base_conf().use_dual_stack(false).load().await;
             assert_eq!(conf.use_dual_stack(), Some(false));
 
-            let conf = from_env().load().await;
+            let conf = base_conf().load().await;
             assert_eq!(conf.use_dual_stack(), None);
         }
     }

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -18,8 +18,30 @@ use aws_smithy_types::retry::RetryConfig;
 use aws_smithy_types::timeout::TimeoutConfig;
 
 use crate::app_name::AppName;
+use crate::docs_for;
 use crate::endpoint::ResolveAwsEndpoint;
 use crate::region::Region;
+
+#[doc(hidden)]
+/// Unified docstrings to keep crates in sync. Not intended for public use
+pub mod unified_docs {
+    #[macro_export]
+    macro_rules! docs_for {
+        (use_fips) => {
+"When true, send this request to the FIPS-compliant regional endpoint.
+
+If no FIPS-compliant endpoint can be determined, dispatching the request will return an error."
+        };
+        (use_dual_stack) => {
+"When true, send this request to the dual-stack endpoint.
+
+If no dual-stack endpoint is available the request MAY return an error.
+
+**Note**: Some services do not offer dual-stack as a configurable parameter (e.g. Code Catalyst). For
+these services, this setting has no effect"
+        };
+    }
+}
 
 /// AWS Shared Configuration
 #[derive(Debug, Clone)]
@@ -192,7 +214,6 @@ impl Builder {
     ///
     /// let mut builder = SdkConfig::builder();
     /// disable_retries(&mut builder);
-    /// let config = builder.build();
     /// ```
     pub fn set_retry_config(&mut self, retry_config: Option<RetryConfig>) -> &mut Self {
         self.retry_config = retry_config;
@@ -465,47 +486,25 @@ impl Builder {
         self
     }
 
-    /// When true, send this request to the FIPS-compliant regional endpoint.
-    ///
-    /// If the configured endpoint does not have a FIPS compliant endpoint, dispatching
-    /// the request will return an error.
-    ///
-    /// **Note**: Not all services and regions support FIPS. If a service does not support FIPS,
-    /// this setting will have no effect.
+    #[doc = docs_for!(use_fips)]
     pub fn use_fips(mut self, use_fips: bool) -> Self {
         self.set_use_fips(Some(use_fips));
         self
     }
 
-    /// When true, send this request to the FIPS-compliant regional endpoint.
-    ///
-    /// If the configured endpoint does not have a FIPS compliant endpoint, dispatching
-    /// the request will return an error.
-    ///
-    /// **Note**: Not all services and regions support FIPS. If a service does not support FIPS,
-    /// this setting will have no effect.
+    #[doc = docs_for!(use_fips)]
     pub fn set_use_fips(&mut self, use_fips: Option<bool>) -> &mut Self {
         self.use_fips = use_fips;
         self
     }
 
-    /// When true, send this request to the dual-stack endpoint.
-    ///
-    /// If the configured endpoint does not support dual-stack, the request MAY return an error.
-    ///
-    /// **Note**: Not all services and regions support dual-stack. If a service does not support
-    /// dual-stack, this setting will have no effect.
+    #[doc = docs_for!(use_dual_stack)]
     pub fn use_dual_stack(mut self, use_dual_stack: bool) -> Self {
         self.set_use_dual_stack(Some(use_dual_stack));
         self
     }
 
-    /// When true, send this request to the dual-stack endpoint.
-    ///
-    /// If the configured endpoint does not support dual-stack, the request MAY return an error.
-    ///
-    /// **Note**: Not all services and regions support dual-stack. If a service does not support
-    /// dual-stack, this setting will have no effect.
+    #[doc = docs_for!(use_dual_stack)]
     pub fn set_use_dual_stack(&mut self, use_dual_stack: Option<bool>) -> &mut Self {
         self.use_dual_stack = use_dual_stack;
         self

--- a/aws/rust-runtime/aws-types/src/sdk_config.rs
+++ b/aws/rust-runtime/aws-types/src/sdk_config.rs
@@ -33,6 +33,8 @@ pub struct SdkConfig {
     sleep_impl: Option<Arc<dyn AsyncSleep>>,
     timeout_config: Option<TimeoutConfig>,
     http_connector: Option<HttpConnector>,
+    use_fips: Option<bool>,
+    use_dual_stack: Option<bool>,
 }
 
 /// Builder for AWS Shared Configuration
@@ -51,6 +53,8 @@ pub struct Builder {
     sleep_impl: Option<Arc<dyn AsyncSleep>>,
     timeout_config: Option<TimeoutConfig>,
     http_connector: Option<HttpConnector>,
+    use_fips: Option<bool>,
+    use_dual_stack: Option<bool>,
 }
 
 impl Builder {
@@ -461,6 +465,52 @@ impl Builder {
         self
     }
 
+    /// When true, send this request to the FIPS-compliant regional endpoint.
+    ///
+    /// If the configured endpoint does not have a FIPS compliant endpoint, dispatching
+    /// the request will return an error.
+    ///
+    /// **Note**: Not all services and regions support FIPS. If a service does not support FIPS,
+    /// this setting will have no effect.
+    pub fn use_fips(mut self, use_fips: bool) -> Self {
+        self.set_use_fips(Some(use_fips));
+        self
+    }
+
+    /// When true, send this request to the FIPS-compliant regional endpoint.
+    ///
+    /// If the configured endpoint does not have a FIPS compliant endpoint, dispatching
+    /// the request will return an error.
+    ///
+    /// **Note**: Not all services and regions support FIPS. If a service does not support FIPS,
+    /// this setting will have no effect.
+    pub fn set_use_fips(&mut self, use_fips: Option<bool>) -> &mut Self {
+        self.use_fips = use_fips;
+        self
+    }
+
+    /// When true, send this request to the dual-stack endpoint.
+    ///
+    /// If the configured endpoint does not support dual-stack, the request MAY return an error.
+    ///
+    /// **Note**: Not all services and regions support dual-stack. If a service does not support
+    /// dual-stack, this setting will have no effect.
+    pub fn use_dual_stack(mut self, use_dual_stack: bool) -> Self {
+        self.set_use_dual_stack(Some(use_dual_stack));
+        self
+    }
+
+    /// When true, send this request to the dual-stack endpoint.
+    ///
+    /// If the configured endpoint does not support dual-stack, the request MAY return an error.
+    ///
+    /// **Note**: Not all services and regions support dual-stack. If a service does not support
+    /// dual-stack, this setting will have no effect.
+    pub fn set_use_dual_stack(&mut self, use_dual_stack: Option<bool>) -> &mut Self {
+        self.use_dual_stack = use_dual_stack;
+        self
+    }
+
     /// Build a [`SdkConfig`](SdkConfig) from this builder
     pub fn build(self) -> SdkConfig {
         SdkConfig {
@@ -473,6 +523,8 @@ impl Builder {
             sleep_impl: self.sleep_impl,
             timeout_config: self.timeout_config,
             http_connector: self.http_connector,
+            use_fips: self.use_fips,
+            use_dual_stack: self.use_dual_stack,
         }
     }
 }
@@ -522,6 +574,16 @@ impl SdkConfig {
     /// Configured HTTP Connector
     pub fn http_connector(&self) -> Option<&HttpConnector> {
         self.http_connector.as_ref()
+    }
+
+    /// Use FIPS endpoints
+    pub fn use_fips(&self) -> Option<bool> {
+        self.use_fips
+    }
+
+    /// Use dual-stack endpoint
+    pub fn use_dual_stack(&self) -> Option<bool> {
+        self.use_dual_stack
     }
 
     /// Config builder

--- a/aws/sdk/integration-tests/dynamodb/tests/endpoints.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/endpoints.rs
@@ -3,45 +3,87 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_dynamodb::{Credentials, Region};
+use aws_sdk_dynamodb::{config, Credentials, Region};
+use aws_types::SdkConfig;
 use http::Uri;
 
-/// Iterative test of loading clients from shared configuration
-#[tokio::test]
-async fn endpoints_can_be_overridden_globally() {
+#[track_caller]
+async fn expect_uri(
+    conf: SdkConfig,
+    uri: &'static str,
+    customize: fn(config::Builder) -> config::Builder,
+) {
     let (conn, request) = aws_smithy_client::test_connection::capture_request(None);
-    let shared_config = aws_types::SdkConfig::builder()
-        .region(Region::new("us-east-4"))
-        .http_connector(conn)
-        .endpoint_url("http://localhost:8000")
-        .build();
-    let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)
-        .credentials_provider(Credentials::for_tests())
-        .build();
+    let conf = customize(
+        aws_sdk_dynamodb::config::Builder::from(&conf)
+            .credentials_provider(Credentials::for_tests())
+            .http_connector(conn),
+    )
+    .build();
     let svc = aws_sdk_dynamodb::Client::from_conf(conf);
     // dbg to see why the request failed if this test is failing
     let _ = dbg!(svc.list_tables().send().await);
-    assert_eq!(
-        request.expect_request().uri(),
-        &Uri::from_static("http://localhost:8000")
-    );
+    assert_eq!(request.expect_request().uri(), &Uri::from_static(uri));
+}
+
+/// Integration test of loading clients from shared configuration
+#[tokio::test]
+async fn endpoints_can_be_overridden_globally() {
+    let conf = aws_types::SdkConfig::builder()
+        .region(Region::new("us-east-4"))
+        .endpoint_url("http://localhost:8000")
+        .build();
+
+    expect_uri(conf, "http://localhost:8000", |b| b).await;
 }
 
 #[tokio::test]
 async fn endpoints_can_be_overridden_locally() {
-    let (conn, request) = aws_smithy_client::test_connection::capture_request(None);
     let shared_config = aws_types::SdkConfig::builder()
         .region(Region::new("us-east-4"))
-        .http_connector(conn)
         .build();
-    let conf = aws_sdk_dynamodb::config::Builder::from(&shared_config)
-        .credentials_provider(Credentials::for_tests())
-        .endpoint_url("http://localhost:8000")
+
+    expect_uri(shared_config, "http://localhost:8000", |b| {
+        b.endpoint_url("http://localhost:8000")
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn dual_stack_endpoints() {
+    let shared_config = SdkConfig::builder()
+        .region(Region::new("us-east-4"))
+        .use_dual_stack(true)
         .build();
-    let svc = aws_sdk_dynamodb::Client::from_conf(conf);
-    let _ = svc.list_tables().send().await;
-    assert_eq!(
-        request.expect_request().uri(),
-        &Uri::from_static("http://localhost:8000")
-    );
+    expect_uri(shared_config, "https://dynamodb.us-east-4.api.aws/", |b| b).await
+}
+
+#[tokio::test]
+async fn dual_stack_disabled_locally_endpoints() {
+    let shared_config = SdkConfig::builder()
+        .region(Region::new("us-east-4"))
+        .use_dual_stack(true)
+        .build();
+    expect_uri(
+        shared_config,
+        "https://dynamodb.us-east-4.amazonaws.com/",
+        |b| b.use_dual_stack(false),
+    )
+    .await
+}
+
+#[tokio::test]
+async fn fips_endpoints() {
+    let shared_config = aws_types::SdkConfig::builder()
+        .region(Region::new("us-east-4"))
+        .use_dual_stack(true)
+        .use_fips(true)
+        .build();
+
+    expect_uri(
+        shared_config,
+        "https://dynamodb-fips.us-east-4.api.aws/",
+        |b| b,
+    )
+    .await;
 }


### PR DESCRIPTION
## Motivation and Context
- #1784 
- fixes #2143 

## Description
- Wire up FIPS & dualstack providers for SdkConfig
- Move tests from `credentials-provider` that belong in `RetryConfig`

## Testing
- local and integration tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
