### PR TITLE
Remove webpki feature dependency

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -142,3 +142,9 @@ references = ["smithy-rs#2162"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 message = "`aws_config::profile::retry_config` && `aws_config::environment::retry_config` have been removed. Use `aws_config::default_provider::retry_config` instead."
 author = "rcoh"
+
+[[smithy-rs]]
+references = ["smithy-rs#2170", "aws-sdk-rust#706"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+message = "Remove the webpki-roots feature from `hyper-rustls`"
+author = "rcoh"

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -13,6 +13,7 @@ test-util = ["aws-smithy-protocol-test", "serde/derive", "rustls"]
 native-tls = ["client-hyper", "hyper-tls", "rt-tokio"]
 rustls = ["client-hyper", "hyper-rustls", "rt-tokio", "lazy_static"]
 client-hyper = ["hyper"]
+hyper-webpki-doctest-only = ["hyper-rustls/webpki-roots"]
 
 [dependencies]
 aws-smithy-async = { path = "../aws-smithy-async" }
@@ -28,7 +29,7 @@ hyper = { version = "0.14.12", features = ["client", "http2", "http1", "tcp"], o
 # cargo does not support optional test dependencies, so to completely disable rustls when
 # the native-tls feature is enabled, we need to add the webpki-roots feature here.
 # https://github.com/rust-lang/cargo/issues/1596
-hyper-rustls = { version = "0.23.0", optional = true, features = ["rustls-native-certs", "http2", "webpki-roots"] }
+hyper-rustls = { version = "0.23.0", optional = true, features = ["rustls-native-certs", "http2"] }
 hyper-tls = { version = "0.5.0", optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project-lite = "0.2.7"

--- a/rust-runtime/aws-smithy-client/src/hyper_ext.rs
+++ b/rust-runtime/aws-smithy-client/src/hyper_ext.rs
@@ -51,7 +51,14 @@
     not(all(feature = "rustls", feature = "client-hyper")),
     doc = "```no_run,ignore"
 )]
-#![cfg_attr(all(feature = "rustls", feature = "client-hyper"), doc = "```no_run")]
+#![cfg_attr(
+    all(
+        feature = "rustls",
+        feature = "client-hyper",
+        feature = "hyper-webpki-doctest-only"
+    ),
+    doc = "```no_run"
+)]
 //! use std::time::Duration;
 //! use aws_smithy_client::{Client, conns, hyper_ext};
 //! use aws_smithy_client::erase::DynConnector;


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/aws-sdk-rust/discussions/706

## Description
- remove webpki feature
- add additional feature to pull in webpki for the doctest

## Testing
- CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
