### PR TITLE
Reorganize credentials, endpoints, region, and op customization

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -9,8 +9,9 @@ import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.traits.TitleTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
-import software.amazon.smithy.rust.codegen.client.smithy.generators.client.CustomizableOperationGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedCustomizeModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientGenerics
@@ -102,10 +103,10 @@ class AwsFluentClientDecorator : ClientCodegenDecorator {
             ),
             retryClassifier = AwsRuntimeType.awsHttp(runtimeConfig).resolve("retry::AwsResponseRetryClassifier"),
         ).render(rustCrate)
-        rustCrate.withModule(CustomizableOperationGenerator.CustomizeModule) {
+        rustCrate.withModule(codegenContext.featureGatedCustomizeModule()) {
             renderCustomizableOperationSendMethod(runtimeConfig, generics, this)
         }
-        rustCrate.withModule(FluentClientGenerator.clientModule) {
+        rustCrate.withModule(ClientRustModule.client) {
             AwsFluentClientExtensions(types).render(this)
         }
         val awsSmithyClient = "aws-smithy-client"

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/BaseRequestIdDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/BaseRequestIdDecorator.kt
@@ -7,10 +7,10 @@ package software.amazon.smithy.rustsdk
 
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.error.ErrorCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.error.ErrorSection
-import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
@@ -66,7 +66,7 @@ abstract class BaseRequestIdDecorator : ClientCodegenDecorator {
     ): List<BuilderCustomization> = baseCustomizations + listOf(RequestIdBuilderCustomization())
 
     override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
-        rustCrate.withModule(RustModule.Types) {
+        rustCrate.withModule(ClientRustModule.Types) {
             // Re-export RequestId in generated crate
             rust("pub use #T;", accessorTrait(codegenContext))
         }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialProviders.kt
@@ -8,9 +8,9 @@ package software.amazon.smithy.rustsdk
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customize.TestUtilFeature
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedConfigModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
-import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
@@ -19,8 +19,6 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 
 class CredentialsProviderDecorator : ClientCodegenDecorator {
     override val name: String = "CredentialsProvider"
@@ -33,13 +31,6 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
         return baseCustomizations + CredentialProviderConfig(codegenContext.runtimeConfig)
     }
 
-    override fun libRsCustomizations(
-        codegenContext: ClientCodegenContext,
-        baseCustomizations: List<LibRsCustomization>,
-    ): List<LibRsCustomization> {
-        return baseCustomizations + PubUseCredentials(codegenContext.runtimeConfig)
-    }
-
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
         listOf(
             adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
@@ -49,6 +40,13 @@ class CredentialsProviderDecorator : ClientCodegenDecorator {
 
     override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
         rustCrate.mergeFeature(TestUtilFeature.copy(deps = listOf("aws-credential-types/test-util")))
+
+        rustCrate.withModule(codegenContext.featureGatedConfigModule()) {
+            rust(
+                "pub use #T::Credentials;",
+                AwsRuntimeType.awsCredentialTypes(codegenContext.runtimeConfig),
+            )
+        }
     }
 }
 
@@ -89,21 +87,6 @@ class CredentialProviderConfig(runtimeConfig: RuntimeConfig) : ConfigCustomizati
                 "${section.configBuilderRef}.set_credentials_provider(Some(#{provider}::SharedCredentialsProvider::new(#{TestCredentials}::for_tests())));",
                 *codegenScope,
             )
-
-            else -> emptySection
-        }
-    }
-}
-
-class PubUseCredentials(private val runtimeConfig: RuntimeConfig) : LibRsCustomization() {
-    override fun section(section: LibRsSection): Writable {
-        return when (section) {
-            is LibRsSection.Body -> writable {
-                rust(
-                    "pub use #T::Credentials;",
-                    AwsRuntimeType.awsCredentialTypes(runtimeConfig),
-                )
-            }
 
             else -> emptySection
         }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -12,6 +12,7 @@ import software.amazon.smithy.rulesengine.language.syntax.parameters.Parameter
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedConfigModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -20,12 +21,11 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.extendIf
 import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
@@ -101,13 +101,6 @@ class RegionDecorator : ClientCodegenDecorator {
         return baseCustomizations.extendIf(usesRegion(codegenContext)) { RegionConfigPlugin() }
     }
 
-    override fun libRsCustomizations(
-        codegenContext: ClientCodegenContext,
-        baseCustomizations: List<LibRsCustomization>,
-    ): List<LibRsCustomization> {
-        return baseCustomizations.extendIf(usesRegion(codegenContext)) { PubUseRegion(codegenContext.runtimeConfig) }
-    }
-
     override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> {
         return usesRegion(codegenContext).thenSingletonListOf {
             adhocCustomization<SdkConfigSection.CopySdkConfigToClientConfig> { section ->
@@ -117,6 +110,14 @@ class RegionDecorator : ClientCodegenDecorator {
                          ${section.serviceConfigBuilder}.region(${section.sdkConfig}.region().cloned());
                     """,
                 )
+            }
+        }
+    }
+
+    override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
+        if (usesRegion(codegenContext)) {
+            rustCrate.withModule(codegenContext.featureGatedConfigModule()) {
+                rust("pub use #T::Region;", region(codegenContext.runtimeConfig))
             }
         }
     }
@@ -213,21 +214,6 @@ class RegionConfigPlugin : OperationCustomization() {
                         ${section.request}.properties_mut().insert(region.clone());
                     }
                     """,
-                )
-            }
-
-            else -> emptySection
-        }
-    }
-}
-
-class PubUseRegion(private val runtimeConfig: RuntimeConfig) : LibRsCustomization() {
-    override fun section(section: LibRsSection): Writable {
-        return when (section) {
-            is LibRsSection.Body -> writable {
-                rust(
-                    "pub use #T::Region;",
-                    region(runtimeConfig),
                 )
             }
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/endpoints/AwsEndpointDecorator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointTypesGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointsModule
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedConfigModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
@@ -27,12 +28,9 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
-import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.adhocCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
-import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsSection
 import software.amazon.smithy.rust.codegen.core.util.extendIf
 import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rust.codegen.core.util.thenSingletonListOf
@@ -91,14 +89,14 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
         }
     }
 
-    override fun libRsCustomizations(
-        codegenContext: ClientCodegenContext,
-        baseCustomizations: List<LibRsCustomization>,
-    ): List<LibRsCustomization> {
-        return baseCustomizations + PubUseEndpoint(codegenContext.runtimeConfig)
-    }
-
     override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
+        rustCrate.withModule(codegenContext.featureGatedConfigModule()) {
+            rust(
+                "pub use #T::endpoint::Endpoint;",
+                CargoDependency.smithyHttp(codegenContext.runtimeConfig).toType(),
+            )
+        }
+
         val epTypes = EndpointTypesGenerator.fromContext(codegenContext)
         if (epTypes.defaultResolver() == null) {
             throw CodegenException(
@@ -254,21 +252,6 @@ class AwsEndpointDecorator : ClientCodegenDecorator {
                 ServiceConfig.ConfigStruct -> rust("endpoint_url: Option<String>,")
                 ServiceConfig.ConfigStructAdditionalDocs -> emptySection
                 ServiceConfig.Extras -> emptySection
-            }
-        }
-    }
-
-    class PubUseEndpoint(private val runtimeConfig: RuntimeConfig) : LibRsCustomization() {
-        override fun section(section: LibRsSection): Writable {
-            return when (section) {
-                is LibRsSection.Body -> writable {
-                    rust(
-                        "pub use #T::endpoint::Endpoint;",
-                        CargoDependency.smithyHttp(runtimeConfig).toType(),
-                    )
-                }
-
-                else -> emptySection
             }
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -20,6 +20,9 @@ import software.amazon.smithy.rust.codegen.core.util.hasTrait
  * Modules for code generated client crates.
  */
 object ClientRustModule {
+    /** crate */
+    val root = RustModule.LibRs
+
     /** crate::client */
     val client = Client.self
     object Client {
@@ -56,4 +59,10 @@ object ClientModuleProvider : ModuleProvider {
 
     override fun moduleForEventStreamError(eventStream: UnionShape): RustModule.LeafModule =
         ClientRustModule.Error
+}
+
+// TODO(CrateReorganization): Remove when cleaning up `enableNewCrateOrganizationScheme`
+fun ClientCodegenContext.featureGatedConfigModule() = when (settings.codegenConfig.enableNewCrateOrganizationScheme) {
+    true -> ClientRustModule.Config
+    else -> ClientRustModule.root
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustModule.kt
@@ -66,3 +66,13 @@ fun ClientCodegenContext.featureGatedConfigModule() = when (settings.codegenConf
     true -> ClientRustModule.Config
     else -> ClientRustModule.root
 }
+
+// TODO(CrateReorganization): Remove when cleaning up `enableNewCrateOrganizationScheme`
+fun ClientCodegenContext.featureGatedCustomizeModule() = when (settings.codegenConfig.enableNewCrateOrganizationScheme) {
+    true -> ClientRustModule.Client.customize
+    else -> RustModule.public(
+        "customize",
+        "Operation customization and supporting types",
+        parent = ClientRustModule.Operation,
+    )
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
@@ -6,6 +6,7 @@
 package software.amazon.smithy.rust.codegen.client.smithy.generators
 
 import software.amazon.smithy.model.shapes.StringShape
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -86,7 +87,7 @@ data class InfallibleEnumType(
     }
 
     private fun unknownVariantValue(context: EnumGeneratorContext): RuntimeType {
-        return RuntimeType.forInlineFun(UnknownVariantValue, RustModule.Types) {
+        return RuntimeType.forInlineFun(UnknownVariantValue, ClientRustModule.Types) {
             docs(
                 """
                 Opaque struct used as inner data for the `Unknown` variant defined in enums in
@@ -167,4 +168,4 @@ data class InfallibleEnumType(
 }
 
 class ClientEnumGenerator(codegenContext: CodegenContext, shape: StringShape) :
-    EnumGenerator(codegenContext.model, codegenContext.symbolProvider, shape, InfallibleEnumType(RustModule.Types))
+    EnumGenerator(codegenContext.model, codegenContext.symbolProvider, shape, InfallibleEnumType(ClientRustModule.Types))

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -5,14 +5,13 @@
 
 package software.amazon.smithy.rust.codegen.client.smithy.generators.client
 
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedCustomizeModule
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.GenericTypeArg
 import software.amazon.smithy.rust.codegen.core.rustlang.RustGenerics
-import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 
@@ -21,20 +20,16 @@ import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
  * fluent client builders.
  */
 class CustomizableOperationGenerator(
-    private val runtimeConfig: RuntimeConfig,
+    private val codegenContext: ClientCodegenContext,
     private val generics: FluentClientGenerics,
-    private val includeFluentClient: Boolean,
 ) {
-
-    companion object {
-        val CustomizeModule = RustModule.public("customize", "Operation customization and supporting types", parent = RustModule.operation(Visibility.PUBLIC))
-    }
-
+    private val includeFluentClient = codegenContext.settings.codegenConfig.includeFluentClient
+    private val runtimeConfig = codegenContext.runtimeConfig
     private val smithyHttp = CargoDependency.smithyHttp(runtimeConfig).toType()
     private val smithyTypes = CargoDependency.smithyTypes(runtimeConfig).toType()
 
     fun render(crate: RustCrate) {
-        crate.withModule(CustomizeModule) {
+        crate.withModule(codegenContext.featureGatedCustomizeModule()) {
             rustTemplate(
                 """
                 pub use #{Operation};
@@ -67,6 +62,7 @@ class CustomizableOperationGenerator(
             "handle_generics_bounds" to handleGenerics.bounds(),
             "operation_generics_decl" to operationGenerics.declaration(),
             "combined_generics_decl" to combinedGenerics.declaration(),
+            "customize_module" to codegenContext.featureGatedCustomizeModule(),
         )
 
         writer.rustTemplate(
@@ -81,7 +77,7 @@ class CustomizableOperationGenerator(
 
             /// A wrapper type for [`Operation`](aws_smithy_http::operation::Operation)s that allows for
             /// customization of the operation before it is sent. A `CustomizableOperation` may be sent
-            /// by calling its [`.send()`][crate::operation::customize::CustomizableOperation::send] method.
+            /// by calling its [`.send()`][#{customize_module}::CustomizableOperation::send] method.
             ##[derive(Debug)]
             pub struct CustomizableOperation#{combined_generics_decl:W} {
                 pub(crate) handle: Arc<Handle#{handle_generics_decl:W}>,

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustModule.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustModule.kt
@@ -99,12 +99,6 @@ sealed class RustModule {
             parent = parent,
         ).cfgTest()
 
-        // TODO(https://github.com/awslabs/smithy-rs/pull/2129): Remove once #2129 merges
-        val Error = public("error", documentation = "All error types that operations can return. Documentation on these types is copied from the model.")
-
-        // TODO(https://github.com/awslabs/smithy-rs/pull/2334): Remove once #2334 merges
-        val Types = public("types", documentation = "Data primitives referenced by other data types.")
-
         /**
          * Helper method to generate the `operation` Rust module.
          * Its visibility depends on the generation context (client or server).

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -705,6 +705,10 @@ class RustWriter private constructor(
                     t.fullyQualifiedName()
                 }
 
+                is RustModule -> {
+                    t.fullyQualifiedPath()
+                }
+
                 is Symbol -> {
                     addDepsRecursively(t)
                     t.rustType().render(fullyQualified = true)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/EventStreamSymbolProvider.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/EventStreamSymbolProvider.kt
@@ -10,9 +10,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.Shape
-import software.amazon.smithy.model.shapes.UnionShape
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
-import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.render
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
@@ -23,11 +21,6 @@ import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.isEventStream
 import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
 import software.amazon.smithy.rust.codegen.core.util.isOutputEventStream
-
-fun UnionShape.eventStreamErrorSymbol(symbolProvider: RustSymbolProvider): RuntimeType {
-    val unionSymbol = symbolProvider.toSymbol(this)
-    return RustModule.Error.toType().resolve("${unionSymbol.name}Error")
-}
 
 /**
  * Wrapping symbol provider to wrap modeled types with the aws-smithy-http Event Stream send/receive types.


### PR DESCRIPTION
## Motivation and Context
This PR reorganizes credentials, endpoints, regions, and operation customizations based on the `enableNewCrateOrganizationScheme` feature flag as part of the new crate organization scheme for [RFC-26](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0026_client_crate_organization.md).

The codegen diff should only reorder things, but otherwise be completely backwards compatible.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
