### PR TITLE
pin ignore to older version with MSRV

### DIFF
--- a/tools/crate-hasher/Cargo.toml
+++ b/tools/crate-hasher/Cargo.toml
@@ -16,7 +16,8 @@ opt-level = 0
 [dependencies]
 anyhow = "1.0"
 clap = { version = "~3.1.18", features = ["derive"] }
-ignore = "0.4"
+# pin to 0.4.18 to deal with newer version relying on 1.65.0
+ignore = "0.4.18"
 sha256 = "1.1"
 
 [dev-dependencies]

--- a/tools/crate-hasher/Cargo.toml
+++ b/tools/crate-hasher/Cargo.toml
@@ -17,7 +17,7 @@ opt-level = 0
 anyhow = "1.0"
 clap = { version = "~3.1.18", features = ["derive"] }
 # pin to 0.4.18 to deal with newer version relying on 1.65.0
-ignore = "0.4.18"
+ignore = "=0.4.18"
 sha256 = "1.1"
 
 [dev-dependencies]


### PR DESCRIPTION
## Motivation and Context
ignore 0.4.19 uses Rust features not available on our MSRV


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
