### PR TITLE
Support `@sparse` constrained map shapes and list shapes

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "`@sparse` list shapes and map shapes with constraint traits and with constrained members are now supported"
+references = ["smithy-rs#2213"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server"}
+author = "david-perez"

--- a/codegen-core/common-test-models/constraints.smithy
+++ b/codegen-core/common-test-models/constraints.smithy
@@ -481,6 +481,10 @@ structure ConA {
     lengthMap: LengthMap,
 
     mapOfMapOfListOfListOfConB: MapOfMapOfListOfListOfConB,
+    sparseMap: SparseMap,
+    sparseList: SparseList,
+    sparseLengthMap: SparseLengthMap,
+    sparseLengthList: SparseLengthList,
 
     constrainedUnion: ConstrainedUnion,
     enumString: EnumString,
@@ -541,6 +545,30 @@ structure ConA {
     // TODO(https://github.com/awslabs/smithy-rs/issues/1401): a `set` shape is
     //  just a `list` shape with `uniqueItems`, which hasn't been implemented yet.
     // lengthSetOfPatternString: LengthSetOfPatternString,
+}
+
+@sparse
+map SparseMap {
+    key: String,
+    value: LengthString
+}
+
+@sparse
+list SparseList {
+    member: LengthString
+}
+
+@sparse
+@length(min: 69)
+map SparseLengthMap {
+    key: String,
+    value: String
+}
+
+@sparse
+@length(min: 69)
+list SparseLengthList {
+    member: String
 }
 
 map MapOfLengthBlob {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PubCrateConstrainedShapeSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PubCrateConstrainedShapeSymbolProvider.kt
@@ -97,9 +97,6 @@ class PubCrateConstrainedShapeSymbolProvider(
             }
 
             is MemberShape -> {
-                require(model.expectShape(shape.container).isStructureShape) {
-                    "This arm is only exercised by `ServerBuilderGenerator`"
-                }
                 require(!shape.hasConstraintTraitOrTargetHasConstraintTrait(model, base)) { errorMessage(shape) }
 
                 val targetShape = model.expectShape(shape.target)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedCollectionGenerator.kt
@@ -70,7 +70,7 @@ class ConstrainedCollectionGenerator(
         }
 
         val name = constrainedShapeSymbolProvider.toSymbol(shape).name
-        val inner = "std::vec::Vec<#{ValueSymbol}>"
+        val inner = "std::vec::Vec<#{ValueMemberSymbol}>"
         val constraintViolation = constraintViolationSymbolProvider.toSymbol(shape)
         val constrainedTypeVisibility = Visibility.publicIf(publicConstrainedTypes, Visibility.PUBCRATE)
         val constrainedTypeMetadata = RustMetadata(
@@ -79,7 +79,7 @@ class ConstrainedCollectionGenerator(
         )
 
         val codegenScope = arrayOf(
-            "ValueSymbol" to constrainedShapeSymbolProvider.toSymbol(model.expectShape(shape.member.target)),
+            "ValueMemberSymbol" to constrainedShapeSymbolProvider.toSymbol(shape.member),
             "From" to RuntimeType.From,
             "TryFrom" to RuntimeType.TryFrom,
             "ConstraintViolation" to constraintViolation,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedMapGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ConstrainedMapGenerator.kt
@@ -58,7 +58,7 @@ class ConstrainedMapGenerator(
         val lengthTrait = shape.expectTrait<LengthTrait>()
 
         val name = constrainedShapeSymbolProvider.toSymbol(shape).name
-        val inner = "std::collections::HashMap<#{KeySymbol}, #{ValueSymbol}>"
+        val inner = "std::collections::HashMap<#{KeySymbol}, #{ValueMemberSymbol}>"
         val constraintViolation = constraintViolationSymbolProvider.toSymbol(shape)
 
         val constrainedTypeVisibility = Visibility.publicIf(publicConstrainedTypes, Visibility.PUBCRATE)
@@ -69,7 +69,7 @@ class ConstrainedMapGenerator(
 
         val codegenScope = arrayOf(
             "KeySymbol" to constrainedShapeSymbolProvider.toSymbol(model.expectShape(shape.key.target)),
-            "ValueSymbol" to constrainedShapeSymbolProvider.toSymbol(model.expectShape(shape.value.target)),
+            "ValueMemberSymbol" to constrainedShapeSymbolProvider.toSymbol(shape.value),
             "From" to RuntimeType.From,
             "TryFrom" to RuntimeType.TryFrom,
             "ConstraintViolation" to constraintViolation,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/PubCrateConstrainedCollectionGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/PubCrateConstrainedCollectionGenerator.kt
@@ -8,8 +8,14 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.conditionalBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.module
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.canReachConstrainedShape
@@ -54,14 +60,14 @@ class PubCrateConstrainedCollectionGenerator(
         val unconstrainedSymbol = unconstrainedShapeSymbolProvider.toSymbol(shape)
         val name = constrainedSymbol.name
         val innerShape = model.expectShape(shape.member.target)
-        val innerConstrainedSymbol = if (innerShape.isTransitivelyButNotDirectlyConstrained(model, symbolProvider)) {
-            pubCrateConstrainedShapeSymbolProvider.toSymbol(innerShape)
+        val innerMemberSymbol = if (innerShape.isTransitivelyButNotDirectlyConstrained(model, symbolProvider)) {
+            pubCrateConstrainedShapeSymbolProvider.toSymbol(shape.member)
         } else {
-            constrainedShapeSymbolProvider.toSymbol(innerShape)
+            constrainedShapeSymbolProvider.toSymbol(shape.member)
         }
 
         val codegenScope = arrayOf(
-            "InnerConstrainedSymbol" to innerConstrainedSymbol,
+            "InnerMemberSymbol" to innerMemberSymbol,
             "ConstrainedTrait" to RuntimeType.ConstrainedTrait,
             "UnconstrainedSymbol" to unconstrainedSymbol,
             "Symbol" to symbol,
@@ -72,7 +78,7 @@ class PubCrateConstrainedCollectionGenerator(
             rustTemplate(
                 """
                 ##[derive(Debug, Clone)]
-                pub(crate) struct $name(pub(crate) std::vec::Vec<#{InnerConstrainedSymbol}>);
+                pub(crate) struct $name(pub(crate) std::vec::Vec<#{InnerMemberSymbol}>);
 
                 impl #{ConstrainedTrait} for $name  {
                     type Unconstrained = #{UnconstrainedSymbol};
@@ -130,22 +136,19 @@ class PubCrateConstrainedCollectionGenerator(
                 val innerNeedsConversion =
                     innerShape.typeNameContainsNonPublicType(model, symbolProvider, publicConstrainedTypes)
 
-                rustTemplate(
-                    """
-                    impl #{From}<$name> for #{Symbol} {
-                        fn from(v: $name) -> Self {
-                            ${
-                    if (innerNeedsConversion) {
-                        "v.0.into_iter().map(|item| item.into()).collect()"
-                    } else {
-                        "v.0"
-                    }
-                    }
+                rustBlockTemplate("impl #{From}<$name> for #{Symbol}", *codegenScope) {
+                    rustBlock("fn from(v: $name) -> Self") {
+                        if (innerNeedsConversion) {
+                            withBlock("v.0.into_iter().map(|item| ", ").collect()") {
+                                conditionalBlock("item.map(|item| ", ")", innerMemberSymbol.isOptional()) {
+                                    rust("item.into()")
+                                }
+                            }
+                        } else {
+                            rust("v.0")
                         }
                     }
-                    """,
-                    *codegenScope,
-                )
+                }
             }
         }
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/PubCrateConstrainedMapGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/PubCrateConstrainedMapGenerator.kt
@@ -9,8 +9,14 @@ import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.conditionalBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.module
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.canReachConstrainedShape
@@ -54,15 +60,15 @@ class PubCrateConstrainedMapGenerator(
         val keyShape = model.expectShape(shape.key.target, StringShape::class.java)
         val valueShape = model.expectShape(shape.value.target)
         val keySymbol = constrainedShapeSymbolProvider.toSymbol(keyShape)
-        val valueSymbol = if (valueShape.isTransitivelyButNotDirectlyConstrained(model, symbolProvider)) {
-            pubCrateConstrainedShapeSymbolProvider.toSymbol(valueShape)
+        val valueMemberSymbol = if (valueShape.isTransitivelyButNotDirectlyConstrained(model, symbolProvider)) {
+            pubCrateConstrainedShapeSymbolProvider.toSymbol(shape.value)
         } else {
-            constrainedShapeSymbolProvider.toSymbol(valueShape)
+            constrainedShapeSymbolProvider.toSymbol(shape.value)
         }
 
         val codegenScope = arrayOf(
             "KeySymbol" to keySymbol,
-            "ValueSymbol" to valueSymbol,
+            "ValueMemberSymbol" to valueMemberSymbol,
             "ConstrainedTrait" to RuntimeType.ConstrainedTrait,
             "UnconstrainedSymbol" to unconstrainedSymbol,
             "Symbol" to symbol,
@@ -73,7 +79,7 @@ class PubCrateConstrainedMapGenerator(
             rustTemplate(
                 """
                 ##[derive(Debug, Clone)]
-                pub(crate) struct $name(pub(crate) std::collections::HashMap<#{KeySymbol}, #{ValueSymbol}>);
+                pub(crate) struct $name(pub(crate) std::collections::HashMap<#{KeySymbol}, #{ValueMemberSymbol}>);
 
                 impl #{ConstrainedTrait} for $name  {
                     type Unconstrained = #{UnconstrainedSymbol};
@@ -117,22 +123,27 @@ class PubCrateConstrainedMapGenerator(
                 val keyNeedsConversion = keyShape.typeNameContainsNonPublicType(model, symbolProvider, publicConstrainedTypes)
                 val valueNeedsConversion = valueShape.typeNameContainsNonPublicType(model, symbolProvider, publicConstrainedTypes)
 
-                rustTemplate(
-                    """
-                    impl #{From}<$name> for #{Symbol} {
-                        fn from(v: $name) -> Self {
-                            ${ if (keyNeedsConversion || valueNeedsConversion) {
-                        val keyConversion = if (keyNeedsConversion) { ".into()" } else { "" }
-                        val valueConversion = if (valueNeedsConversion) { ".into()" } else { "" }
-                        "v.0.into_iter().map(|(k, v)| (k$keyConversion, v$valueConversion)).collect()"
-                    } else {
-                        "v.0"
-                    } }
+                rustBlockTemplate("impl #{From}<$name> for #{Symbol}", *codegenScope) {
+                    rustBlock("fn from(v: $name) -> Self") {
+                        if (keyNeedsConversion || valueNeedsConversion) {
+                            withBlock("v.0.into_iter().map(|(k, v)| {", "}).collect()") {
+                                if (keyNeedsConversion) {
+                                    rust("let k = k.into();")
+                                }
+                                if (valueNeedsConversion) {
+                                    withBlock("let v = {", "};") {
+                                        conditionalBlock("v.map(|v| ", ")", valueMemberSymbol.isOptional()) {
+                                            rust("v.into()")
+                                        }
+                                    }
+                                }
+                                rust("(k, v)")
+                            }
+                        } else {
+                            rust("v.0")
                         }
                     }
-                    """,
-                    *codegenScope,
-                )
+                }
             }
         }
     }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedMapGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedMapGenerator.kt
@@ -139,7 +139,6 @@ class UnconstrainedMapGenerator(
                                         }
                                         """,
                                         "ConstrainedValueSymbol" to constrainedValueSymbol,
-                                        "Epilogue" to epilogueWritable,
                                     )
                                 }
                             }


### PR DESCRIPTION
Turns out we've never supported them, neither directly constrained nor
with constrained members, because of a lack of tests. Yet another data
point to prioritize working on code-generating `constraints.smithy` (see
https://github.com/awslabs/smithy-rs/issues/2101).

The implementation is simple: we just need to call the symbol provider
on the member symbols instead of on the target symbols so we get
`Option<T>` list members / map values if applicable, and handle the
wrapper when converting between unconstrained and constrained types with
help from `match` and `Option<T>::map`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
