### PR TITLE
update: remove ServiceBuilder from Client::call_raw

### DIFF
--- a/rust-runtime/aws-smithy-http-tower/src/dispatch.rs
+++ b/rust-runtime/aws-smithy-http-tower/src/dispatch.rs
@@ -22,6 +22,12 @@ pub struct DispatchService<S> {
     inner: S,
 }
 
+impl<S> DispatchService<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
 type BoxedResultFuture<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
 
 impl<S> Service<operation::Request> for DispatchService<S>

--- a/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
+++ b/rust-runtime/aws-smithy-http-tower/src/parse_response.rs
@@ -27,6 +27,15 @@ pub struct ParseResponseService<S, O, R> {
     _output_type: PhantomData<(O, R)>,
 }
 
+impl<S, O, R> ParseResponseService<S, O, R> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            _output_type: Default::default(),
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct ParseResponseLayer<O, R> {
     _output_type: PhantomData<(O, R)>,


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR removes the use of tower's service builder in favor of creating the service stack explicitly. This is one of the first steps towards smithy interceptors. This change should have no effect from a user's perspective.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran existing tests

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
