### PR TITLE
Run CI on merge groups.

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -6,6 +6,7 @@
 name: CI
 on:
   pull_request:
+  merge_group:
 
 # Allow one instance of this workflow per pull request, and cancel older runs when new changes are pushed
 concurrency:


### PR DESCRIPTION
## Motivation and Context
Changes in the merge queue are not getting merged because the CI checks are not triggering.
This should fix it according to the GitHub guide - https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
