### PR TITLE
Bump version to 0.54.1 in `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ rust.msrv=1.62.1
 org.gradle.jvmargs=-Xmx1024M
 
 # Version number to use for the generated runtime crates
-smithy.rs.runtime.crate.version=0.54.0
+smithy.rs.runtime.crate.version=0.54.1
 
 kotlin.code.style=official
 


### PR DESCRIPTION
## Description
Release 0.54.1 for this bug fix: https://github.com/awslabs/smithy-rs/pull/2247.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
