### PR TITLE
Add static stability support to IMDS credentials provider 

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -38,6 +38,9 @@ ring = "0.16"
 hex = "0.4.3"
 zeroize = "1"
 
+# implementation detail of IMDS credentials provider
+fastrand = "1"
+
 bytes = "1.1.0"
 http = "0.2.4"
 tower = { version = "0.4.8" }

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -470,6 +470,7 @@ mod test {
                     "./test-data/profile-provider/",
                     stringify!($name)
                 ))
+                .await
                 .unwrap()
                 .execute(|conf| async move { Builder::default().configure(&conf).build() })
                 .await

--- a/aws/sdk/integration-tests/Cargo.toml
+++ b/aws/sdk/integration-tests/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "ec2",
     "glacier",
     "iam",
+    "imds",
     "kms",
     "lambda",
     "no-default-features",

--- a/aws/sdk/integration-tests/imds/Cargo.toml
+++ b/aws/sdk/integration-tests/imds/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "imds-tests"
+version = "0.1.0"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+edition = "2021"
+
+[dev-dependencies]
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config" }
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
+aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3" }
+aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["rt-tokio"] }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
+serde_json = "1"
+tokio = { version = "1.8.4", features = ["full", "test-util"]}

--- a/aws/sdk/integration-tests/imds/tests/fixture.rs
+++ b/aws/sdk/integration-tests/imds/tests/fixture.rs
@@ -1,0 +1,81 @@
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
+
+use aws_config::{
+    imds::{self, credentials::ImdsCredentialsProvider},
+    provider_config::ProviderConfig,
+    SdkConfig,
+};
+use aws_credential_types::{
+    cache::CredentialsCache,
+    time_source::{TestingTimeSource, TimeSource},
+};
+use aws_smithy_async::rt::sleep::TokioSleep;
+use aws_smithy_client::{
+    dvr::{Event, ReplayingConnection},
+    erase::DynConnector,
+};
+use aws_types::region::Region;
+
+pub(crate) struct TestFixture {
+    replayer: ReplayingConnection,
+    time_source: TestingTimeSource,
+}
+
+impl TestFixture {
+    #[allow(dead_code)]
+    pub(crate) fn new(http_traffic_json_str: &str, start_time: SystemTime) -> Self {
+        let events: Vec<Event> = serde_json::from_str(http_traffic_json_str).unwrap();
+        Self {
+            replayer: ReplayingConnection::new(events),
+            time_source: TestingTimeSource::new(start_time),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn setup(&self) -> SdkConfig {
+        let time_source = TimeSource::testing(&self.time_source);
+
+        let provider_config = ProviderConfig::empty()
+            .with_http_connector(DynConnector::new(self.replayer.clone()))
+            .with_sleep(TokioSleep::new())
+            .with_time_source(time_source.clone());
+
+        let client = imds::client::Client::builder()
+            .configure(&provider_config)
+            .build()
+            .await
+            .unwrap();
+
+        let provider = ImdsCredentialsProvider::builder()
+            .configure(&provider_config)
+            .imds_client(client)
+            .build();
+
+        SdkConfig::builder()
+            .region(Region::from_static("us-east-1"))
+            .credentials_cache(
+                CredentialsCache::lazy_builder()
+                    .time_source(time_source)
+                    .into_credentials_cache(),
+            )
+            .credentials_provider(Arc::new(provider))
+            .http_connector(self.replayer.clone())
+            .build()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn advance_time(&mut self, delta: Duration) {
+        self.time_source.advance(delta);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn verify(self, headers: &[&str]) {
+        self.replayer
+            .validate(headers, |_, _| Ok(()))
+            .await
+            .unwrap();
+    }
+}

--- a/aws/sdk/integration-tests/imds/tests/send-first-request-with-expired-creds.rs
+++ b/aws/sdk/integration-tests/imds/tests/send-first-request-with-expired-creds.rs
@@ -1,0 +1,46 @@
+mod fixture;
+
+use std::{
+    convert::Infallible,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use aws_sdk_s3::Client;
+
+#[tokio::test]
+async fn test_request_should_be_sent_when_first_call_to_imds_returns_expired_credentials() {
+    // This represents the time of a request being made, 21 Sep 2021 17:41:25 GMT.
+    let time_of_request = UNIX_EPOCH + Duration::from_secs(1632246085);
+
+    let test_fixture = fixture::TestFixture::new(
+        include_str!("test-data/send-first-request-with-expired-creds.json"),
+        time_of_request,
+    );
+
+    let sdk_config = test_fixture.setup().await;
+    let s3_client = Client::new(&sdk_config);
+
+    tokio::time::pause();
+
+    // The JSON file above specifies the credentials expiry is 21 Sep 2021 11:29:29 GMT,
+    // which is already invalid at the time of the request but will be made valid as the
+    // code execution will go through the expiration extension.
+    s3_client
+        .create_bucket()
+        .bucket("test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is0")
+        .customize()
+        .await
+        .unwrap()
+        .map_operation(|mut op| {
+            op.properties_mut().insert(time_of_request);
+            Result::Ok::<_, Infallible>(op)
+        })
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    // The fact that the authorization of a request exists implies that the request has
+    // been properly generated out of expired credentials.
+    test_fixture.verify(&["authorization"]).await;
+}

--- a/aws/sdk/integration-tests/imds/tests/send-request-after-500-response-from-imds.rs
+++ b/aws/sdk/integration-tests/imds/tests/send-request-after-500-response-from-imds.rs
@@ -1,0 +1,65 @@
+mod fixture;
+
+use std::{
+    convert::Infallible,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use aws_sdk_s3::Client;
+
+#[tokio::test]
+async fn test_request_should_be_sent_with_expired_credentials_after_imds_returns_500_during_credentials_refresh(
+) {
+    // This represents the time of a request being made, 21 Sep 2021 17:41:25 GMT.
+    let time_of_request = UNIX_EPOCH + Duration::from_secs(1632246085);
+
+    let mut test_fixture = fixture::TestFixture::new(
+        include_str!("test-data/send-request-after-500-response-from-imds.json"),
+        time_of_request,
+    );
+
+    let sdk_config = test_fixture.setup().await;
+    let s3_client = Client::new(&sdk_config);
+
+    tokio::time::pause();
+
+    // Requests are made at 21 Sep 2021 17:41:25 GMT and 21 Sep 2021 23:41:25 GMT.
+    let time_of_first_request = time_of_request;
+    let time_of_second_request = UNIX_EPOCH + Duration::from_secs(1632267685);
+
+    // The JSON file above specifies credentials will expire at between the two requests, 21 Sep 2021 23:33:13 GMT.
+    // The second request will receive response 500 from IMDS but `s3_client` will eventually
+    // be able to send it thanks to expired credentials held by `ImdsCredentialsProvider`.
+    for (i, time_of_request_to_s3) in [time_of_first_request, time_of_second_request]
+        .into_iter()
+        .enumerate()
+    {
+        s3_client
+            .create_bucket()
+            .bucket(format!(
+                "test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is{}",
+                i
+            ))
+            .customize()
+            .await
+            .unwrap()
+            .map_operation(|mut op| {
+                op.properties_mut().insert(time_of_request_to_s3);
+                Result::Ok::<_, Infallible>(op)
+            })
+            .unwrap()
+            .send()
+            .await
+            .unwrap();
+
+        test_fixture.advance_time(
+            time_of_second_request
+                .duration_since(time_of_first_request)
+                .unwrap(),
+        );
+    }
+
+    // The fact that the authorization of each request exists implies that the requests have
+    // been properly generated out of expired credentials.
+    test_fixture.verify(&["authorization"]).await;
+}

--- a/aws/sdk/integration-tests/imds/tests/send-successive-requests-with-expired-creds.rs
+++ b/aws/sdk/integration-tests/imds/tests/send-successive-requests-with-expired-creds.rs
@@ -1,0 +1,56 @@
+mod fixture;
+
+use std::{
+    convert::Infallible,
+    time::{Duration, UNIX_EPOCH},
+};
+
+use aws_sdk_s3::Client;
+
+#[tokio::test]
+async fn test_successive_requests_should_be_sent_with_expired_credentials_and_imds_being_called_only_once(
+) {
+    // This represents the time of a request being made, 21 Sep 2021 17:41:25 GMT.
+    let time_of_request = UNIX_EPOCH + Duration::from_secs(1632246085);
+
+    let test_fixture = fixture::TestFixture::new(
+        include_str!("test-data/send-successive-requests-with-expired-creds.json"),
+        time_of_request,
+    );
+
+    let sdk_config = test_fixture.setup().await;
+    let s3_client = Client::new(&sdk_config);
+
+    tokio::time::pause();
+
+    // The JSON file above specifies the credentials expiry is 21 Sep 2021 11:29:29 GMT,
+    // which is already invalid at the time of the request but will be made valid as the
+    // code execution will go through the expiration extension.
+    for i in 1..=3 {
+        // If IMDS were called more than once, the last `unwrap` would fail with an error looking like:
+        // panicked at 'called `Result::unwrap()` on an `Err` value: ConstructionFailure(ConstructionFailure { source: CredentialsStageError { ... } })'
+        // This is because the accompanying JSON file assumes that connection_id 4 (and 5) represents a request to S3,
+        // not to IMDS, so its response cannot be serialized into `Credentials`.
+        s3_client
+            .create_bucket()
+            .bucket(format!(
+                "test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is{}",
+                i
+            ))
+            .customize()
+            .await
+            .unwrap()
+            .map_operation(|mut op| {
+                op.properties_mut().insert(time_of_request);
+                Result::Ok::<_, Infallible>(op)
+            })
+            .unwrap()
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // The fact that the authorization of each request exists implies that the requests have
+    // been properly generated out of expired credentials.
+    test_fixture.verify(&["authorization"]).await;
+}

--- a/aws/sdk/integration-tests/imds/tests/test-data/send-first-request-with-expired-creds.json
+++ b/aws/sdk/integration-tests/imds/tests/test-data/send-first-request-with-expired-creds.json
@@ -1,0 +1,373 @@
+[
+    {
+        "connection_id": 0,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "56"
+                            ],
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "imdssesiontoken=="
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                    "headers": {
+                        "x-aws-ec2-metadata-token": [
+                            "imdssesiontoken=="
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "GET"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "last-modified": [
+                                "Tue, 21 Sep 2021 17:30:41 GMT"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ],
+                            "content-length": [
+                                "21"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "accept-ranges": [
+                                "none"
+                            ],
+                            "server": [
+                                "EC2ws"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "imds-assume-role-test"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/imds-assume-role-test",
+                    "headers": {
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-aws-ec2-metadata-token": [
+                            "imdssesiontoken=="
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "GET"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "connection": [
+                                "close"
+                            ],
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ],
+                            "accept-ranges": [
+                                "none"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "last-modified": [
+                                "Tue, 21 Sep 2021 17:30:41 GMT"
+                            ],
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "content-length": [
+                                "1322"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-21T17:31:21Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"ASIARSTSBASE\",\n  \"SecretAccessKey\" : \"secretbase\",\n  \"Token\" : \"tokenbase\",\n  \"Expiration\" : \"2021-09-21T11:29:29Z\"\n}"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "https://test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is0.s3.us-east-1.amazonaws.com",
+                    "headers": {
+                        "x-amz-date": [
+                            "20210921T174125Z"
+                        ],
+                        "x-amz-content-sha256": [
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ],
+                        "content-type": [
+                            "application/xml"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.51.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.51.0 api/s3/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "authorization": [
+                            "AWS4-HMAC-SHA256 Credential=ASIARSTSBASE/20210921/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=021dadec3fb3769ff21165f1abf9516887d1f93c504a98e399ccc5df8adef01f"
+                        ],
+                        "content-length": [
+                            "0"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "AmazonS3"
+                            ],
+                            "content-length": [
+                                "0"
+                            ],
+                            "location": [
+                                "/test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is0"
+                            ],
+                            "x-amz-id-2": [
+                                "hndxcVIq5ILod5JoH+4ULZAi4lo6BXJvJm78Oxro48vNw5s4MFsZqKCHM0GIhYlDf/RWsnmmHpg="
+                            ],
+                            "x-amz-request-id": [
+                                "YYP6QSB3XZ50PZ07"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    }
+]

--- a/aws/sdk/integration-tests/imds/tests/test-data/send-request-after-500-response-from-imds.json
+++ b/aws/sdk/integration-tests/imds/tests/test-data/send-request-after-500-response-from-imds.json
@@ -1,0 +1,804 @@
+[
+    {
+        "connection_id": 0,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "56"
+                            ],
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "imdssesiontoken=="
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                    "headers": {
+                        "x-aws-ec2-metadata-token": [
+                            "imdssesiontoken=="
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "GET"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "last-modified": [
+                                "Tue, 21 Sep 2021 17:30:41 GMT"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ],
+                            "content-length": [
+                                "21"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "accept-ranges": [
+                                "none"
+                            ],
+                            "server": [
+                                "EC2ws"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "imds-assume-role-test"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/imds-assume-role-test",
+                    "headers": {
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-aws-ec2-metadata-token": [
+                            "imdssesiontoken=="
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "GET"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "connection": [
+                                "close"
+                            ],
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ],
+                            "accept-ranges": [
+                                "none"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "last-modified": [
+                                "Tue, 21 Sep 2021 17:30:41 GMT"
+                            ],
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "content-length": [
+                                "1322"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-21T17:31:21Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"ASIARSTSBASE\",\n  \"SecretAccessKey\" : \"secretbase\",\n  \"Token\" : \"tokenbase\",\n  \"Expiration\" : \"2021-09-21T23:33:13Z\"\n}"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "https://test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is0.s3.us-east-1.amazonaws.com",
+                    "headers": {
+                        "x-amz-date": [
+                            "20210921T174125Z"
+                        ],
+                        "x-amz-content-sha256": [
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ],
+                        "content-type": [
+                            "application/xml"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.51.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.51.0 api/s3/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "authorization": [
+                            "AWS4-HMAC-SHA256 Credential=ASIARSTSBASE/20210921/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=021dadec3fb3769ff21165f1abf9516887d1f93c504a98e399ccc5df8adef01f"
+                        ],
+                        "content-length": [
+                            "0"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "AmazonS3"
+                            ],
+                            "content-length": [
+                                "0"
+                            ],
+                            "location": [
+                                "/test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is0"
+                            ],
+                            "x-amz-id-2": [
+                                "hndxcVIq5ILod5JoH+4ULZAi4lo6BXJvJm78Oxro48vNw5s4MFsZqKCHM0GIhYlDf/RWsnmmHpg="
+                            ],
+                            "x-amz-request-id": [
+                                "YYP6QSB3XZ50PZ07"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 500,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "363"
+                            ],
+                            "content-type": [
+                                "text/html"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 23:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\t \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>500 - Internal Server Error</title>\n </head>\n <body>\n  <h1>500 - Internal Server Error</h1>\n </body>\n</html>\n"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 500,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "363"
+                            ],
+                            "content-type": [
+                                "text/html"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 23:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\t \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>500 - Internal Server Error</title>\n </head>\n <body>\n  <h1>500 - Internal Server Error</h1>\n </body>\n</html>\n"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 6,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 6,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 6,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 500,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "363"
+                            ],
+                            "content-type": [
+                                "text/html"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 23:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 6,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\t \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>500 - Internal Server Error</title>\n </head>\n <body>\n  <h1>500 - Internal Server Error</h1>\n </body>\n</html>\n"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 6,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 7,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 7,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 7,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 500,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "363"
+                            ],
+                            "content-type": [
+                                "text/html"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 23:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 7,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "<?xml version=\"1.0\" encoding=\"iso-8859-1\"?>\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"\n\t\t \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\n<html xmlns=\"http://www.w3.org/1999/xhtml\" xml:lang=\"en\" lang=\"en\">\n <head>\n  <title>500 - Internal Server Error</title>\n </head>\n <body>\n  <h1>500 - Internal Server Error</h1>\n </body>\n</html>\n"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 7,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 8,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "https://test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is1.s3.us-east-1.amazonaws.com",
+                    "headers": {
+                        "x-amz-date": [
+                            "20210921T234125Z"
+                        ],
+                        "x-amz-content-sha256": [
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ],
+                        "content-type": [
+                            "application/xml"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.51.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.51.0 api/s3/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "authorization": [
+                            "AWS4-HMAC-SHA256 Credential=ASIARSTSBASE/20210921/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=58c85ad354a8226e1bf6fef0180665e79a37f3c0f26a61dde9de40baf27e64c1"
+                        ],
+                        "content-length": [
+                            "0"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 8,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 8,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 8,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "AmazonS3"
+                            ],
+                            "content-length": [
+                                "0"
+                            ],
+                            "location": [
+                                "/test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is1"
+                            ],
+                            "x-amz-id-2": [
+                                "hndxcVIq5ILod5JoH+4ULZAi4lo6BXJvJm78Oxro48vNw5s4MFsZqKCHM0GIhYlDf/RWsnmmHpg="
+                            ],
+                            "x-amz-request-id": [
+                                "1GNPPM15K9554BVN"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 23:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 8,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 8,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    }
+]

--- a/aws/sdk/integration-tests/imds/tests/test-data/send-successive-requests-with-expired-creds.json
+++ b/aws/sdk/integration-tests/imds/tests/test-data/send-successive-requests-with-expired-creds.json
@@ -1,0 +1,587 @@
+[
+    {
+        "connection_id": 0,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/api/token",
+                    "headers": {
+                        "x-aws-ec2-metadata-token-ttl-seconds": [
+                            "21600"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "content-length": [
+                                "56"
+                            ],
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "imdssesiontoken=="
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 0,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                    "headers": {
+                        "x-aws-ec2-metadata-token": [
+                            "imdssesiontoken=="
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "GET"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "last-modified": [
+                                "Tue, 21 Sep 2021 17:30:41 GMT"
+                            ],
+                            "connection": [
+                                "close"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ],
+                            "content-length": [
+                                "21"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "accept-ranges": [
+                                "none"
+                            ],
+                            "server": [
+                                "EC2ws"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "imds-assume-role-test"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 1,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "http://169.254.169.254/latest/meta-data/iam/security-credentials/imds-assume-role-test",
+                    "headers": {
+                        "user-agent": [
+                            "aws-sdk-rust/0.52.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-aws-ec2-metadata-token": [
+                            "imdssesiontoken=="
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.52.0 api/imds/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ]
+                    },
+                    "method": "GET"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "connection": [
+                                "close"
+                            ],
+                            "server": [
+                                "EC2ws"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ],
+                            "accept-ranges": [
+                                "none"
+                            ],
+                            "x-aws-ec2-metadata-token-ttl-seconds": [
+                                "21600"
+                            ],
+                            "last-modified": [
+                                "Tue, 21 Sep 2021 17:30:41 GMT"
+                            ],
+                            "content-type": [
+                                "text/plain"
+                            ],
+                            "content-length": [
+                                "1322"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2021-09-21T17:31:21Z\",\n  \"Type\" : \"AWS-HMAC\",\n  \"AccessKeyId\" : \"ASIARSTSBASE\",\n  \"SecretAccessKey\" : \"secretbase\",\n  \"Token\" : \"tokenbase\",\n  \"Expiration\" : \"2021-09-21T11:29:29Z\"\n}"
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 2,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "https://test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is1.s3.us-east-1.amazonaws.com",
+                    "headers": {
+                        "x-amz-date": [
+                            "20210921T174125Z"
+                        ],
+                        "x-amz-content-sha256": [
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ],
+                        "content-type": [
+                            "application/xml"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.51.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.51.0 api/s3/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "authorization": [
+                            "AWS4-HMAC-SHA256 Credential=ASIARSTSBASE/20210921/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=00656bafea35c08230e6f15a3571e7357b53d6d2a265bd7c05773274a46575bd"
+                        ],
+                        "content-length": [
+                            "0"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "AmazonS3"
+                            ],
+                            "content-length": [
+                                "0"
+                            ],
+                            "location": [
+                                "/test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is1"
+                            ],
+                            "x-amz-id-2": [
+                                "hndxcVIq5ILod5JoH+4ULZAi4lo6BXJvJm78Oxro48vNw5s4MFsZqKCHM0GIhYlDf/RWsnmmHpg="
+                            ],
+                            "x-amz-request-id": [
+                                "YYP6QSB3XZ50PZ07"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 3,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "https://test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is2.s3.us-east-1.amazonaws.com",
+                    "headers": {
+                        "x-amz-date": [
+                            "20210921T174125Z"
+                        ],
+                        "x-amz-content-sha256": [
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ],
+                        "content-type": [
+                            "application/xml"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.51.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.51.0 api/s3/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "authorization": [
+                            "AWS4-HMAC-SHA256 Credential=ASIARSTSBASE/20210921/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=92e946d999548daeda9c93199d6a6c1d64b0b72c4c30be23bf1b22afcfb78820"
+                        ],
+                        "content-length": [
+                            "0"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "AmazonS3"
+                            ],
+                            "content-length": [
+                                "0"
+                            ],
+                            "location": [
+                                "/test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is2"
+                            ],
+                            "x-amz-id-2": [
+                                "hndxcVIq5ILod5JoH+4ULZAi4lo6BXJvJm78Oxro48vNw5s4MFsZqKCHM0GIhYlDf/RWsnmmHpg="
+                            ],
+                            "x-amz-request-id": [
+                                "EEFG3N4NG60B4AW0"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 4,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Request": {
+                "request": {
+                    "uri": "https://test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is3.s3.us-east-1.amazonaws.com",
+                    "headers": {
+                        "x-amz-date": [
+                            "20210921T174125Z"
+                        ],
+                        "x-amz-content-sha256": [
+                            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                        ],
+                        "content-type": [
+                            "application/xml"
+                        ],
+                        "user-agent": [
+                            "aws-sdk-rust/0.51.0 os/linux lang/rust/1.62.1"
+                        ],
+                        "x-amz-user-agent": [
+                            "aws-sdk-rust/0.51.0 api/s3/0.0.0-smithy-rs-head os/linux lang/rust/1.62.1"
+                        ],
+                        "authorization": [
+                            "AWS4-HMAC-SHA256 Credential=ASIARSTSBASE/20210921/us-east-1/s3/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date;x-amz-security-token;x-amz-user-agent, Signature=158f6eff17078babdebbb01318d2380ac376a9ffe1a1ef0ff68f1e9432de50a1"
+                        ],
+                        "content-length": [
+                            "0"
+                        ]
+                    },
+                    "method": "PUT"
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Request"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Response": {
+                "response": {
+                    "Ok": {
+                        "status": 200,
+                        "version": "HTTP/1.1",
+                        "headers": {
+                            "server": [
+                                "AmazonS3"
+                            ],
+                            "content-length": [
+                                "0"
+                            ],
+                            "location": [
+                                "/test-bucket-s2dhlj57-3mg8-54949-bn28-fj37tnw91is3"
+                            ],
+                            "x-amz-id-2": [
+                                "hndxcVIq5ILod5JoH+4ULZAi4lo6BXJvJm78Oxro48vNw5s4MFsZqKCHM0GIhYlDf/RWsnmmHpg="
+                            ],
+                            "x-amz-request-id": [
+                                "1GNPPM15K9554BVN"
+                            ],
+                            "date": [
+                                "Tue, 21 Sep 2021 17:41:25 GMT"
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Data": {
+                "data": {
+                    "Utf8": ""
+                },
+                "direction": "Response"
+            }
+        }
+    },
+    {
+        "connection_id": 5,
+        "action": {
+            "Eof": {
+                "ok": true,
+                "direction": "Response"
+            }
+        }
+    }
+]


### PR DESCRIPTION
## Motivation and Context
Implements https://github.com/awslabs/smithy-rs/issues/2117

## Description
This PR adds static stability support to the IMDS credentials provider. The basic idea is that `ImdsCredentialsProvider` now holds on to a last retrieved credentials and if it cannot fetch the latest credentials from IMDS possibly due to the service being unavailable, it will serve the last retrieved credentials instead. That way, the Rust SDK will not fail fast in sending a request with expired credentials  and allows the target service to make the ultimate decision as to whether the request sent is valid.

Even though IMDS is available, it may return stale credentials. Static stability support specifies that `ImdsCredentialsProvider` should extend the credentials expiry by the calculated amount. The implementation of that is defined in `ImdsCredentialsProvider::extend_expiration` and references that in [botocore](https://github.com/boto/botocore/blob/develop/botocore/utils.py#L652-L685).

The code changes in the PR that accomplish the above are mostly in `aws-config`. However, we found out that those changes alone are not enough to meet requirements for static stability support. Specifically, the timeout logic in `LazyCredentialsCache` prior to this PR did not work well with the timeout logic required by the updated `ImdsCredentialsProvider` (see cfeab3b for more details). The bottom lines is that the additional changes have been made in `aws-credential-types` and the `ProvideCredentials` trait now has a new method `provide_credentials_with_timeout` to address the said impedance mismatch.

## Testing
- Expired Credential Test Cases
  - [x] SDK can use IMDS credential provider if first IMDS call returns expired credentials (implemented by `test_request_should_be_sent_when_first_call_to_imds_returns_expired_credentials`).
  - [x] SDK can send request if expired credentials are available (there's no explicit test added for this as it is implicitly handled by two tests for `Refresh Failures`).
  - [x] SDK can perform 3 successive requests with expired credentials. IMDS must only be called once (implemented by `test_successive_requests_should_be_sent_with_expired_credentials_and_imds_being_called_only_once`).
- Refresh Failures
  - [x] SDK can send a request after a read timeout during a refresh (implemented by `read_timeout_during_credentials_refresh_should_yield_last_retrieved_credentials`).
  - [x] SDK can send a request after receiving a 500 HTTP response from IMDS during a refresh (implemented by `test_request_should_be_sent_with_expired_credentials_after_imds_returns_500_during_credentials_refresh`).
- Logging
  - [x] SDK must log a message when expired credentials are used (implemented by `log_message_informing_expired_credentials_are_used`).
- [ ] Passed tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
