### PR TITLE
Determine modules after running the Rust reserved word symbol provider

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
@@ -31,7 +31,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.implBlock
 import software.amazon.smithy.rust.codegen.core.smithy.DirectedWalker
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
@@ -67,7 +67,7 @@ class ClientCodegenVisitor(
     private val protocolGenerator: ClientProtocolGenerator
 
     init {
-        val symbolVisitorConfig = SymbolVisitorConfig(
+        val rustSymbolProviderConfig = RustSymbolProviderConfig(
             runtimeConfig = settings.runtimeConfig,
             renameExceptions = settings.codegenConfig.renameExceptions,
             nullabilityCheckMode = NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1,
@@ -82,7 +82,7 @@ class ClientCodegenVisitor(
         model = codegenDecorator.transformModel(untransformedService, baseModel)
         // the model transformer _might_ change the service shape
         val service = settings.getService(model)
-        symbolProvider = RustClientCodegenPlugin.baseSymbolProvider(model, service, symbolVisitorConfig)
+        symbolProvider = RustClientCodegenPlugin.baseSymbolProvider(model, service, rustSymbolProviderConfig)
 
         codegenContext = ClientCodegenContext(model, symbolProvider, service, protocol, settings, codegenDecorator)
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -40,7 +40,7 @@ object ClientRustModule {
 }
 
 object ClientModuleProvider : ModuleProvider {
-    override fun moduleForShape(shape: Shape): RustModule.LeafModule = when (shape) {
+    override fun moduleForShape(shapeName: String, shape: Shape): RustModule.LeafModule = when (shape) {
         is OperationShape -> ClientRustModule.Operation
         is StructureShape -> when {
             shape.hasTrait<ErrorTrait>() -> ClientRustModule.Error
@@ -51,9 +51,9 @@ object ClientModuleProvider : ModuleProvider {
         else -> ClientRustModule.Model
     }
 
-    override fun moduleForOperationError(operation: OperationShape): RustModule.LeafModule =
+    override fun moduleForOperationError(operationName: String, operation: OperationShape): RustModule.LeafModule =
         ClientRustModule.Error
 
-    override fun moduleForEventStreamError(eventStream: UnionShape): RustModule.LeafModule =
+    override fun moduleForEventStreamError(eventStreamName: String, eventStream: UnionShape): RustModule.LeafModule =
         ClientRustModule.Error
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -23,10 +23,10 @@ import software.amazon.smithy.rust.codegen.core.smithy.BaseSymbolMetadataProvide
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.ModuleAttachingSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.StreamingShapeMetadataProvider
 import software.amazon.smithy.rust.codegen.core.smithy.StreamingShapeSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -73,8 +73,8 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
          * The Symbol provider is composed of a base [SymbolVisitor] which handles the core functionality, then is layered
          * with other symbol providers, documented inline, to handle the full scope of Smithy types.
          */
-        fun baseSymbolProvider(model: Model, serviceShape: ServiceShape, symbolVisitorConfig: SymbolVisitorConfig) =
-            SymbolVisitor(model, serviceShape = serviceShape, config = symbolVisitorConfig)
+        fun baseSymbolProvider(model: Model, serviceShape: ServiceShape, rustSymbolProviderConfig: RustSymbolProviderConfig) =
+            SymbolVisitor(model, serviceShape = serviceShape, config = rustSymbolProviderConfig)
                 // Generate `ByteStream` instead of `Blob` for streaming binary shapes (e.g. S3 GetObject)
                 .let { StreamingShapeSymbolProvider(it) }
                 // Add Rust attributes (like `#[derive(PartialEq)]`) to generated shapes
@@ -87,6 +87,6 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
                 // Attach modules to the generated symbols
                 .let { ModuleAttachingSymbolProvider(it) }
                 // Generate different types for EventStream shapes (e.g. transcribe streaming)
-                .let { EventStreamSymbolProvider(it, symbolVisitorConfig.runtimeConfig, CodegenTarget.CLIENT) }
+                .let { EventStreamSymbolProvider(it, rustSymbolProviderConfig.runtimeConfig, CodegenTarget.CLIENT) }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGenerator.kt
@@ -69,7 +69,7 @@ class PaginatorGenerator private constructor(
     }
 
     private val paginatorName = "${operation.id.name.toPascalCase()}Paginator"
-    private val runtimeConfig = symbolProvider.config().runtimeConfig
+    private val runtimeConfig = symbolProvider.config.runtimeConfig
     private val idx = PaginatedIndex.of(model)
     private val paginationInfo =
         idx.getPaginationInfo(service, operation).orNull() ?: PANIC("failed to load pagination info")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/error/ErrorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/error/ErrorGenerator.kt
@@ -36,7 +36,7 @@ class ErrorGenerator(
     private val error: ErrorTrait,
     private val implCustomizations: List<ErrorImplCustomization>,
 ) {
-    private val runtimeConfig = symbolProvider.config().runtimeConfig
+    private val runtimeConfig = symbolProvider.config.runtimeConfig
 
     fun render() {
         val symbol = symbolProvider.toSymbol(shape)

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/error/OperationErrorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/error/OperationErrorGenerator.kt
@@ -49,9 +49,8 @@ class OperationErrorGenerator(
     private val operationOrEventStream: Shape,
     private val customizations: List<ErrorCustomization>,
 ) {
-    private val runtimeConfig = symbolProvider.config().runtimeConfig
-    private val symbol = symbolProvider.toSymbol(operationOrEventStream)
-    private val errorMetadata = errorMetadata(symbolProvider.config().runtimeConfig)
+    private val runtimeConfig = symbolProvider.config.runtimeConfig
+    private val errorMetadata = errorMetadata(symbolProvider.config.runtimeConfig)
     private val createUnhandledError =
         RuntimeType.smithyHttp(runtimeConfig).resolve("result::CreateUnhandledError")
 
@@ -148,10 +147,10 @@ class OperationErrorGenerator(
 
         writer.writeCustomizations(customizations, ErrorSection.OperationErrorAdditionalTraitImpls(errorSymbol, errors))
 
-        val retryErrorKindT = RuntimeType.retryErrorKind(symbolProvider.config().runtimeConfig)
+        val retryErrorKindT = RuntimeType.retryErrorKind(symbolProvider.config.runtimeConfig)
         writer.rustBlock(
             "impl #T for ${errorSymbol.name}",
-            RuntimeType.provideErrorKind(symbolProvider.config().runtimeConfig),
+            RuntimeType.provideErrorKind(symbolProvider.config.runtimeConfig),
         ) {
             rustBlock("fn code(&self) -> Option<&str>") {
                 rust("#T::code(self)", RuntimeType.provideErrorMetadataTrait(runtimeConfig))

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
@@ -19,7 +19,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.CoreRustSettings
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
 import software.amazon.smithy.rust.codegen.core.testutil.testRustSettings
 
@@ -49,7 +49,7 @@ fun clientTestRustSettings(
     customizationConfig,
 )
 
-val ClientTestSymbolVisitorConfig = SymbolVisitorConfig(
+val ClientTestRustSymbolProviderConfig = RustSymbolProviderConfig(
     runtimeConfig = TestRuntimeConfig,
     renameExceptions = true,
     nullabilityCheckMode = NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1,
@@ -60,7 +60,7 @@ fun testSymbolProvider(model: Model, serviceShape: ServiceShape? = null): RustSy
     RustClientCodegenPlugin.baseSymbolProvider(
         model,
         serviceShape ?: ServiceShape.builder().version("test").id("test#Service").build(),
-        ClientTestSymbolVisitorConfig,
+        ClientTestRustSymbolProviderConfig,
     )
 
 fun testCodegenContext(

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/EventStreamSymbolProviderTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/EventStreamSymbolProviderTest.kt
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.rust.codegen.client.testutil.ClientTestSymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.client.testutil.ClientTestRustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
@@ -49,7 +49,7 @@ class EventStreamSymbolProviderTest {
         val service = model.expectShape(ShapeId.from("test#TestService")) as ServiceShape
         val provider = EventStreamSymbolProvider(
             ModuleAttachingSymbolProvider(
-                SymbolVisitor(model, ClientTestSymbolVisitorConfig, service),
+                SymbolVisitor(model, ClientTestRustSymbolProviderConfig, service),
             ),
             TestRuntimeConfig,
             CodegenTarget.CLIENT,
@@ -91,7 +91,7 @@ class EventStreamSymbolProviderTest {
         val service = model.expectShape(ShapeId.from("test#TestService")) as ServiceShape
         val provider = EventStreamSymbolProvider(
             ModuleAttachingSymbolProvider(
-                SymbolVisitor(model, ClientTestSymbolVisitorConfig, service),
+                SymbolVisitor(model, ClientTestRustSymbolProviderConfig, service),
             ),
             TestRuntimeConfig,
             CodegenTarget.CLIENT,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/EventStreamSymbolProviderTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/EventStreamSymbolProviderTest.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.client.testutil.ClientTestSymbolVisit
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.ModuleAttachingSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.OperationNormalizer
@@ -46,7 +47,13 @@ class EventStreamSymbolProviderTest {
         )
 
         val service = model.expectShape(ShapeId.from("test#TestService")) as ServiceShape
-        val provider = EventStreamSymbolProvider(TestRuntimeConfig, SymbolVisitor(model, service, ClientTestSymbolVisitorConfig), model, CodegenTarget.CLIENT)
+        val provider = EventStreamSymbolProvider(
+            ModuleAttachingSymbolProvider(
+                SymbolVisitor(model, ClientTestSymbolVisitorConfig, service),
+            ),
+            TestRuntimeConfig,
+            CodegenTarget.CLIENT,
+        )
 
         // Look up the synthetic input/output rather than the original input/output
         val inputStream = model.expectShape(ShapeId.from("test.synthetic#TestOperationInput\$inputStream")) as MemberShape
@@ -82,7 +89,13 @@ class EventStreamSymbolProviderTest {
         )
 
         val service = model.expectShape(ShapeId.from("test#TestService")) as ServiceShape
-        val provider = EventStreamSymbolProvider(TestRuntimeConfig, SymbolVisitor(model, service, ClientTestSymbolVisitorConfig), model, CodegenTarget.CLIENT)
+        val provider = EventStreamSymbolProvider(
+            ModuleAttachingSymbolProvider(
+                SymbolVisitor(model, ClientTestSymbolVisitorConfig, service),
+            ),
+            TestRuntimeConfig,
+            CodegenTarget.CLIENT,
+        )
 
         // Look up the synthetic input/output rather than the original input/output
         val inputStream = model.expectShape(ShapeId.from("test.synthetic#TestOperationInput\$inputStream")) as MemberShape

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/StreamingShapeSymbolProviderTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/StreamingShapeSymbolProviderTest.kt
@@ -9,8 +9,10 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.rust.codegen.client.testutil.testSymbolProvider
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.smithy.Default
 import software.amazon.smithy.rust.codegen.core.smithy.defaultValue
+import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.util.lookup
@@ -38,8 +40,18 @@ internal class StreamingShapeSymbolProviderTest {
         // "doing the right thing"
         val modelWithOperationTraits = OperationNormalizer.transform(model)
         val symbolProvider = testSymbolProvider(modelWithOperationTraits)
-        symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechOutput\$data")).name shouldBe ("ByteStream")
-        symbolProvider.toSymbol(modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechInput\$data")).name shouldBe ("ByteStream")
+        modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechOutput\$data").also { shape ->
+            symbolProvider.toSymbol(shape).also { symbol ->
+                symbol.name shouldBe "data"
+                symbol.rustType() shouldBe RustType.Opaque("ByteStream", "aws_smithy_http::byte_stream")
+            }
+        }
+        modelWithOperationTraits.lookup<MemberShape>("test.synthetic#GenerateSpeechInput\$data").also { shape ->
+            symbolProvider.toSymbol(shape).also { symbol ->
+                symbol.name shouldBe "data"
+                symbol.rustType() shouldBe RustType.Opaque("ByteStream", "aws_smithy_http::byte_stream")
+            }
+        }
     }
 
     @Test

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWords.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWords.kt
@@ -8,30 +8,31 @@ package software.amazon.smithy.rust.codegen.core.rustlang
 import software.amazon.smithy.codegen.core.ReservedWordSymbolProvider
 import software.amazon.smithy.codegen.core.ReservedWords
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.EnumShape
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumDefinition
-import software.amazon.smithy.rust.codegen.core.smithy.MaybeRenamed
+import software.amazon.smithy.model.traits.EnumTrait
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.WrappingSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.renamedFrom
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.letIf
-import software.amazon.smithy.rust.codegen.core.util.orNull
-import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 
-class RustReservedWordSymbolProvider(private val base: RustSymbolProvider, private val model: Model) :
-    WrappingSymbolProvider(base) {
-    private val internal =
-        ReservedWordSymbolProvider.builder().symbolProvider(base).memberReservedWords(RustReservedWords).build()
+class RustReservedWordSymbolProvider(base: RustSymbolProvider) : WrappingSymbolProvider(base) {
+    private val reservedWordRenamer = ReservedWordSymbolProvider.builder()
+        .symbolProvider(base)
+        .memberReservedWords(RustReservedWords)
+        .build()
 
     override fun toMemberName(shape: MemberShape): String {
-        val baseName = internal.toMemberName(shape)
-        return when (val container = model.expectShape(shape.container)) {
-            is StructureShape -> when (baseName) {
+        val baseName = super.toMemberName(shape)
+        val reservedWordReplacedName = reservedWordRenamer.toMemberName(shape)
+        val container = model.expectShape(shape.container)
+        return when {
+            container is StructureShape -> when (baseName) {
                 "build" -> "build_value"
                 "builder" -> "builder_value"
                 "default" -> "default_value"
@@ -42,10 +43,10 @@ class RustReservedWordSymbolProvider(private val base: RustSymbolProvider, priva
                 "customize" -> "customize_value"
                 // To avoid conflicts with the error metadata `meta` field
                 "meta" -> "meta_value"
-                else -> baseName
+                else -> reservedWordReplacedName
             }
 
-            is UnionShape -> when (baseName) {
+            container is UnionShape -> when (baseName) {
                 // Unions contain an `Unknown` variant. This exists to support parsing data returned from the server
                 // that represent union variants that have been added since this SDK was generated.
                 UnionGenerator.UnknownVariantName -> "${UnionGenerator.UnknownVariantName}Value"
@@ -55,7 +56,20 @@ class RustReservedWordSymbolProvider(private val base: RustSymbolProvider, priva
                 "Self" -> "SelfValue"
                 // Real models won't end in `_` so it's safe to stop here
                 "SelfValue" -> "SelfValue_"
-                else -> baseName
+                else -> reservedWordReplacedName
+            }
+
+            container is EnumShape || container.hasTrait<EnumTrait>() -> when (baseName) {
+                // Self cannot be used as a raw identifier, so we can't use the normal escaping strategy
+                // https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094/4
+                "Self" -> "SelfValue"
+                // Real models won't end in `_` so it's safe to stop here
+                "SelfValue" -> "SelfValue_"
+                // Unknown is used as the name of the variant containing unexpected values
+                "Unknown" -> "UnknownValue"
+                // Real models won't end in `_` so it's safe to stop here
+                "UnknownValue" -> "UnknownValue_"
+                else -> reservedWordReplacedName
             }
 
             else -> error("unexpected container: $container")
@@ -69,44 +83,28 @@ class RustReservedWordSymbolProvider(private val base: RustSymbolProvider, priva
      * code generators to generate special docs.
      */
     override fun toSymbol(shape: Shape): Symbol {
+        // Sanity check that the symbol provider stack is set up correctly
+        check(super.toSymbol(shape).renamedFrom() == null) {
+            "RustReservedWordSymbolProvider should only run once"
+        }
+
+        var renamedSymbol = reservedWordRenamer.toSymbol(shape)
         return when (shape) {
             is MemberShape -> {
                 val container = model.expectShape(shape.container)
-                if (!(container is StructureShape || container is UnionShape)) {
-                    return base.toSymbol(shape)
+                val containerIsEnum = container is EnumShape || container.hasTrait<EnumTrait>()
+                if (container !is StructureShape && container !is UnionShape && !containerIsEnum) {
+                    return renamedSymbol
                 }
-                val previousName = base.toMemberName(shape)
+
+                val previousName = super.toMemberName(shape)
                 val escapedName = this.toMemberName(shape)
-                val baseSymbol = base.toSymbol(shape)
                 // if the names don't match and it isn't a simple escaping with `r#`, record a rename
-                baseSymbol.letIf(escapedName != previousName && !escapedName.contains("r#")) {
-                    it.toBuilder().renamedFrom(previousName).build()
-                }
+                renamedSymbol.toBuilder().name(escapedName).letIf(escapedName != previousName && !escapedName.contains("r#")) {
+                    it.renamedFrom(previousName)
+                }.build()
             }
-
-            else -> base.toSymbol(shape)
-        }
-    }
-
-    override fun toEnumVariantName(definition: EnumDefinition): MaybeRenamed? {
-        val baseName = base.toEnumVariantName(definition) ?: return null
-        check(definition.name.orNull()?.toPascalCase() == baseName.name) {
-            "Enum variants must already be in pascal case ${baseName.name} differed from ${baseName.name.toPascalCase()}. Definition: ${definition.name}"
-        }
-        check(baseName.renamedFrom == null) {
-            "definitions should only pass through the renamer once"
-        }
-        return when (baseName.name) {
-            // Self cannot be used as a raw identifier, so we can't use the normal escaping strategy
-            // https://internals.rust-lang.org/t/raw-identifiers-dont-work-for-all-identifiers/9094/4
-            "Self" -> MaybeRenamed("SelfValue", "Self")
-            // Real models won't end in `_` so it's safe to stop here
-            "SelfValue" -> MaybeRenamed("SelfValue_", "SelfValue")
-            // Unknown is used as the name of the variant containing unexpected values
-            "Unknown" -> MaybeRenamed("UnknownValue", "Unknown")
-            // Real models won't end in `_` so it's safe to stop here
-            "UnknownValue" -> MaybeRenamed("UnknownValue_", "UnknownValue")
-            else -> baseName
+            else -> renamedSymbol
         }
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/EventStreamSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/EventStreamSymbolProvider.kt
@@ -6,13 +6,10 @@
 package software.amazon.smithy.rust.codegen.core.smithy
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
-import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
-import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.render
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
@@ -24,18 +21,13 @@ import software.amazon.smithy.rust.codegen.core.util.isEventStream
 import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
 import software.amazon.smithy.rust.codegen.core.util.isOutputEventStream
 
-fun UnionShape.eventStreamErrorSymbol(symbolProvider: RustSymbolProvider): RuntimeType {
-    val unionSymbol = symbolProvider.toSymbol(this)
-    return RustModule.Error.toType().resolve("${unionSymbol.name}Error")
-}
-
 /**
- * Wrapping symbol provider to wrap modeled types with the aws-smithy-http Event Stream send/receive types.
+ * Swaps out the types for event stream member shapes to use the event stream types
+ * from aws-smithy-http (EventStreamSender and Receiver).
  */
 class EventStreamSymbolProvider(
-    private val runtimeConfig: RuntimeConfig,
     base: RustSymbolProvider,
-    private val model: Model,
+    private val runtimeConfig: RuntimeConfig,
     private val target: CodegenTarget,
 ) : WrappingSymbolProvider(base) {
     override fun toSymbol(shape: Shape): Symbol {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/ModuleAttachingSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/ModuleAttachingSymbolProvider.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.util.letIf
+
+/**
+ * Attaches modules to symbols.
+ *
+ * This happens separately at the end of the symbol provider chain so that the result of
+ * the RustReservedWordSymbolProvider can impact module names.
+ */
+class ModuleAttachingSymbolProvider(base: RustSymbolProvider) : WrappingSymbolProvider(base) {
+    override fun symbolForOperationError(operation: OperationShape): Symbol =
+        super.symbolForOperationError(operation).let { symbol ->
+            val module = config.moduleProvider.moduleForOperationError(symbol.name, operation)
+            symbol.toBuilder().locatedIn(module).build()
+        }
+
+    override fun symbolForEventStreamError(eventStream: UnionShape): Symbol =
+        super.symbolForEventStreamError(eventStream).let { symbol ->
+            val module = config.moduleProvider.moduleForEventStreamError(symbol.name, eventStream)
+            symbol.toBuilder().locatedIn(module).build()
+        }
+
+    override fun toSymbol(shape: Shape): Symbol = super.toSymbol(shape).let { symbol ->
+        val module = config.moduleProvider.moduleForShape(symbol.name, shape)
+        val newRustType = when (val oldRustType = symbol.rustType()) {
+            is RustType.Container -> {
+                val maybeNewType: RustType = oldRustType.recursivelyMapMember { member ->
+                    if (member is RustType.Opaque && member.namespace == null) {
+                        member.copy(namespace = module.fullyQualifiedPath())
+                    } else {
+                        member
+                    }
+                }
+                (maybeNewType as RustType?).letIf(maybeNewType == oldRustType) { null }
+            }
+            is RustType.Opaque -> if (oldRustType.namespace == null) {
+                oldRustType.copy(namespace = module.fullyQualifiedPath())
+            } else {
+                null
+            }
+            // Other RustType variants (which are mostly std library types) have modules that shouldn't be manipulated
+            else -> null
+        }
+        if (newRustType != null) {
+            symbol.toBuilder().definitionFile(module.definitionFile())
+                .namespace(module.fullyQualifiedPath(), "::")
+                .module(module)
+                .rustType(newRustType)
+                .build()
+        } else {
+            symbol
+        }
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/PublicImportSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/PublicImportSymbolProvider.kt
@@ -14,10 +14,12 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustType
  *
  * This enables generating code into `tests` and other public locations.
  */
-class PublicImportSymbolProvider(private val base: RustSymbolProvider, private val publicUseName: String) :
-    WrappingSymbolProvider(base) {
+class PublicImportSymbolProvider(
+    base: RustSymbolProvider,
+    private val publicUseName: String,
+) : WrappingSymbolProvider(base) {
     override fun toSymbol(shape: Shape): Symbol {
-        val baseSymbol = base.toSymbol(shape)
+        val baseSymbol = super.toSymbol(shape)
 
         val currentRustType = baseSymbol.rustType()
         val currentNamespace = currentRustType.namespace

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RustSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RustSymbolProvider.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.codegen.core.SymbolProvider
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.NullableIndex
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+
+/**
+ * Symbol provider with access to config and functions to get symbols for types that don't have shapes.
+ */
+interface RustSymbolProvider : SymbolProvider {
+    val model: Model
+    val config: SymbolVisitorConfig
+
+    /** Returns the symbol for an operation error */
+    fun symbolForOperationError(operation: OperationShape): Symbol
+
+    /** Returns the symbol for an event stream error */
+    fun symbolForEventStreamError(eventStream: UnionShape): Symbol
+}
+
+/**
+ * Provider for RustModules so that the symbol provider knows where to organize things.
+ */
+interface ModuleProvider {
+    /** Returns the module for a shape */
+    fun moduleForShape(
+        shapeName: String,
+        shape: Shape,
+    ): RustModule.LeafModule
+
+    /** Returns the module for an operation error */
+    fun moduleForOperationError(
+        operationName: String,
+        operation: OperationShape,
+    ): RustModule.LeafModule
+
+    /** Returns the module for an event stream error */
+    fun moduleForEventStreamError(
+        eventStreamName: String,
+        eventStream: UnionShape,
+    ): RustModule.LeafModule
+}
+
+data class SymbolVisitorConfig(
+    val runtimeConfig: RuntimeConfig,
+    val renameExceptions: Boolean,
+    val nullabilityCheckMode: NullableIndex.CheckMode,
+    val moduleProvider: ModuleProvider,
+)
+
+/**
+ * Delegator to enable easily decorating another named symbol provider.
+ */
+open class WrappingSymbolProvider(private val base: RustSymbolProvider) : RustSymbolProvider {
+    override val model: Model get() = base.model
+    override val config: SymbolVisitorConfig get() = base.config
+
+    override fun symbolForOperationError(operation: OperationShape): Symbol = base.symbolForOperationError(operation)
+
+    override fun symbolForEventStreamError(eventStream: UnionShape): Symbol = base.symbolForEventStreamError(eventStream)
+
+    override fun toMemberName(shape: MemberShape): String = base.toMemberName(shape)
+
+    override fun toSymbol(shape: Shape): Symbol = base.toSymbol(shape)
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RustSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RustSymbolProvider.kt
@@ -20,7 +20,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
  */
 interface RustSymbolProvider : SymbolProvider {
     val model: Model
-    val config: SymbolVisitorConfig
+    val config: RustSymbolProviderConfig
 
     /** Returns the symbol for an operation error */
     fun symbolForOperationError(operation: OperationShape): Symbol
@@ -52,7 +52,7 @@ interface ModuleProvider {
     ): RustModule.LeafModule
 }
 
-data class SymbolVisitorConfig(
+data class RustSymbolProviderConfig(
     val runtimeConfig: RuntimeConfig,
     val renameExceptions: Boolean,
     val nullabilityCheckMode: NullableIndex.CheckMode,
@@ -64,7 +64,7 @@ data class SymbolVisitorConfig(
  */
 open class WrappingSymbolProvider(private val base: RustSymbolProvider) : RustSymbolProvider {
     override val model: Model get() = base.model
-    override val config: SymbolVisitorConfig get() = base.config
+    override val config: RustSymbolProviderConfig get() = base.config
 
     override fun symbolForOperationError(operation: OperationShape): Symbol = base.symbolForOperationError(operation)
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolExt.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolExt.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
+import software.amazon.smithy.rust.codegen.core.util.orNull
+
+/** Set the symbolLocation for this symbol builder */
+fun Symbol.Builder.locatedIn(rustModule: RustModule.LeafModule): Symbol.Builder {
+    val currentRustType = this.build().rustType()
+    check(currentRustType is RustType.Opaque) {
+        "Only `Opaque` can have their namespace updated. Received $currentRustType."
+    }
+    val newRustType = currentRustType.copy(namespace = rustModule.fullyQualifiedPath())
+    return this.definitionFile(rustModule.definitionFile())
+        .namespace(rustModule.fullyQualifiedPath(), "::")
+        .rustType(newRustType)
+        .module(rustModule)
+}
+
+/**
+ * Make the Rust type of a symbol optional (hold `Option<T>`)
+ *
+ * This is idempotent and will have no change if the type is already optional.
+ */
+fun Symbol.makeOptional(): Symbol =
+    if (isOptional()) {
+        this
+    } else {
+        val rustType = RustType.Option(this.rustType())
+        Symbol.builder()
+            .rustType(rustType)
+            .addReference(this)
+            .name(rustType.name)
+            .build()
+    }
+
+/**
+ * Make the Rust type of a symbol boxed (hold `Box<T>`).
+ *
+ * This is idempotent and will have no change if the type is already boxed.
+ */
+fun Symbol.makeRustBoxed(): Symbol =
+    if (isRustBoxed()) {
+        this
+    } else {
+        val rustType = RustType.Box(this.rustType())
+        Symbol.builder()
+            .rustType(rustType)
+            .addReference(this)
+            .name(rustType.name)
+            .build()
+    }
+
+/**
+ * Make the Rust type of a symbol wrapped in `MaybeConstrained`. (hold `MaybeConstrained<T>`).
+ *
+ * This is idempotent and will have no change if the type is already `MaybeConstrained<T>`.
+ */
+fun Symbol.makeMaybeConstrained(): Symbol =
+    if (this.rustType() is RustType.MaybeConstrained) {
+        this
+    } else {
+        val rustType = RustType.MaybeConstrained(this.rustType())
+        Symbol.builder()
+            .rustType(rustType)
+            .addReference(this)
+            .name(rustType.name)
+            .build()
+    }
+
+/**
+ * Map the [RustType] of a symbol with [f].
+ *
+ * WARNING: This function does not set any `SymbolReference`s on the returned symbol. You will have to add those
+ * yourself if your logic relies on them.
+ **/
+fun Symbol.mapRustType(f: (RustType) -> RustType): Symbol {
+    val newType = f(this.rustType())
+    return Symbol.builder().rustType(newType)
+        .name(newType.name)
+        .build()
+}
+
+/**
+ * True when it is valid to use the default/0 value for [this] symbol during construction.
+ */
+fun Symbol.canUseDefault(): Boolean = this.defaultValue() != Default.NoDefault
+
+/**
+ * True when [this] is will be represented by Option<T> in Rust
+ */
+fun Symbol.isOptional(): Boolean = when (this.rustType()) {
+    is RustType.Option -> true
+    else -> false
+}
+
+fun Symbol.isRustBoxed(): Boolean = rustType().stripOuter<RustType.Option>() is RustType.Box
+
+private const val RUST_TYPE_KEY = "rusttype"
+private const val SHAPE_KEY = "shape"
+private const val RUST_MODULE_KEY = "rustmodule"
+private const val RENAMED_FROM_KEY = "renamedfrom"
+private const val SYMBOL_DEFAULT = "symboldefault"
+
+// Symbols should _always_ be created with a Rust type & shape attached
+fun Symbol.rustType(): RustType = this.expectProperty(RUST_TYPE_KEY, RustType::class.java)
+fun Symbol.Builder.rustType(rustType: RustType): Symbol.Builder = this.putProperty(RUST_TYPE_KEY, rustType)
+fun Symbol.shape(): Shape = this.expectProperty(SHAPE_KEY, Shape::class.java)
+fun Symbol.Builder.shape(shape: Shape?): Symbol.Builder = this.putProperty(SHAPE_KEY, shape)
+fun Symbol.module(): RustModule.LeafModule = this.expectProperty(RUST_MODULE_KEY, RustModule.LeafModule::class.java)
+fun Symbol.Builder.module(module: RustModule.LeafModule): Symbol.Builder = this.putProperty(RUST_MODULE_KEY, module)
+fun Symbol.renamedFrom(): String? = this.getProperty(RENAMED_FROM_KEY, String::class.java).orNull()
+fun Symbol.Builder.renamedFrom(name: String): Symbol.Builder = this.putProperty(RENAMED_FROM_KEY, name)
+fun Symbol.defaultValue(): Default = this.getProperty(SYMBOL_DEFAULT, Default::class.java).orElse(Default.NoDefault)
+fun Symbol.Builder.setDefault(default: Default): Symbol.Builder = this.putProperty(SYMBOL_DEFAULT, default)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
@@ -184,7 +184,7 @@ fun Shape.contextName(serviceShape: ServiceShape?): String {
  */
 open class SymbolVisitor(
     override val model: Model,
-    override val config: SymbolVisitorConfig,
+    override val config: RustSymbolProviderConfig,
     private val serviceShape: ServiceShape?,
 ) : RustSymbolProvider, ShapeVisitor<Symbol> {
     private val nullableIndex = NullableIndex.of(model)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/SymbolVisitor.kt
@@ -43,12 +43,10 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustReservedWords
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
-import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.core.smithy.traits.RustBoxTrait
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.letIf
-import software.amazon.smithy.rust.codegen.core.util.orNull
 import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 import kotlin.reflect.KClass
@@ -64,83 +62,6 @@ val SimpleShapes: Map<KClass<out Shape>, RustType> = mapOf(
     LongShape::class to RustType.Integer(64),
     StringShape::class to RustType.String,
 )
-
-/**
- * Make the Rust type of a symbol optional (hold `Option<T>`)
- *
- * This is idempotent and will have no change if the type is already optional.
- */
-fun Symbol.makeOptional(): Symbol =
-    if (isOptional()) {
-        this
-    } else {
-        val rustType = RustType.Option(this.rustType())
-        Symbol.builder()
-            .rustType(rustType)
-            .addReference(this)
-            .name(rustType.name)
-            .build()
-    }
-
-/**
- * Make the Rust type of a symbol boxed (hold `Box<T>`).
- *
- * This is idempotent and will have no change if the type is already boxed.
- */
-fun Symbol.makeRustBoxed(): Symbol =
-    if (isRustBoxed()) {
-        this
-    } else {
-        val rustType = RustType.Box(this.rustType())
-        Symbol.builder()
-            .rustType(rustType)
-            .addReference(this)
-            .name(rustType.name)
-            .build()
-    }
-
-/**
- * Make the Rust type of a symbol wrapped in `MaybeConstrained`. (hold `MaybeConstrained<T>`).
- *
- * This is idempotent and will have no change if the type is already `MaybeConstrained<T>`.
- */
-fun Symbol.makeMaybeConstrained(): Symbol =
-    if (this.rustType() is RustType.MaybeConstrained) {
-        this
-    } else {
-        val rustType = RustType.MaybeConstrained(this.rustType())
-        Symbol.builder()
-            .rustType(rustType)
-            .addReference(this)
-            .name(rustType.name)
-            .build()
-    }
-
-/**
- * Map the [RustType] of a symbol with [f].
- *
- * WARNING: This function does not set any `SymbolReference`s on the returned symbol. You will have to add those
- * yourself if your logic relies on them.
- **/
-fun Symbol.mapRustType(f: (RustType) -> RustType): Symbol {
-    val newType = f(this.rustType())
-    return Symbol.builder().rustType(newType)
-        .name(newType.name)
-        .build()
-}
-
-/** Set the symbolLocation for this symbol builder */
-fun Symbol.Builder.locatedIn(rustModule: RustModule.LeafModule): Symbol.Builder {
-    val currentRustType = this.build().rustType()
-    check(currentRustType is RustType.Opaque) {
-        "Only `Opaque` can have their namespace updated. Received $currentRustType."
-    }
-    val newRustType = currentRustType.copy(namespace = rustModule.fullyQualifiedPath())
-    return this.definitionFile(rustModule.definitionFile())
-        .namespace(rustModule.fullyQualifiedPath(), "::")
-        .rustType(newRustType)
-        .module(rustModule)
-}
 
 /**
  * Track both the past and current name of a symbol
@@ -345,8 +266,9 @@ fun handleRustBoxing(symbol: Symbol, shape: MemberShape): Symbol =
     } else symbol
 
 fun symbolBuilder(shape: Shape?, rustType: RustType): Symbol.Builder {
-    val builder = Symbol.builder().putProperty(SHAPE_KEY, shape)
-    return builder.rustType(rustType)
+    return Symbol.builder()
+        .shape(shape)
+        .rustType(rustType)
         .name(rustType.name)
         // Every symbol that actually gets defined somewhere should set a definition file
         // If we ever generate a `thisisabug.rs`, there is a bug in our symbol generation
@@ -355,16 +277,6 @@ fun symbolBuilder(shape: Shape?, rustType: RustType): Symbol.Builder {
 
 fun handleOptionality(symbol: Symbol, member: MemberShape, nullableIndex: NullableIndex, nullabilityCheckMode: CheckMode): Symbol =
     symbol.letIf(nullableIndex.isMemberNullable(member, nullabilityCheckMode)) { symbol.makeOptional() }
-
-private const val RUST_TYPE_KEY = "rusttype"
-private const val RUST_MODULE_KEY = "rustmodule"
-private const val SHAPE_KEY = "shape"
-private const val SYMBOL_DEFAULT = "symboldefault"
-private const val RENAMED_FROM_KEY = "renamedfrom"
-
-fun Symbol.Builder.rustType(rustType: RustType): Symbol.Builder = this.putProperty(RUST_TYPE_KEY, rustType)
-fun Symbol.Builder.module(module: RustModule.LeafModule): Symbol.Builder = this.putProperty(RUST_MODULE_KEY, module)
-fun Symbol.module(): RustModule.LeafModule = this.expectProperty(RUST_MODULE_KEY, RustModule.LeafModule::class.java)
 
 /**
  * Creates a test module for this symbol.
@@ -388,15 +300,6 @@ fun SymbolProvider.testModuleForShape(shape: Shape): RustModule.LeafModule {
     )
 }
 
-fun Symbol.Builder.renamedFrom(name: String): Symbol.Builder {
-    return this.putProperty(RENAMED_FROM_KEY, name)
-}
-
-fun Symbol.renamedFrom(): String? = this.getProperty(RENAMED_FROM_KEY, String::class.java).orNull()
-
-fun Symbol.defaultValue(): Default = this.getProperty(SYMBOL_DEFAULT, Default::class.java).orElse(Default.NoDefault)
-fun Symbol.Builder.setDefault(default: Default): Symbol.Builder = this.putProperty(SYMBOL_DEFAULT, default)
-
 /**
  * Type representing the default value for a given type. (eg. for Strings, this is `""`)
  */
@@ -411,25 +314,6 @@ sealed class Default {
      */
     object RustDefault : Default()
 }
-
-/**
- * True when it is valid to use the default/0 value for [this] symbol during construction.
- */
-fun Symbol.canUseDefault(): Boolean = this.defaultValue() != Default.NoDefault
-
-/**
- * True when [this] is will be represented by Option<T> in Rust
- */
-fun Symbol.isOptional(): Boolean = when (this.rustType()) {
-    is RustType.Option -> true
-    else -> false
-}
-
-fun Symbol.isRustBoxed(): Boolean = rustType().stripOuter<RustType.Option>() is RustType.Box
-
-// Symbols should _always_ be created with a Rust type & shape attached
-fun Symbol.rustType(): RustType = this.expectProperty(RUST_TYPE_KEY, RustType::class.java)
-fun Symbol.shape(): Shape = this.expectProperty(SHAPE_KEY, Shape::class.java)
 
 /**
  *  You should rarely need this function, rust names in general should be symbol-aware,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -135,7 +135,7 @@ class BuilderGenerator(
                     }
     }
 
-    private val runtimeConfig = symbolProvider.config().runtimeConfig
+    private val runtimeConfig = symbolProvider.config.runtimeConfig
     private val members: List<MemberShape> = shape.allMembers.values.toList()
     private val structureSymbol = symbolProvider.toSymbol(shape)
     private val builderSymbol = shape.builderSymbol(symbolProvider)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
@@ -7,6 +7,8 @@ package software.amazon.smithy.rust.codegen.core.smithy.generators
 
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.StringShape
 import software.amazon.smithy.model.traits.DocumentationTrait
 import software.amazon.smithy.model.traits.EnumDefinition
@@ -27,12 +29,14 @@ import software.amazon.smithy.rust.codegen.core.smithy.MaybeRenamed
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
+import software.amazon.smithy.rust.codegen.core.smithy.renamedFrom
 import software.amazon.smithy.rust.codegen.core.util.REDACTION
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.orNull
 import software.amazon.smithy.rust.codegen.core.util.shouldRedact
+import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 
 data class EnumGeneratorContext(
     val enumName: String,
@@ -71,14 +75,42 @@ abstract class EnumType {
 }
 
 /** Model that wraps [EnumDefinition] to calculate and cache values required to generate the Rust enum source. */
-class EnumMemberModel(private val definition: EnumDefinition, private val symbolProvider: RustSymbolProvider) {
+class EnumMemberModel(
+    private val parentShape: Shape,
+    private val definition: EnumDefinition,
+    private val symbolProvider: RustSymbolProvider,
+) {
+    companion object {
+        /**
+         * Return the name of a given `enum` variant. Note that this refers to `enum` in the Smithy context
+         * where enum is a trait that can be applied to [StringShape] and not in the Rust context of an algebraic data type.
+         *
+         * Ordinarily, the symbol provider would determine this name, but the enum trait doesn't allow for this.
+         *
+         * TODO(EnumShape): Remove this function when refactoring to EnumShape.
+         */
+        @Deprecated("This function will go away when we handle EnumShape instead of EnumTrait")
+        fun toEnumVariantName(
+            symbolProvider: RustSymbolProvider,
+            parentShape: Shape,
+            definition: EnumDefinition,
+        ): MaybeRenamed? {
+            val name = definition.name.orNull()?.toPascalCase() ?: return null
+            // Create a fake member shape for symbol look up until we refactor to use EnumShape
+            val fakeMemberShape =
+                MemberShape.builder().id(parentShape.id.withMember(name)).target("smithy.api#String").build()
+            val symbol = symbolProvider.toSymbol(fakeMemberShape)
+            return MaybeRenamed(symbol.name, symbol.renamedFrom())
+        }
+    }
+
     // Because enum variants always start with an upper case letter, they will never
     // conflict with reserved words (which are always lower case), therefore, we never need
     // to fall back to raw identifiers
 
     val value: String get() = definition.value
 
-    fun name(): MaybeRenamed? = symbolProvider.toEnumVariantName(definition)
+    fun name(): MaybeRenamed? = toEnumVariantName(symbolProvider, parentShape, definition)
 
     private fun renderDocumentation(writer: RustWriter) {
         val name =
@@ -97,7 +129,7 @@ class EnumMemberModel(private val definition: EnumDefinition, private val symbol
         }
     }
 
-    fun derivedName() = checkNotNull(symbolProvider.toEnumVariantName(definition)).name
+    fun derivedName() = checkNotNull(toEnumVariantName(symbolProvider, parentShape, definition)).name
 
     fun render(writer: RustWriter) {
         renderDocumentation(writer)
@@ -138,7 +170,7 @@ open class EnumGenerator(
         enumName = symbol.name,
         enumMeta = symbol.expectRustMetadata(),
         enumTrait = enumTrait,
-        sortedMembers = enumTrait.values.sortedBy { it.value }.map { EnumMemberModel(it, symbolProvider) },
+        sortedMembers = enumTrait.values.sortedBy { it.value }.map { EnumMemberModel(shape, it, symbolProvider) },
     )
 
     fun render(writer: RustWriter) {

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/ErrorImplGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/error/ErrorImplGenerator.kt
@@ -90,7 +90,7 @@ class ErrorImplGenerator(
     private val error: ErrorTrait,
     private val customizations: List<ErrorImplCustomization>,
 ) {
-    private val runtimeConfig = symbolProvider.config().runtimeConfig
+    private val runtimeConfig = symbolProvider.config.runtimeConfig
 
     fun render(forWhom: CodegenTarget = CodegenTarget.CLIENT) {
         val symbol = symbolProvider.toSymbol(shape)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamErrorMarshallerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/EventStreamErrorMarshallerGenerator.kt
@@ -100,10 +100,10 @@ class EventStreamErrorMarshallerGenerator(
                 } else {
                     rustBlock("let payload = match _input") {
                         errorsShape.errorMembers.forEach { error ->
-                            val errorSymbol = symbolProvider.toSymbol(error)
                             val errorString = error.memberName
                             val target = model.expectShape(error.target, StructureShape::class.java)
-                            rustBlock("#T::${errorSymbol.name}(inner) => ", operationErrorSymbol) {
+                            val targetSymbol = symbolProvider.toSymbol(target)
+                            rustBlock("#T::${targetSymbol.name}(inner) => ", operationErrorSymbol) {
                                 addStringHeader(":exception-type", "${errorString.dq()}.into()")
                                 renderMarshallEvent(error, target)
                             }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/EventStreamTestTools.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/EventStreamTestTools.kt
@@ -124,7 +124,7 @@ object EventStreamTestTools {
             .filterIsInstance<StructureShape>()
             .filter { shape -> shape.hasTrait<ErrorTrait>() }
         check(errors.isNotEmpty()) { "must have at least one error modeled" }
-        project.withModule(codegenContext.symbolProvider.moduleForShape(errors[0])) {
+        project.moduleFor(errors[0]) {
             requirements.renderOperationError(this, model, symbolProvider, operationShape)
             requirements.renderOperationError(this, model, symbolProvider, unionShape)
             for (shape in errors) {
@@ -132,7 +132,7 @@ object EventStreamTestTools {
             }
         }
         val inputOutput = model.lookup<StructureShape>("test#TestStreamInputOutput")
-        project.withModule(codegenContext.symbolProvider.moduleForShape(inputOutput)) {
+        project.moduleFor(inputOutput) {
             recursivelyGenerateModels(model, symbolProvider, inputOutput, this, codegenTarget)
         }
         operationShape.outputShape(model).also { outputShape ->

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/TestHelpers.kt
@@ -29,8 +29,8 @@ import software.amazon.smithy.rust.codegen.core.smithy.ModuleProvider
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeCrateLocation
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticInputTrait
@@ -79,7 +79,7 @@ private object CodegenCoreTestModules {
     }
 }
 
-val TestSymbolVisitorConfig = SymbolVisitorConfig(
+val TestRustSymbolProviderConfig = RustSymbolProviderConfig(
     runtimeConfig = TestRuntimeConfig,
     renameExceptions = true,
     nullabilityCheckMode = NullableIndex.CheckMode.CLIENT_ZERO_VALUE_V1,
@@ -120,7 +120,7 @@ fun String.asSmithyModel(sourceLocation: String? = null, smithyVersion: String =
 // Intentionally only visible to codegen-core since the other modules have their own symbol providers
 internal fun testSymbolProvider(model: Model): RustSymbolProvider = SymbolVisitor(
     model,
-    TestSymbolVisitorConfig,
+    TestRustSymbolProviderConfig,
     ServiceShape.builder().version("test").id("test#Service").build(),
 ).let { BaseSymbolMetadataProvider(it, additionalAttributes = listOf(Attribute.NonExhaustive)) }
     .let { RustReservedWordSymbolProvider(it) }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWordsTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWordsTest.kt
@@ -14,12 +14,12 @@ import software.amazon.smithy.rust.codegen.core.smithy.MaybeRenamed
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
 import software.amazon.smithy.rust.codegen.core.smithy.WrappingSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.renamedFrom
-import software.amazon.smithy.rust.codegen.core.testutil.TestSymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.testutil.TestRustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 
 internal class RustReservedWordSymbolProviderTest {
     private class TestSymbolProvider(override val model: Model) :
-        WrappingSymbolProvider(SymbolVisitor(model, TestSymbolVisitorConfig, null))
+        WrappingSymbolProvider(SymbolVisitor(model, TestRustSymbolProviderConfig, null))
 
     @Test
     fun `member names are escaped`() {

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWordsTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustReservedWordsTest.kt
@@ -7,34 +7,19 @@ package software.amazon.smithy.rust.codegen.core.rustlang
 
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
-import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
-import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.Shape
-import software.amazon.smithy.model.shapes.UnionShape
-import software.amazon.smithy.model.traits.EnumDefinition
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.core.smithy.MaybeRenamed
-import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
+import software.amazon.smithy.rust.codegen.core.smithy.WrappingSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.renamedFrom
+import software.amazon.smithy.rust.codegen.core.testutil.TestSymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
-import software.amazon.smithy.rust.codegen.core.util.PANIC
-import software.amazon.smithy.rust.codegen.core.util.orNull
-import software.amazon.smithy.rust.codegen.core.util.toPascalCase
 
 internal class RustReservedWordSymbolProviderTest {
-    class Stub : RustSymbolProvider {
-        override fun config(): SymbolVisitorConfig = PANIC()
-        override fun symbolForOperationError(operation: OperationShape): Symbol = PANIC()
-        override fun symbolForEventStreamError(eventStream: UnionShape): Symbol = PANIC()
-
-        override fun toEnumVariantName(definition: EnumDefinition): MaybeRenamed? {
-            return definition.name.orNull()?.let { MaybeRenamed(it.toPascalCase(), null) }
-        }
-
-        override fun toSymbol(shape: Shape): Symbol {
-            return Symbol.builder().name(shape.id.name).build()
-        }
-    }
+    private class TestSymbolProvider(override val model: Model) :
+        WrappingSymbolProvider(SymbolVisitor(model, TestSymbolVisitorConfig, null))
 
     @Test
     fun `member names are escaped`() {
@@ -44,7 +29,7 @@ internal class RustReservedWordSymbolProviderTest {
                 async: String
             }
         """.trimMargin().asSmithyModel()
-        val provider = RustReservedWordSymbolProvider(Stub(), model)
+        val provider = RustReservedWordSymbolProvider(TestSymbolProvider(model))
         provider.toMemberName(
             MemberShape.builder().id("namespace#container\$async").target("namespace#Integer").build(),
         ) shouldBe "r##async"
@@ -56,6 +41,23 @@ internal class RustReservedWordSymbolProviderTest {
 
     @Test
     fun `enum variant names are updated to avoid conflicts`() {
+        val model = """
+            namespace foo
+            @enum([{ name: "dontcare", value: "dontcare" }]) string Container
+        """.asSmithyModel()
+        val provider = RustReservedWordSymbolProvider(TestSymbolProvider(model))
+
+        fun expectEnumRename(original: String, expected: MaybeRenamed) {
+            val symbol = provider.toSymbol(
+                MemberShape.builder()
+                    .id(ShapeId.fromParts("foo", "Container").withMember(original))
+                    .target("smithy.api#String")
+                    .build(),
+            )
+            symbol.name shouldBe expected.name
+            symbol.renamedFrom() shouldBe expected.renamedFrom
+        }
+
         expectEnumRename("Unknown", MaybeRenamed("UnknownValue", "Unknown"))
         expectEnumRename("UnknownValue", MaybeRenamed("UnknownValue_", "UnknownValue"))
         expectEnumRename("UnknownOther", MaybeRenamed("UnknownOther", null))
@@ -64,11 +66,5 @@ internal class RustReservedWordSymbolProviderTest {
         expectEnumRename("SelfValue", MaybeRenamed("SelfValue_", "SelfValue"))
         expectEnumRename("SelfOther", MaybeRenamed("SelfOther", null))
         expectEnumRename("SELF", MaybeRenamed("SelfValue", "Self"))
-    }
-
-    private fun expectEnumRename(original: String, expected: MaybeRenamed) {
-        val model = "namespace foo".asSmithyModel()
-        val provider = RustReservedWordSymbolProvider(Stub(), model)
-        provider.toEnumVariantName(EnumDefinition.builder().name(original).value("foo").build()) shouldBe expected
     }
 }

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/ModuleAttachingSymbolProviderTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/ModuleAttachingSymbolProviderTest.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
-import software.amazon.smithy.rust.codegen.core.testutil.TestSymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.testutil.TestRustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.util.lookup
 
@@ -74,7 +74,7 @@ class ModuleAttachingSymbolProviderTest {
 
     val symbolProvider = EventStreamSymbolProvider(
         ModuleAttachingSymbolProvider(
-            SymbolVisitor(model, TestSymbolVisitorConfig, null),
+            SymbolVisitor(model, TestRustSymbolProviderConfig, null),
         ),
         TestRuntimeConfig,
         CodegenTarget.CLIENT,

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/ModuleAttachingSymbolProviderTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/ModuleAttachingSymbolProviderTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.UnionShape
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
+import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
+import software.amazon.smithy.rust.codegen.core.testutil.TestSymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.util.lookup
+
+class ModuleAttachingSymbolProviderTest {
+    val model = """
+        namespace test
+
+        operation SomeOperation {
+            input: Input,
+            output: Output,
+            errors: [SomeError]
+        }
+
+        structure Input {
+            int: Integer,
+            someStruct: SomeStruct,
+            someList: SomeList,
+            nestedList: NestedList,
+            enumKeyedMap: EnumKeyedMap,
+        }
+
+        structure Output {
+            stream: SomeEventStream,
+        }
+
+        @error("server")
+        structure SomeError {
+        }
+
+        @streaming
+        union SomeEventStream {
+            event: Event,
+        }
+
+        structure Event {
+            foo: String,
+        }
+
+        list SomeList {
+            member: SomeStruct,
+        }
+
+        list NestedList {
+            member: SomeList,
+        }
+
+        structure SomeStruct {
+        }
+
+        @enum([{ name: "test", value: "test" }])
+        string SomeEnum
+
+        map EnumKeyedMap {
+            key: SomeEnum,
+            value: SomeStruct,
+        }
+    """.asSmithyModel()
+
+    val symbolProvider = EventStreamSymbolProvider(
+        ModuleAttachingSymbolProvider(
+            SymbolVisitor(model, TestSymbolVisitorConfig, null),
+        ),
+        TestRuntimeConfig,
+        CodegenTarget.CLIENT,
+    )
+
+    @Test
+    fun toSymbolSimpleInt() {
+        val shape = model.lookup<MemberShape>("test#Input\$int")
+        val symbol = symbolProvider.toSymbol(shape)
+        symbol.rustType() shouldBe RustType.Option(RustType.Integer(32))
+        assertThrows<IllegalArgumentException>("there should be no module") { symbol.module() }
+        symbol.namespace shouldBe ""
+    }
+
+    @Test
+    fun toSymbolStruct() {
+        val shape = model.lookup<MemberShape>("test#Input\$someStruct")
+        val symbol = symbolProvider.toSymbol(shape)
+        symbol.rustType() shouldBe RustType.Option(RustType.Opaque("SomeStruct", "crate::test_model"))
+        symbol.module().fullyQualifiedPath() shouldBe "crate::test_model"
+        symbol.namespace shouldBe "crate::test_model"
+    }
+
+    @Test
+    fun toSymbolList() {
+        val shape = model.lookup<MemberShape>("test#Input\$someList")
+        val symbol = symbolProvider.toSymbol(shape)
+        symbol.rustType() shouldBe RustType.Option(RustType.Vec(RustType.Opaque("SomeStruct", "crate::test_model")))
+        symbol.module().fullyQualifiedPath() shouldBe "crate::test_model"
+        symbol.namespace shouldBe "crate::test_model"
+    }
+
+    @Test
+    fun toSymbolNestedList() {
+        val shape = model.lookup<MemberShape>("test#Input\$nestedList")
+        val symbol = symbolProvider.toSymbol(shape)
+        symbol.rustType() shouldBe RustType.Option(
+            RustType.Vec(
+                RustType.Vec(
+                    RustType.Opaque(
+                        "SomeStruct",
+                        "crate::test_model",
+                    ),
+                ),
+            ),
+        )
+        symbol.module().fullyQualifiedPath() shouldBe "crate::test_model"
+        symbol.namespace shouldBe "crate::test_model"
+    }
+
+    @Test
+    fun toSymbolEnumKeyedMap() {
+        val shape = model.lookup<MemberShape>("test#Input\$enumKeyedMap")
+        val symbol = symbolProvider.toSymbol(shape)
+        symbol.rustType() shouldBe RustType.Option(
+            RustType.HashMap(
+                RustType.Opaque("SomeEnum", "crate::test_model"),
+                RustType.Opaque("SomeStruct", "crate::test_model"),
+            ),
+        )
+        symbol.module().fullyQualifiedPath() shouldBe "crate::test_model"
+        symbol.namespace shouldBe "crate::test_model"
+    }
+
+    @Test
+    fun symbolForOperationError() {
+        val shape = model.lookup<OperationShape>("test#SomeOperation")
+        val symbol = symbolProvider.symbolForOperationError(shape)
+        symbol.rustType() shouldBe RustType.Opaque("SomeOperationError", "crate::test_error")
+        symbol.module().fullyQualifiedPath() shouldBe "crate::test_error"
+        symbol.namespace shouldBe "crate::test_error"
+    }
+
+    @Test
+    fun symbolForEventStreamError() {
+        val shape = model.lookup<UnionShape>("test#SomeEventStream")
+        val symbol = symbolProvider.symbolForEventStreamError(shape)
+        symbol.rustType() shouldBe RustType.Opaque("SomeEventStreamError", "crate::test_error")
+        symbol.module().fullyQualifiedPath() shouldBe "crate::test_error"
+        symbol.namespace shouldBe "crate::test_error"
+    }
+}

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGeneratorTest.kt
@@ -51,8 +51,11 @@ class EnumGeneratorTest {
 
         private val enumTrait = testModel.lookup<StringShape>("test#EnumWithUnknown").expectTrait<EnumTrait>()
 
-        private fun model(name: String): EnumMemberModel =
-            EnumMemberModel(enumTrait.values.first { it.name.orNull() == name }, symbolProvider)
+        private fun model(name: String): EnumMemberModel = EnumMemberModel(
+            testModel.lookup("test#EnumWithUnknown"),
+            enumTrait.values.first { it.name.orNull() == name },
+            symbolProvider,
+        )
 
         @Test
         fun `it converts enum names to PascalCase and renames any named Unknown to UnknownValue`() {

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -20,7 +20,7 @@ import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.generators.error.ErrorImplGenerator
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerEnumGenerator
@@ -48,8 +48,8 @@ class PythonServerCodegenVisitor(
 ) : ServerCodegenVisitor(context, codegenDecorator) {
 
     init {
-        val symbolVisitorConfig =
-            SymbolVisitorConfig(
+        val rustSymbolProviderConfig =
+            RustSymbolProviderConfig(
                 runtimeConfig = settings.runtimeConfig,
                 renameExceptions = false,
                 nullabilityCheckMode = NullableIndex.CheckMode.SERVER,
@@ -76,14 +76,14 @@ class PythonServerCodegenVisitor(
         fun baseSymbolProviderFactory(
             model: Model,
             serviceShape: ServiceShape,
-            symbolVisitorConfig: SymbolVisitorConfig,
+            rustSymbolProviderConfig: RustSymbolProviderConfig,
             publicConstrainedTypes: Boolean,
-        ) = RustServerCodegenPythonPlugin.baseSymbolProvider(model, serviceShape, symbolVisitorConfig, publicConstrainedTypes)
+        ) = RustServerCodegenPythonPlugin.baseSymbolProvider(model, serviceShape, rustSymbolProviderConfig, publicConstrainedTypes)
 
         val serverSymbolProviders = ServerSymbolProviders.from(
             model,
             service,
-            symbolVisitorConfig,
+            rustSymbolProviderConfig,
             settings.codegenConfig.publicConstrainedTypes,
             ::baseSymbolProviderFactory,
         )

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerSymbolProvider.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerSymbolProvider.kt
@@ -22,9 +22,9 @@ import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.RustMetadata
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolMetadataProvider
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
 import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticInputTrait
 import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticOutputTrait
@@ -45,7 +45,7 @@ import software.amazon.smithy.rust.codegen.core.util.isStreaming
  */
 class PythonServerSymbolVisitor(
     model: Model,
-    config: SymbolVisitorConfig,
+    config: RustSymbolProviderConfig,
     serviceShape: ServiceShape?,
 ) : SymbolVisitor(model, config, serviceShape) {
     private val runtimeConfig = config.runtimeConfig

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerSymbolProvider.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerSymbolProvider.kt
@@ -44,11 +44,11 @@ import software.amazon.smithy.rust.codegen.core.util.isStreaming
  * `aws_smithy_http_server_python::types`.
  */
 class PythonServerSymbolVisitor(
-    private val model: Model,
-    serviceShape: ServiceShape?,
+    model: Model,
     config: SymbolVisitorConfig,
-) : SymbolVisitor(model, serviceShape, config) {
-    private val runtimeConfig = config().runtimeConfig
+    serviceShape: ServiceShape?,
+) : SymbolVisitor(model, config, serviceShape) {
+    private val runtimeConfig = config.runtimeConfig
 
     override fun toSymbol(shape: Shape): Symbol {
         val initial = shape.accept(this)
@@ -68,7 +68,7 @@ class PythonServerSymbolVisitor(
         // For example a TimestampShape doesn't become a different symbol when streaming is involved, but BlobShape
         // become a ByteStream.
         return if (target is BlobShape && shape.isStreaming(model)) {
-            PythonServerRuntimeType.byteStream(config().runtimeConfig).toSymbol()
+            PythonServerRuntimeType.byteStream(config.runtimeConfig).toSymbol()
         } else {
             initial
         }
@@ -95,7 +95,7 @@ class PythonServerSymbolVisitor(
  *
  * Note that since streaming members can only be used on the root shape, this can only impact input and output shapes.
  */
-class PythonStreamingShapeMetadataProvider(private val base: RustSymbolProvider, private val model: Model) : SymbolMetadataProvider(base) {
+class PythonStreamingShapeMetadataProvider(private val base: RustSymbolProvider) : SymbolMetadataProvider(base) {
     override fun structureMeta(structureShape: StructureShape): RustMetadata {
         val baseMetadata = base.toSymbol(structureShape).expectRustMetadata()
         return if (structureShape.hasStreamingMember(model)) {

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.BaseSymbolMetadataProvide
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.ModuleAttachingSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.server.python.smithy.customizations.DECORATORS
 import software.amazon.smithy.rust.codegen.server.smithy.ConstrainedShapeSymbolMetadataProvider
 import software.amazon.smithy.rust.codegen.server.smithy.ConstrainedShapeSymbolProvider
@@ -71,12 +71,12 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
         fun baseSymbolProvider(
             model: Model,
             serviceShape: ServiceShape,
-            symbolVisitorConfig: SymbolVisitorConfig,
+            rustSymbolProviderConfig: RustSymbolProviderConfig,
             constrainedTypes: Boolean = true,
         ) =
             // Rename a set of symbols that do not implement `PyClass` and have been wrapped in
             // `aws_smithy_http_server_python::types`.
-            PythonServerSymbolVisitor(model, serviceShape = serviceShape, config = symbolVisitorConfig)
+            PythonServerSymbolVisitor(model, serviceShape = serviceShape, config = rustSymbolProviderConfig)
                 // Generate public constrained types for directly constrained shapes.
                 // In the Python server project, this is only done to generate constrained types for simple shapes (e.g.
                 // a `string` shape with the `length` trait), but these always remain `pub(crate)`.
@@ -95,6 +95,6 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
                 // Attach modules to the generated symbols
                 .let { ModuleAttachingSymbolProvider(it) }
                 // Generate different types for EventStream shapes (e.g. transcribe streaming)
-                .let { EventStreamSymbolProvider(it, symbolVisitorConfig.runtimeConfig, CodegenTarget.SERVER) }
+                .let { EventStreamSymbolProvider(it, rustSymbolProviderConfig.runtimeConfig, CodegenTarget.SERVER) }
     }
 }

--- a/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerSymbolProviderTest.kt
+++ b/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerSymbolProviderTest.kt
@@ -12,7 +12,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.server.python.smithy.PythonServerSymbolVisitor
-import software.amazon.smithy.rust.codegen.server.smithy.testutil.ServerTestSymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.server.smithy.testutil.ServerTestRustSymbolProviderConfig
 
 internal class PythonServerSymbolProviderTest {
     private val pythonBlobType = RustType.Opaque("Blob", "aws_smithy_http_server_python::types")
@@ -45,7 +45,7 @@ internal class PythonServerSymbolProviderTest {
                 value: Timestamp
             }
         """.asSmithyModel()
-        val provider = PythonServerSymbolVisitor(model, ServerTestSymbolVisitorConfig, null)
+        val provider = PythonServerSymbolVisitor(model, ServerTestRustSymbolProviderConfig, null)
 
         // Struct test
         val timestamp = provider.toSymbol(model.expectShape(ShapeId.from("test#TimestampStruct\$inner"))).rustType()
@@ -95,7 +95,7 @@ internal class PythonServerSymbolProviderTest {
                 value: Blob
             }
         """.asSmithyModel()
-        val provider = PythonServerSymbolVisitor(model, ServerTestSymbolVisitorConfig, null)
+        val provider = PythonServerSymbolVisitor(model, ServerTestRustSymbolProviderConfig, null)
 
         // Struct test
         val blob = provider.toSymbol(model.expectShape(ShapeId.from("test#BlobStruct\$inner"))).rustType()

--- a/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerSymbolProviderTest.kt
+++ b/codegen-server/python/src/test/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerSymbolProviderTest.kt
@@ -45,7 +45,7 @@ internal class PythonServerSymbolProviderTest {
                 value: Timestamp
             }
         """.asSmithyModel()
-        val provider = PythonServerSymbolVisitor(model, null, ServerTestSymbolVisitorConfig)
+        val provider = PythonServerSymbolVisitor(model, ServerTestSymbolVisitorConfig, null)
 
         // Struct test
         val timestamp = provider.toSymbol(model.expectShape(ShapeId.from("test#TimestampStruct\$inner"))).rustType()
@@ -95,7 +95,7 @@ internal class PythonServerSymbolProviderTest {
                 value: Blob
             }
         """.asSmithyModel()
-        val provider = PythonServerSymbolVisitor(model, null, ServerTestSymbolVisitorConfig)
+        val provider = PythonServerSymbolVisitor(model, ServerTestSymbolVisitorConfig, null)
 
         // Struct test
         val blob = provider.toSymbol(model.expectShape(ShapeId.from("test#BlobStruct\$inner"))).rustType()

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolMetadataProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolMetadataProvider.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy
 
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.ListShape
 import software.amazon.smithy.model.shapes.MapShape
@@ -29,7 +28,6 @@ import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
  */
 class ConstrainedShapeSymbolMetadataProvider(
     private val base: RustSymbolProvider,
-    private val model: Model,
     private val constrainedTypes: Boolean,
 ) : SymbolMetadataProvider(base) {
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolProvider.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.rust.codegen.server.smithy
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.ByteShape
@@ -54,7 +53,6 @@ import software.amazon.smithy.rust.codegen.core.util.toPascalCase
  */
 class ConstrainedShapeSymbolProvider(
     private val base: RustSymbolProvider,
-    private val model: Model,
     private val serviceShape: ServiceShape,
 ) : WrappingSymbolProvider(base) {
     private val nullableIndex = NullableIndex.of(model)
@@ -74,7 +72,7 @@ class ConstrainedShapeSymbolProvider(
                 val target = model.expectShape(shape.target)
                 val targetSymbol = this.toSymbol(target)
                 // Handle boxing first, so we end up with `Option<Box<_>>`, not `Box<Option<_>>`.
-                handleOptionality(handleRustBoxing(targetSymbol, shape), shape, nullableIndex, base.config().nullabilityCheckMode)
+                handleOptionality(handleRustBoxing(targetSymbol, shape), shape, nullableIndex, base.config.nullabilityCheckMode)
             }
             is MapShape -> {
                 if (shape.isDirectlyConstrained(base)) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstraintViolationSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstraintViolationSymbolProvider.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.rust.codegen.server.smithy
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.ByteShape
 import software.amazon.smithy.model.shapes.CollectionShape
@@ -67,7 +66,6 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.serverBuilde
  */
 class ConstraintViolationSymbolProvider(
     private val base: RustSymbolProvider,
-    private val model: Model,
     private val publicConstrainedTypes: Boolean,
     private val serviceShape: ServiceShape,
 ) : WrappingSymbolProvider(base) {

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/DeriveEqAndHashSymbolMetadataProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/DeriveEqAndHashSymbolMetadataProvider.kt
@@ -5,7 +5,6 @@
 
 package software.amazon.smithy.rust.codegen.server.smithy
 
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.DocumentShape
 import software.amazon.smithy.model.shapes.DoubleShape
@@ -49,7 +48,6 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
  */
 class DeriveEqAndHashSymbolMetadataProvider(
     private val base: RustSymbolProvider,
-    val model: Model,
 ) : SymbolMetadataProvider(base) {
     private val walker = DirectedWalker(model)
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PubCrateConstrainedShapeSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/PubCrateConstrainedShapeSymbolProvider.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.rust.codegen.server.smithy
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.MapShape
@@ -61,7 +60,6 @@ import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
  */
 class PubCrateConstrainedShapeSymbolProvider(
     private val base: RustSymbolProvider,
-    private val model: Model,
     private val serviceShape: ServiceShape,
 ) : WrappingSymbolProvider(base) {
     private val nullableIndex = NullableIndex.of(model)
@@ -109,7 +107,7 @@ class PubCrateConstrainedShapeSymbolProvider(
                         handleRustBoxing(targetSymbol, shape),
                         shape,
                         nullableIndex,
-                        base.config().nullabilityCheckMode,
+                        base.config.nullabilityCheckMode,
                     )
                 }
             }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
@@ -14,10 +14,10 @@ import software.amazon.smithy.rust.codegen.core.smithy.BaseSymbolMetadataProvide
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.ModuleAttachingSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.StreamingShapeMetadataProvider
 import software.amazon.smithy.rust.codegen.core.smithy.StreamingShapeSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitor
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.CustomValidationExceptionWithReasonDecorator
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.ServerRequiredCustomizations
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionDecorator
@@ -66,10 +66,10 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
         fun baseSymbolProvider(
             model: Model,
             serviceShape: ServiceShape,
-            symbolVisitorConfig: SymbolVisitorConfig,
+            rustSymbolProviderConfig: RustSymbolProviderConfig,
             constrainedTypes: Boolean = true,
         ) =
-            SymbolVisitor(model, serviceShape = serviceShape, config = symbolVisitorConfig)
+            SymbolVisitor(model, serviceShape = serviceShape, config = rustSymbolProviderConfig)
                 // Generate public constrained types for directly constrained shapes.
                 .let { if (constrainedTypes) ConstrainedShapeSymbolProvider(it, serviceShape) else it }
                 // Generate [ByteStream] instead of `Blob` for streaming binary shapes (e.g. S3 GetObject)
@@ -88,6 +88,6 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
                 // Attach modules to the generated symbols
                 .let { ModuleAttachingSymbolProvider(it) }
                 // Generate different types for EventStream shapes (e.g. transcribe streaming)
-                .let { EventStreamSymbolProvider(it, symbolVisitorConfig.runtimeConfig, CodegenTarget.SERVER) }
+                .let { EventStreamSymbolProvider(it, rustSymbolProviderConfig.runtimeConfig, CodegenTarget.SERVER) }
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -36,7 +36,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.CoreRustSettings
 import software.amazon.smithy.rust.codegen.core.smithy.DirectedWalker
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.UnionGenerator
@@ -103,7 +103,7 @@ open class ServerCodegenVisitor(
     protected var validationExceptionConversionGenerator: ValidationExceptionConversionGenerator
 
     init {
-        val symbolVisitorConfig = SymbolVisitorConfig(
+        val rustSymbolProviderConfig = RustSymbolProviderConfig(
             runtimeConfig = settings.runtimeConfig,
             renameExceptions = false,
             nullabilityCheckMode = NullableIndex.CheckMode.SERVER,
@@ -127,7 +127,7 @@ open class ServerCodegenVisitor(
         val serverSymbolProviders = ServerSymbolProviders.from(
             model,
             service,
-            symbolVisitorConfig,
+            rustSymbolProviderConfig,
             settings.codegenConfig.publicConstrainedTypes,
             RustServerCodegenPlugin::baseSymbolProvider,
         )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustModule.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustModule.kt
@@ -31,7 +31,7 @@ object ServerRustModule {
 }
 
 object ServerModuleProvider : ModuleProvider {
-    override fun moduleForShape(shape: Shape): RustModule.LeafModule = when (shape) {
+    override fun moduleForShape(shapeName: String, shape: Shape): RustModule.LeafModule = when (shape) {
         is OperationShape -> ServerRustModule.Operation
         is StructureShape -> when {
             shape.hasTrait<ErrorTrait>() -> ServerRustModule.Error
@@ -42,9 +42,9 @@ object ServerModuleProvider : ModuleProvider {
         else -> ServerRustModule.Model
     }
 
-    override fun moduleForOperationError(operation: OperationShape): RustModule.LeafModule =
+    override fun moduleForOperationError(operationName: String, operation: OperationShape): RustModule.LeafModule =
         ServerRustModule.Error
 
-    override fun moduleForEventStreamError(eventStream: UnionShape): RustModule.LeafModule =
+    override fun moduleForEventStreamError(eventStreamName: String, eventStream: UnionShape): RustModule.LeafModule =
         ServerRustModule.Error
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
@@ -46,16 +46,14 @@ class ServerSymbolProviders private constructor(
                         symbolVisitorConfig,
                         false,
                     ),
-                    model, publicConstrainedTypes, service,
+                    publicConstrainedTypes, service,
                 ),
                 pubCrateConstrainedShapeSymbolProvider = PubCrateConstrainedShapeSymbolProvider(
                     baseSymbolProvider,
-                    model,
                     service,
                 ),
                 constraintViolationSymbolProvider = ConstraintViolationSymbolProvider(
                     baseSymbolProvider,
-                    model,
                     publicConstrainedTypes,
                     service,
                 ),

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
@@ -8,7 +8,7 @@ package software.amazon.smithy.rust.codegen.server.smithy
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 
 /**
  * Just a handy class to centralize initialization all the symbol providers required by the server code generators, to
@@ -26,24 +26,24 @@ class ServerSymbolProviders private constructor(
         fun from(
             model: Model,
             service: ServiceShape,
-            symbolVisitorConfig: SymbolVisitorConfig,
+            rustSymbolProviderConfig: RustSymbolProviderConfig,
             publicConstrainedTypes: Boolean,
-            baseSymbolProviderFactory: (model: Model, service: ServiceShape, symbolVisitorConfig: SymbolVisitorConfig, publicConstrainedTypes: Boolean) -> RustSymbolProvider,
+            baseSymbolProviderFactory: (model: Model, service: ServiceShape, rustSymbolProviderConfig: RustSymbolProviderConfig, publicConstrainedTypes: Boolean) -> RustSymbolProvider,
         ): ServerSymbolProviders {
-            val baseSymbolProvider = baseSymbolProviderFactory(model, service, symbolVisitorConfig, publicConstrainedTypes)
+            val baseSymbolProvider = baseSymbolProviderFactory(model, service, rustSymbolProviderConfig, publicConstrainedTypes)
             return ServerSymbolProviders(
                 symbolProvider = baseSymbolProvider,
                 constrainedShapeSymbolProvider = baseSymbolProviderFactory(
                     model,
                     service,
-                    symbolVisitorConfig,
+                    rustSymbolProviderConfig,
                     true,
                 ),
                 unconstrainedShapeSymbolProvider = UnconstrainedShapeSymbolProvider(
                     baseSymbolProviderFactory(
                         model,
                         service,
-                        symbolVisitorConfig,
+                        rustSymbolProviderConfig,
                         false,
                     ),
                     publicConstrainedTypes, service,

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/UnconstrainedShapeSymbolProvider.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/UnconstrainedShapeSymbolProvider.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.rust.codegen.server.smithy
 
 import software.amazon.smithy.codegen.core.Symbol
-import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.knowledge.NullableIndex
 import software.amazon.smithy.model.shapes.CollectionShape
 import software.amazon.smithy.model.shapes.MapShape
@@ -77,7 +76,6 @@ import software.amazon.smithy.rust.codegen.server.smithy.generators.serverBuilde
  */
 class UnconstrainedShapeSymbolProvider(
     private val base: RustSymbolProvider,
-    private val model: Model,
     private val publicConstrainedTypes: Boolean,
     private val serviceShape: ServiceShape,
 ) : WrappingSymbolProvider(base) {
@@ -166,7 +164,7 @@ class UnconstrainedShapeSymbolProvider(
                         handleRustBoxing(targetSymbol, shape),
                         shape,
                         nullableIndex,
-                        base.config().nullabilityCheckMode,
+                        base.config.nullabilityCheckMode,
                     )
                 } else {
                     base.toSymbol(shape)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorCommon.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerBuilderGeneratorCommon.kt
@@ -39,6 +39,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumMemberModel
 import software.amazon.smithy.rust.codegen.core.util.UNREACHABLE
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.expectTrait
@@ -143,7 +144,9 @@ fun defaultValue(
                 .entries
                 .filter { entry -> entry.value == value }
                 .map { entry ->
-                    symbolProvider.toEnumVariantName(
+                    EnumMemberModel.toEnumVariantName(
+                        symbolProvider,
+                        target,
                         EnumDefinition.builder().name(entry.key).value(entry.value.toString()).build(),
                     )!!
                 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.implBlock
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
-import software.amazon.smithy.rust.codegen.core.smithy.SymbolVisitorConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
 import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
 import software.amazon.smithy.rust.codegen.server.smithy.RustServerCodegenPlugin
@@ -28,7 +28,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyVa
 import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerBuilderGenerator
 
 // These are the settings we default to if the user does not override them in their `smithy-build.json`.
-val ServerTestSymbolVisitorConfig = SymbolVisitorConfig(
+val ServerTestRustSymbolProviderConfig = RustSymbolProviderConfig(
     runtimeConfig = TestRuntimeConfig,
     renameExceptions = false,
     nullabilityCheckMode = NullableIndex.CheckMode.SERVER,
@@ -49,7 +49,7 @@ fun serverTestSymbolProviders(
     ServerSymbolProviders.from(
         model,
         serviceShape ?: testServiceShapeFor(model),
-        ServerTestSymbolVisitorConfig,
+        ServerTestRustSymbolProviderConfig,
         (
             settings ?: serverTestRustSettings(
                 (serviceShape ?: testServiceShapeFor(model)).id,
@@ -98,7 +98,7 @@ fun serverTestCodegenContext(
     val serverSymbolProviders = ServerSymbolProviders.from(
         model,
         service,
-        ServerTestSymbolVisitorConfig,
+        ServerTestRustSymbolProviderConfig,
         settings.codegenConfig.publicConstrainedTypes,
         RustServerCodegenPlugin::baseSymbolProvider,
     )

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolProviderTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ConstrainedShapeSymbolProviderTest.kt
@@ -90,7 +90,7 @@ class ConstrainedShapeSymbolProviderTest {
     private val model = baseModelString.asSmithyModel()
     private val serviceShape = model.lookup<ServiceShape>("test#TestService")
     private val symbolProvider = serverTestSymbolProvider(model, serviceShape)
-    private val constrainedShapeSymbolProvider = ConstrainedShapeSymbolProvider(symbolProvider, model, serviceShape)
+    private val constrainedShapeSymbolProvider = ConstrainedShapeSymbolProvider(symbolProvider, serviceShape)
 
     companion object {
         @JvmStatic

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/DeriveEqAndHashSymbolMetadataProviderTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/DeriveEqAndHashSymbolMetadataProviderTest.kt
@@ -171,8 +171,8 @@ internal class DeriveEqAndHashSymbolMetadataProviderTest {
         """.asSmithyModel(smithyVersion = "2.0")
     private val serviceShape = model.lookup<ServiceShape>("test#TestService")
     private val deriveEqAndHashSymbolMetadataProvider = serverTestSymbolProvider(model, serviceShape)
-        .let { BaseSymbolMetadataProvider(it, model, additionalAttributes = listOf()) }
-        .let { DeriveEqAndHashSymbolMetadataProvider(it, model) }
+        .let { BaseSymbolMetadataProvider(it, additionalAttributes = listOf()) }
+        .let { DeriveEqAndHashSymbolMetadataProvider(it) }
 
     companion object {
         @JvmStatic


### PR DESCRIPTION
## Motivation and Context
For [RFC-26](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0026_client_crate_organization.md), several types need to be added to modules that are named after operations.

There are actually examples of modules being named after shapes for builder codegen, as can be seen in:
https://github.com/awslabs/smithy-rs/blob/83656ec994581f6e5b9c4701cd0c127d11db31ac/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt#L84-L85

However, for RFC-26, that `symbolProvider.toSymbol` call would actually infinite loop when determining a module for an operation since the operation symbol resolution itself needs a module for the operation symbol, and determining the module requires an operation symbol.

This PR refactors module resolution to the end of the symbol provider chain in a separate `ModuleAttachingSymbolProvider`. This allows names to be resolved in the first half of the chain, and then modules to be resolved based on those names in the second half of the chain.

This PR also eliminates `RustSymbolProvider.toEnumVariantName` by refactoring the code that called that to create fake `MemberShape`s instead, which brings us slightly closer to supporting `EnumShape` rather than `EnumTrait`.

This refactor should be entirely contained to the code generator and should result in no generated code differences.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
