### PR TITLE
Fix S3 canary match statement

### DIFF
--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -8,7 +8,6 @@ use crate::{mk_canary, CanaryEnv};
 use anyhow::Context;
 use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
-use s3::error::GetObjectError;
 use s3::types::ByteStream;
 use uuid::Uuid;
 

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -8,7 +8,6 @@ use crate::{mk_canary, CanaryEnv};
 use anyhow::Context;
 use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
-use aws_sdk_s3::error::GetObjectErrorKind;
 use s3::error::GetObjectError;
 use s3::types::ByteStream;
 use uuid::Uuid;
@@ -36,15 +35,13 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
                 CanaryError(format!("Expected object {} to not exist in S3", test_key)).into(),
             );
         }
-        Err(err) => match err.into_service_error() {
-            GetObjectError {
-                kind: GetObjectErrorKind::NoSuchKey(..),
-                ..
-            } => {
-                // good
+        Err(err) => {
+            let err = err.into_service_error();
+            // If we get anything other than "No such key", we have a problem
+            if !err.is_no_such_key() {
+                return Err(err).context("unexpected s3::GetObject failure");
             }
-            err => Err(err).context("unexpected s3::GetObject failure")?,
-        },
+        }
     }
 
     // Put the test object

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -8,6 +8,7 @@ use crate::{mk_canary, CanaryEnv};
 use anyhow::Context;
 use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
+use aws_sdk_s3::error::GetObjectErrorKind;
 use s3::error::GetObjectError;
 use s3::types::ByteStream;
 use uuid::Uuid;
@@ -36,7 +37,10 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
             );
         }
         Err(err) => match err.into_service_error() {
-            GetObjectError::NoSuchKey(..) => {
+            GetObjectError {
+                kind: GetObjectErrorKind::NoSuchKey(..),
+                ..
+            } => {
                 // good
             }
             err => Err(err).context("unexpected s3::GetObject failure")?,


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-rust/actions/runs/4158886176

## Description
<!--- Describe your changes in detail -->
We updated the preferred way of matching on service errors but forgot to update the canary. This PR updates the canary.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `cargo check`

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
