### PR TITLE
Fix action paths, part 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,11 +117,12 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: ${{ inputs.release_branch }}
+        path: smithy-rs
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
     - name: Upgrade gradle.properties
-      uses: ./.github/actions/docker-build
+      uses: ./smithy-rs/.github/actions/docker-build
       with:
-        action: upgrade-gradle-smithy-rs-release ${{ inputs.semantic_version }}
+        action: upgrade-gradle-properties ${{ inputs.semantic_version }}
     - name: Push gradle.properties changes
       id: gradle-push
       shell: bash
@@ -217,9 +218,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: ${{ inputs.commit_sha }}
+        path: smithy-rs
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
     - name: Empty CHANGELOG.next.toml
-      uses: ./.github/actions/docker-build
+      uses: ./smithy-rs/.github/actions/docker-build
       with:
         action: generate-new-changelog-next-toml
     - name: Push smithy-rs changes

--- a/tools/ci-scripts/generate-new-changelog-next-toml
+++ b/tools/ci-scripts/generate-new-changelog-next-toml
@@ -6,4 +6,4 @@
 
 set -eux
 
-changelogger init > CHANGELOG.next.toml
+changelogger init > smithy-rs/CHANGELOG.next.toml

--- a/tools/ci-scripts/upgrade-gradle-properties
+++ b/tools/ci-scripts/upgrade-gradle-properties
@@ -6,4 +6,4 @@
 
 set -eux
 
-publisher upgrade-runtime-crates-version --version ${1}
+publisher upgrade-runtime-crates-version --version ${1} --gradle-properties-path smithy-rs/gradle.properties


### PR DESCRIPTION
We need to checkout in the `smithy-rs` folder because that's an assumption baked into the definition of the docker-build action.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
