### PR TITLE
Add CI action to test aws-sdk-services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         - action: check-aws-config
         - action: check-aws-sdk-canary
         - action: check-aws-sdk-cargo-deny
-        - action: check-aws-sdk-services
+        - action: check-only-aws-sdk-services
         - action: check-aws-sdk-smoketest-docs-clippy-udeps
         - action: check-aws-sdk-smoketest-unit-tests
         - action: check-aws-sdk-standalone-integration-tests

--- a/aws/sdk-adhoc-test/models/single-static-endpoint.smithy
+++ b/aws/sdk-adhoc-test/models/single-static-endpoint.smithy
@@ -48,11 +48,17 @@ use smithy.rules#endpointTests
             }
         },
         "params": { }
+        "operationInputs": [
+            { "operationName": "TestOperation", "operationParams": {
+                "bar": { f: "blah" }
+              } }
+        ]
     }]
 })
 @restJson1
 @title("Test Service")
 @service(sdkId: "Test")
+@aws.auth#sigv4(name: "test-service")
 service TestService {
     operations: [TestOperation]
 }
@@ -60,7 +66,7 @@ service TestService {
 @input
 structure Foo { bar: Bar }
 
-structure Bar {}
+structure Bar { f: String }
 
 @http(uri: "/foo", method: "POST")
 operation TestOperation {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/OperationInputTestGenerator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/OperationInputTestGenerator.kt
@@ -24,6 +24,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.PublicImportSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
@@ -113,7 +114,8 @@ fun usesDeprecatedBuiltIns(testOperationInput: EndpointTestOperationInput): Bool
  * Doing this in AWS codegen allows us to actually integration test generated clients.
  */
 
-class OperationInputTestGenerator(private val ctx: ClientCodegenContext, private val test: EndpointTestCase) {
+class OperationInputTestGenerator(_ctx: ClientCodegenContext, private val test: EndpointTestCase) {
+    private val ctx = _ctx.copy(symbolProvider = PublicImportSymbolProvider(_ctx.symbolProvider, _ctx.moduleUseName()))
     private val runtimeConfig = ctx.runtimeConfig
     private val moduleName = ctx.moduleUseName()
     private val endpointCustomizations = ctx.rootDecorator.endpointCustomizations(ctx)

--- a/ci.mk
+++ b/ci.mk
@@ -36,6 +36,10 @@ check-aws-sdk-examples: generate-aws-sdk
 check-aws-sdk-services: generate-aws-sdk
 	$(CI_ACTION) $@ $(ARGS)
 
+.PHONY: check-only-aws-sdk-services
+check-only-aws-sdk-services: generate-aws-sdk
+	$(CI_ACTION) $@ $(ARGS)
+
 .PHONY: check-aws-sdk-smoketest-docs-clippy-udeps
 check-aws-sdk-smoketest-docs-clippy-udeps: generate-aws-sdk-smoketest
 	$(CI_ACTION) $@ $(ARGS)

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointsDecoratorTest.kt
@@ -81,7 +81,7 @@ class EndpointsDecoratorTest {
                 "Region": "test-region"
               },
               "operationInputs": [
-                { "operationName": "TestOperation" }
+                { "operationName": "TestOperation", "operationParams": { "nested": { "field": "test" } } }
               ],
               "expect": {
                 "endpoint": {
@@ -110,7 +110,12 @@ class EndpointsDecoratorTest {
 
         structure TestOperationInput {
             @contextParam(name: "Bucket")
-            bucket: String
+            bucket: String,
+            nested: NestedStructure
+        }
+
+        structure NestedStructure {
+            field: String
         }
     """.asSmithyModel()
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/PublicImportSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/PublicImportSymbolProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+
+/**
+ * Rewrite crate::* with `<moduleusename>::*`
+ *
+ * This enables generating code into `tests` and other public locations.
+ */
+class PublicImportSymbolProvider(private val base: RustSymbolProvider, private val publicUseName: String) :
+    WrappingSymbolProvider(base) {
+    override fun toSymbol(shape: Shape): Symbol {
+        val baseSymbol = base.toSymbol(shape)
+
+        val currentRustType = baseSymbol.rustType()
+        val currentNamespace = currentRustType.namespace
+        val newRustType =
+            if (currentRustType is RustType.Opaque && currentNamespace != null && currentNamespace.startsWith("crate::")) {
+                currentRustType.copy(namespace = currentNamespace.replace("crate::", "$publicUseName::"))
+            } else {
+                currentRustType
+            }
+        return baseSymbol.toBuilder().rustType(newRustType).build()
+    }
+}

--- a/tools/ci-build/scripts/check-aws-sdk-services
+++ b/tools/ci-build/scripts/check-aws-sdk-services
@@ -10,4 +10,4 @@ cd aws-sdk
 # Remove examples from workspace
 sed -i '/"examples\//d' Cargo.toml
 
-cargo check
+cargo test --all-features

--- a/tools/ci-build/scripts/check-only-aws-sdk-services
+++ b/tools/ci-build/scripts/check-only-aws-sdk-services
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# this job runs `cargo check` only instead of `cargo test --all-features`
+
+set -eux
+cd aws-sdk
+
+# Remove examples from workspace
+sed -i '/"examples\//d' Cargo.toml
+
+cargo check --all-targets --all-features


### PR DESCRIPTION
## Motivation and Context
Currently, tests of aws-sdk are not being run in CI—this lead to 0.53 being released with some tests not compiling / failing.

## Description
- Add additional target to build image
- Use architecture independent path so that the build image also works on aarch64


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
