### PR TITLE
Fix CI on main and don't acquire Docker login for forks

### DIFF
--- a/.github/scripts/acquire-build-image
+++ b/.github/scripts/acquire-build-image
@@ -64,8 +64,8 @@ class Context:
         image_tag = get_cmd_output("./docker-image-hash", cwd=script_path)[1]
         allow_local_build = os.getenv("ALLOW_LOCAL_BUILD") != "false"
         github_actions = os.getenv("GITHUB_ACTIONS") == "true"
-        encrypted_docker_password = os.getenv("ENCRYPTED_DOCKER_PASSWORD")
-        docker_passphrase = os.getenv("DOCKER_LOGIN_TOKEN_PASSPHRASE")
+        encrypted_docker_password = os.getenv("ENCRYPTED_DOCKER_PASSWORD") or None
+        docker_passphrase = os.getenv("DOCKER_LOGIN_TOKEN_PASSPHRASE") or None
 
         print(f"Start path: {start_path}")
         print(f"Script path: {script_path}")

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -49,6 +49,13 @@ jobs:
         aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
         docker push "${{ env.ecr_repository }}:${IMAGE_TAG}"
         docker push "${{ env.ecr_repository }}:main"
+    - name: Save the docker login password to the output
+      id: set-token
+      run: |
+        ENCRYPTED_PAYLOAD=$(
+          gpg --symmetric --batch --passphrase "${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}" --output - <(aws ecr-public get-login-password --region us-east-1) | base64 -w0
+        )
+        echo "docker-login-password=$ENCRYPTED_PAYLOAD" >> $GITHUB_OUTPUT
 
   # Run the shared CI after a Docker build image has been uploaded to ECR
   ci:
@@ -56,3 +63,6 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       run_sdk_examples: true
+    secrets:
+      ENCRYPTED_DOCKER_PASSWORD: ${{ needs.rebuild-docker-build-image.outputs.docker-login-password }}
+      DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -19,36 +19,24 @@ env:
   ecr_repository: public.ecr.aws/w0m4q9l7/github-awslabs-smithy-rs-ci
 
 jobs:
-  # Rebuild and upload the Docker build image
-  rebuild-docker-build-image:
+  # Build and upload the Docker build image if necessary
+  acquire-base-image:
     runs-on: smithy_ubuntu-latest_8-core
-    name: Rebuild image
+    name: Acquire Base Image
+    outputs:
+      docker-login-password: ${{ steps.set-token.outputs.docker-login-password }}
     permissions:
       id-token: write
       contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Build image
-      run: |
-        IMAGE_TAG="$(./.github/scripts/docker-image-hash)"
-        cd tools/ci-build
-        docker build \
-          -t "${{ env.ecr_repository }}:${IMAGE_TAG}" \
-          -t "${{ env.ecr_repository }}:main" \
-          .
     - name: Acquire credentials
       uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         role-to-assume: ${{ secrets.SMITHY_RS_PUBLIC_ECR_PUSH_ROLE_ARN }}
         role-session-name: GitHubActions
         aws-region: us-west-2
-    - name: Upload image
-      run: |
-        IMAGE_TAG="$(./.github/scripts/docker-image-hash)"
-        aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-        docker push "${{ env.ecr_repository }}:${IMAGE_TAG}"
-        docker push "${{ env.ecr_repository }}:main"
     - name: Save the docker login password to the output
       id: set-token
       run: |
@@ -56,13 +44,26 @@ jobs:
           gpg --symmetric --batch --passphrase "${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}" --output - <(aws ecr-public get-login-password --region us-east-1) | base64 -w0
         )
         echo "docker-login-password=$ENCRYPTED_PAYLOAD" >> $GITHUB_OUTPUT
+    - name: Acquire base image
+      id: acquire
+      env:
+        DOCKER_BUILDKIT: 1
+        ENCRYPTED_DOCKER_PASSWORD: ${{ steps.set-token.outputs.docker-login-password }}
+        DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}
+      run: ./.github/scripts/acquire-build-image
+    - name: Tag and upload image
+      run: |
+        IMAGE_TAG="$(./.github/scripts/docker-image-hash)"
+        docker tag "${{ env.ecr_repository }}:${IMAGE_TAG}" "${{ env.ecr_repository }}:main"
+        docker push "${{ env.ecr_repository }}:${IMAGE_TAG}"
+        docker push "${{ env.ecr_repository }}:main"
 
   # Run the shared CI after a Docker build image has been uploaded to ECR
   ci:
-    needs: rebuild-docker-build-image
+    needs: acquire-base-image
     uses: ./.github/workflows/ci.yml
     with:
       run_sdk_examples: true
     secrets:
-      ENCRYPTED_DOCKER_PASSWORD: ${{ needs.rebuild-docker-build-image.outputs.docker-login-password }}
+      ENCRYPTED_DOCKER_PASSWORD: ${{ needs.acquire-base-image.outputs.docker-login-password }}
       DOCKER_LOGIN_TOKEN_PASSPHRASE: ${{ secrets.DOCKER_LOGIN_TOKEN_PASSPHRASE }}

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -20,13 +20,14 @@ jobs:
   # be encrypted with the passphrase stored as a GitHub secret. The login password expires after 12h.
   # The login password is encrypted with the repo secret DOCKER_LOGIN_TOKEN_PASSPHRASE
   save-docker-login-token:
+    name: Save a docker login token
+    if: ${{ github.event.pull_request.head.repo.full_name == 'awslabs/smithy-rs' }}
     outputs:
       docker-login-password: ${{ steps.set-token.outputs.docker-login-password }}
     permissions:
       id-token: write
       contents: read
     continue-on-error: true
-    name: Save a docker login token
     runs-on: ubuntu-latest
     steps:
     - name: Attempt to load a docker login password


### PR DESCRIPTION
Also fixes a bug where PRs from forks were throwing an exception in `acquire-base-image` because the environment variable existed but was an empty string.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
