### PR TITLE
Add unstable flag on tests

### DIFF
--- a/buildSrc/src/main/kotlin/RustBuildTool.kt
+++ b/buildSrc/src/main/kotlin/RustBuildTool.kt
@@ -28,6 +28,7 @@ private fun runCli(
                 }
             }
             .copyTo(action)
+        action.environment("RUSTFLAGS", "--cfg aws_sdk_unstable")
         action.execute()
     }
 }


### PR DESCRIPTION
## Motivation and Context
Add `--cfg aws_sdk_unstable` flag on tests

## Description
It can check whether the implementation of RFC30 is correct and other stuff if we were ever to add feature behind that feature-gate.

## Testing
It was compiling serde when I ran it so I think it's working but I believe we should have a proper tests. Suggestions are much appreciated.

## Checklist
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
