### PR TITLE
Fix consistent service naming and add test coverage

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -192,3 +192,9 @@ message = "`aws_smithy_types::Error` has been renamed to `aws_smithy_types::erro
 references = ["smithy-rs#76", "smithy-rs#2129"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Fix inconsistent casing in services re-export."
+references = ["smithy-rs#2349"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server" }
+author = "hlbarber"

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -80,6 +80,11 @@ val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
             imports = listOf("$commonModels/naming-obstacle-course-ops.smithy"),
         ),
         CodegenTest(
+            "casing#ACRONYMInside_Service",
+            "naming_test_casing",
+            imports = listOf("$commonModels/naming-obstacle-course-casing.smithy"),
+        ),
+        CodegenTest(
             "naming_obs_structs#NamingObstacleCourseStructs",
             "naming_test_structs",
             """

--- a/codegen-core/common-test-models/naming-obstacle-course-casing.smithy
+++ b/codegen-core/common-test-models/naming-obstacle-course-casing.smithy
@@ -10,16 +10,19 @@ use aws.protocols#awsJson1_1
 @awsJson1_1
 service ACRONYMInside_Service {
     operations: [
-       ACRONYMInside_Op
+        DoNothing,
+    //    ACRONYMInside_Op
     //    ACRONYM_InsideOp
     ]
 }
 
-operation ACRONYMInside_Op {
-    // input: Input,
-    // output: Output,
-    // errors: [Error],
-}
+operation DoNothing {}
+
+// operation ACRONYMInside_Op {
+//     input: Input,
+//     output: Output,
+//     errors: [Error],
+// }
 
 // operation ACRONYM_InsideOp {
 //     input: Input,

--- a/codegen-core/common-test-models/naming-obstacle-course-casing.smithy
+++ b/codegen-core/common-test-models/naming-obstacle-course-casing.smithy
@@ -3,8 +3,8 @@ namespace casing
 
 use aws.protocols#awsJson1_1
 
-// TODO(https://github.com/awslabs/smithy-rs/issues/2340): The commented part of the model breaks the code in a miriad
-// of ways. The solution to the linked issue must solve them.
+// TODO(https://github.com/awslabs/smithy-rs/issues/2340): The commented part of the model breaks the generator in a
+// miriad of ways. Any solution to the linked issue must address this.
 
 /// Confounds model generation machinery with lots of problematic casing
 @awsJson1_1

--- a/codegen-core/common-test-models/naming-obstacle-course-casing.smithy
+++ b/codegen-core/common-test-models/naming-obstacle-course-casing.smithy
@@ -1,0 +1,60 @@
+$version: "1.0"
+namespace casing
+
+use aws.protocols#awsJson1_1
+
+// TODO(https://github.com/awslabs/smithy-rs/issues/2340): The commented part of the model breaks the code in a miriad
+// of ways. The solution to the linked issue must solve them.
+
+/// Confounds model generation machinery with lots of problematic casing
+@awsJson1_1
+service ACRONYMInside_Service {
+    operations: [
+       ACRONYMInside_Op
+    //    ACRONYM_InsideOp
+    ]
+}
+
+operation ACRONYMInside_Op {
+    // input: Input,
+    // output: Output,
+    // errors: [Error],
+}
+
+// operation ACRONYM_InsideOp {
+//     input: Input,
+//     output: Output,
+//     errors: [Error],
+// }
+
+// structure Input {
+//     ACRONYMInside_Member: ACRONYMInside_Struct,
+//     ACRONYM_Inside_Member: ACRONYM_InsideStruct,
+//     ACRONYM_InsideMember: ACRONYMInsideStruct
+// }
+
+// structure Output {
+//     ACRONYMInside_Member: ACRONYMInside_Struct,
+//     ACRONYM_Inside_Member: ACRONYM_InsideStruct,
+//     ACRONYM_InsideMember: ACRONYMInsideStruct
+// }
+
+// @error("client")
+// structure Error {
+//     ACRONYMInside_Member: ACRONYMInside_Struct,
+//     ACRONYM_Inside_Member: ACRONYM_InsideStruct,
+//     ACRONYM_InsideMember: ACRONYMInsideStruct
+// }
+
+// structure ACRONYMInside_Struct {
+//     ACRONYMInside_Member: ACRONYM_InsideStruct,
+//     ACRONYM_Inside_Member: Integer,
+// }
+
+// structure ACRONYM_InsideStruct {
+//     ACRONYMInside_Member: Integer,
+// }
+
+// structure ACRONYMInsideStruct {
+//     ACRONYMInside_Member: Integer,
+// }

--- a/codegen-server-test/build.gradle.kts
+++ b/codegen-server-test/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
     listOf(
         CodegenTest("crate#Config", "naming_test_ops", imports = listOf("$commonModels/naming-obstacle-course-ops.smithy")),
+        CodegenTest("casing#ACRONYMInside_Service", "naming_test_casing", imports = listOf("$commonModels/naming-obstacle-course-casing.smithy")),
         CodegenTest(
             "naming_obs_structs#NamingObstacleCourseStructs",
             "naming_test_structs",

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -42,7 +42,7 @@ open class ServerServiceGenerator(
 ) {
     private val index = TopDownIndex.of(codegenContext.model)
     protected val operations = index.getContainedOperations(codegenContext.serviceShape).sortedBy { it.id }
-    private val serviceName = codegenContext.serviceShape.id.name.toString()
+    private val serviceName = codegenContext.serviceShape.id.name.toPascalCase()
 
     fun documentation(writer: RustWriter) {
         val operations = index.getContainedOperations(codegenContext.serviceShape).toSortedSet(compareBy { it.id })

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -17,6 +17,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
+import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCargoDependency
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext


### PR DESCRIPTION
## Motivation and Context

The casing scheme is inconsistent between the service in `lib.rs` and `service.rs` causing a bug when service names contain acronyms.

## Description

- Make service casing consistent between `lib.rs` and `service.rs`.
- Add test coverage for unusual casing.

## Notes

There is a wider problem of the server side symbol not providing a value for service. https://github.com/awslabs/smithy-rs/issues/1724