### PR TITLE
Add feature gate for crate reorganization and move `AppName` behind it

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -20,6 +20,9 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
  * Modules for code generated client crates.
  */
 object ClientRustModule {
+    /** crate */
+    val root = RustModule.LibRs
+
     /** crate::client */
     val client = Client.self
     object Client {
@@ -33,6 +36,7 @@ object ClientRustModule {
     val Config = RustModule.public("config", documentation = "Configuration for the service.")
     val Error = RustModule.public("error", documentation = "All error types that operations can return. Documentation on these types is copied from the model.")
     val Operation = RustModule.public("operation", documentation = "All operations that this crate can perform.")
+    val Meta = RustModule.public("meta", documentation = "Information about this crate.")
     val Model = RustModule.public("model", documentation = "Data structures used by operation inputs/outputs. Documentation on these types is copied from the model.")
     val Input = RustModule.public("input", documentation = "Input structures for operations. Documentation on these types is copied from the model.")
     val Output = RustModule.public("output", documentation = "Output structures for operations. Documentation on these types is copied from the model.")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
@@ -86,6 +86,8 @@ data class ClientCodegenConfig(
     val addMessageToErrors: Boolean = defaultAddMessageToErrors,
     // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
     val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
+    // TODO(CrateReorganization): Remove this once we commit to the breaking change
+    val enableNewCrateOrganizationScheme: Boolean = defaultEnableNewCrateOrganizationScheme,
 ) : CoreCodegenConfig(
     formatTimeoutSeconds, debugMode,
 ) {
@@ -94,6 +96,7 @@ data class ClientCodegenConfig(
         private const val defaultIncludeFluentClient = true
         private const val defaultAddMessageToErrors = true
         private val defaultEventStreamAllowList: Set<String> = emptySet()
+        private const val defaultEnableNewCrateOrganizationScheme = false
 
         fun fromCodegenConfigAndNode(coreCodegenConfig: CoreCodegenConfig, node: Optional<ObjectNode>) =
             if (node.isPresent) {
@@ -106,12 +109,14 @@ data class ClientCodegenConfig(
                     renameExceptions = node.get().getBooleanMemberOrDefault("renameErrors", defaultRenameExceptions),
                     includeFluentClient = node.get().getBooleanMemberOrDefault("includeFluentClient", defaultIncludeFluentClient),
                     addMessageToErrors = node.get().getBooleanMemberOrDefault("addMessageToErrors", defaultAddMessageToErrors),
+                    enableNewCrateOrganizationScheme = node.get().getBooleanMemberOrDefault("enableNewCrateOrganizationScheme", false),
                 )
             } else {
                 ClientCodegenConfig(
                     formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                     debugMode = coreCodegenConfig.debugMode,
                     eventStreamAllowList = defaultEventStreamAllowList,
+                    enableNewCrateOrganizationScheme = defaultEnableNewCrateOrganizationScheme,
                 )
             }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -55,7 +55,7 @@ class RequiredCustomizations : ClientCodegenDecorator {
         codegenContext: ClientCodegenContext,
         baseCustomizations: List<LibRsCustomization>,
     ): List<LibRsCustomization> =
-        baseCustomizations + CrateVersionCustomization() + AllowLintsCustomization()
+        baseCustomizations + AllowLintsCustomization()
 
     override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
         // Add rt-tokio feature for `ByteStream::from_path`
@@ -68,6 +68,14 @@ class RequiredCustomizations : ClientCodegenDecorator {
 
         rustCrate.withModule(ClientRustModule.Types) {
             pubUseSmithyTypes(codegenContext, codegenContext.model)(this)
+        }
+
+        val metaModule = when (codegenContext.settings.codegenConfig.enableNewCrateOrganizationScheme) {
+            true -> ClientRustModule.Meta
+            else -> ClientRustModule.root
+        }
+        rustCrate.withModule(metaModule) {
+            CrateVersionCustomization.extras(rustCrate, metaModule)
         }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy.generators.protocol
 import software.amazon.smithy.aws.traits.ServiceTrait
 import software.amazon.smithy.model.shapes.BlobShape
 import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.http.RequestBindingGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
@@ -54,7 +55,7 @@ open class MakeOperationGenerator(
             ?: codegenContext.serviceShape.id.getName(codegenContext.serviceShape)
 
     private val codegenScope = arrayOf(
-        "config" to RuntimeType.Config,
+        "config" to ClientRustModule.Config,
         "header_util" to RuntimeType.smithyHttp(runtimeConfig).resolve("header"),
         "http" to RuntimeType.Http,
         "HttpRequestBuilder" to RuntimeType.HttpRequestBuilder,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGenerator.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.protocoltests.traits.HttpRequestTestsTrait
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestCase
 import software.amazon.smithy.protocoltests.traits.HttpResponseTestsTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.clientInstantiator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute.Companion.allow
@@ -168,12 +169,12 @@ class ProtocolTestGenerator(
         } ?: writable { }
         rustTemplate(
             """
-            let builder = #{Config}::Config::builder().with_test_defaults().endpoint_resolver("https://example.com");
+            let builder = #{config}::Config::builder().with_test_defaults().endpoint_resolver("https://example.com");
             #{customParams}
             let config = builder.build();
 
             """,
-            "Config" to RuntimeType.Config,
+            "config" to ClientRustModule.Config,
             "customParams" to customParams,
         )
         writeInline("let input =")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -705,6 +705,10 @@ class RustWriter private constructor(
                     t.fullyQualifiedName()
                 }
 
+                is RustModule -> {
+                    t.fullyQualifiedPath()
+                }
+
                 is Symbol -> {
                     addDepsRecursively(t)
                     t.rustType().render(fullyQualified = true)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -241,7 +241,6 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         val Tracing = CargoDependency.Tracing.toType()
 
         // codegen types
-        val Config = RuntimeType("crate::config")
         val ConstrainedTrait = RuntimeType("crate::constrained::Constrained", InlineDependency.constrained())
         val MaybeConstrained = RuntimeType("crate::constrained::MaybeConstrained", InlineDependency.constrained())
 

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/CrateVersionCustomization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customizations/CrateVersionCustomization.kt
@@ -5,24 +5,24 @@
 
 package software.amazon.smithy.rust.codegen.core.smithy.customizations
 
+import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
-import software.amazon.smithy.rust.codegen.core.rustlang.writable
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 
 /**
  * Add `PGK_VERSION` const in lib.rs to enable knowing the version of the current module
  */
-class CrateVersionCustomization : LibRsCustomization() {
-    override fun section(section: LibRsSection) =
-        writable {
-            if (section is LibRsSection.Body) {
-                rust(
-                    """
-                    /// Crate version number.
-                    pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
-                    """,
-                )
-            }
+object CrateVersionCustomization {
+    fun pkgVersion(module: RustModule): RuntimeType = RuntimeType(module.fullyQualifiedPath() + "::PKG_VERSION")
+
+    fun extras(rustCrate: RustCrate, module: RustModule) =
+        rustCrate.withModule(module) {
+            rust(
+                """
+                /// Crate version number.
+                pub static PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+                """,
+            )
         }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustModule.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerRustModule.kt
@@ -17,8 +17,11 @@ import software.amazon.smithy.rust.codegen.core.smithy.traits.SyntheticOutputTra
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 
 object ServerRustModule {
+    val root = RustModule.LibRs
+
     val Error = RustModule.public("error", documentation = "All error types that operations can return. Documentation on these types is copied from the model.")
     val Operation = RustModule.public("operation", documentation = "All operations that this crate can perform.")
+    val Meta = RustModule.public("meta", documentation = "Information about this crate.")
     val Model = RustModule.public("model", documentation = "Data structures used by operation inputs/outputs. Documentation on these types is copied from the model.")
     val Input = RustModule.public("input", documentation = "Input structures for operations. Documentation on these types is copied from the model.")
     val Output = RustModule.public("output", documentation = "Output structures for operations. Documentation on these types is copied from the model.")

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/customizations/ServerRequiredCustomizations.kt
@@ -30,7 +30,7 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
         codegenContext: ServerCodegenContext,
         baseCustomizations: List<LibRsCustomization>,
     ): List<LibRsCustomization> =
-        baseCustomizations + CrateVersionCustomization() + AllowLintsCustomization()
+        baseCustomizations + AllowLintsCustomization()
 
     override fun extras(codegenContext: ServerCodegenContext, rustCrate: RustCrate) {
         // Add rt-tokio feature for `ByteStream::from_path`
@@ -38,6 +38,10 @@ class ServerRequiredCustomizations : ServerCodegenDecorator {
 
         rustCrate.withModule(ServerRustModule.Types) {
             pubUseSmithyTypes(codegenContext, codegenContext.model)(this)
+        }
+
+        rustCrate.withModule(ServerRustModule.root) {
+            CrateVersionCustomization.extras(rustCrate, ServerRustModule.root)
         }
     }
 }


### PR DESCRIPTION
## Motivation and Context
This PR establishes the opt-in `enableNewCrateOrganizationScheme` `smithy-build.json` config flag to turn on the new crate organization scheme for [RFC-26](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0026_client_crate_organization.md). It then uses that flag to reorganize the `AppName` re-export as a proof of concept.

~This PR should result in no codegen diff.~ Codegen diff should only reorder things.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
