### PR TITLE
`git push origin` fails if there is nothing to push.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,7 @@ jobs:
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         # The file was actually changed, we need to commit the changes
-        git diff-index --quiet HEAD || git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}"
-        echo "Pushing upgraded gradle.properties commit..."
-        # This will succeed even if nothing new was committed
-        git push origin
+        git diff-index --quiet HEAD || git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}" && git push origin
 
   release:
     name: Release


### PR DESCRIPTION


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
