### PR TITLE
AwsJson1.0 `@streaming` unique in payload

### DIFF
--- a/codegen-core/common-test-models/pokemon-awsjson.smithy
+++ b/codegen-core/common-test-models/pokemon-awsjson.smithy
@@ -27,7 +27,6 @@ service PokemonService {
 }
 
 /// Capture Pokémons via event streams.
-@http(uri: "/capture-pokemon-event/{region}", method: "POST")
 operation CapturePokemon {
     input: CapturePokemonEventsInput,
     output: CapturePokemonEventsOutput,
@@ -36,17 +35,11 @@ operation CapturePokemon {
 
 @input
 structure CapturePokemonEventsInput {
-    @httpPayload
     events: AttemptCapturingPokemonEvent,
-
-    @httpLabel
-    @required
-    region: String,
 }
 
 @output
 structure CapturePokemonEventsOutput {
-    @httpPayload
     events: CapturePokemonEvents,
 }
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
@@ -5,6 +5,7 @@
 
 package software.amazon.smithy.rust.codegen.core.smithy.protocols
 
+import software.amazon.smithy.codegen.core.CodegenException
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.pattern.UriPattern
 import software.amazon.smithy.model.shapes.MemberShape
@@ -49,16 +50,21 @@ class AwsJsonHttpBindingResolver(
         .uri(UriPattern.parse("/"))
         .build()
 
-    private fun bindings(shape: ToShapeId) =
-        shape.let { model.expectShape(it.toShapeId()) }.members()
-            .map {
-                if (it.isStreaming(model)) {
-                    HttpBindingDescriptor(it, HttpLocation.PAYLOAD, "document")
-                } else {
-                    HttpBindingDescriptor(it, HttpLocation.DOCUMENT, "document")
-                }
+    private fun bindings(shape: ToShapeId): List<HttpBindingDescriptor> {
+        val members = shape.let { model.expectShape(it.toShapeId()) }.members()
+        if (members.size > 1 && members.any { it.isStreaming(model) }) {
+            throw CodegenException("A streaming members must be the only member in the payload of the request")
+        }
+
+        return members.map {
+            if (it.isStreaming(model)) {
+                HttpBindingDescriptor(it, HttpLocation.PAYLOAD, "document")
+            } else {
+                HttpBindingDescriptor(it, HttpLocation.DOCUMENT, "document")
             }
+        }
             .toList()
+    }
 
     override fun httpTrait(operationShape: OperationShape): HttpTrait = httpTrait
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/AwsJson.kt
@@ -52,12 +52,12 @@ class AwsJsonHttpBindingResolver(
 
     private fun bindings(shape: ToShapeId): List<HttpBindingDescriptor> {
         val members = shape.let { model.expectShape(it.toShapeId()) }.members()
-        // In RestJson, a streaming member is the unique member in the payload and must be marked with `@httpPayload`.
-        // Until we have an answer on https://github.com/awslabs/smithy/issues/1584, we should restrict protocols
-        // that don't support http traits and have data in payloads to unique streaming member in the payload.
-        // The change is backwards compatible as no release supports @streaming in AwsJson1.0 and relaxing this change in the future will not be breaking.
+        // TODO(https://github.com/awslabs/smithy-rs/issues/2237): support non-streaming members too
         if (members.size > 1 && members.any { it.isStreaming(model) }) {
-            throw CodegenException("A streaming member must be the only member in the payload of a request")
+            throw CodegenException(
+                "We only support one payload member if that payload contains a streaming member." +
+                    "Tracking issue to relax this constraint: https://github.com/awslabs/smithy-rs/issues/2237",
+            )
         }
 
         return members.map {


### PR DESCRIPTION
## Motivation and Context

In RestJson, a streaming member is the unique member in the payload and must be marked with `@httpPayload`. 

Until we have an answer on https://github.com/awslabs/smithy/issues/1584, we should restrict protocols that don't support http traits and have data in payloads to unique streaming member in the payload.

The change is backwards compatible as no release supports `@streaming` in AwsJson1.0 and relaxing this change in the future will not be breaking.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
