### PR TITLE
Add presigned URL canary & ep2 test

### DIFF
--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -130,3 +130,15 @@ async fn test_presigned_upload_part() -> Result<(), Box<dyn Error>> {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn test_presigning_object_lambda() -> Result<(), Box<dyn Error>> {
+    let presigned = presign_input!(s3::input::GetObjectInput::builder()
+        .bucket("arn:aws:s3-object-lambda:us-west-2:123456789012:accesspoint:my-banner-ap-name")
+        .key("test2.txt")
+        .build()
+        .unwrap());
+    // since the URI is `my-banner-api-name...` we know EP2 is working properly for presigning
+    assert_eq!(presigned.uri().to_string(), "https://my-banner-ap-name-123456789012.s3-object-lambda.us-west-2.amazonaws.com/test2.txt?x-id=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F20090213%2Fus-west-2%2Fs3-object-lambda%2Faws4_request&X-Amz-Date=20090213T233131Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=027976453050b6f9cca7af80a59c05ee572b462e0fc1ef564c59412b903fcdf2&X-Amz-Security-Token=notarealsessiontoken");
+    Ok(())
+}

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -10,7 +10,6 @@ use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
 use aws_sdk_s3::presigning::config::PresigningConfig;
 use s3::types::ByteStream;
-use std::fmt::format;
 use std::time::Duration;
 use uuid::Uuid;
 

--- a/tools/ci-cdk/canary-lambda/src/s3_canary.rs
+++ b/tools/ci-cdk/canary-lambda/src/s3_canary.rs
@@ -8,7 +8,10 @@ use crate::{mk_canary, CanaryEnv};
 use anyhow::Context;
 use aws_config::SdkConfig;
 use aws_sdk_s3 as s3;
+use aws_sdk_s3::presigning::config::PresigningConfig;
 use s3::types::ByteStream;
+use std::fmt::format;
+use std::time::Duration;
 use uuid::Uuid;
 
 const METADATA_TEST_VALUE: &str = "some   value";
@@ -62,6 +65,23 @@ pub async fn s3_canary(client: s3::Client, s3_bucket_name: String) -> anyhow::Re
         .send()
         .await
         .context("s3::GetObject[2]")?;
+
+    // repeat the test with a presigned url
+    let uri = client
+        .get_object()
+        .bucket(&s3_bucket_name)
+        .key(&test_key)
+        .presigned(PresigningConfig::expires_in(Duration::from_secs(120)).unwrap())
+        .await
+        .unwrap();
+    let response = reqwest::get(uri.uri().to_string())
+        .await
+        .context("s3::presigned")?
+        .text()
+        .await?;
+    if response != "test" {
+        return Err(CanaryError(format!("presigned URL returned bad data: {:?}", response)).into());
+    }
 
     let mut result = Ok(());
     match output.metadata() {

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -53,6 +53,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "0.8", features = ["v4"] }
 tokio-stream = "0"
 tracing-texray = "0.1.1"
+reqwest = "0.11.14"
 "#;
 
 const REQUIRED_SDK_CRATES: &[&str] = &[

--- a/tools/ci-cdk/canary-runner/src/build_bundle.rs
+++ b/tools/ci-cdk/canary-runner/src/build_bundle.rs
@@ -429,6 +429,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "0.8", features = ["v4"] }
 tokio-stream = "0"
 tracing-texray = "0.1.1"
+reqwest = "0.11.14"
 aws-config = { path = "some/sdk/path/aws-config" }
 aws-sdk-s3 = { path = "some/sdk/path/s3" }
 aws-sdk-ec2 = { path = "some/sdk/path/ec2" }
@@ -491,6 +492,7 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 uuid = { version = "0.8", features = ["v4"] }
 tokio-stream = "0"
 tracing-texray = "0.1.1"
+reqwest = "0.11.14"
 aws-config = "0.46.0"
 aws-sdk-s3 = "0.20.0"
 aws-sdk-ec2 = "0.19.0"


### PR DESCRIPTION
## Motivation and Context
- #1784 additional testing

## Description
- adds canary for presigned URLs
- adds test that presigned URLs respect custom S3 behavior

## Testing
- these changes are tests

## Checklist
- no changelog
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
