### PR TITLE
Rename Rust server codegen plugins

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -66,10 +66,10 @@ class RustClientCodegenPlugin : DecoratableBuildPlugin() {
     }
 
     companion object {
-        /** SymbolProvider
+        /**
          * When generating code, smithy types need to be converted into Rust types—that is the core role of the symbol provider
          *
-         * The Symbol provider is composed of a base `SymbolVisitor` which handles the core functionality, then is layered
+         * The Symbol provider is composed of a base [SymbolVisitor] which handles the core functionality, then is layered
          * with other symbol providers, documented inline, to handle the full scope of Smithy types.
          */
         fun baseSymbolProvider(model: Model, serviceShape: ServiceShape, symbolVisitorConfig: SymbolVisitorConfig) =

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -481,7 +481,7 @@ class RustWriter private constructor(
      * Callers must take care to use [this] when writing to ensure code is written to the right place:
      * ```kotlin
      * val writer = RustWriter.forModule("model")
-     * writer.withModule(RustModule.public("nested")) {
+     * writer.withInlineModule(RustModule.public("nested")) {
      *   Generator(...).render(this) // GOOD
      *   Generator(...).render(writer) // WRONG!
      * }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/DirectedWalker.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/DirectedWalker.kt
@@ -19,11 +19,8 @@ import java.util.function.Predicate
 class DirectedWalker(model: Model) {
     private val inner = Walker(model)
 
-    fun walkShapes(shape: Shape): Set<Shape> {
-        return walkShapes(shape) { _ -> true }
-    }
+    fun walkShapes(shape: Shape): Set<Shape> = walkShapes(shape) { true }
 
-    fun walkShapes(shape: Shape, predicate: Predicate<Relationship>): Set<Shape> {
-        return inner.walkShapes(shape) { rel -> predicate.test(rel) && rel.direction == RelationshipDirection.DIRECTED }
-    }
+    fun walkShapes(shape: Shape, predicate: Predicate<Relationship>): Set<Shape> =
+        inner.walkShapes(shape) { rel -> predicate.test(rel) && rel.direction == RelationshipDirection.DIRECTED }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -190,8 +190,7 @@ fun generatePluginContext(
         )
     }
 
-    val settings = settingsBuilder.merge(additionalSettings)
-        .build()
+    val settings = settingsBuilder.merge(additionalSettings).build()
     val pluginContext = PluginContext.builder().model(model).fileManifest(manifest).settings(settings).build()
     return pluginContext to testPath
 }

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -74,7 +74,7 @@ class PythonServerCodegenVisitor(
             serviceShape: ServiceShape,
             symbolVisitorConfig: SymbolVisitorConfig,
             publicConstrainedTypes: Boolean,
-        ) = PythonCodegenServerPlugin.baseSymbolProvider(model, serviceShape, symbolVisitorConfig, publicConstrainedTypes)
+        ) = RustServerCodegenPythonPlugin.baseSymbolProvider(model, serviceShape, symbolVisitorConfig, publicConstrainedTypes)
 
         val serverSymbolProviders = ServerSymbolProviders.from(
             model,

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
@@ -14,7 +14,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustReservedWordSymbolP
 import software.amazon.smithy.rust.codegen.core.smithy.BaseSymbolMetadataProvider
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.server.python.smithy.customizations.DECORATORS
 import software.amazon.smithy.rust.codegen.server.smithy.ConstrainedShapeSymbolMetadataProvider
@@ -26,16 +25,20 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 /**
- * Rust with Python bindings Codegen Plugin.
+ * Rust Server with Python bindings Codegen Plugin.
+ *
  * This is the entrypoint for code generation, triggered by the smithy-build plugin.
  * `resources/META-INF.services/software.amazon.smithy.build.SmithyBuildPlugin` refers to this class by name which
  * enables the smithy-build plugin to invoke `execute` with all of the Smithy plugin context + models.
  */
-class PythonCodegenServerPlugin : SmithyBuildPlugin {
+class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
     private val logger = Logger.getLogger(javaClass.name)
 
     override fun getName(): String = "rust-server-codegen-python"
 
+    /**
+     * See [software.amazon.smithy.rust.codegen.client.smithy.RustClientCodegenPlugin].
+     */
     override fun execute(context: PluginContext) {
         // Suppress extremely noisy logs about reserved words
         Logger.getLogger(ReservedWordSymbolProvider::class.java.name).level = Level.OFF
@@ -57,10 +60,7 @@ class PythonCodegenServerPlugin : SmithyBuildPlugin {
 
     companion object {
         /**
-         * When generating code, smithy types need to be converted into Rust types—that is the core role of the symbol provider
-         *
-         * The Symbol provider is composed of a base [SymbolVisitor] which handles the core functionality, then is layered
-         * with other symbol providers, documented inline, to handle the full scope of Smithy types.
+         * See [software.amazon.smithy.rust.codegen.client.smithy.RustClientCodegenPlugin].
          */
         fun baseSymbolProvider(
             model: Model,

--- a/codegen-server/python/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/codegen-server/python/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -2,4 +2,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-software.amazon.smithy.rust.codegen.server.python.smithy.PythonCodegenServerPlugin
+software.amazon.smithy.rust.codegen.server.python.smithy.RustServerCodegenPythonPlugin

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
@@ -30,33 +30,30 @@ import java.util.logging.Logger
  * `resources/META-INF.services/software.amazon.smithy.build.SmithyBuildPlugin` refers to this class by name which
  * enables the smithy-build plugin to invoke `execute` with all Smithy plugin context + models.
  */
-class RustCodegenServerPlugin : SmithyBuildPlugin {
+class RustServerCodegenPlugin : SmithyBuildPlugin {
     private val logger = Logger.getLogger(javaClass.name)
 
     override fun getName(): String = "rust-server-codegen"
 
-    override fun execute(context: PluginContext) {
-        // Suppress extremely noisy logs about reserved words
+    /**
+     * See [software.amazon.smithy.rust.codegen.client.smithy.RustClientCodegenPlugin].
+     */
+    override fun execute(
+        context: PluginContext,
+    ) {
         Logger.getLogger(ReservedWordSymbolProvider::class.java.name).level = Level.OFF
-        // Discover [RustCodegenDecorators] on the classpath. [RustCodegenDecorator] returns different types of
-        // customizations. A customization is a function of:
-        // - location (e.g. the mutate section of an operation)
-        // - context (e.g. the of the operation)
-        // - writer: The active RustWriter at the given location
-        val codegenDecorator: CombinedServerCodegenDecorator =
-            CombinedServerCodegenDecorator.fromClasspath(context, ServerRequiredCustomizations())
-
-        // ServerCodegenVisitor is the main driver of code generation that traverses the model and generates code
+        val codegenDecorator =
+            CombinedServerCodegenDecorator.fromClasspath(
+                context,
+                ServerRequiredCustomizations(),
+            )
         logger.info("Loaded plugin to generate pure Rust bindings for the server SDK")
         ServerCodegenVisitor(context, codegenDecorator).execute()
     }
 
     companion object {
         /**
-         * When generating code, smithy types need to be converted into Rust types—that is the core role of the symbol provider.
-         *
-         * The Symbol provider is composed of a base [SymbolVisitor] which handles the core functionality, then is layered
-         * with other symbol providers, documented inline, to handle the full scope of Smithy types.
+         * See [software.amazon.smithy.rust.codegen.client.smithy.RustClientCodegenPlugin].
          */
         fun baseSymbolProvider(
             model: Model,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenContext.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenContext.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 
 /**
- * [ServerCodegenContext] contains code-generation context that is _specific_ to the [RustCodegenServerPlugin] plugin
+ * [ServerCodegenContext] contains code-generation context that is _specific_ to the [RustServerCodegenPlugin] plugin
  * from the `rust-codegen-server` subproject.
  *
  * It inherits from [CodegenContext], which contains code-generation context that is common to _all_ smithy-rs plugins.

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -129,7 +129,7 @@ open class ServerCodegenVisitor(
             service,
             symbolVisitorConfig,
             settings.codegenConfig.publicConstrainedTypes,
-            RustCodegenServerPlugin::baseSymbolProvider,
+            RustServerCodegenPlugin::baseSymbolProvider,
         )
 
         codegenContext = ServerCodegenContext(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustSettings.kt
@@ -25,7 +25,7 @@ import java.util.Optional
  */
 
 /**
- * Settings used by [RustCodegenServerPlugin].
+ * Settings used by [RustServerCodegenPlugin].
  */
 data class ServerRustSettings(
     override val service: ShapeId,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
@@ -134,6 +134,9 @@ data class ValidationResult(val shouldAbort: Boolean, val messages: List<LogMess
 
 private val unsupportedConstraintsOnMemberShapes = allConstraintTraits - RequiredTrait::class.java
 
+/**
+ * Validate that all constrained operations have the shape [validationExceptionShapeId] shape attached to their errors.
+ */
 fun validateOperationsWithConstrainedInputHaveValidationExceptionAttached(
     model: Model,
     service: ServiceShape,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customize/ServerCodegenDecorator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customize/ServerCodegenDecorator.kt
@@ -28,7 +28,7 @@ interface ServerCodegenDecorator : CoreCodegenDecorator<ServerCodegenContext> {
  *
  * This makes the actual concrete codegen simpler by not needing to deal with multiple separate decorators.
  */
-class CombinedServerCodegenDecorator(decorators: List<ServerCodegenDecorator>) :
+class CombinedServerCodegenDecorator(private val decorators: List<ServerCodegenDecorator>) :
     CombinedCoreCodegenDecorator<ServerCodegenContext, ServerCodegenDecorator>(decorators),
     ServerCodegenDecorator {
     override val name: String

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
@@ -19,7 +19,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.implBlock
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
-import software.amazon.smithy.rust.codegen.server.smithy.RustCodegenServerPlugin
+import software.amazon.smithy.rust.codegen.server.smithy.RustServerCodegenPlugin
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenConfig
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.ServerRustSettings
@@ -53,7 +53,7 @@ fun serverTestSymbolProviders(
                 (serviceShape ?: testServiceShapeFor(model)).id,
             )
             ).codegenConfig.publicConstrainedTypes,
-        RustCodegenServerPlugin::baseSymbolProvider,
+        RustServerCodegenPlugin::baseSymbolProvider,
     )
 
 fun serverTestRustSettings(
@@ -98,7 +98,7 @@ fun serverTestCodegenContext(
         service,
         ServerTestSymbolVisitorConfig,
         settings.codegenConfig.publicConstrainedTypes,
-        RustCodegenServerPlugin::baseSymbolProvider,
+        RustServerCodegenPlugin::baseSymbolProvider,
     )
 
     return ServerCodegenContext(

--- a/codegen-server/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
+++ b/codegen-server/src/main/resources/META-INF/services/software.amazon.smithy.build.SmithyBuildPlugin
@@ -2,4 +2,4 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-software.amazon.smithy.rust.codegen.server.smithy.RustCodegenServerPlugin
+software.amazon.smithy.rust.codegen.server.smithy.RustServerCodegenPlugin


### PR DESCRIPTION
Rename `RustCodegenServerPlugin` to `RustServerCodegenPlugin`, for
consistency with `RustClientCodegenPlugin`. This is a better name, since
the plugin is named `rust-server-codegen`.

This commit also renames `PythonCodegenServerPlugin` to
`RustServerCodegenPythonPlugin` for the same reasons.

This commit also contains other drive-by improvements made while working
on #2302.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
