### PR TITLE
Workaround bug in smithy-rules-engine

### DIFF
--- a/aws/sdk-adhoc-test/build.gradle.kts
+++ b/aws/sdk-adhoc-test/build.gradle.kts
@@ -54,6 +54,22 @@ val allCodegenTests = listOf(
             }
         """,
     ),
+    CodegenTest(
+        "com.amazonaws.testservice#TestService",
+        "endpoint-test-service",
+        imports = listOf("models/single-static-endpoint.smithy"),
+        extraConfig = """
+            ,
+            "codegen": {
+                "includeFluentClient": false
+            },
+            "customizationConfig": {
+                "awsSdk": {
+                    "generateReadme": false
+                }
+            }
+        """,
+    ),
 )
 
 project.registerGenerateSmithyBuildTask(rootProject, pluginName, allCodegenTests)

--- a/aws/sdk-adhoc-test/models/single-static-endpoint.smithy
+++ b/aws/sdk-adhoc-test/models/single-static-endpoint.smithy
@@ -1,0 +1,68 @@
+$version: "2"
+namespace com.amazonaws.testservice
+
+use aws.api#service
+use aws.protocols#restJson1
+use smithy.rules#endpointRuleSet
+use smithy.rules#endpointTests
+
+@endpointRuleSet({
+    "version": "1.0",
+    "parameters": {
+        "Region": {
+            "required": true,
+            "type": "String",
+            "builtIn": "AWS::Region",
+            "default": "us-east-2",
+        },
+    },
+    "rules": [
+        {
+            "type": "endpoint",
+            "conditions": [],
+            "endpoint": {
+                "url": "https://prod.{Region}.api.myservice.aws.dev",
+                "properties": {
+                    "authSchemes": [{
+                                        "name": "sigv4",
+                                        "signingRegion": "{Region}",
+                                    }]
+                }
+            }
+        }
+    ]
+})
+@endpointTests({"version": "1", "testCases": [
+    {
+        "documentation": "region should fallback to the default",
+        "expect": {
+            "endpoint": {
+                "url": "https://prod.us-east-2.api.myservice.aws.dev",
+                "properties": {
+                    "authSchemes": [{
+                                        "name": "sigv4",
+                                        "signingRegion": "us-east-2",
+                                    }]
+
+                }
+            }
+        },
+        "params": { }
+    }]
+})
+@restJson1
+@title("Test Service")
+@service(sdkId: "Test")
+service TestService {
+    operations: [TestOperation]
+}
+
+@input
+structure Foo { bar: Bar }
+
+structure Bar {}
+
+@http(uri: "/foo", method: "POST")
+operation TestOperation {
+    input: Foo
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -60,8 +60,12 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
                     val newParameters = Parameters.builder()
                     epRules.parameters.toList()
                         .map { param ->
-                            param.letIf(param.builtIn == Builtins.REGION.builtIn) {
-                                it.toBuilder().required(true).build()
+                            param.letIf(param.builtIn == Builtins.REGION.builtIn) { parameter ->
+                                val builder = parameter.toBuilder().required(true)
+                                // workaround a smithy bug
+                                parameter.defaultValue.ifPresent { default -> builder.defaultValue(default) }
+
+                                builder.build()
                             }
                         }
                         .forEach(newParameters::addParameter)

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsEndpointDecorator.kt
@@ -62,7 +62,7 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
                         .map { param ->
                             param.letIf(param.builtIn == Builtins.REGION.builtIn) { parameter ->
                                 val builder = parameter.toBuilder().required(true)
-                                // workaround a smithy bug
+                                // TODO(https://github.com/awslabs/smithy-rs/issues/2187): undo this workaround
                                 parameter.defaultValue.ifPresent { default -> builder.defaultValue(default) }
 
                                 builder.build()

--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -129,6 +129,7 @@ fun Project.registerGenerateSmithyBuildTask(
     this.tasks.register("generateSmithyBuild") {
         description = "generate smithy-build.json"
         outputs.file(project.projectDir.resolve("smithy-build.json"))
+        allCodegenTests.flatMap { it.imports }.forEach { inputs.file(project.projectDir.resolve(it)) }
 
         doFirst {
             project.projectDir.resolve("smithy-build.json")


### PR DESCRIPTION
## Motivation and Context
This PR works around a bug in smithy-rules-engine `Parameter.toBuilder()` — the method was discarding the default value (and other fields). This was fixed here: https://github.com/awslabs/smithy/pull/1571/files. Until that's merged, this works around it by copying the value manually. This also adds an SDK adhoc test that includes an endpoint test.

## Description
- add test (fails until this fix was added)
- copy default value when set

## Testing
- new adhoc test

## Checklist
no changelog

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
