### PR TITLE
Fix `OperationExtensionFuture` poll order

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -10,3 +10,9 @@
 # references = ["smithy-rs#920"]
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
+
+[[smithy-rs]]
+message = "Fix bug in `OperationExtensionFuture`s `Future::poll` implementation"
+references = ["smithy-rs#920"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server"}
+author = "hlbarber"

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -101,11 +101,11 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
+        let resp = ready!(this.inner.try_poll(cx));
         let ext = this
             .operation_extension
             .take()
             .expect("futures cannot be polled after completion");
-        let resp = ready!(this.inner.try_poll(cx));
         Poll::Ready(resp.map(|mut resp| {
             resp.extensions_mut().insert(ext);
             resp


### PR DESCRIPTION
## Motivation and Context

Multiple `Future::poll` to `OperationExtensionFuture` will cause a panic to occur.

## Description

Permute the order of operations in `OperationExtensionFuture`s `Future::poll` method to prevent this.
