### PR TITLE
Idempotent release action

### DIFF
--- a/.github/scripts/get-or-create-release-branch.sh
+++ b/.github/scripts/get-or-create-release-branch.sh
@@ -8,8 +8,6 @@ set -eux
 # Compute the name of the release branch starting from the version that needs to be released ($SEMANTIC_VERSION).
 # If it's the beginning of a new release series, the branch is created and pushed to the remote (chosen according to
 # the value $DRY_RUN).
-# If it isn't the beginning of a new release series, the script makes sure that the commit that will be tagged is at
-# the tip of the (pre-existing) release branch.
 #
 # The script populates an output file with key-value pairs that are needed in the release CI workflow to carry out
 # the next steps in the release flow: the name of the release branch and a boolean flag that is set to 'true' if this

--- a/.github/scripts/get-or-create-release-branch.sh
+++ b/.github/scripts/get-or-create-release-branch.sh
@@ -57,16 +57,7 @@ if [[ "${DRY_RUN}" == "true" ]]; then
     git push --force origin "HEAD:refs/heads/${branch_name}"
 else
     commit_sha=$(git rev-parse --short HEAD)
-    if git ls-remote --exit-code --heads origin "${branch_name}"; then
-        # The release branch already exists, we need to make sure that our commit is its current tip
-        branch_head_sha=$(git rev-parse --verify --short "refs/remotes/origin/${branch_name}")
-        if [[ "${branch_head_sha}" != "${commit_sha}" ]]; then
-            echo "The release branch - ${branch_name} - already exists. ${commit_sha}, the commit you chose when "
-            echo "launching this release, is not its current HEAD (${branch_head_sha}). This is not allowed: you "
-            echo "MUST release from the HEAD of the release branch if it already exists."
-            exit 1
-        fi
-    else
+    if ! git ls-remote --exit-code --heads origin "${branch_name}"; then
         # The release branch does not exist.
         # We need to make sure that the commit SHA that we are releasing is on `main`.
         git fetch origin main
@@ -75,7 +66,7 @@ else
             git checkout -b "${branch_name}"
             git push origin "${branch_name}"
         else
-            echo "You must choose a commit from main to create a new release series!"
+            echo "You must choose a commit from main to create a new release branch!"
             exit 1
         fi
     fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,7 +178,7 @@ jobs:
     - name: Checkout smithy-rs
       uses: actions/checkout@v3
       with:
-        ref: ${{ needs.upgrade-gradle-properties.outputs.release_branch }}
+        ref: ${{ needs.upgrade-gradle-properties.outputs.commit_sha }}
         path: smithy-rs
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
     - name: Generate release artifacts
@@ -190,9 +190,18 @@ jobs:
     - name: Push smithy-rs changes
       shell: bash
       working-directory: smithy-rs-release/smithy-rs
+      env:
+        RELEASE_BRANCH_NAME: ${{ needs.upgrade-gradle-properties.outputs.release_branch }}
       run: |
-        echo "Pushing release commits..."
-        git push origin
+        if ! git diff-index --quiet HEAD; then
+          echo "Pushing release commits..."
+          # This will fail if we tried to release from a non-HEAD commit on the release branch.
+          # The only scenario where we would try to release a non-HEAD commit from the release branch is
+          # to retry a release action execution that failed due to a transient issue.
+          # In that case, we expect the commit to be releasable as-is, i.e. the changelog should have already
+          # been processed.
+          git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
+        fi
     - name: Tag release
       uses: actions/github-script@v6
       with:
@@ -203,7 +212,6 @@ jobs:
             github,
             isDryRun: ${{ inputs.dry_run }},
             releaseManifestPath: "smithy-rs-release/smithy-rs-release-manifest.json"
-            releaseCommitish: ${{ needs.upgrade-gradle-properties.outputs.commit_sha }},
           });
     - name: Publish to crates.io
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,6 @@ jobs:
       shell: bash
       env:
         SEMANTIC_VERSION: ${{ inputs.semantic_version }}
-        RELEASE_BRANCH_NAME: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
         RELEASE_COMMIT_SHA: ${{ inputs.commit_sha }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
@@ -144,21 +143,14 @@ jobs:
         git status
         
         if ! git diff-index --quiet HEAD; then
-          branch_head_sha=$(git rev-parse --verify "refs/remotes/origin/${RELEASE_BRANCH_NAME}")
+          # gradle.properties was changed, we need to commit and push the diff 
+          git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}" 
+        
+          # This will fail if we tried to release from a non-HEAD commit on the release branch.
           # The only scenario where we would try to release a non-HEAD commit from the release branch is
           # to retry a release action execution that failed due to a transient issue.
-          if [[ "${branch_head_sha}" != "${RELEASE_COMMIT_SHA}" ]]; then
-            echo "You are trying to release a commit (${RELEASE_COMMIT_SHA}) that is not the"
-            echo "HEAD of the relevant release branch (${RELEASE_BRANCH_NAME})."
-            echo "This is only allowed if the commit is releasable as-is, i.e. no changes are needed"
-            echo "to the runtime crate version specified in the 'gradle.properties' file."
-            echo "This is not the case here, therefore we cannot move forward with the release."
-            git diff
-            exit 1
-          fi
-        
-          # The file was actually changed, we need to commit and push the changes
-          git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}" 
+          # In that case, we expect the commit to be releasable as-is, i.e. the runtime crate version in gradle.properties
+          # should already be the expected one.
           git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
         
           echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,7 +209,7 @@ jobs:
             github,
             isDryRun: ${{ inputs.dry_run }},
             releaseManifestPath: "smithy-rs-release/smithy-rs-release-manifest.json"
-            releaseCommitish: ${{ needs.upgrade-gradle-properties.outputs.release_branch }},
+            releaseCommitish: ${{ needs.upgrade-gradle-properties.outputs.commit_sha }},
           });
     - name: Publish to crates.io
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,7 @@ jobs:
     - name: Push smithy-rs changes
       shell: bash
       working-directory: smithy-rs-release/smithy-rs
+      id: push-changelog
       env:
         RELEASE_BRANCH_NAME: ${{ needs.upgrade-gradle-properties.outputs.release_branch }}
       run: |
@@ -202,6 +203,7 @@ jobs:
           # been processed.
           git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
         fi
+        echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
     - name: Tag release
       uses: actions/github-script@v6
       with:
@@ -212,6 +214,7 @@ jobs:
             github,
             isDryRun: ${{ inputs.dry_run }},
             releaseManifestPath: "smithy-rs-release/smithy-rs-release-manifest.json"
+            releaseCommitish: ${{ steps.push-changelog.outputs.commit_sha }}
           });
     - name: Publish to crates.io
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_branch: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
+      commit_sha: ${{ steps.gradle-push.outputs.commit_sha }}
     steps:
     - uses: actions/checkout@v3
       with:
@@ -132,13 +133,37 @@ jobs:
       shell: bash
       env:
         SEMANTIC_VERSION: ${{ inputs.semantic_version }}
+        RELEASE_BRANCH_NAME: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
+        RELEASE_COMMIT_SHA: ${{ inputs.commit_sha }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -x
+        
         # For debugging purposes
         git status
-        # The file was actually changed, we need to commit the changes
-        git diff-index --quiet HEAD || { git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}" && git push origin; }
+        
+        if ! git diff-index --quiet HEAD; then
+          branch_head_sha=$(git rev-parse --verify "refs/remotes/origin/${RELEASE_BRANCH_NAME}")
+          # The only scenario where we would try to release a non-HEAD commit from the release branch is
+          # to retry a release action execution that failed due to a transient issue.
+          if [[ "${branch_head_sha}" != "${RELEASE_COMMIT_SHA}" ]]; then
+            echo "You are trying to release a commit (${RELEASE_COMMIT_SHA}) that is not the"
+            echo "HEAD of the relevant release branch (${RELEASE_BRANCH_NAME})."
+            echo "This is only allowed if the commit is releasable as-is, i.e. no changes are needed"
+            echo "to the runtime crate version specified in the 'gradle.properties' file."
+            echo "This is not the case here, therefore we cannot move forward with the release."
+            git diff
+            exit 1
+          fi
+        
+          # The file was actually changed, we need to commit and push the changes
+          git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}" 
+          git push origin
+        
+          echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
+        else
+          echo "commit_sha=${RELEASE_COMMIT_SHA}" > $GITHUB_OUTPUT
+        fi
 
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
+        ref: ${{ inputs.commit_sha }}
         path: smithy-rs
+        fetch-depth: 0
         token: ${{ secrets.RELEASE_AUTOMATION_BOT_PAT }}
     - name: Upgrade gradle.properties
       uses: ./smithy-rs/.github/actions/docker-build
@@ -158,7 +159,7 @@ jobs:
         
           # The file was actually changed, we need to commit and push the changes
           git -c 'user.name=AWS SDK Rust Bot' -c 'user.email=aws-sdk-rust-primary@amazon.com' commit gradle.properties --message "Upgrade the smithy-rs runtime crates version to ${SEMANTIC_VERSION}" 
-          git push origin
+          git push origin "HEAD:refs/heads/${RELEASE_BRANCH_NAME}"
         
           echo "commit_sha=$(git rev-parse HEAD)" > $GITHUB_OUTPUT
         else

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
       env:
         SEMANTIC_VERSION: ${{ inputs.semantic_version }}
         RELEASE_COMMIT_SHA: ${{ inputs.commit_sha }}
-        RELEASE_BRANCH_NAME: ${{ outputs.release_branch }}
+        RELEASE_BRANCH_NAME: ${{ needs.get-or-create-release-branch.outputs.release_branch }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
       env:
         SEMANTIC_VERSION: ${{ inputs.semantic_version }}
         RELEASE_COMMIT_SHA: ${{ inputs.commit_sha }}
+        RELEASE_BRANCH_NAME: ${{ outputs.release_branch }}
         DRY_RUN: ${{ inputs.dry_run }}
       run: |
         set -x


### PR DESCRIPTION
## Motivation and Context
Allow us to re-trigger the release workflow for a commit that is no longer the HEAD of the relevant release branch.
The commit should be releasable as-is - both `gradle.properties` and changelogs should be in the expected shape. 

This would have allowed us to retry the release of `0.54.2` via GitHub Actions, instead of having to complete it manually.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
