### PR TITLE
fix: time not implemented on wasm

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -29,7 +29,7 @@ aws-smithy-json = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-json" }
 aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 hyper = { version = "0.14.12", default-features = false }
-time = { version = "0.3.4", features = ["parsing"] }
+time = { version = "0.3.17", features = ["parsing"] }
 tokio = { version = "1.8.4", features = ["sync"] }
 tracing = { version = "0.1" }
 

--- a/aws/rust-runtime/aws-config/src/sts/util.rs
+++ b/aws/rust-runtime/aws-config/src/sts/util.rs
@@ -6,6 +6,7 @@
 use aws_credential_types::provider::{self, error::CredentialsError};
 use aws_credential_types::Credentials as AwsCredentials;
 use aws_sdk_sts::model::Credentials as StsCredentials;
+use aws_smithy_types::date_time;
 
 use std::convert::TryFrom;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -46,7 +47,7 @@ pub(crate) fn into_credentials(
 /// provide a name for the session, the provider will choose a name composed of a base + a timestamp,
 /// e.g. `profile-file-provider-123456789`
 pub(crate) fn default_session_name(base: &str) -> String {
-    let now = SystemTime::now()
+    let now = date_time::now()
         .duration_since(UNIX_EPOCH)
         .expect("post epoch");
     format!("{}-{}", base, now.as_millis())

--- a/aws/rust-runtime/aws-credential-types/src/cache/lazy_caching.rs
+++ b/aws/rust-runtime/aws-credential-types/src/cache/lazy_caching.rs
@@ -6,10 +6,11 @@
 //! Lazy, credentials cache implementation
 
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use aws_smithy_async::future::timeout::Timeout;
 use aws_smithy_async::rt::sleep::AsyncSleep;
+use aws_smithy_types::date_time;
 use tracing::{debug, info, info_span, Instrument};
 
 use crate::cache::{ExpiringCache, ProvideCachedCredentials};
@@ -74,7 +75,7 @@ impl ProvideCachedCredentials for LazyCredentialsCache {
                 // since the futures are not eagerly executed, and the cache will only run one
                 // of them.
                 let future = Timeout::new(provider.provide_credentials(), timeout_future);
-                let start_time = Instant::now();
+                let start_time = date_time::now();
                 let result = cache
                     .get_or_load(|| {
                         let span = info_span!("lazy_load_credentials");

--- a/aws/rust-runtime/aws-credential-types/src/time_source.rs
+++ b/aws/rust-runtime/aws-credential-types/src/time_source.rs
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use aws_smithy_types::date_time;
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime};
@@ -39,7 +40,7 @@ impl TimeSource {
     /// Returns the current system time based on the mode.
     pub fn now(&self) -> SystemTime {
         match &self.0 {
-            Inner::Default => SystemTime::now(),
+            Inner::Default => date_time::now(),
             Inner::Testing(testing) => testing.now(),
         }
     }

--- a/aws/rust-runtime/aws-inlineable/src/presigning.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning.rs
@@ -7,6 +7,7 @@
 
 /// Presigning config and builder
 pub mod config {
+    use aws_smithy_types::date_time;
     use std::fmt;
     use std::time::{Duration, SystemTime};
 
@@ -149,7 +150,7 @@ pub mod config {
                 return Err(ErrorKind::ExpiresInDurationTooLong.into());
             }
             Ok(PresigningConfig {
-                start_time: self.start_time.unwrap_or_else(SystemTime::now),
+                start_time: self.start_time.unwrap_or_else(date_time::now),
                 expires_in,
             })
         }

--- a/aws/rust-runtime/aws-sig-auth/Cargo.toml
+++ b/aws/rust-runtime/aws-sig-auth/Cargo.toml
@@ -15,6 +15,7 @@ aws-credential-types = { path = "../aws-credential-types" }
 aws-sigv4 = { path = "../aws-sigv4" }
 aws-smithy-eventstream = { path = "../../../rust-runtime/aws-smithy-eventstream", optional = true }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
+aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-types = { path = "../aws-types" }
 http = "0.2.2"
 tracing = "0.1"

--- a/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
@@ -9,6 +9,7 @@ use aws_sigv4::event_stream::{sign_empty_message, sign_message};
 use aws_sigv4::SigningParams;
 use aws_smithy_eventstream::frame::{Message, SignMessage, SignMessageError};
 use aws_smithy_http::property_bag::{PropertyBag, SharedPropertyBag};
+use aws_smithy_types::date_time;
 use aws_types::region::SigningRegion;
 use aws_types::SigningService;
 use std::time::SystemTime;
@@ -37,7 +38,7 @@ impl SigV4Signer {
         let time = properties
             .get::<SystemTime>()
             .copied()
-            .unwrap_or_else(SystemTime::now);
+            .unwrap_or_else(date_time::now);
         let mut builder = SigningParams::builder()
             .access_key(credentials.access_key_id())
             .secret_key(credentials.secret_access_key())

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -10,6 +10,7 @@ use std::time::SystemTime;
 use aws_smithy_http::middleware::MapRequest;
 use aws_smithy_http::operation::Request;
 use aws_smithy_http::property_bag::PropertyBag;
+use aws_smithy_types::date_time;
 
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::SignableBody;
@@ -147,7 +148,7 @@ fn signing_config(
         request_ts: config
             .get::<SystemTime>()
             .copied()
-            .unwrap_or_else(SystemTime::now),
+            .unwrap_or_else(date_time::now),
         region,
         payload_override,
         service: signing_service,

--- a/aws/rust-runtime/aws-sigv4/Cargo.toml
+++ b/aws/rust-runtime/aws-sigv4/Cargo.toml
@@ -23,7 +23,7 @@ http = { version = "0.2", optional = true }
 once_cell = "1.8"
 percent-encoding = { version = "2.1", optional = true }
 regex = "1.5"
-time = "0.3.5"
+time = "0.3.17"
 tracing = "0.1"
 hmac = "0.12"
 sha2 = "0.10"
@@ -34,7 +34,7 @@ bytes = "1"
 httparse = "1.5"
 pretty_assertions = "1.0"
 proptest = "1"
-time = { version = "0.3.4", features = ["parsing"] }
+time = { version = "0.3.17", features = ["parsing"] }
 
 [target.'cfg(not(any(target_arch = "powerpc", target_arch = "powerpc64")))'.dev-dependencies]
 ring = "0.16"

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -14,7 +14,7 @@ convert-time = ["aws-smithy-types", "time"]
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types", optional = true }
 chrono = { version = "0.4.19", optional = true, default-features = false, features = ["std"] }
-time = { version = "0.3.4", optional = true }
+time = { version = "0.3.17", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/awslabs/smithy-rs"
 itoa = "1.0.0"
 num-integer = "0.1.44"
 ryu = "1.0.5"
-time = { version = "0.3.4", features = ["parsing"] }
+time = { version = "0.3.17", features = ["parsing", "wasm-bindgen"] }
 base64-simd = "0.7"
 
 [dev-dependencies]

--- a/rust-runtime/aws-smithy-types/src/date_time/mod.rs
+++ b/rust-runtime/aws-smithy-types/src/date_time/mod.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
+use time::OffsetDateTime;
 
 mod format;
 pub use self::format::DateTimeFormatError;
@@ -25,6 +26,17 @@ const NANOS_PER_SECOND: i128 = 1_000_000_000;
 const NANOS_PER_SECOND_U32: u32 = 1_000_000_000;
 
 /* ANCHOR: date_time */
+
+// A std::time replacement that works on WASM as well .
+#[doc(hidden)]
+pub fn now_utc() -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+}
+
+#[doc(hidden)]
+pub fn now() -> SystemTime {
+    OffsetDateTime::now_utc().into()
+}
 
 /// DateTime in time.
 ///


### PR DESCRIPTION
## Motivation and Context

Related to https://github.com/awslabs/smithy-rs/issues/2087 and https://github.com/awslabs/aws-sdk-rust/discussions/679#discussioncomment-4357224.

Whenever targeting a platform that the `std::time::SystemTime::now()` or `std::time::Instant::now()` is not supported, it will compile successfully but panic during runtime with the following message:
> time not implemented on this platform

## Description

In order to prevent that from happening, we will use the time library with the [wasm-bindgen feature flag](https://docs.rs/time/latest/time/#feature-flags) enabled. The crate `aws-smithy-types` will have that feature enabled by default and we will consume that function to get the current time for the system.

## Testing
Unit tests already in place
Tested in the browser based on example here: https://github.com/awsdocs/aws-doc-sdk-examples/pull/4325

## Checklist
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
