### PR TITLE
test: override connect_timeout and read_timeout in clients

### DIFF
--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.0.0"
 criterion = { version = "0.4.0" }
 futures-util = "0.3.16"
 http = "0.2.0"
+hyper-rustls = { version = "0.23.2", features = ["webpki-tokio"] }
 serde_json = "1.0.0"
 tokio = { version = "1.8.4", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/dynamodb/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/timeouts.rs
@@ -10,7 +10,6 @@ use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::Credentials;
 use aws_sdk_dynamodb::types::SdkError;
 use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep, Sleep};
-use aws_smithy_client::http_connector::ConnectorSettings;
 use aws_smithy_client::hyper_ext;
 use aws_smithy_client::never::NeverConnector;
 use aws_smithy_types::error::display::DisplayErrorContext;
@@ -78,7 +77,7 @@ async fn building_client_from_sdk_config_allows_to_override_connect_timeout() {
             hyper_ext::Adapter::builder()
                 // // feel free to uncomment this if you want to make sure that the test pass when timeout is correctly set
                 // .connector_settings(
-                //     ConnectorSettings::builder()
+                //     aws_smithy_client::http_connector::ConnectorSettings::builder()
                 //         .connect_timeout(Duration::from_millis(connect_timeout_value))
                 //         .build(),
                 // )

--- a/aws/sdk/integration-tests/dynamodb/tests/timeouts.rs
+++ b/aws/sdk/integration-tests/dynamodb/tests/timeouts.rs
@@ -9,8 +9,11 @@ use std::time::Duration;
 use aws_credential_types::provider::SharedCredentialsProvider;
 use aws_credential_types::Credentials;
 use aws_sdk_dynamodb::types::SdkError;
-use aws_smithy_async::rt::sleep::{AsyncSleep, Sleep};
+use aws_smithy_async::rt::sleep::{default_async_sleep, AsyncSleep, Sleep};
+use aws_smithy_client::http_connector::ConnectorSettings;
+use aws_smithy_client::hyper_ext;
 use aws_smithy_client::never::NeverConnector;
+use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_smithy_types::retry::RetryConfig;
 use aws_smithy_types::timeout::TimeoutConfig;
 use aws_types::region::Region;
@@ -55,6 +58,66 @@ async fn api_call_timeout_retries() {
         "expected a timeout error, got: {}",
         resp
     );
+}
+
+#[tokio::test]
+async fn building_client_from_sdk_config_allows_to_override_connect_timeout() {
+    let connect_timeout_value = 100;
+    let connector = hyper_rustls::HttpsConnectorBuilder::new()
+        .with_webpki_roots()
+        .https_or_http()
+        .enable_http1()
+        .build();
+    let conf = SdkConfig::builder()
+        .region(Some(Region::from_static("us-east-1")))
+        .endpoint_url(
+            // Emulate a connect timeout error by hitting an unroutable IP
+            "http://172.255.255.0:18104",
+        )
+        .http_connector(
+            hyper_ext::Adapter::builder()
+                // // feel free to uncomment this if you want to make sure that the test pass when timeout is correctly set
+                // .connector_settings(
+                //     ConnectorSettings::builder()
+                //         .connect_timeout(Duration::from_millis(connect_timeout_value))
+                //         .build(),
+                // )
+                .build(connector),
+        )
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
+        .retry_config(RetryConfig::disabled())
+        .sleep_impl(default_async_sleep().unwrap())
+        .build();
+
+    // overwrite connect_timeout config with Client::from_conf
+    let client = aws_sdk_dynamodb::Client::from_conf(
+        aws_sdk_dynamodb::config::Builder::from(&conf)
+            .timeout_config(
+                TimeoutConfig::builder()
+                    .connect_timeout(Duration::from_millis(connect_timeout_value))
+                    .build(),
+            )
+            .build(),
+    );
+
+    if let Ok(result) =
+        tokio::time::timeout(Duration::from_millis(1000), client.list_tables().send()).await
+    {
+        match result {
+            Ok(_) => panic!("should not have succeeded"),
+            Err(err) => {
+                let message = format!("{}", DisplayErrorContext(&err));
+                let expected =
+                    format!("timeout: error trying to connect: HTTP connect timeout occurred after {connect_timeout_value}ms");
+                assert!(
+                    message.contains(&expected),
+                    "expected '{message}' to contain '{expected}'"
+                );
+            }
+        }
+    } else {
+        panic!("the client didn't timeout");
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
A simple PR to reproduce the fact that `connect_timeout` is not properly applied on a DynamoDB client constructed from a SDK config that already has a **real** http_connector set (e.g. when users run `aws_config::load_from_env().await`).

ℹ️ The bug is **also** present for `read_timeout` (but I don't know how to write an integration test for that).
ℹ️ The bug is **not** present for `operation_timeout` and `operation_attempt_timeout` (probably because they are not set on the http_connector).

## Description
<!--- Describe your changes in detail -->
Only added an integration test, because I don't know how to fix this bug.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] waiting for a maintainer to run CI workflows and see that the new test fails
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
