### PR TITLE
Add `Data limit exceeded` to build image throttle messages

### DIFF
--- a/tools/ci-build/acquire-build-image
+++ b/tools/ci-build/acquire-build-image
@@ -69,6 +69,13 @@ class Context:
         return Context(start_path, script_path, tools_path, user_id, image_tag, allow_local_build, github_actions)
 
 
+def output_contains_any(stdout, stderr, messages):
+    for message in messages:
+        if message in stdout or message in stderr:
+            return True
+    return False
+
+
 # Mockable shell commands
 class Shell:
     # Returns the platform that this script is running on
@@ -93,19 +100,17 @@ class Shell:
         print(stderr)
         print("-------------------")
 
-        not_found_message = "not found: manifest unknown"
-        throttle_message = "toomanyrequests: Rate exceeded"
+        not_found_messages = ["not found: manifest unknown"]
+        throttle_messages = ["toomanyrequests: Rate exceeded", "toomanyrequests: Data limit exceeded"]
         retryable_messages = ["net/http: TLS handshake timeout"]
         if status == 0:
             return DockerPullResult.SUCCESS
-        elif throttle_message in stdout or throttle_message in stderr:
+        elif output_contains_any(stdout, stderr, throttle_messages):
             return DockerPullResult.ERROR_THROTTLED
-        elif not_found_message in stdout or not_found_message in stderr:
+        elif output_contains_any(stdout, stderr, not_found_messages):
             return DockerPullResult.NOT_FOUND
-        else:
-            for message in retryable_messages:
-                if message in stdout or message in stderr:
-                    return DockerPullResult.RETRYABLE_ERROR
+        elif output_contains_any(stdout, stderr, retryable_messages):
+            return DockerPullResult.RETRYABLE_ERROR
         return DockerPullResult.UNKNOWN_ERROR
 
     # Builds the base image with the Dockerfile in `path` and tags with with `image_tag`


### PR DESCRIPTION
## Motivation and Context
This should improve the reliability of CI which has been failing a lot lately due to `toomanyrequests: Data limit exceeded`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
