### PR TITLE
Simplify `AdHocSection`

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 
 class CredentialsCacheDecorator : ClientCodegenDecorator {
     override val name: String = "CredentialsCache"
@@ -39,7 +40,7 @@ class CredentialsCacheDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
-            AdHocCustomization.customize { section: SdkConfigSection.CopySdkConfigToClientConfig ->
+            adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust("${section.serviceConfigBuilder}.set_credentials_cache(${section.sdkConfig}.credentials_cache().cloned());")
             },
         )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
@@ -16,7 +16,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 
@@ -38,7 +37,7 @@ class CredentialsCacheDecorator : ClientCodegenDecorator {
         return baseCustomizations + CredentialsCacheFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
             AdHocCustomization.customize { section: SdkConfigSection.CopySdkConfigToClientConfig ->
                 rust("${section.serviceConfigBuilder}.set_credentials_cache(${section.sdkConfig}.credentials_cache().cloned());")

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
@@ -15,10 +15,9 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 
 class CredentialsCacheDecorator : ClientCodegenDecorator {
     override val name: String = "CredentialsCache"
@@ -38,7 +37,7 @@ class CredentialsCacheDecorator : ClientCodegenDecorator {
         return baseCustomizations + CredentialsCacheFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
         listOf(
             SdkConfigCustomization.create { section ->
                 writable {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
@@ -39,10 +40,8 @@ class CredentialsCacheDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
         listOf(
-            SdkConfigCustomization.create { section ->
-                writable {
-                    rust("${section.serviceConfigBuilder}.set_credentials_cache(${section.sdkConfig}.credentials_cache().cloned());")
-                }
+            AdHocCustomization.customize { section: SdkConfigSection.CopySdkConfigToClientConfig ->
+                rust("${section.serviceConfigBuilder}.set_credentials_cache(${section.sdkConfig}.credentials_cache().cloned());")
             },
         )
 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
@@ -38,9 +38,9 @@ class CredentialsCacheDecorator : ClientCodegenDecorator {
         return baseCustomizations + CredentialsCacheFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
         listOf(
-            SdkConfigSection.create { section ->
+            SdkConfigCustomization.create { section ->
                 writable {
                     rust("${section.serviceConfigBuilder}.set_credentials_cache(${section.sdkConfig}.credentials_cache().cloned());")
                 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 
@@ -41,7 +42,7 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
-            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+            adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")
             },
         )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -18,7 +18,6 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 
@@ -40,7 +39,7 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
         return baseCustomizations + PubUseCredentials(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
             AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
@@ -41,10 +42,8 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
         listOf(
-            SdkConfigCustomization.create { section ->
-                writable {
-                    rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")
-                }
+            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+                rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")
             },
         )
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -17,8 +17,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 
@@ -40,7 +39,7 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
         return baseCustomizations + PubUseCredentials(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
         listOf(
             SdkConfigCustomization.create { section ->
                 writable {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -17,7 +17,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
@@ -40,9 +40,9 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
         return baseCustomizations + PubUseCredentials(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
         listOf(
-            SdkConfigSection.create { section ->
+            SdkConfigCustomization.create { section ->
                 writable {
                     rust("${section.serviceConfigBuilder}.set_credentials_provider(${section.sdkConfig}.credentials_provider().cloned());")
                 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -29,7 +29,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -71,7 +71,7 @@ fun Model.sdkConfigSetter(
     serviceId: ShapeId,
     builtInSrc: Parameter,
     configParameterNameOverride: String?,
-): Pair<AdHocSection<*>, (Section) -> Writable>? {
+): Pair<AdHocCustomization<*>, (Section) -> Writable>? {
     val builtIn = loadBuiltIn(serviceId, builtInSrc) ?: return null
     val fieldName = configParameterNameOverride ?: builtIn.name.rustName()
 
@@ -79,7 +79,7 @@ fun Model.sdkConfigSetter(
         ParameterType.STRING -> writable { rust("|s|s.to_string()") }
         ParameterType.BOOLEAN -> null
     }
-    return SdkConfigSection.copyField(fieldName, map)
+    return SdkConfigCustomization.copyField(fieldName, map)
 }
 
 /**
@@ -99,7 +99,7 @@ fun decoratorForBuiltIn(
         private fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
             codegenContext.getBuiltIn(builtIn) != null
 
-        override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> {
+        override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
             return listOfNotNull(
                 codegenContext.model.sdkConfigSetter(codegenContext.serviceShape.id, builtIn, clientParam?.name),
             )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -29,8 +29,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.extendIf
@@ -71,7 +70,7 @@ fun Model.sdkConfigSetter(
     serviceId: ShapeId,
     builtInSrc: Parameter,
     configParameterNameOverride: String?,
-): Pair<AdHocCustomization<*>, (Section) -> Writable>? {
+): AdHocCustomizationWriter? {
     val builtIn = loadBuiltIn(serviceId, builtInSrc) ?: return null
     val fieldName = configParameterNameOverride ?: builtIn.name.rustName()
 
@@ -99,7 +98,7 @@ fun decoratorForBuiltIn(
         private fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
             codegenContext.getBuiltIn(builtIn) != null
 
-        override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
+        override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
             return listOfNotNull(
                 codegenContext.model.sdkConfigSetter(codegenContext.serviceShape.id, builtIn, clientParam?.name),
             )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -29,7 +29,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.extendIf
@@ -70,7 +70,7 @@ fun Model.sdkConfigSetter(
     serviceId: ShapeId,
     builtInSrc: Parameter,
     configParameterNameOverride: String?,
-): AdHocCustomizationWriter? {
+): AdHocCustomization? {
     val builtIn = loadBuiltIn(serviceId, builtInSrc) ?: return null
     val fieldName = configParameterNameOverride ?: builtIn.name.rustName()
 
@@ -98,7 +98,7 @@ fun decoratorForBuiltIn(
         private fun rulesetContainsBuiltIn(codegenContext: ClientCodegenContext) =
             codegenContext.getBuiltIn(builtIn) != null
 
-        override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
+        override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
             return listOfNotNull(
                 codegenContext.model.sdkConfigSetter(codegenContext.serviceShape.id, builtIn, clientParam?.name),
             )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -23,6 +23,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -109,7 +110,7 @@ class RegionDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return usesRegion(codegenContext).thenSingletonListOf {
-            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+            adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust(
                     """
                     ${section.serviceConfigBuilder} =

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -21,7 +21,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
@@ -108,7 +107,7 @@ class RegionDecorator : ClientCodegenDecorator {
         return baseCustomizations.extendIf(usesRegion(codegenContext)) { PubUseRegion(codegenContext.runtimeConfig) }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return usesRegion(codegenContext).thenSingletonListOf {
             AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -20,10 +20,9 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -108,7 +107,7 @@ class RegionDecorator : ClientCodegenDecorator {
         return baseCustomizations.extendIf(usesRegion(codegenContext)) { PubUseRegion(codegenContext.runtimeConfig) }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
         return usesRegion(codegenContext).thenSingletonListOf {
             SdkConfigCustomization.create { section ->
                 {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
@@ -109,15 +110,13 @@ class RegionDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
         return usesRegion(codegenContext).thenSingletonListOf {
-            SdkConfigCustomization.create { section ->
-                {
-                    rust(
-                        """
-                        ${section.serviceConfigBuilder} =
-                             ${section.serviceConfigBuilder}.region(${section.sdkConfig}.region().cloned());
-                        """,
-                    )
-                }
+            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+                rust(
+                    """
+                    ${section.serviceConfigBuilder} =
+                         ${section.serviceConfigBuilder}.region(${section.sdkConfig}.region().cloned());
+                    """,
+                )
             }
         }
     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -20,7 +20,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
@@ -108,9 +108,9 @@ class RegionDecorator : ClientCodegenDecorator {
         return baseCustomizations.extendIf(usesRegion(codegenContext)) { PubUseRegion(codegenContext.runtimeConfig) }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
         return usesRegion(codegenContext).thenSingletonListOf {
-            SdkConfigSection.create { section ->
+            SdkConfigCustomization.create { section ->
                 {
                     rust(
                         """

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -17,10 +17,11 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
 
-sealed class SdkConfigSection(name: String) : Section(name) {
+sealed class SdkConfigSection(name: String) : AdHocSection(name) {
     /**
      * [sdkConfig]: A reference to the SDK config struct
      * [serviceConfigBuilder]: A reference (owned) to the `<service>::config::Builder` struct.
@@ -49,7 +50,7 @@ object SdkConfigCustomization {
      * ```
      */
     fun copyField(fieldName: String, map: Writable?) =
-        AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+        adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
             val mapBlock = map?.let { writable { rust(".map(#W)", it) } } ?: writable { }
             rustTemplate(
                 "${section.serviceConfigBuilder}.set_$fieldName(${section.sdkConfig}.$fieldName()#{map});",
@@ -67,7 +68,7 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
-            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+            adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust(
                     """
                     // resiliency

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -17,13 +17,13 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 
 /**
  * Section enabling linkage between `SdkConfig` and <service>::Config
  */
-object SdkConfigSection : AdHocSection<SdkConfigSection.CopySdkConfigToClientConfig>("SdkConfig") {
+object SdkConfigCustomization : AdHocCustomization<SdkConfigCustomization.CopySdkConfigToClientConfig>("SdkConfig") {
     /**
      * [sdkConfig]: A reference to the SDK config struct
      * [serviceConfigBuilder]: A reference (owned) to the `<service>::config::Builder` struct.
@@ -43,10 +43,10 @@ object SdkConfigSection : AdHocSection<SdkConfigSection.CopySdkConfigToClientCon
      *
      * # Examples
      * ```kotlin
-     * SdkConfigSection.copyField("some_string_field") { rust("|s|s.to_to_string()") }
+     * SdkConfigCustomization.copyField("some_string_field") { rust("|s|s.to_to_string()") }
      * ```
      */
-    fun copyField(fieldName: String, map: Writable?) = SdkConfigSection.create { section ->
+    fun copyField(fieldName: String, map: Writable?) = SdkConfigCustomization.create { section ->
         {
             val mapBlock = map?.let { writable { rust(".map(#W)", it) } } ?: writable { }
             rustTemplate(
@@ -64,9 +64,9 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
     override val name: String = "GenericSmithySdkConfigSettings"
     override val order: Byte = 0
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
         listOf(
-            SdkConfigSection.create { section ->
+            SdkConfigCustomization.create { section ->
                 writable {
                     rust(
                         """
@@ -125,9 +125,9 @@ class SdkConfigDecorator : ClientCodegenDecorator {
                 }
                 """,
                 "augmentBuilder" to codegenContext.rootDecorator.extraSections(codegenContext)
-                    .filter { (t, _) -> t is SdkConfigSection }.map { (_, sectionWriter) ->
+                    .filter { (t, _) -> t is SdkConfigCustomization }.map { (_, sectionWriter) ->
                         sectionWriter(
-                            SdkConfigSection.CopySdkConfigToClientConfig(
+                            SdkConfigCustomization.CopySdkConfigToClientConfig(
                                 sdkConfig = "input",
                                 serviceConfigBuilder = "builder",
                             ),

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 
 /**
@@ -64,7 +65,7 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
     override val name: String = "GenericSmithySdkConfigSettings"
     override val order: Byte = 0
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
         listOf(
             SdkConfigCustomization.create { section ->
                 writable {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -17,7 +17,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
 
@@ -66,7 +65,7 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
     override val name: String = "GenericSmithySdkConfigSettings"
     override val order: Byte = 0
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> =
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
             AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -57,7 +58,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return listOf(
-            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+            adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());")
             },
         )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -16,7 +16,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
@@ -56,9 +56,9 @@ class UserAgentDecorator : ClientCodegenDecorator {
         return baseCustomizations + UserAgentFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
         return listOf(
-            SdkConfigSection.create { section ->
+            SdkConfigCustomization.create { section ->
                 writable { rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());") }
             },
         )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -16,6 +16,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
@@ -57,8 +58,8 @@ class UserAgentDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
         return listOf(
-            SdkConfigCustomization.create { section ->
-                writable { rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());") }
+            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+                rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());")
             },
         )
     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -16,10 +16,9 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.dq
@@ -56,7 +55,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
         return baseCustomizations + UserAgentFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
         return listOf(
             SdkConfigCustomization.create { section ->
                 writable { rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());") }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -17,7 +17,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
@@ -56,7 +55,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
         return baseCustomizations + UserAgentFeature(codegenContext.runtimeConfig)
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return listOf(
             AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust("${section.serviceConfigBuilder}.set_app_name(${section.sdkConfig}.app_name().cloned());")

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
@@ -30,6 +30,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.extendIf
@@ -134,7 +135,7 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return codegenContext.isRegionalized().thenSingletonListOf {
-            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+            adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust(
                     """
                     ${section.serviceConfigBuilder}.set_aws_endpoint_resolver(${section.sdkConfig}.endpoint_resolver().clone());

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
@@ -29,8 +29,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.extendIf
@@ -133,7 +132,7 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
         }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
         return codegenContext.isRegionalized().thenSingletonListOf {
             SdkConfigCustomization.create { section ->
                 {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
@@ -30,7 +30,6 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.extendIf
@@ -133,7 +132,7 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
         }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return codegenContext.isRegionalized().thenSingletonListOf {
             AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
                 rust(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
@@ -29,6 +29,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomizationWriter
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
@@ -36,7 +37,7 @@ import software.amazon.smithy.rust.codegen.core.util.extendIf
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
 import software.amazon.smithy.rustsdk.AwsRuntimeType
-import software.amazon.smithy.rustsdk.SdkConfigCustomization
+import software.amazon.smithy.rustsdk.SdkConfigSection
 import software.amazon.smithy.rustsdk.getBuiltIn
 
 class AwsEndpointDecorator : ClientCodegenDecorator {
@@ -134,14 +135,12 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
 
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomizationWriter> {
         return codegenContext.isRegionalized().thenSingletonListOf {
-            SdkConfigCustomization.create { section ->
-                {
-                    rust(
-                        """
-                        ${section.serviceConfigBuilder}.set_aws_endpoint_resolver(${section.sdkConfig}.endpoint_resolver().clone());
-                        """,
-                    )
-                }
+            AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+                rust(
+                    """
+                    ${section.serviceConfigBuilder}.set_aws_endpoint_resolver(${section.sdkConfig}.endpoint_resolver().clone());
+                    """,
+                )
             }
         }
     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
@@ -29,7 +29,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
@@ -37,7 +37,7 @@ import software.amazon.smithy.rust.codegen.core.util.extendIf
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
 import software.amazon.smithy.rustsdk.AwsRuntimeType
-import software.amazon.smithy.rustsdk.SdkConfigSection
+import software.amazon.smithy.rustsdk.SdkConfigCustomization
 import software.amazon.smithy.rustsdk.getBuiltIn
 
 class AwsEndpointDecorator : ClientCodegenDecorator {
@@ -133,9 +133,9 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
         }
     }
 
-    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> {
+    override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> {
         return codegenContext.isRegionalized().thenSingletonListOf {
-            SdkConfigSection.create { section ->
+            SdkConfigCustomization.create { section ->
                 {
                     rust(
                         """

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDecorator.kt
@@ -17,7 +17,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
@@ -72,7 +72,7 @@ sealed class FluentClientSection(name: String) : Section(name) {
     data class FluentClientDocs(val serviceShape: ServiceShape) : FluentClientSection("FluentClientDocs")
 }
 
-abstract class FluentClientCustomization : NamedSectionGenerator<FluentClientSection>()
+abstract class FluentClientCustomization : NamedCustomization<FluentClientSection>()
 
 class GenericFluentClient(codegenContext: CodegenContext) : FluentClientCustomization() {
     private val moduleUseName = codegenContext.moduleUseName()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
@@ -10,12 +10,12 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 
 /**
  * Add a `make_token` field to Service config. See below for the resulting generated code.
  */
-class IdempotencyTokenProviderCustomization : NamedSectionGenerator<ServiceConfig>() {
+class IdempotencyTokenProviderCustomization : NamedCustomization<ServiceConfig>() {
     override fun section(section: ServiceConfig): Writable {
         return when (section) {
             is ServiceConfig.ConfigStruct -> writable {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -23,7 +23,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.makeOptional
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
@@ -39,7 +39,7 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
  *
  * Usage:
  * ```kotlin
- * class AddRegion : NamedSectionGenerator<ServiceConfig>() {
+ * class AddRegion : NamedCustomization<ServiceConfig>() {
  *  override fun section(section: ServiceConfig): Writable {
  *    return when (section) {
  *      is ServiceConfig.ConfigStruct -> writeable {
@@ -156,7 +156,7 @@ fun ServiceShape.needsIdempotencyToken(model: Model): Boolean {
         .any { it.hasTrait<IdempotencyTokenTrait>() }
 }
 
-typealias ConfigCustomization = NamedSectionGenerator<ServiceConfig>
+typealias ConfigCustomization = NamedCustomization<ServiceConfig>
 
 /**
  * Generate a `Config` struct, implementation & builder for a given service, approximately:

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGeneratorTest.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
@@ -78,7 +78,7 @@ internal class ServiceConfigGeneratorTest {
 
     @Test
     fun `generate customizations as specified`() {
-        class ServiceCustomizer : NamedSectionGenerator<ServiceConfig>() {
+        class ServiceCustomizer : NamedCustomization<ServiceConfig>() {
             override fun section(section: ServiceConfig): Writable {
                 return when (section) {
                     ServiceConfig.ConfigStructAdditionalDocs -> emptySection

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -8,7 +8,6 @@ package software.amazon.smithy.rust.codegen.core.smithy.customize
 import software.amazon.smithy.build.PluginContext
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
-import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.ManifestCustomizations
@@ -66,7 +65,7 @@ interface CoreCodegenDecorator<CodegenContext> {
     /**
      * Extra sections allow one decorator to influence another. This is intended to be used by querying the `rootDecorator`
      */
-    fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> = listOf()
+    fun extraSections(codegenContext: CodegenContext): List<AdHocCustomizationWriter> = listOf()
 }
 
 /**
@@ -99,7 +98,7 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
             decorator.transformModel(otherModel.expectShape(service.id, ServiceShape::class.java), otherModel)
         }
 
-    final override fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
+    final override fun extraSections(codegenContext: CodegenContext): List<AdHocCustomizationWriter> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -65,7 +65,7 @@ interface CoreCodegenDecorator<CodegenContext> {
     /**
      * Extra sections allow one decorator to influence another. This is intended to be used by querying the `rootDecorator`
      */
-    fun extraSections(codegenContext: CodegenContext): List<AdHocCustomizationWriter> = listOf()
+    fun extraSections(codegenContext: CodegenContext): List<AdHocCustomization> = listOf()
 }
 
 /**
@@ -98,7 +98,7 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
             decorator.transformModel(otherModel.expectShape(service.id, ServiceShape::class.java), otherModel)
         }
 
-    final override fun extraSections(codegenContext: CodegenContext): List<AdHocCustomizationWriter> =
+    final override fun extraSections(codegenContext: CodegenContext): List<AdHocCustomization> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -66,7 +66,7 @@ interface CoreCodegenDecorator<CodegenContext> {
     /**
      * Extra sections allow one decorator to influence another. This is intended to be used by querying the `rootDecorator`
      */
-    fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> = listOf()
+    fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> = listOf()
 }
 
 /**
@@ -99,7 +99,7 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
             decorator.transformModel(otherModel.expectShape(service.id, ServiceShape::class.java), otherModel)
         }
 
-    final override fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
+    final override fun extraSections(codegenContext: CodegenContext): List<Pair<AdHocCustomization<*>, (Section) -> Writable>> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
@@ -23,35 +23,20 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
  */
 abstract class Section(val name: String)
 
-/**
- * Detached section abstraction to allow adhoc sections to be created. By using the `.writer` method, an
- * instantiation of this section can be easily created.
- */
-abstract class AdHocCustomization : NamedCustomization<Section>() {
-    companion object {
-        /**
-         * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
-         *
-         * Note: When calling this, be sure to set the type of the section. For example:
-         * ```
-         * // The part in angle brackets is important:
-         * AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
-         *     // snip
-         * },
-         * ```
-         */
-        inline fun <reified T> customize(
-            crossinline customization: RustWriter.(T) -> Unit,
-        ): AdHocCustomization =
-            object : AdHocCustomization() {
-                override fun section(section: Section): Writable = writable {
-                    if (section is T) {
-                        customization(section)
-                    }
-                }
+typealias AdHocCustomization = NamedCustomization<AdHocSection>
+
+abstract class AdHocSection(name: String) : Section(name)
+
+inline fun <reified T : AdHocSection> adhocCustomization(
+    crossinline customization: RustWriter.(T) -> Unit,
+): AdHocCustomization =
+    object : AdHocCustomization() {
+        override fun section(section: AdHocSection): Writable = writable {
+            if (section is T) {
+                customization(section)
             }
+        }
     }
-}
 
 /**
  * A named section generator allows customization via a predefined set of named sections.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
@@ -23,10 +23,16 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
  */
 abstract class Section(val name: String)
 
+/** Customization type returned by [adhocCustomization] */
 typealias AdHocCustomization = NamedCustomization<AdHocSection>
 
+/** Adhoc section for code generation. Similar to [Section], but for use with [adhocCustomization]. */
 abstract class AdHocSection(name: String) : Section(name)
 
+/**
+ * Allows for one-off customizations such that a `when` statement switching on
+ * the section type is not necessary.
+ */
 inline fun <reified T : AdHocSection> adhocCustomization(
     crossinline customization: RustWriter.(T) -> Unit,
 ): AdHocCustomization =
@@ -39,7 +45,7 @@ inline fun <reified T : AdHocSection> adhocCustomization(
     }
 
 /**
- * A named section generator allows customization via a predefined set of named sections.
+ * A named section generator that allows customization via a predefined set of named sections.
  *
  * Implementors MUST override section and use a `when` clause to handle each section individually
  */

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
@@ -27,7 +27,7 @@ abstract class Section(val name: String)
  * Detached section abstraction to allow adhoc sections to be created. By using the `.writer` method, an
  * instantiation of this section can be easily created.
  */
-abstract class AdHocCustomization : NamedSectionGenerator<Section>() {
+abstract class AdHocCustomization : NamedCustomization<Section>() {
     companion object {
         /**
          * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
@@ -58,13 +58,13 @@ abstract class AdHocCustomization : NamedSectionGenerator<Section>() {
  *
  * Implementors MUST override section and use a `when` clause to handle each section individually
  */
-abstract class NamedSectionGenerator<T : Section> {
+abstract class NamedCustomization<T : Section> {
     abstract fun section(section: T): Writable
     protected val emptySection = writable { }
 }
 
 /** Convenience for rendering a list of customizations for a given section */
-fun <T : Section> RustWriter.writeCustomizations(customizations: List<NamedSectionGenerator<T>>, section: T) {
+fun <T : Section> RustWriter.writeCustomizations(customizations: List<NamedCustomization<T>>, section: T) {
     for (customization in customizations) {
         customization.section(section)(this)
     }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
@@ -23,6 +23,8 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
  */
 abstract class Section(val name: String)
 
+typealias AdHocCustomizationWriter = Pair<AdHocCustomization<*>, (Section) -> Writable>
+
 /**
  * Detached section abstraction to allow adhoc sections to be created. By using the `.writer` method, an
  * instantiation of this section can be easily created.
@@ -31,7 +33,7 @@ abstract class AdHocCustomization<T : Section>(val name: String) {
     /**
      * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
      */
-    fun create(w: (T) -> Writable): Pair<AdHocCustomization<*>, (Section) -> Writable> = this to { s: Section ->
+    fun create(w: (T) -> Writable): AdHocCustomizationWriter = this to { s: Section ->
         w((s as T))
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
@@ -23,34 +23,34 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
  */
 abstract class Section(val name: String)
 
-typealias AdHocCustomizationWriter = NamedSectionGenerator<Section>
-
 /**
  * Detached section abstraction to allow adhoc sections to be created. By using the `.writer` method, an
  * instantiation of this section can be easily created.
  */
-object AdHocCustomization {
-    /**
-     * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
-     *
-     * Note: When calling this, be sure to set the type of the section. For example:
-     * ```
-     * // The part in angle brackets is important:
-     * AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
-     *     // snip
-     * },
-     * ```
-     */
-    inline fun <reified T> customize(
-        crossinline customization: RustWriter.(T) -> Unit,
-    ): NamedSectionGenerator<Section> =
-        object : NamedSectionGenerator<Section>() {
-            override fun section(section: Section): Writable = writable {
-                if (section is T) {
-                    customization(section)
+abstract class AdHocCustomization : NamedSectionGenerator<Section>() {
+    companion object {
+        /**
+         * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
+         *
+         * Note: When calling this, be sure to set the type of the section. For example:
+         * ```
+         * // The part in angle brackets is important:
+         * AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
+         *     // snip
+         * },
+         * ```
+         */
+        inline fun <reified T> customize(
+            crossinline customization: RustWriter.(T) -> Unit,
+        ): AdHocCustomization =
+            object : AdHocCustomization() {
+                override fun section(section: Section): Writable = writable {
+                    if (section is T) {
+                        customization(section)
+                    }
                 }
             }
-        }
+    }
 }
 
 /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
@@ -27,11 +27,11 @@ abstract class Section(val name: String)
  * Detatched section abstraction to allow adhoc sections to be created. By using the `.writer` method, a instantiation
  * of this section can be easily created.
  */
-abstract class AdHocSection<T : Section>(val name: String) {
+abstract class AdHocCustomization<T : Section>(val name: String) {
     /**
      * Helper to enable easily combining detached sections with the [CoreCodegenDecorator.extraSections] method.
      */
-    fun create(w: (T) -> Writable): Pair<AdHocSection<*>, (Section) -> Writable> = this to { s: Section ->
+    fun create(w: (T) -> Writable): Pair<AdHocCustomization<*>, (Section) -> Writable> = this to { s: Section ->
         w((s as T))
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/NamedSectionGenerator.kt
@@ -24,8 +24,8 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 abstract class Section(val name: String)
 
 /**
- * Detatched section abstraction to allow adhoc sections to be created. By using the `.writer` method, a instantiation
- * of this section can be easily created.
+ * Detached section abstraction to allow adhoc sections to be created. By using the `.writer` method, an
+ * instantiation of this section can be easily created.
  */
 abstract class AdHocCustomization<T : Section>(val name: String) {
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/OperationCustomization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/OperationCustomization.kt
@@ -55,7 +55,7 @@ sealed class OperationSection(name: String) : Section(name) {
     ) : OperationSection("MutateOutput")
 }
 
-abstract class OperationCustomization : NamedSectionGenerator<OperationSection>() {
+abstract class OperationCustomization : NamedCustomization<OperationSection>() {
     open fun retryType(): RuntimeType? = null
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/Instantiator.kt
@@ -46,7 +46,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
@@ -66,7 +66,7 @@ sealed class InstantiatorSection(name: String) : Section(name) {
 /**
  * Customization for the instantiator.
  */
-typealias InstantiatorCustomization = NamedSectionGenerator<InstantiatorSection>
+typealias InstantiatorCustomization = NamedCustomization<InstantiatorSection>
 
 /**
  * Instantiator generates code to instantiate a given shape given a `Node` representing the value.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/LibRsGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/LibRsGenerator.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.escape
 import software.amazon.smithy.rust.codegen.core.rustlang.isEmpty
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.smithy.CoreRustSettings
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 
@@ -27,7 +27,7 @@ sealed class LibRsSection(name: String) : Section(name) {
     }
 }
 
-typealias LibRsCustomization = NamedSectionGenerator<LibRsSection>
+typealias LibRsCustomization = NamedCustomization<LibRsSection>
 
 class LibRsGenerator(
     private val settings: CoreRustSettings,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/http/HttpBindingGenerator.kt
@@ -41,7 +41,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.OperationBuildError
 import software.amazon.smithy.rust.codegen.core.smithy.generators.operationBuildError
@@ -90,7 +90,7 @@ sealed class HttpBindingSection(name: String) : Section(name) {
         HttpBindingSection("AfterDeserializingIntoAHashMapOfHttpPrefixHeaders")
 }
 
-typealias HttpBindingCustomization = NamedSectionGenerator<HttpBindingSection>
+typealias HttpBindingCustomization = NamedCustomization<HttpBindingSection>
 
 /**
  * This class generates Rust functions that (de)serialize data from/to an HTTP message.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/parse/JsonParserGenerator.kt
@@ -40,7 +40,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.canUseDefault
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.TypeConversionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
@@ -70,7 +70,7 @@ sealed class JsonParserSection(name: String) : Section(name) {
 /**
  * Customization for the JSON parser.
  */
-typealias JsonParserCustomization = NamedSectionGenerator<JsonParserSection>
+typealias JsonParserCustomization = NamedCustomization<JsonParserSection>
 
 data class ReturnSymbolToParse(val symbol: Symbol, val isUnconstrained: Boolean)
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -36,7 +36,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedSectionGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.customize.NamedCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.Section
 import software.amazon.smithy.rust.codegen.core.smithy.generators.TypeConversionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
@@ -81,7 +81,7 @@ sealed class JsonSerializerSection(name: String) : Section(name) {
 /**
  * Customization for the JSON serializer.
  */
-typealias JsonSerializerCustomization = NamedSectionGenerator<JsonSerializerSection>
+typealias JsonSerializerCustomization = NamedCustomization<JsonSerializerSection>
 
 class JsonSerializerGenerator(
     codegenContext: CodegenContext,


### PR DESCRIPTION
## Motivation and Context
I struggled to understand and use `AdHocSection`, so decided to simplify it a bit.

Previously, when customizing an extra section, you would have to:
```kotlin
override fun extraSections(codegenContext: ClientCodegenContext): List<Pair<AdHocSection<*>, (Section) -> Writable>> =
     listOf(
         SdkConfigSection.create { section ->
             writable {
                 // snip
             }   
         }   
     )
```

Now it's:
```kotlin
override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
    listOf(
        AdHocCustomization.customize<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
            // snip
        },   
    )
```

The hook side of things has also been simplified. Previously a manual filter/map/join was required:

```kotlin
rustTemplate(
    """
    // snip
    #{augmentBuilder}
    // snip
    """,
    "augmentBuilder" to codegenContext.rootDecorator.extraSections(codegenContext)
        .filter { (t, _) -> t is SdkConfigSection }
        .map { (_, sectionWriter) ->
            sectionWriter(
                SdkConfigSection.CopySdkConfigToClientConfig(
                    sdkConfig = "input",
                    serviceConfigBuilder = "builder", 
                ),           
            )            
        }.join("\n"),
)
```

Now it's simply:
```kotlin
rustTemplate(
    """
    // snip
    #{augmentBuilder:W}
    // snip
    """,
    "augmentBuilder" to writable {
        writeCustomizations(
            codegenContext.rootDecorator.extraSections(codegenContext),
            SdkConfigSection.CopySdkConfigToClientConfig(
                sdkConfig = "input",
                serviceConfigBuilder = "builder", 
            ),           
        )
    },
)
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
