### PR TITLE
add: deprecation notice to deprecated fluent builder methods

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -210,3 +210,15 @@ message = "Fix issue where clients using native-tls connector were prevented fro
 references = ["aws-sdk-rust#736"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client" }
 author = "Velfi"
+
+[[aws-sdk-rust]]
+message = "Fluent builder methods on the client are now marked as deprecated when the related operation is deprecated."
+references = ["aws-sdk-rust#740"]
+meta = { "breaking" = false, "tada" = true, "bug" = true }
+author = "Velfi"
+
+[[smithy-rs]]
+message = "Fluent builder methods on the client are now marked as deprecated when the related operation is deprecated."
+references = ["aws-sdk-rust#740"]
+meta = { "breaking" = false, "tada" = true, "bug" = true, "target" = "client"}
+author = "Velfi"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -202,6 +202,9 @@ class FluentClientGenerator(
                     """,
                 )
 
+                // Write a deprecation notice if this operation is deprecated.
+                writer.deprecatedShape(operation)
+
                 writer.rust(
                     """
                     pub fn ${


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
aws-sdk-rust#740

## Description
<!--- Describe your changes in detail -->
Generate deprecation warnings for fluent builder methods when the related operation is deprecated.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I generated the service crate that the user reported as missing a deprecation notice and verified a notice is now included.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
