### PR TITLE
Bump `gradle.properties` runtime crates version to 0.53.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ rust.msrv=1.62.1
 org.gradle.jvmargs=-Xmx1024M
 
 # Version number to use for the generated runtime crates
-smithy.rs.runtime.crate.version=0.53.0
+smithy.rs.runtime.crate.version=0.53.1
 
 kotlin.code.style=official
 


### PR DESCRIPTION
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
