### PR TITLE
refactor: extract retry quota into a tower service

### DIFF
--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -23,6 +23,7 @@ aws-smithy-protocol-test = { path = "../aws-smithy-protocol-test", optional = tr
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 fastrand = "1.4.0"
+futures-util = "0.3.25"
 http = "0.2.3"
 http-body = "0.4.4"
 hyper = { version = "0.14.12", features = ["client", "http2", "http1", "tcp"], optional = true }

--- a/rust-runtime/aws-smithy-client/src/bounds.rs
+++ b/rust-runtime/aws-smithy-client/src/bounds.rs
@@ -134,7 +134,7 @@ where
 /// This trait has a blanket implementation for all compatible types, and should never be
 /// implemented.
 pub trait SmithyRetryPolicy<O, T, E, Retry>:
-    tower::retry::Policy<Operation<O, Retry>, SdkSuccess<T>, SdkError<E>> + Clone
+    tower::retry::Policy<Operation<O, Retry>, SdkSuccess<T>, SdkError<E>> + Clone + 'static
 {
     /// Forwarding type to `O` for bound inference.
     ///
@@ -153,7 +153,7 @@ pub trait SmithyRetryPolicy<O, T, E, Retry>:
 
 impl<R, O, T, E, Retry> SmithyRetryPolicy<O, T, E, Retry> for R
 where
-    R: tower::retry::Policy<Operation<O, Retry>, SdkSuccess<T>, SdkError<E>> + Clone,
+    R: tower::retry::Policy<Operation<O, Retry>, SdkSuccess<T>, SdkError<E>> + Clone + 'static,
     O: ParseHttpResponse<Output = Result<T, E>> + Send + Sync + Clone + 'static,
     E: Error,
     Retry: ClassifyRetry<SdkSuccess<T>, SdkError<E>>,

--- a/rust-runtime/aws-smithy-client/src/erase.rs
+++ b/rust-runtime/aws-smithy-client/src/erase.rs
@@ -61,6 +61,7 @@ where
             retry_policy: self.retry_policy,
             operation_timeout_config: self.operation_timeout_config,
             sleep_impl: self.sleep_impl,
+            token_bucket: self.token_bucket,
         }
     }
 }
@@ -101,6 +102,7 @@ where
             retry_policy: self.retry_policy,
             operation_timeout_config: self.operation_timeout_config,
             sleep_impl: self.sleep_impl,
+            token_bucket: self.token_bucket,
         }
     }
 

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -258,9 +258,8 @@ where
 
         let result = async move {
             check_send_sync(svc)
-                // TODO
-                .ready()
-                .await?
+                // .ready()
+                // .await?
                 .call(op)
                 .await
         }

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -236,9 +236,6 @@ where
             .layer(DispatchLayer::new())
             .service(connector);
 
-        // let c: Box<dyn tower::Service<_, Response = _, Error = _, Future = _>> =
-        //     Box::new(svc.clone());
-
         // send_operation records the full request-response lifecycle.
         // NOTE: For operations that stream output, only the setup is captured in this span.
         let span = debug_span!(
@@ -259,7 +256,9 @@ where
 
         let result = async move {
             check_send_sync(svc)
-                // .ready().await?
+                // TODO
+                .ready()
+                .await?
                 .call(op)
                 .await
         }

--- a/rust-runtime/aws-smithy-client/src/quota.rs
+++ b/rust-runtime/aws-smithy-client/src/quota.rs
@@ -37,7 +37,6 @@ where
     S::Future: 'static,
     E: 'static,
     Tb: TokenBucket,
-    // Tb::Token: Send + 'static,
 {
     type Response = S::Response;
     type Error = SdkError<E>;
@@ -46,7 +45,7 @@ where
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Check the inner service to see if it's ready yet. If no tokens are available, requests
         // should fail with an error instead of waiting for the next token.
-        self.inner.poll_ready(cx).map_err(|err| {
+        self.inner.poll_ready(cx).map_err(|_err| {
             SdkError::construction_failure(format!("inner service failed to become ready"))
         })
     }

--- a/rust-runtime/aws-smithy-client/src/quota.rs
+++ b/rust-runtime/aws-smithy-client/src/quota.rs
@@ -5,8 +5,11 @@
 
 //! Token bucket management
 
-use crate::token_bucket::TokenBucket;
-use aws_smithy_http::result::SdkError;
+use crate::token_bucket::{Token, TokenBucket};
+use aws_smithy_http::operation::Operation;
+use aws_smithy_http::result::{SdkError, SdkSuccess};
+use aws_smithy_http::retry::{ClassifyRetry, DefaultResponseRetryClassifier};
+use aws_smithy_types::retry::{ProvideErrorKind, RetryKind};
 use futures_util::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -30,15 +33,17 @@ impl<S, Tb: TokenBucket> QuotaService<S, Tb> {
     }
 }
 
-impl<S, Req, Tb, E> Service<Req> for QuotaService<S, Tb>
+impl<S, H, R, Tb, To, E, T> Service<Operation<H, R>> for QuotaService<S, Tb>
 where
-    S: Service<Req, Error = SdkError<E>>,
+    S: Service<Operation<H, R>, Error = SdkError<E>, Response = SdkSuccess<T>>,
     S::Response: 'static,
     S::Future: 'static,
-    E: 'static,
-    Tb: TokenBucket,
+    E: ProvideErrorKind + 'static,
+    T: 'static,
+    To: Token + 'static,
+    Tb: TokenBucket<Token = To>,
 {
-    type Response = S::Response;
+    type Response = SdkSuccess<T>;
     type Error = SdkError<E>;
     type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>>>>;
 
@@ -50,22 +55,37 @@ where
         })
     }
 
-    fn call(&mut self, mut req: Req) -> Self::Future {
-        match self.token_bucket.try_acquire(None) {
-            Ok(token) => {
-                // req.properties_mut().insert(token);
-                let fut = self.inner.call(req);
-
-                Box::pin(fut)
-            }
+    fn call(&mut self, req: Operation<H, R>) -> Self::Future {
+        let previous_response_kind = req.properties().get::<RetryKind>().cloned();
+        let (fut, token) = match self
+            .token_bucket
+            .try_acquire(previous_response_kind.clone())
+        {
+            Ok(token) => (self.inner.call(req), token),
             Err(err) => {
-                let fut = futures_util::future::err::<_, SdkError<E>>(
+                return Box::pin(futures_util::future::err::<_, SdkError<E>>(
                     SdkError::construction_failure(err),
-                );
-
-                Box::pin(fut)
+                ))
             }
-        }
+        };
+
+        Box::pin(async move {
+            let res = fut.await;
+            let classifier = DefaultResponseRetryClassifier::new();
+            // If this request failed with a reason that's relevant to our token bucket,
+            // insert that info into the property bag so we can retrieve the correct number
+            // of tokens if the request is retried.
+            let response_kind = classifier.classify_retry(res.as_ref());
+            // res.properties_mut().insert(response_kind);
+
+            if res.is_ok() {
+                token.release()
+            } else {
+                token.forget()
+            }
+
+            res
+        })
     }
 }
 
@@ -101,126 +121,125 @@ where
         QuotaService::new(inner, (self.token_bucket_builder)())
     }
 }
-//
-// #[cfg(test)]
-// mod tests {
-//     use super::QuotaService;
-//     use crate::token_bucket::standard;
-//     use crate::token_bucket::TokenBucket;
-//     use aws_smithy_http::body::SdkBody;
-//     use aws_smithy_http::operation::Operation;
-//     use aws_smithy_http::result::SdkError;
-//     use aws_smithy_types::retry::ErrorKind;
-//     use futures_util::future::TryFutureExt;
-//     use http::{Request, Response, StatusCode};
-//     use std::future::Future;
-//     use std::marker::PhantomData;
-//     use std::pin::Pin;
-//     use std::task::{Context, Poll};
-//     use std::time::Duration;
-//     use tower::{Service, ServiceExt};
-//
-//     #[derive(Clone)]
-//     struct TestService<H, R> {
-//         handler: PhantomData<H>,
-//         retry: PhantomData<R>,
-//     }
-//
-//     impl<H, R> TestService<H, R> {
-//         pub fn new() -> Self {
-//             Self {
-//                 handler: PhantomData::default(),
-//                 retry: PhantomData::default(),
-//             }
-//         }
-//     }
-//
-//     impl<H, R> Service<Operation<H, R>> for TestService<H, R> {
-//         type Response = Response<&'static str>;
-//         type Error = SdkError<()>;
-//         type Future =
-//             Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>>;
-//
-//         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-//             Poll::Ready(Ok(()))
-//         }
-//
-//         fn call(&mut self, _req: Operation<H, R>) -> Self::Future {
-//             let fut = async {
-//                 Ok(Response::builder()
-//                     .status(StatusCode::OK)
-//                     .body("Hello, world!")
-//                     .unwrap())
-//             };
-//
-//             Box::pin(fut)
-//         }
-//     }
-//
-//     #[tokio::test]
-//     async fn quota_service_has_ready_trait_method() {
-//         let mut svc = QuotaService::new(
-//             TestService::<(), ()>::new(),
-//             standard::TokenBucket::builder().build(),
-//         );
-//
-//         let _mut_ref = svc.ready().await.unwrap();
-//     }
-//
-//     #[tokio::test]
-//     async fn quota_service_is_send_sync() {
-//         fn check_send_sync<T: Send + Sync>(t: T) -> T {
-//             t
-//         }
-//
-//         let svc = QuotaService::new(
-//             TestService::<(), ()>::new(),
-//             standard::TokenBucket::builder().build(),
-//         );
-//
-//         let _mut_ref = check_send_sync(svc).ready().await.unwrap();
-//     }
-//
-//     #[tokio::test]
-//     async fn quota_layer_keeps_working_after_getting_emptied_and_then_refilled() {
-//         let quota_state = standard::TokenBucket::builder()
-//             .max_tokens(500)
-//             .retryable_error_cost(5)
-//             .timeout_error_cost(10)
-//             .starting_tokens(10)
-//             .build();
-//         assert_eq!(quota_state.available(), 10);
-//         // Remove the only token in the bucket, from the bucket
-//         let the_only_token_in_the_bucket = quota_state
-//             .try_acquire(Some(ErrorKind::TransientError))
-//             .unwrap();
-//         assert_eq!(quota_state.available(), 0);
-//
-//         let mut svc = QuotaService::new(TestService::new(), quota_state);
-//
-//         let req = Request::builder()
-//             .body(SdkBody::empty())
-//             .expect("failed to construct empty request");
-//         let req = aws_smithy_http::operation::Request::new(req);
-//         let op = Operation::new(req, ());
-//
-//         let op_clone = op.try_clone().unwrap();
-//         let svc_clone = svc.clone();
-//         let handle_a = tokio::task::spawn(async move {
-//             let mut svc = svc_clone;
-//             let _ = svc.ready().await;
-//             svc.call(op_clone).await
-//         });
-//
-//         // We need to make sure that the task has time to check readiness and find that the token
-//         // bucket is empty.
-//         tokio::time::sleep(Duration::from_secs(1)).await;
-//
-//         // Relinquish the semaphore token we held, enabling future requests to succeed.
-//         drop(the_only_token_in_the_bucket);
-//         let res_a = handle_a.await.expect("join handle is valid");
-//         let res_b = svc.ready().and_then(|f| f.call(op)).await;
-//
-//         println!("{res_a:#?}, {res_b:#?}");
-//     }
-// }
+
+#[cfg(test)]
+mod tests {
+    use super::QuotaService;
+    use crate::token_bucket::standard;
+    use crate::token_bucket::TokenBucket;
+    use aws_smithy_http::body::SdkBody;
+    use aws_smithy_http::operation::Operation;
+    use aws_smithy_http::result::SdkError;
+    use aws_smithy_types::retry::{ErrorKind, RetryKind};
+    use http::{Request, Response, StatusCode};
+    use std::future::Future;
+    use std::marker::PhantomData;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use tower::{Service, ServiceExt};
+
+    #[derive(Clone)]
+    struct TestService<H, R> {
+        handler: PhantomData<H>,
+        retry: PhantomData<R>,
+    }
+
+    impl<H, R> TestService<H, R> {
+        pub fn new() -> Self {
+            Self {
+                handler: PhantomData::default(),
+                retry: PhantomData::default(),
+            }
+        }
+    }
+
+    impl<H, R> Service<Operation<H, R>> for TestService<H, R> {
+        type Response = Response<&'static str>;
+        type Error = SdkError<()>;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Operation<H, R>) -> Self::Future {
+            let fut = async {
+                Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .body("Hello, world!")
+                    .unwrap())
+            };
+
+            Box::pin(fut)
+        }
+    }
+
+    #[tokio::test]
+    async fn quota_service_has_ready_trait_method() {
+        let mut svc = QuotaService::new(
+            TestService::<(), ()>::new(),
+            standard::TokenBucket::builder().build(),
+        );
+
+        let _mut_ref = svc.ready().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn quota_service_is_send_sync() {
+        fn check_send_sync<T: Send + Sync>(t: T) -> T {
+            t
+        }
+
+        let svc = QuotaService::new(
+            TestService::<(), ()>::new(),
+            standard::TokenBucket::builder().build(),
+        );
+
+        let _mut_ref = check_send_sync(svc).ready().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn quota_layer_keeps_working_after_getting_emptied_and_then_refilled() {
+        let quota_state = standard::TokenBucket::builder()
+            .max_tokens(500)
+            .retryable_error_cost(5)
+            .timeout_error_cost(10)
+            .starting_tokens(10)
+            .build();
+        assert_eq!(quota_state.available(), 10);
+        // Remove the only token in the bucket, from the bucket
+        let the_only_token_in_the_bucket = quota_state
+            .try_acquire(Some(RetryKind::Error(ErrorKind::TransientError)))
+            .unwrap();
+        assert_eq!(quota_state.available(), 0);
+
+        let mut svc = QuotaService::new(TestService::new(), quota_state);
+
+        let req = Request::builder()
+            .body(SdkBody::empty())
+            .expect("failed to construct empty request");
+        let req = aws_smithy_http::operation::Request::new(req);
+        let op = Operation::new(req, ());
+
+        let op_clone = op.try_clone().unwrap();
+        let svc_clone = svc.clone();
+        let handle_a = tokio::task::spawn(async move {
+            let mut svc = svc_clone;
+            let _ = svc.ready().await;
+            svc.call(op_clone).await
+        });
+
+        // We need to make sure that the task has time to check readiness and find that the token
+        // bucket is empty.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Relinquish the semaphore token we held, enabling future requests to succeed.
+        drop(the_only_token_in_the_bucket);
+        let res_a = handle_a.await.expect("join handle is valid");
+        let res_b = svc.ready().and_then(|f| f.call(op)).await;
+
+        println!("{res_a:#?}, {res_b:#?}");
+    }
+}

--- a/rust-runtime/aws-smithy-client/src/quota.rs
+++ b/rust-runtime/aws-smithy-client/src/quota.rs
@@ -1,0 +1,235 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Token bucket management
+
+use crate::token_bucket::TokenBucket;
+use aws_smithy_http::result::SdkError;
+use futures_util::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::Layer;
+
+/// A service that wraps another service, adding the ability to set a quota for requests
+/// handled by the inner service.
+#[derive(Clone)]
+pub struct QuotaService<S, Tb> {
+    inner: S,
+    token_bucket: Arc<Tb>,
+}
+
+impl<S, Tb> QuotaService<S, Tb>
+where
+    Tb: TokenBucket,
+{
+    /// Create a new `QuotaService`
+    pub fn new(inner: S, token_bucket: Tb) -> Self {
+        Self {
+            inner,
+            token_bucket: Arc::new(token_bucket),
+        }
+    }
+}
+
+type BoxedResultFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>>>>;
+
+impl<InnerService, Req, E, Tb> tower::Service<Req> for QuotaService<InnerService, Tb>
+where
+    InnerService: tower::Service<Req, Error = SdkError<E>>,
+    InnerService::Response: Send + 'static,
+    InnerService::Future: Send + 'static,
+    E: Send + 'static,
+    Tb: TokenBucket,
+    Tb::Token: Send + 'static,
+{
+    type Response = InnerService::Response;
+    type Error = SdkError<E>;
+    type Future = BoxedResultFuture<Self::Response, Self::Error>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Check the inner service to see if it's ready yet. If no tokens are available, requests
+        // should fail with an error instead of waiting for the next token.
+        self.inner.poll_ready(cx).map_err(|err| {
+            SdkError::construction_failure(format!("inner service failed to become ready"))
+        })
+    }
+
+    fn call(&mut self, mut req: Req) -> Self::Future {
+        match self.token_bucket.try_acquire(None) {
+            Ok(token) => {
+                // req.properties_mut().insert(token);
+                let fut = self.inner.call(req);
+
+                Box::pin(fut)
+            }
+            Err(err) => {
+                let fut = futures_util::future::err::<_, SdkError<E>>(
+                    SdkError::construction_failure(err),
+                );
+
+                Box::pin(fut)
+            }
+        }
+    }
+}
+
+/// A layer that wraps services in a quota service
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct QuotaLayer<Tbb> {
+    token_bucket_builder: Tbb,
+}
+
+impl<Tb, TbBuilder> QuotaLayer<TbBuilder>
+where
+    Tb: TokenBucket,
+    TbBuilder: Fn() -> Tb,
+{
+    /// Create a new `QuotaLayer`
+    pub fn new(token_bucket_builder: TbBuilder) -> Self {
+        QuotaLayer {
+            token_bucket_builder,
+        }
+    }
+}
+
+impl<S, Tb, TbBuilder> Layer<S> for QuotaLayer<TbBuilder>
+where
+    Tb: TokenBucket,
+    TbBuilder: Fn() -> Tb,
+{
+    type Service = QuotaService<S, Tb>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        QuotaService {
+            inner,
+            token_bucket: Arc::new((self.token_bucket_builder)()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::QuotaService;
+    use crate::token_bucket::standard;
+    use crate::token_bucket::TokenBucket;
+    use aws_smithy_http::body::SdkBody;
+    use aws_smithy_http::operation::Operation;
+    use aws_smithy_http::result::SdkError;
+    use aws_smithy_types::retry::ErrorKind;
+    use futures_util::future::TryFutureExt;
+    use http::{Request, Response, StatusCode};
+    use std::future::Future;
+    use std::marker::PhantomData;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+    use tower::{Service, ServiceExt};
+
+    #[derive(Clone)]
+    struct TestService<H, R> {
+        handler: PhantomData<H>,
+        retry: PhantomData<R>,
+    }
+
+    impl<H, R> TestService<H, R> {
+        pub fn new() -> Self {
+            Self {
+                handler: PhantomData::default(),
+                retry: PhantomData::default(),
+            }
+        }
+    }
+
+    impl<H, R> Service<Operation<H, R>> for TestService<H, R> {
+        type Response = Response<&'static str>;
+        type Error = SdkError<()>;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Operation<H, R>) -> Self::Future {
+            let fut = async {
+                Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .body("Hello, world!")
+                    .unwrap())
+            };
+
+            Box::pin(fut)
+        }
+    }
+
+    #[tokio::test]
+    async fn quota_service_has_ready_trait_method() {
+        let mut svc = QuotaService::new(
+            TestService::<(), ()>::new(),
+            standard::TokenBucket::builder().build(),
+        );
+
+        let _mut_ref = svc.ready().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn quota_service_is_send_sync() {
+        fn check_send_sync<T: Send + Sync>(t: T) -> T {
+            t
+        }
+
+        let svc = QuotaService::new(
+            TestService::<(), ()>::new(),
+            standard::TokenBucket::builder().build(),
+        );
+
+        let _mut_ref = check_send_sync(svc).ready().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn quota_layer_keeps_working_after_getting_emptied_and_then_refilled() {
+        let quota_state = standard::TokenBucket::builder()
+            .max_tokens(500)
+            .retryable_error_cost(5)
+            .timeout_error_cost(10)
+            .starting_tokens(10)
+            .build();
+        assert_eq!(quota_state.available(), 10);
+        // Remove the only token in the bucket, from the bucket
+        let the_only_token_in_the_bucket = quota_state
+            .try_acquire(Some(ErrorKind::TransientError))
+            .unwrap();
+        assert_eq!(quota_state.available(), 0);
+
+        let mut svc = QuotaService::new(TestService::new(), quota_state);
+
+        let req = Request::builder()
+            .body(SdkBody::empty())
+            .expect("failed to construct empty request");
+        let req = aws_smithy_http::operation::Request::new(req);
+        let op = Operation::new(req, ());
+
+        let op_clone = op.try_clone().unwrap();
+        let svc_clone = svc.clone();
+        let handle_a = tokio::task::spawn(async move {
+            let mut svc = svc_clone;
+            let _ = svc.ready().await;
+            svc.call(op_clone).await
+        });
+
+        // We need to make sure that the task has time to check readiness and find that the token
+        // bucket is empty.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        // Relinquish the semaphore token we held, enabling future requests to succeed.
+        drop(the_only_token_in_the_bucket);
+        let res_a = handle_a.await.expect("join handle is valid");
+        let res_b = svc.ready().and_then(|f| f.call(op)).await;
+
+        println!("{res_a:#?}, {res_b:#?}");
+    }
+}

--- a/rust-runtime/aws-smithy-client/src/quota.rs
+++ b/rust-runtime/aws-smithy-client/src/quota.rs
@@ -9,45 +9,39 @@ use crate::token_bucket::TokenBucket;
 use aws_smithy_http::result::SdkError;
 use futures_util::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
-use tower::Layer;
+use tower::{Layer, Service};
 
 /// A service that wraps another service, adding the ability to set a quota for requests
 /// handled by the inner service.
-#[derive(Clone)]
-pub struct QuotaService<S, Tb> {
+#[derive(Clone, Debug)]
+pub struct QuotaService<S: 'static, Tb: TokenBucket> {
     inner: S,
-    token_bucket: Arc<Tb>,
+    token_bucket: Tb,
 }
 
-impl<S, Tb> QuotaService<S, Tb>
-where
-    Tb: TokenBucket,
-{
+impl<S, Tb: TokenBucket> QuotaService<S, Tb> {
     /// Create a new `QuotaService`
     pub fn new(inner: S, token_bucket: Tb) -> Self {
         Self {
             inner,
-            token_bucket: Arc::new(token_bucket),
+            token_bucket,
         }
     }
 }
 
-type BoxedResultFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>>>>;
-
-impl<InnerService, Req, E, Tb> tower::Service<Req> for QuotaService<InnerService, Tb>
+impl<S, Req, Tb, E> Service<Req> for QuotaService<S, Tb>
 where
-    InnerService: tower::Service<Req, Error = SdkError<E>>,
-    InnerService::Response: Send + 'static,
-    InnerService::Future: Send + 'static,
-    E: Send + 'static,
+    S: Service<Req, Error = SdkError<E>>,
+    S::Response: 'static,
+    S::Future: 'static,
+    E: 'static,
     Tb: TokenBucket,
-    Tb::Token: Send + 'static,
+    // Tb::Token: Send + 'static,
 {
-    type Response = InnerService::Response;
+    type Response = S::Response;
     type Error = SdkError<E>;
-    type Future = BoxedResultFuture<Self::Response, Self::Error>;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, S::Error>>>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         // Check the inner service to see if it's ready yet. If no tokens are available, requests
@@ -98,138 +92,136 @@ where
 
 impl<S, Tb, TbBuilder> Layer<S> for QuotaLayer<TbBuilder>
 where
+    S: 'static,
     Tb: TokenBucket,
     TbBuilder: Fn() -> Tb,
 {
     type Service = QuotaService<S, Tb>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        QuotaService {
-            inner,
-            token_bucket: Arc::new((self.token_bucket_builder)()),
-        }
+        QuotaService::new(inner, (self.token_bucket_builder)())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::QuotaService;
-    use crate::token_bucket::standard;
-    use crate::token_bucket::TokenBucket;
-    use aws_smithy_http::body::SdkBody;
-    use aws_smithy_http::operation::Operation;
-    use aws_smithy_http::result::SdkError;
-    use aws_smithy_types::retry::ErrorKind;
-    use futures_util::future::TryFutureExt;
-    use http::{Request, Response, StatusCode};
-    use std::future::Future;
-    use std::marker::PhantomData;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-    use std::time::Duration;
-    use tower::{Service, ServiceExt};
-
-    #[derive(Clone)]
-    struct TestService<H, R> {
-        handler: PhantomData<H>,
-        retry: PhantomData<R>,
-    }
-
-    impl<H, R> TestService<H, R> {
-        pub fn new() -> Self {
-            Self {
-                handler: PhantomData::default(),
-                retry: PhantomData::default(),
-            }
-        }
-    }
-
-    impl<H, R> Service<Operation<H, R>> for TestService<H, R> {
-        type Response = Response<&'static str>;
-        type Error = SdkError<()>;
-        type Future =
-            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>>;
-
-        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            Poll::Ready(Ok(()))
-        }
-
-        fn call(&mut self, _req: Operation<H, R>) -> Self::Future {
-            let fut = async {
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .body("Hello, world!")
-                    .unwrap())
-            };
-
-            Box::pin(fut)
-        }
-    }
-
-    #[tokio::test]
-    async fn quota_service_has_ready_trait_method() {
-        let mut svc = QuotaService::new(
-            TestService::<(), ()>::new(),
-            standard::TokenBucket::builder().build(),
-        );
-
-        let _mut_ref = svc.ready().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn quota_service_is_send_sync() {
-        fn check_send_sync<T: Send + Sync>(t: T) -> T {
-            t
-        }
-
-        let svc = QuotaService::new(
-            TestService::<(), ()>::new(),
-            standard::TokenBucket::builder().build(),
-        );
-
-        let _mut_ref = check_send_sync(svc).ready().await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn quota_layer_keeps_working_after_getting_emptied_and_then_refilled() {
-        let quota_state = standard::TokenBucket::builder()
-            .max_tokens(500)
-            .retryable_error_cost(5)
-            .timeout_error_cost(10)
-            .starting_tokens(10)
-            .build();
-        assert_eq!(quota_state.available(), 10);
-        // Remove the only token in the bucket, from the bucket
-        let the_only_token_in_the_bucket = quota_state
-            .try_acquire(Some(ErrorKind::TransientError))
-            .unwrap();
-        assert_eq!(quota_state.available(), 0);
-
-        let mut svc = QuotaService::new(TestService::new(), quota_state);
-
-        let req = Request::builder()
-            .body(SdkBody::empty())
-            .expect("failed to construct empty request");
-        let req = aws_smithy_http::operation::Request::new(req);
-        let op = Operation::new(req, ());
-
-        let op_clone = op.try_clone().unwrap();
-        let svc_clone = svc.clone();
-        let handle_a = tokio::task::spawn(async move {
-            let mut svc = svc_clone;
-            let _ = svc.ready().await;
-            svc.call(op_clone).await
-        });
-
-        // We need to make sure that the task has time to check readiness and find that the token
-        // bucket is empty.
-        tokio::time::sleep(Duration::from_secs(1)).await;
-
-        // Relinquish the semaphore token we held, enabling future requests to succeed.
-        drop(the_only_token_in_the_bucket);
-        let res_a = handle_a.await.expect("join handle is valid");
-        let res_b = svc.ready().and_then(|f| f.call(op)).await;
-
-        println!("{res_a:#?}, {res_b:#?}");
-    }
-}
+//
+// #[cfg(test)]
+// mod tests {
+//     use super::QuotaService;
+//     use crate::token_bucket::standard;
+//     use crate::token_bucket::TokenBucket;
+//     use aws_smithy_http::body::SdkBody;
+//     use aws_smithy_http::operation::Operation;
+//     use aws_smithy_http::result::SdkError;
+//     use aws_smithy_types::retry::ErrorKind;
+//     use futures_util::future::TryFutureExt;
+//     use http::{Request, Response, StatusCode};
+//     use std::future::Future;
+//     use std::marker::PhantomData;
+//     use std::pin::Pin;
+//     use std::task::{Context, Poll};
+//     use std::time::Duration;
+//     use tower::{Service, ServiceExt};
+//
+//     #[derive(Clone)]
+//     struct TestService<H, R> {
+//         handler: PhantomData<H>,
+//         retry: PhantomData<R>,
+//     }
+//
+//     impl<H, R> TestService<H, R> {
+//         pub fn new() -> Self {
+//             Self {
+//                 handler: PhantomData::default(),
+//                 retry: PhantomData::default(),
+//             }
+//         }
+//     }
+//
+//     impl<H, R> Service<Operation<H, R>> for TestService<H, R> {
+//         type Response = Response<&'static str>;
+//         type Error = SdkError<()>;
+//         type Future =
+//             Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + Sync>>;
+//
+//         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+//             Poll::Ready(Ok(()))
+//         }
+//
+//         fn call(&mut self, _req: Operation<H, R>) -> Self::Future {
+//             let fut = async {
+//                 Ok(Response::builder()
+//                     .status(StatusCode::OK)
+//                     .body("Hello, world!")
+//                     .unwrap())
+//             };
+//
+//             Box::pin(fut)
+//         }
+//     }
+//
+//     #[tokio::test]
+//     async fn quota_service_has_ready_trait_method() {
+//         let mut svc = QuotaService::new(
+//             TestService::<(), ()>::new(),
+//             standard::TokenBucket::builder().build(),
+//         );
+//
+//         let _mut_ref = svc.ready().await.unwrap();
+//     }
+//
+//     #[tokio::test]
+//     async fn quota_service_is_send_sync() {
+//         fn check_send_sync<T: Send + Sync>(t: T) -> T {
+//             t
+//         }
+//
+//         let svc = QuotaService::new(
+//             TestService::<(), ()>::new(),
+//             standard::TokenBucket::builder().build(),
+//         );
+//
+//         let _mut_ref = check_send_sync(svc).ready().await.unwrap();
+//     }
+//
+//     #[tokio::test]
+//     async fn quota_layer_keeps_working_after_getting_emptied_and_then_refilled() {
+//         let quota_state = standard::TokenBucket::builder()
+//             .max_tokens(500)
+//             .retryable_error_cost(5)
+//             .timeout_error_cost(10)
+//             .starting_tokens(10)
+//             .build();
+//         assert_eq!(quota_state.available(), 10);
+//         // Remove the only token in the bucket, from the bucket
+//         let the_only_token_in_the_bucket = quota_state
+//             .try_acquire(Some(ErrorKind::TransientError))
+//             .unwrap();
+//         assert_eq!(quota_state.available(), 0);
+//
+//         let mut svc = QuotaService::new(TestService::new(), quota_state);
+//
+//         let req = Request::builder()
+//             .body(SdkBody::empty())
+//             .expect("failed to construct empty request");
+//         let req = aws_smithy_http::operation::Request::new(req);
+//         let op = Operation::new(req, ());
+//
+//         let op_clone = op.try_clone().unwrap();
+//         let svc_clone = svc.clone();
+//         let handle_a = tokio::task::spawn(async move {
+//             let mut svc = svc_clone;
+//             let _ = svc.ready().await;
+//             svc.call(op_clone).await
+//         });
+//
+//         // We need to make sure that the task has time to check readiness and find that the token
+//         // bucket is empty.
+//         tokio::time::sleep(Duration::from_secs(1)).await;
+//
+//         // Relinquish the semaphore token we held, enabling future requests to succeed.
+//         drop(the_only_token_in_the_bucket);
+//         let res_a = handle_a.await.expect("join handle is valid");
+//         let res_b = svc.ready().and_then(|f| f.call(op)).await;
+//
+//         println!("{res_a:#?}, {res_b:#?}");
+//     }
+// }

--- a/rust-runtime/aws-smithy-client/src/retry.rs
+++ b/rust-runtime/aws-smithy-client/src/retry.rs
@@ -16,7 +16,7 @@ use crate::{SdkError, SdkSuccess};
 use aws_smithy_async::rt::sleep::AsyncSleep;
 use aws_smithy_http::operation::Operation;
 use aws_smithy_http::retry::ClassifyRetry;
-use aws_smithy_types::retry::{ErrorKind, RetryKind};
+use aws_smithy_types::retry::RetryKind;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/rust-runtime/aws-smithy-client/src/token_bucket.rs
+++ b/rust-runtime/aws-smithy-client/src/token_bucket.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_types::retry::ErrorKind;
+use std::fmt;
+
+pub mod standard;
+
+pub trait Token {
+    /// Release this token back to the bucket.
+    fn release(self);
+
+    /// Forget this token, forever banishing it to the shadow realm, from whence no tokens return.
+    fn forget(self);
+}
+
+pub trait TokenBucket {
+    type Token;
+
+    /// Attempt to acquire a token from the bucket. This will fail if the bucket has no more tokens.
+    fn try_acquire(
+        &self,
+        previous_request_failed_because: Option<ErrorKind>,
+    ) -> Result<Self::Token, TokenBucketError>;
+
+    // TODO should this be exposed for non-`test` usage?
+    /// Get the number of available tokens in the bucket.
+    fn available(&self) -> usize;
+
+    /// Refill the bucket with the given number of tokens.
+    fn refill(&self, tokens: usize);
+}
+
+#[derive(Debug)]
+pub enum TokenBucketError {
+    NoTokens,
+    Bug(String),
+}
+
+impl fmt::Display for TokenBucketError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoTokens => write!(f, "No more tokens are left in the bucket."),
+            Self::Bug(msg) => write!(f, "you've encountered a bug that needs reporting: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for TokenBucketError {}

--- a/rust-runtime/aws-smithy-client/src/token_bucket/standard.rs
+++ b/rust-runtime/aws-smithy-client/src/token_bucket/standard.rs
@@ -1,0 +1,183 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use super::Token as TokenTrait;
+use super::TokenBucket as TokenBucketTrait;
+use super::TokenBucketError;
+use aws_smithy_types::retry::ErrorKind;
+use std::sync::Arc;
+use tokio::sync::OwnedSemaphorePermit;
+use tokio::sync::Semaphore;
+use tokio::sync::TryAcquireError;
+
+/// The default number of tokens to start with
+const DEFAULT_INITIAL_RETRY_TOKENS: usize = 500;
+/// The amount of tokens to remove from the bucket when a timeout error occurs
+const DEFAULT_TIMEOUT_ERROR_RETRY_COST: u32 = 10;
+/// The amount of tokens to remove from the bucket when a throttling error occurs
+const DEFAULT_RETRYABLE_ERROR_RETRY_COST: u32 = 5;
+/// The amount of tokens to add to the bucket when a request succeeds on the first try
+const SUCCESS_ON_FIRST_TRY_REFILL_AMOUNT: u32 = 1;
+
+pub struct Token {
+    permit: OwnedSemaphorePermit,
+}
+
+impl TokenTrait for Token {
+    fn release(self) {
+        drop(self.permit)
+    }
+
+    fn forget(self) {
+        self.permit.forget()
+    }
+}
+
+/// A token bucket implementation that uses a `tokio::sync::Semaphore` to track the number of tokens.
+///
+/// - Whenever a request succeeds on the first try, `<success_on_first_try_refill_amount>` token(s)
+///     are added back to the bucket.
+/// - When a request fails with a timeout error, `<timeout_error_cost>` token(s)
+///     are removed from the bucket.
+/// - When a request fails with a retryable error, `<retryable_error_cost>` token(s)
+///     are removed from the bucket.
+///
+/// The number of tokens in the bucket will always be >= `0` and <= `<max_tokens>`.
+#[derive(Clone)]
+pub struct TokenBucket {
+    inner: Arc<Semaphore>,
+    max_tokens: usize,
+    success_on_first_try_refill_amount: u32,
+    timeout_error_cost: u32,
+    retryable_error_cost: u32,
+}
+
+impl TokenBucket {
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+}
+
+#[derive(Default)]
+pub struct Builder {
+    starting_tokens: Option<usize>,
+    max_tokens: Option<usize>,
+    success_on_first_try_refill_amount: Option<u32>,
+    timeout_error_cost: Option<u32>,
+    retryable_error_cost: Option<u32>,
+}
+
+impl Builder {
+    pub fn starting_tokens(mut self, starting_tokens: usize) -> Self {
+        self.starting_tokens = Some(starting_tokens);
+        self
+    }
+
+    pub fn max_tokens(mut self, max_tokens: usize) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    pub fn success_on_first_try_refill_amount(
+        mut self,
+        success_on_first_try_refill_amount: u32,
+    ) -> Self {
+        self.success_on_first_try_refill_amount = Some(success_on_first_try_refill_amount);
+        self
+    }
+
+    pub fn timeout_error_cost(mut self, timeout_error_cost: u32) -> Self {
+        self.timeout_error_cost = Some(timeout_error_cost);
+        self
+    }
+
+    pub fn retryable_error_cost(mut self, retryable_error_cost: u32) -> Self {
+        self.retryable_error_cost = Some(retryable_error_cost);
+        self
+    }
+
+    pub fn build(self) -> TokenBucket {
+        let starting_tokens = self.starting_tokens.unwrap_or(DEFAULT_INITIAL_RETRY_TOKENS);
+        let max_tokens = self.max_tokens.unwrap_or(starting_tokens);
+        let success_on_first_try_refill_amount = self
+            .success_on_first_try_refill_amount
+            .unwrap_or(SUCCESS_ON_FIRST_TRY_REFILL_AMOUNT);
+        let timeout_error_cost = self
+            .timeout_error_cost
+            .unwrap_or(DEFAULT_TIMEOUT_ERROR_RETRY_COST);
+        let retryable_error_cost = self
+            .retryable_error_cost
+            .unwrap_or(DEFAULT_RETRYABLE_ERROR_RETRY_COST);
+
+        TokenBucket {
+            inner: Arc::new(Semaphore::new(starting_tokens)),
+            max_tokens,
+            success_on_first_try_refill_amount,
+            timeout_error_cost,
+            retryable_error_cost,
+        }
+    }
+}
+
+impl TokenBucketTrait for TokenBucket {
+    type Token = Token;
+
+    fn try_acquire(
+        &self,
+        previous_request_failed_because: Option<ErrorKind>,
+    ) -> Result<Self::Token, TokenBucketError> {
+        match self.inner.clone().try_acquire_owned() {
+            Ok(permit) => Ok(Token { permit }),
+            Err(TryAcquireError::NoPermits) => Err(TokenBucketError::NoTokens),
+            Err(other) => Err(TokenBucketError::Bug(other.to_string())),
+        }
+    }
+
+    fn refill(&self, tokens: usize) {
+        self.inner.add_permits(tokens)
+    }
+
+    fn available(&self) -> usize {
+        self.inner.available_permits()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use aws_smithy_types::retry::ErrorKind;
+
+    use super::{
+        TokenBucket, DEFAULT_INITIAL_RETRY_TOKENS, DEFAULT_RETRYABLE_ERROR_RETRY_COST,
+        DEFAULT_TIMEOUT_ERROR_RETRY_COST,
+    };
+    use crate::token_bucket::{Token, TokenBucket as TokenBucketTrait};
+
+    #[test]
+    fn bucket_works() {
+        let bucket = TokenBucket::builder().build();
+        assert_eq!(bucket.available(), DEFAULT_INITIAL_RETRY_TOKENS);
+
+        let token = bucket.try_acquire(Some(ErrorKind::ServerError)).unwrap();
+        assert_eq!(
+            bucket.available(),
+            DEFAULT_INITIAL_RETRY_TOKENS - DEFAULT_RETRYABLE_ERROR_RETRY_COST as usize
+        );
+        token.release();
+
+        let token = bucket.try_acquire(Some(ErrorKind::TransientError)).unwrap();
+        assert_eq!(
+            bucket.available(),
+            DEFAULT_INITIAL_RETRY_TOKENS - DEFAULT_TIMEOUT_ERROR_RETRY_COST as usize
+        );
+        token.forget();
+        assert_eq!(
+            bucket.available(),
+            DEFAULT_INITIAL_RETRY_TOKENS - DEFAULT_TIMEOUT_ERROR_RETRY_COST as usize
+        );
+
+        bucket.refill(DEFAULT_TIMEOUT_ERROR_RETRY_COST as usize);
+        assert_eq!(bucket.available(), DEFAULT_INITIAL_RETRY_TOKENS);
+    }
+}

--- a/rust-runtime/aws-smithy-client/src/token_bucket/standard.rs
+++ b/rust-runtime/aws-smithy-client/src/token_bucket/standard.rs
@@ -8,9 +8,7 @@
 use super::Token as TokenTrait;
 use super::TokenBucket as TokenBucketTrait;
 use super::TokenBucketError;
-use aws_smithy_http::result::ServiceError;
 use aws_smithy_types::retry::{ErrorKind, RetryKind};
-use futures_util::future::err;
 use std::sync::Arc;
 use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
@@ -226,8 +224,8 @@ impl TokenBucketTrait for TokenBucket {
 #[cfg(test)]
 mod test {
     use super::{
-        ResponseKind, TokenBucket, DEFAULT_INITIAL_RETRY_TOKENS,
-        DEFAULT_RETRYABLE_ERROR_RETRY_COST, DEFAULT_TIMEOUT_ERROR_RETRY_COST,
+        TokenBucket, DEFAULT_INITIAL_RETRY_TOKENS, DEFAULT_RETRYABLE_ERROR_RETRY_COST,
+        DEFAULT_TIMEOUT_ERROR_RETRY_COST,
     };
     use crate::token_bucket::{Token, TokenBucket as TokenBucketTrait};
 

--- a/rust-runtime/aws-smithy-http/src/retry.rs
+++ b/rust-runtime/aws-smithy-http/src/retry.rs
@@ -77,11 +77,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use crate::body::SdkBody;
     use crate::operation;
     use crate::result::{SdkError, SdkSuccess};
-    use crate::retry::ClassifyRetry;
+    use crate::retry::{ClassifyRetry, DefaultResponseRetryClassifier};
     use aws_smithy_types::retry::{ErrorKind, ProvideErrorKind, RetryKind};
     use std::fmt;
 

--- a/rust-runtime/aws-smithy-types/src/retry.rs
+++ b/rust-runtime/aws-smithy-types/src/retry.rs
@@ -61,7 +61,7 @@ pub trait ProvideErrorKind {
 /// - The required retry delay exceeds the maximum backoff configured by the client
 /// - No retry tokens are available due to service health
 #[non_exhaustive]
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Clone, Eq, PartialEq, Debug)]
 pub enum RetryKind {
     /// Retry the associated request due to a known `ErrorKind`.
     Error(ErrorKind),


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
#1785 

## Description
<!--- Describe your changes in detail -->
This PR extracts the retry quota state from the `RetryHandler` and places it in its own `tower::Layer`. This is a first step in the process to introduce adaptive retry behavior which will use its own specialized retry quota layer.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran existing tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
