### PR TITLE
Remove old entries from CHANGELOG.next.toml

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -49,30 +49,6 @@ references = ["smithy-rs#1784", "smithy-rs#2074"]
 meta = { "breaking" = true, "tada" = true, "bug" = false }
 author = "rcoh"
 
-[[smithy-rs]]
-message = "In 0.52, `@length`-constrained collection shapes whose members are not constrained made the server code generator crash. This has been fixed."
-references = ["smithy-rs#2103"]
-meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server" }
-author = "david-perez"
-
-[[smithy-rs]]
-message = "The Rust client codegen plugin is now called `rust-client-codegen` instead of `rust-codegen`. Be sure to update your `smithy-build.json` files to refer to the correct plugin name."
-references = ["smithy-rs#2099"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
-author = "jdisanti"
-
-[[smithy-rs]]
-message = "Client codegen plugins need to define a service named `software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator` (this is the new file name for the plugin definition in `resources/META-INF/services`)."
-references = ["smithy-rs#2099"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
-author = "jdisanti"
-
-[[smithy-rs]]
-message = "Server codegen plugins need to define a service named `software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator` (this is the new file name for the plugin definition in `resources/META-INF/services`)."
-references = ["smithy-rs#2099"]
-meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
-author = "jdisanti"
-
 [[aws-sdk-rust]]
 message = """
 Move types for AWS SDK credentials to a separate crate.
@@ -81,18 +57,6 @@ A new AWS runtime crate called `aws-credential-types` has been introduced. Types
 references = ["smithy-rs#2108"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "ysaito1001"
-
-[[smithy-rs]]
-message = "Servers support the `@default` trait: models can specify default values. Default values will be automatically supplied when not manually set."
-references = ["smithy-rs#1879"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server" }
-author = "82marbag"
-
-[[smithy-rs]]
-message = "The constraint `@length` on non-streaming blob shapes is supported."
-references = ["smithy-rs#2131"]
-meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "server" }
-author = "82marbag"
 
 [[aws-sdk-rust]]
 references = ["smithy-rs#2152"]

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -101,22 +101,10 @@ let sdk_config = aws_config::from_env()
 /// ```
 """
 
-[[smithy-rs]]
-message = "Fix bug where string default values were not supported for endpoint parameters"
-references = ["smithy-rs#2150"]
-meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
-author = "rcoh"
-
 [[aws-sdk-rust]]
 references = ["smithy-rs#2162"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 message = "`aws_config::profile::retry_config` && `aws_config::environment::retry_config` have been removed. Use `aws_config::default_provider::retry_config` instead."
-author = "rcoh"
-
-[[smithy-rs]]
-references = ["smithy-rs#2170", "aws-sdk-rust#706"]
-meta = { "breaking" = false, "tada" = false, "bug" = true }
-message = "Remove the webpki-roots feature from `hyper-rustls`"
 author = "rcoh"
 
 [[aws-sdk-rust]]


### PR DESCRIPTION
These were already released in 0.53.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
