### PR TITLE
Enforce https for native-tls backend

### DIFF
--- a/rust-runtime/aws-smithy-client/src/lib.rs
+++ b/rust-runtime/aws-smithy-client/src/lib.rs
@@ -84,7 +84,8 @@ pub mod conns {
     /// Return a default HTTPS connector backed by the `hyper_tls` crate.
     ///
     /// It requires a minimum TLS version of 1.2.
-    /// It allows you to connect to both `http` and `https` URLs.
+    /// It allows only https connections. 
+    /// To enable http connections, call `https_only(false)` on the retured NativeTls. 
     pub fn native_tls() -> NativeTls {
         let mut tls = hyper_tls::native_tls::TlsConnector::builder();
         let tls = tls
@@ -92,7 +93,9 @@ pub mod conns {
             .build()
             .unwrap_or_else(|e| panic!("Error while creating TLS connector: {}", e));
         let http = hyper::client::HttpConnector::new();
-        hyper_tls::HttpsConnector::from((http, tls.into()))
+        let mut https = hyper_tls::HttpsConnector::from((http, tls.into()));
+        https.https_only(true);
+        https
     }
 
     #[cfg(feature = "native-tls")]


### PR DESCRIPTION
## Motivation and Context
@LukeMathWalker just set the minimum TLS version for native-tls to v.1.2;
I suggest that we also enforce HTTPS connections, because this might prevent customers from accidentally supplying http URLs. 

The main concern not to do this was that some customers might rely on http connections. 
But given that http support can easily be re-enabled by customers as described in the added doc/comment (see diff), this should not be an issue. 

The `hyper_tls::HttpsConnector` used here also doesn't sent https data to http endpoints, instead it will refuse to connect when given an http URL:
```
        let is_https = dst.scheme_str() == Some("https");
        // Early abort if HTTPS is forced but can't be used
        if !is_https && self.force_https {
            return err(ForceHttpsButUriNotHttps.into());
        }
```

## Description

Forcing https connections by default for the native_tls connector. 

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
