### PR TITLE
Upgrade `base64-simd` to 0.8

### DIFF
--- a/rust-runtime/aws-smithy-types/Cargo.toml
+++ b/rust-runtime/aws-smithy-types/Cargo.toml
@@ -12,7 +12,7 @@ itoa = "1.0.0"
 num-integer = "0.1.44"
 ryu = "1.0.5"
 time = { version = "0.3.4", features = ["parsing"] }
-base64-simd = "0.7"
+base64-simd = "0.8"
 
 [dev-dependencies]
 base64 = "0.13.0"

--- a/rust-runtime/aws-smithy-types/src/base64.rs
+++ b/rust-runtime/aws-smithy-types/src/base64.rs
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-//! A thin wrapper over `base64-simd`
+//! A thin wrapper over [`base64-simd`](https://docs.rs/base64-simd/)
 
-use base64_simd::Base64;
+use base64_simd::STANDARD;
 use std::error::Error;
 
 /// Failure to decode a base64 value.
@@ -28,20 +28,15 @@ impl std::fmt::Display for DecodeError {
 ///
 /// If input is not a valid base64 encoded string, this function will return `DecodeError`.
 pub fn decode(input: impl AsRef<str>) -> Result<Vec<u8>, DecodeError> {
-    Base64::STANDARD
-        .decode_to_boxed_bytes(input.as_ref().as_bytes())
-        .map(|bytes| bytes.into_vec())
-        .map_err(DecodeError)
+    STANDARD.decode_to_vec(input.as_ref()).map_err(DecodeError)
 }
 
 /// Encode `input` into base64 using the standard base64 alphabet
 pub fn encode(input: impl AsRef<[u8]>) -> String {
-    Base64::STANDARD
-        .encode_to_boxed_str(input.as_ref())
-        .into_string()
+    STANDARD.encode_to_string(input.as_ref())
 }
 
 /// Returns the base64 representation's length for the given `length` of data
 pub fn encoded_length(length: usize) -> usize {
-    Base64::STANDARD.encoded_length(length)
+    STANDARD.encoded_length(length)
 }


### PR DESCRIPTION
## Motivation and Context

base64-simd v0.8 supports aarch64 simd out of box.
base64-simd v0.7 has an unmaintained dependency.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
