### PR TITLE
Sample changes to remove @required from the inmemory model

### DIFF
--- a/codegen-core/common-test-models/minimal-constraints.smithy
+++ b/codegen-core/common-test-models/minimal-constraints.smithy
@@ -1,0 +1,46 @@
+$version: "1.0"
+
+namespace com.amazonaws.constraints
+
+use aws.protocols#restJson1
+
+/// A service to test aspects of code generation where shapes have constraint traits.
+@restJson1
+@title("ConstraintsService")
+service ConstraintsService {
+    operations: [
+        ConstrainedHttpBoundShapesOperation,
+    ],
+}
+
+@http(
+    uri: "/constrained-http-bound-shapes-operation/{rangeIntegerLabel}/{rangeShortLabel}/{rangeLongLabel}/{rangeByteLabel}/{lengthStringLabel}",
+    method: "POST"
+)
+operation ConstrainedHttpBoundShapesOperation {
+    input: ConstrainedHttpBoundShapesOperationInputOutput,
+    output: ConstrainedHttpBoundShapesOperationInputOutput,
+    errors: []
+}
+
+structure ConstrainedHttpBoundShapesOperationInputOutput {
+    @required
+    @httpLabel
+    lengthStringLabel: String,
+
+    @required
+    @httpLabel
+    rangeIntegerLabel: Integer,
+
+    @required
+    @httpLabel
+    rangeShortLabel: Short,
+
+    @required
+    @httpLabel
+    rangeLongLabel: Long,
+
+    @required
+    @httpLabel
+    rangeByteLabel: Byte,
+}

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -40,6 +40,8 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
         CodegenTest("crate#Config", "naming_test_ops", imports = listOf("$commonModels/naming-obstacle-course-ops.smithy")),
         CodegenTest("naming_obs_structs#NamingObstacleCourseStructs", "naming_test_structs", imports = listOf("$commonModels/naming-obstacle-course-structs.smithy")),
         CodegenTest("com.amazonaws.simple#SimpleService", "simple", imports = listOf("$commonModels/simple.smithy")),
+        CodegenTest("com.amazonaws.constraints#ConstraintsService", "minimal_constraints_without_public_constrained_types",
+            imports = listOf("$commonModels/minimal-constraints.smithy")),
         CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
         CodegenTest("aws.protocoltests.restjson#RestJsonExtras", "rest_json_extras", imports = listOf("$commonModels/rest-json-extras.smithy")),
         CodegenTest("aws.protocoltests.restjson.validation#RestJsonValidation", "rest_json_validation"),

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -40,6 +40,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerServic
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocol
 import software.amazon.smithy.rust.codegen.server.smithy.generators.protocol.ServerProtocolGenerator
 import software.amazon.smithy.rust.codegen.server.smithy.protocols.ServerProtocolLoader
+import software.amazon.smithy.rust.codegen.server.smithy.transformers.RequiredMemberTransform
 import java.util.logging.Logger
 
 val DefaultServerPublicModules = setOf(
@@ -111,6 +112,7 @@ open class ServerCodegenVisitor(
         model
             // Flattens mixins out of the model and removes them from the model
             .let { ModelTransformer.create().flattenAndRemoveMixins(it) }
+            .let (RequiredMemberTransform::transform)
             // Add errors attached at the service level to the models
             .let { ModelTransformer.create().copyServiceErrorsToOperations(it, settings.getService(it)) }
             // Add `Box<T>` to recursive shapes as necessary

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/RemoveRequiredTransform.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/transformers/RemoveRequiredTransform.kt
@@ -1,0 +1,121 @@
+package software.amazon.smithy.rust.codegen.server.smithy.transformers
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.neighbor.Relationship
+import software.amazon.smithy.model.neighbor.RelationshipDirection
+import software.amazon.smithy.model.neighbor.Walker
+import software.amazon.smithy.model.shapes.ListShape
+import software.amazon.smithy.model.shapes.MapShape
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.model.traits.RequiredTrait
+import software.amazon.smithy.model.traits.Trait
+import software.amazon.smithy.model.transform.ModelTransformer
+import java.util.*
+import software.amazon.smithy.rust.codegen.core.util.orNull
+import java.util.function.Predicate
+
+class DirectedWalker(model: Model) {
+    private val inner = Walker(model)
+
+    fun walkShapes(shape: Shape): Set<Shape> {
+        return walkShapes(shape) { _ -> true }
+    }
+
+    fun walkShapes(shape: Shape, predicate: Predicate<Relationship>): Set<Shape> {
+        return inner.walkShapes(shape) { rel -> predicate.test(rel) && rel.direction == RelationshipDirection.DIRECTED }
+    }
+}
+
+/**
+ * Transforms `@required` member shapes into non-required member shapes
+ */
+object RequiredMemberTransform {
+    private data class MemberShapeTransformation(
+        val memberToChange: MemberShape,
+        val traitsToKeep: List<Trait>,
+    )
+
+    private val constraintsToRemove = setOf(RequiredTrait::class.java)
+
+    private fun Shape.hasRequiredMemberTrait() =
+        constraintsToRemove.any(this::hasTrait)
+
+    fun transform(model: Model): Model {
+        val additionalNames = HashSet<ShapeId>()
+        val walker = DirectedWalker(model)
+
+        val transformations = model.operationShapes
+            .flatMap { operation ->
+                listOfNotNull(operation.input.orNull(), operation.output.orNull())
+            }
+            .map { model.expectShape(it) }
+            .flatMap {
+                walker.walkShapes(it)
+            }
+            .filter { it is StructureShape || it is ListShape || it is UnionShape || it is MapShape }
+            .flatMap {
+                it.requiredMembers()
+            }
+            .mapNotNull {
+                it.makeNonRequired(model, additionalNames)
+            }
+
+        return applyTransformations(model, transformations)
+    }
+
+    /***
+     * Returns a Model that has all the transformations applied on the original model.
+     */
+    private fun applyTransformations(
+        model: Model,
+        transformations: List<MemberShapeTransformation>,
+    ): Model {
+        if (transformations.isEmpty())
+            return model
+
+        val modelBuilder = model.toBuilder()
+        val memberShapesToChange: MutableList<MemberShape> = mutableListOf()
+
+        transformations.forEach {
+            val changedMember = it.memberToChange.toBuilder()
+                .traits(it.traitsToKeep)
+                .build()
+            memberShapesToChange.add(changedMember)
+        }
+
+        return ModelTransformer.create()
+            .replaceShapes(modelBuilder.build(), memberShapesToChange)
+    }
+
+    /**
+     * Returns a list of members that have constraint traits applied to them
+     */
+    private fun Shape.requiredMembers(): List<MemberShape> =
+        this.allMembers.values.filter {
+            it.hasRequiredMemberTrait()
+        }
+
+    /**
+     * Returns the transformation that would be required to turn the given member shape
+     * into a non-constrained member shape.
+     */
+    private fun MemberShape.makeNonRequired(
+        model: Model,
+        additionalNames: MutableSet<ShapeId>,
+    ): MemberShapeTransformation? {
+        val (requiredTrait, otherTraits) = this.allTraits.values
+            .partition {
+                constraintsToRemove.any { traitToRemove -> traitToRemove == it.javaClass }
+            }
+
+        // No transformation required in case the member shape has no required trait.
+        if (requiredTrait.isEmpty())
+            return null
+
+        return MemberShapeTransformation(this, otherTraits)
+    }
+}


### PR DESCRIPTION
Remove `@required` from the in-memory model

*This is branched off from 0.51 / release-2022-10-24*