### PR TITLE
Rename `PokemonService` `NotAuthorized`

### DIFF
--- a/codegen-core/common-test-models/pokemon.smithy
+++ b/codegen-core/common-test-models/pokemon.smithy
@@ -38,13 +38,13 @@ resource Storage {
 operation GetStorage {
     input: GetStorageInput,
     output: GetStorageOutput,
-    errors: [ResourceNotFoundException, NotAuthorized, ValidationException],
+    errors: [ResourceNotFoundException, StorageAccessNotAuthorized, ValidationException],
 }
 
 /// Not authorized to access Pokémon storage.
 @error("client")
 @httpError(401)
-structure NotAuthorized {}
+structure StorageAccessNotAuthorized {}
 
 /// A request to access Pokémon storage.
 @input

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-connect-info.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-connect-info.rs
@@ -12,7 +12,7 @@ use aws_smithy_http_server::{
 use clap::Parser;
 use pokemon_service::{capture_pokemon, check_health, get_pokemon_species, get_server_statistics, setup_tracing};
 use pokemon_service_server_sdk::{
-    error::{GetStorageError, NotAuthorized},
+    error::{GetStorageError, StorageAccessNotAuthorized},
     input::{DoNothingInput, GetStorageInput},
     output::{DoNothingOutput, GetStorageOutput},
     PokemonService,
@@ -53,7 +53,9 @@ pub async fn get_storage_with_local_approved(
         });
     }
     tracing::debug!("authentication failed");
-    Err(GetStorageError::NotAuthorized(NotAuthorized {}))
+    Err(GetStorageError::StorageAccessNotAuthorized(
+        StorageAccessNotAuthorized {},
+    ))
 }
 
 pub async fn do_nothing_but_log_request_ids(

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-lambda.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-lambda.rs
@@ -26,7 +26,9 @@ pub async fn get_storage_lambda(
     // We currently only support Ash and he has nothing stored
     if !(input.user == "ash" && input.passcode == "pikachu123") {
         tracing::debug!("authentication failed");
-        return Err(error::GetStorageError::NotAuthorized(error::NotAuthorized {}));
+        return Err(error::GetStorageError::StorageAccessNotAuthorized(
+            error::StorageAccessNotAuthorized {},
+        ));
     }
     Ok(output::GetStorageOutput { collection: vec![] })
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
@@ -185,7 +185,9 @@ pub async fn get_storage(
     // We currently only support Ash and he has nothing stored
     if !(input.user == "ash" && input.passcode == "pikachu123") {
         tracing::debug!("authentication failed");
-        return Err(error::GetStorageError::NotAuthorized(error::NotAuthorized {}));
+        return Err(error::GetStorageError::StorageAccessNotAuthorized(
+            error::StorageAccessNotAuthorized {},
+        ));
     }
     Ok(output::GetStorageOutput { collection: vec![] })
 }

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/tests/simple_integration_test.rs
@@ -14,7 +14,7 @@ use aws_smithy_types::error::display::DisplayErrorContext;
 use pokemon_service_client::{
     error::{
         AttemptCapturingPokemonEventError, AttemptCapturingPokemonEventErrorKind, GetStorageError, GetStorageErrorKind,
-        MasterBallUnsuccessful, NotAuthorized,
+        MasterBallUnsuccessful, StorageAccessNotAuthorized,
     },
     model::{AttemptCapturingPokemonEvent, CapturingEvent, CapturingPayload},
     types::SdkError,
@@ -78,7 +78,7 @@ async fn simple_integration_test() {
         matches!(
             context.err(),
             GetStorageError {
-                kind: GetStorageErrorKind::NotAuthorized(NotAuthorized { .. }),
+                kind: GetStorageErrorKind::StorageAccessNotAuthorized(StorageAccessNotAuthorized { .. }),
                 ..
             }
         )


### PR DESCRIPTION
## Motivation and Context

In the `PokemonService`, the `NotAuthorized` Smithy error is very generic and is therefore likely to conflict with existing errors.

## Description

Rename `NotAuthorized` to `StorageAccessNotAuthorized`.
