### PR TITLE
Add feature flag for the crate reorganization

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
@@ -86,6 +86,8 @@ data class ClientCodegenConfig(
     val addMessageToErrors: Boolean = defaultAddMessageToErrors,
     // TODO(EventStream): [CLEANUP] Remove this property when turning on Event Stream for all services
     val eventStreamAllowList: Set<String> = defaultEventStreamAllowList,
+    // TODO(CrateReorganization): Remove this once we commit to the breaking change
+    val enableNewCrateOrganizationScheme: Boolean = defaultEnableNewCrateOrganizationScheme,
 ) : CoreCodegenConfig(
     formatTimeoutSeconds, debugMode,
 ) {
@@ -94,6 +96,7 @@ data class ClientCodegenConfig(
         private const val defaultIncludeFluentClient = true
         private const val defaultAddMessageToErrors = true
         private val defaultEventStreamAllowList: Set<String> = emptySet()
+        private const val defaultEnableNewCrateOrganizationScheme = false
 
         fun fromCodegenConfigAndNode(coreCodegenConfig: CoreCodegenConfig, node: Optional<ObjectNode>) =
             if (node.isPresent) {
@@ -106,12 +109,14 @@ data class ClientCodegenConfig(
                     renameExceptions = node.get().getBooleanMemberOrDefault("renameErrors", defaultRenameExceptions),
                     includeFluentClient = node.get().getBooleanMemberOrDefault("includeFluentClient", defaultIncludeFluentClient),
                     addMessageToErrors = node.get().getBooleanMemberOrDefault("addMessageToErrors", defaultAddMessageToErrors),
+                    enableNewCrateOrganizationScheme = node.get().getBooleanMemberOrDefault("enableNewCrateOrganizationScheme", false),
                 )
             } else {
                 ClientCodegenConfig(
                     formatTimeoutSeconds = coreCodegenConfig.formatTimeoutSeconds,
                     debugMode = coreCodegenConfig.debugMode,
                     eventStreamAllowList = defaultEventStreamAllowList,
+                    enableNewCrateOrganizationScheme = defaultEnableNewCrateOrganizationScheme,
                 )
             }
     }


### PR DESCRIPTION
## Motivation and Context
This PR establishes the opt-in `enableNewCrateOrganizationScheme` `smithy-build.json` config flag to turn on the new crate organization scheme for [RFC-26](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0026_client_crate_organization.md).

This PR should result in no codegen diff.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
