### PR TITLE
Enforce the same minimum TLS version (1.2) for both TLS backends

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,6 +11,12 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
+[[smithy-rs]]
+message = "Raise the minimum TLS version from 1.0 to 1.2 when using the `native-tls` feature in `aws-smithy-client`."
+references = ["smithy-rs#2312"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+author = "LukeMathWalker"
+
 [[aws-sdk-rust]]
 message = """
 Provide a way to retrieve fallback credentials if a call to `provide_credentials` is interrupted. An interrupt can occur when a timeout future is raced against a future for `provide_credentials`, and the former wins the race. A new method, `fallback_on_interrupt` on the `ProvideCredentials` trait, can be used in that case. The following code snippet from `LazyCredentialsCache::provide_cached_credentials` has been updated like so:

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -78,7 +78,13 @@ pub mod conns {
 
     #[cfg(feature = "native-tls")]
     pub fn native_tls() -> NativeTls {
-        hyper_tls::HttpsConnector::new()
+        let mut tls = hyper_tls::native_tls::TlsConnector::builder();
+        let tls = tls
+            .min_protocol_version(Some(hyper_tls::native_tls::Protocol::Tlsv12))
+            .build()
+            .unwrap_or_else(|e| panic!("Error while creating TLS connector: {}", e));
+        let mut http = hyper::client::HttpConnector::new();
+        hyper_tls::HttpsConnector::from((http, tls.into()))
     }
 
     #[cfg(feature = "native-tls")]

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -72,11 +72,19 @@ pub mod conns {
     }
 
     #[cfg(feature = "rustls")]
+    /// Return a default HTTPS connector backed by the `rustls` crate.
+    ///
+    /// It requires a minimum TLS version of 1.2.
+    /// It allows you to connect to both `http` and `https` URLs.
     pub fn https() -> Https {
         HTTPS_NATIVE_ROOTS.clone()
     }
 
     #[cfg(feature = "native-tls")]
+    /// Return a default HTTPS connector backed by the `hyper_tls` crate.
+    ///
+    /// It requires a minimum TLS version of 1.2.
+    /// It allows you to connect to both `http` and `https` URLs.
     pub fn native_tls() -> NativeTls {
         let mut tls = hyper_tls::native_tls::TlsConnector::builder();
         let tls = tls

--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -91,7 +91,7 @@ pub mod conns {
             .min_protocol_version(Some(hyper_tls::native_tls::Protocol::Tlsv12))
             .build()
             .unwrap_or_else(|e| panic!("Error while creating TLS connector: {}", e));
-        let mut http = hyper::client::HttpConnector::new();
+        let http = hyper::client::HttpConnector::new();
         hyper_tls::HttpsConnector::from((http, tls.into()))
     }
 


### PR DESCRIPTION
## Motivation and Context
We already require TLS 1.2 or above when using the `rustls` backend. This PR makes sure that the same minimum applies to the `native-tls` backend.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
