### PR TITLE
Rfc30/cargo.toml update

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -44,9 +44,9 @@ meta = { "breaking" = true, "tada" = true, "bug" = false }
 author = "rcoh"
 
 [[smithy-rs]]
-message = """Add serde crate to aws-smithy-types`.
+message = """Add serde crate to `aws-smithy-types`.
 
-It's behind feature gate `aws_sdk_unstable` which can only enabled via --cfg flag.
+It's behind the feature gate `aws_sdk_unstable` which can only be enabled via a `--cfg` flag.
 """
 references = ["smithy-rs#1944"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -44,6 +44,15 @@ meta = { "breaking" = true, "tada" = true, "bug" = false }
 author = "rcoh"
 
 [[smithy-rs]]
+message = """Add serde crate to aws-smithy-types`.
+
+It's behind feature gate `aws_sdk_unstable` which can only enabled via --cfg flag.
+"""
+references = ["smithy-rs#1944"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "thomas-k-cameron"
+
+[[smithy-rs]]
 message = "In 0.52, `@length`-constrained collection shapes whose members are not constrained made the server code generator crash. This has been fixed."
 references = ["smithy-rs#2103"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server" }

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -14,6 +14,12 @@ ryu = "1.0.5"
 time = { version = "0.3.4", features = ["parsing"] }
 base64-simd = "0.7"
 
+[target.'cfg(aws_sdk_unstable)'.dependencies.serde]
+version = "1"
+features = ["derive"]
+optional = true
+
+
 [dev-dependencies]
 base64 = "0.13.0"
 lazy_static = "1.4"
@@ -32,3 +38,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [[bench]]
 name = "base64"
 harness = false
+
+[features]
+"serialize" = []
+"deserialize" = []


### PR DESCRIPTION
## Motivation and Context
part of RFC30

## Description
adds serde under aws_sdk_unstable feature gate

## Testing
no testing

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
