### PR TITLE
Reorganize the types/models/primitives modules

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/BaseRequestIdDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/BaseRequestIdDecorator.kt
@@ -66,7 +66,12 @@ abstract class BaseRequestIdDecorator : ClientCodegenDecorator {
     ): List<BuilderCustomization> = baseCustomizations + listOf(RequestIdBuilderCustomization())
 
     override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
-        rustCrate.withModule(ClientRustModule.Types) {
+        rustCrate.withModule(
+            when (codegenContext.settings.codegenConfig.enableNewCrateOrganizationScheme) {
+                true -> ClientRustModule.Operation
+                else -> ClientRustModule.types
+            },
+        ) {
             // Re-export RequestId in generated crate
             rust("pub use #T;", accessorTrait(codegenContext))
         }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/HttpConnectorConfigCustomizationTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/HttpConnectorConfigCustomizationTest.kt
@@ -7,30 +7,13 @@ package software.amazon.smithy.rustsdk
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.testutil.validateConfigCustomizations
-import software.amazon.smithy.rust.codegen.core.smithy.CoreRustSettings
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
-import software.amazon.smithy.rust.codegen.core.testutil.rustSettings
 
 class HttpConnectorConfigCustomizationTest {
     @Test
     fun `generates a valid config`() {
         val project = TestWorkspace.testProject()
-        val projectSettings = project.rustSettings()
-        val codegenContext = awsTestCodegenContext(
-            coreRustSettings = CoreRustSettings(
-                service = projectSettings.service,
-                moduleName = projectSettings.moduleName,
-                moduleVersion = projectSettings.moduleVersion,
-                moduleAuthors = projectSettings.moduleAuthors,
-                moduleDescription = projectSettings.moduleDescription,
-                moduleRepository = projectSettings.moduleRepository,
-                runtimeConfig = AwsTestRuntimeConfig,
-                codegenConfig = projectSettings.codegenConfig,
-                license = projectSettings.license,
-                examplesUri = projectSettings.examplesUri,
-                customizationConfig = projectSettings.customizationConfig,
-            ),
-        )
+        val codegenContext = awsTestCodegenContext()
         validateConfigCustomizations(HttpConnectorConfigCustomization(codegenContext), project)
     }
 }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/RegionProviderConfigTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/RegionProviderConfigTest.kt
@@ -6,8 +6,8 @@
 package software.amazon.smithy.rustsdk
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.client.testutil.testClientRustSettings
 import software.amazon.smithy.rust.codegen.client.testutil.validateConfigCustomizations
-import software.amazon.smithy.rust.codegen.core.smithy.CoreRustSettings
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.rustSettings
 
@@ -15,21 +15,12 @@ internal class RegionProviderConfigTest {
     @Test
     fun `generates a valid config`() {
         val project = TestWorkspace.testProject()
-        val projectSettings = project.rustSettings()
-        val coreRustSettings = CoreRustSettings(
-            service = projectSettings.service,
-            moduleName = projectSettings.moduleName,
-            moduleVersion = projectSettings.moduleVersion,
-            moduleAuthors = projectSettings.moduleAuthors,
-            moduleDescription = projectSettings.moduleDescription,
-            moduleRepository = projectSettings.moduleRepository,
-            runtimeConfig = AwsTestRuntimeConfig,
-            codegenConfig = projectSettings.codegenConfig,
-            license = projectSettings.license,
-            examplesUri = projectSettings.examplesUri,
-            customizationConfig = projectSettings.customizationConfig,
+        val codegenContext = awsTestCodegenContext(
+            settings = testClientRustSettings(
+                moduleName = project.rustSettings().moduleName,
+                runtimeConfig = AwsTestRuntimeConfig,
+            ),
         )
-        val codegenContext = awsTestCodegenContext(coreRustSettings = coreRustSettings)
         validateConfigCustomizations(RegionProviderConfig(codegenContext), project)
     }
 }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TestUtil.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/TestUtil.kt
@@ -8,15 +8,15 @@ package software.amazon.smithy.rustsdk
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.node.ObjectNode
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustSettings
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
-import software.amazon.smithy.rust.codegen.core.smithy.CoreRustSettings
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientRustSettings
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeCrateLocation
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
-import software.amazon.smithy.rust.codegen.core.testutil.testRustSettings
 import java.io.File
 
 // In aws-sdk-codegen, the working dir when gradle runs tests is actually `./aws`. So, to find the smithy runtime, we need
@@ -29,10 +29,10 @@ val AwsTestRuntimeConfig = TestRuntimeConfig.copy(
     },
 )
 
-fun awsTestCodegenContext(model: Model? = null, coreRustSettings: CoreRustSettings?) =
-    testCodegenContext(
+fun awsTestCodegenContext(model: Model? = null, settings: ClientRustSettings? = null) =
+    testClientCodegenContext(
         model ?: "namespace test".asSmithyModel(),
-        settings = coreRustSettings ?: testRustSettings(runtimeConfig = AwsTestRuntimeConfig),
+        settings = settings ?: testClientRustSettings(runtimeConfig = AwsTestRuntimeConfig),
     )
 
 fun awsSdkIntegrationTest(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpVers
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdempotencyTokenGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyReExportCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedPrimitivesModule
 import software.amazon.smithy.rust.codegen.client.smithy.featureGatedMetaModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.core.rustlang.Feature
@@ -68,7 +69,7 @@ class RequiredCustomizations : ClientCodegenDecorator {
         // Re-export resiliency types
         ResiliencyReExportCustomization(codegenContext.runtimeConfig).extras(rustCrate)
 
-        rustCrate.withModule(ClientRustModule.Types) {
+        rustCrate.withModule(codegenContext.featureGatedPrimitivesModule()) {
             pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)
             if (!codegenContext.settings.codegenConfig.enableNewCrateOrganizationScheme) {
                 pubUseSmithyErrorTypes(codegenContext)(this)

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -14,8 +14,8 @@ import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpVers
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdempotencyTokenGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyReExportCustomization
-import software.amazon.smithy.rust.codegen.client.smithy.featureGatedPrimitivesModule
 import software.amazon.smithy.rust.codegen.client.smithy.featureGatedMetaModule
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedPrimitivesModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.core.rustlang.Feature
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGenerator.kt
@@ -6,7 +6,8 @@
 package software.amazon.smithy.rust.codegen.client.smithy.generators
 
 import software.amazon.smithy.model.shapes.StringShape
-import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.featureGatedPrimitivesModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustModule
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
@@ -15,7 +16,6 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
-import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.generators.EnumGeneratorContext
@@ -87,7 +87,7 @@ data class InfallibleEnumType(
     }
 
     private fun unknownVariantValue(context: EnumGeneratorContext): RuntimeType {
-        return RuntimeType.forInlineFun(UnknownVariantValue, ClientRustModule.Types) {
+        return RuntimeType.forInlineFun(UnknownVariantValue, unknownVariantModule) {
             docs(
                 """
                 Opaque struct used as inner data for the `Unknown` variant defined in enums in
@@ -167,5 +167,10 @@ data class InfallibleEnumType(
     }
 }
 
-class ClientEnumGenerator(codegenContext: CodegenContext, shape: StringShape) :
-    EnumGenerator(codegenContext.model, codegenContext.symbolProvider, shape, InfallibleEnumType(ClientRustModule.Types))
+class ClientEnumGenerator(codegenContext: ClientCodegenContext, shape: StringShape) :
+    EnumGenerator(
+        codegenContext.model,
+        codegenContext.symbolProvider,
+        shape,
+        InfallibleEnumType(codegenContext.featureGatedPrimitivesModule()),
+    )

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/customizations/ResiliencyConfigCustomizationTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/customizations/ResiliencyConfigCustomizationTest.kt
@@ -6,16 +6,17 @@
 package software.amazon.smithy.rust.codegen.client.customizations
 
 import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenConfig
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyReExportCustomization
+import software.amazon.smithy.rust.codegen.client.testutil.clientRustSettings
 import software.amazon.smithy.rust.codegen.client.testutil.stubConfigProject
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.OperationNormalizer
 import software.amazon.smithy.rust.codegen.core.smithy.transformers.RecursiveShapeBoxer
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
-import software.amazon.smithy.rust.codegen.core.testutil.rustSettings
 
 internal class ResiliencyConfigCustomizationTest {
     private val baseModel = """
@@ -37,8 +38,8 @@ internal class ResiliencyConfigCustomizationTest {
     @Test
     fun `generates a valid config`() {
         val model = RecursiveShapeBoxer().transform(OperationNormalizer.transform(baseModel))
-        val project = TestWorkspace.testProject()
-        val codegenContext = testCodegenContext(model, settings = project.rustSettings())
+        val project = TestWorkspace.testProject(model, ClientCodegenConfig())
+        val codegenContext = testClientCodegenContext(model, settings = project.clientRustSettings())
 
         stubConfigProject(ResiliencyConfigCustomization(codegenContext), project)
         ResiliencyReExportCustomization(codegenContext.runtimeConfig).extras(project)

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/ClientContextConfigCustomizationTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/ClientContextConfigCustomizationTest.kt
@@ -7,7 +7,7 @@ package software.amazon.smithy.rust.codegen.client.endpoint
 
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.ClientContextConfigCustomization
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.testutil.validateConfigCustomizations
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
@@ -52,6 +52,6 @@ class ClientContextConfigCustomizationTest {
                 """,
             )
         }
-        validateConfigCustomizations(ClientContextConfigCustomization(testCodegenContext(model)), project)
+        validateConfigCustomizations(ClientContextConfigCustomization(testClientCodegenContext(model)), project)
     }
 }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointResolverGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/endpoint/EndpointResolverGeneratorTest.kt
@@ -23,7 +23,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.End
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.generators.EndpointTestGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.SmithyEndpointsStdLib
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rulesgen.awsStandardLib
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.testutil.TestRuntimeConfig
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
@@ -64,7 +64,7 @@ class EndpointResolverGeneratorTest {
                 paramsType = EndpointParamsGenerator(suite.ruleSet().parameters).paramsStruct(),
                 resolverType = ruleset,
                 suite.ruleSet().parameters,
-                codegenContext = testCodegenContext(model = Model.builder().build()),
+                codegenContext = testClientCodegenContext(model = Model.builder().build()),
                 endpointCustomizations = listOf(),
             )
             testGenerator.generate()(this)
@@ -90,7 +90,7 @@ class EndpointResolverGeneratorTest {
                 paramsType = EndpointParamsGenerator(suite.ruleSet().parameters).paramsStruct(),
                 resolverType = ruleset,
                 suite.ruleSet().parameters,
-                codegenContext = testCodegenContext(Model.builder().build()),
+                codegenContext = testClientCodegenContext(Model.builder().build()),
                 endpointCustomizations = listOf(),
             )
             testGenerator.generate()(this)

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/EventStreamSymbolProviderTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/EventStreamSymbolProviderTest.kt
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.MemberShape
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.rust.codegen.client.testutil.ClientTestRustSymbolProviderConfig
-import software.amazon.smithy.rust.codegen.client.testutil.clientTestRustSettings
+import software.amazon.smithy.rust.codegen.client.testutil.TestClientRustSymbolProviderConfig
+import software.amazon.smithy.rust.codegen.client.testutil.testClientRustSettings
 import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.smithy.CodegenTarget
 import software.amazon.smithy.rust.codegen.core.smithy.EventStreamSymbolProvider
@@ -49,7 +49,7 @@ class EventStreamSymbolProviderTest {
         val service = model.expectShape(ShapeId.from("test#TestService")) as ServiceShape
         val provider = EventStreamSymbolProvider(
             TestRuntimeConfig,
-            SymbolVisitor(clientTestRustSettings(), model, service, ClientTestRustSymbolProviderConfig),
+            SymbolVisitor(testClientRustSettings(), model, service, TestClientRustSymbolProviderConfig),
             CodegenTarget.CLIENT,
         )
 
@@ -89,7 +89,7 @@ class EventStreamSymbolProviderTest {
         val service = model.expectShape(ShapeId.from("test#TestService")) as ServiceShape
         val provider = EventStreamSymbolProvider(
             TestRuntimeConfig,
-            SymbolVisitor(clientTestRustSettings(), model, service, ClientTestRustSymbolProviderConfig),
+            SymbolVisitor(testClientRustSettings(), model, service, TestClientRustSymbolProviderConfig),
             CodegenTarget.CLIENT,
         )
 

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientEnumGeneratorTest.kt
@@ -8,7 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy.generators
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.StringShape
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
@@ -21,7 +21,7 @@ class ClientEnumGeneratorTest {
     fun `matching on enum should be forward-compatible`() {
         fun expectMatchExpressionCompiles(model: Model, shapeId: String, enumToMatchOn: String) {
             val shape = model.lookup<StringShape>(shapeId)
-            val context = testCodegenContext(model)
+            val context = testClientCodegenContext(model)
             val project = TestWorkspace.testProject(context.symbolProvider)
             project.moduleFor(shape) {
                 ClientEnumGenerator(context, shape).render(this)
@@ -78,7 +78,7 @@ class ClientEnumGeneratorTest {
         """.asSmithyModel()
 
         val shape = model.lookup<StringShape>("test#SomeEnum")
-        val context = testCodegenContext(model)
+        val context = testClientCodegenContext(model)
         val project = TestWorkspace.testProject(context.symbolProvider)
         project.moduleFor(shape) {
             ClientEnumGenerator(context, shape).render(this)
@@ -110,7 +110,7 @@ class ClientEnumGeneratorTest {
         """.asSmithyModel()
 
         val shape = model.lookup<StringShape>("test#SomeEnum")
-        val context = testCodegenContext(model)
+        val context = testClientCodegenContext(model)
         val project = TestWorkspace.testProject(context.symbolProvider)
         project.moduleFor(shape) {
             ClientEnumGenerator(context, shape).render(this)
@@ -138,7 +138,7 @@ class ClientEnumGeneratorTest {
         """.asSmithyModel()
 
         val shape = model.lookup<StringShape>("test#InstanceType")
-        val context = testCodegenContext(model)
+        val context = testClientCodegenContext(model)
         val project = TestWorkspace.testProject(context.symbolProvider)
         project.moduleFor(shape) {
             rust("##![allow(deprecated)]")

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientInstantiatorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ClientInstantiatorTest.kt
@@ -8,7 +8,7 @@ package software.amazon.smithy.rust.codegen.client.smithy.generators
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.node.Node
 import software.amazon.smithy.model.shapes.StringShape
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
@@ -41,7 +41,7 @@ internal class ClientInstantiatorTest {
         string NamedEnum
     """.asSmithyModel()
 
-    private val codegenContext = testCodegenContext(model)
+    private val codegenContext = testClientCodegenContext(model)
     private val symbolProvider = codegenContext.symbolProvider
 
     @Test

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/http/RequestBindingGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/http/RequestBindingGeneratorTest.kt
@@ -12,7 +12,7 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.HttpTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
@@ -130,7 +130,7 @@ class RequestBindingGeneratorTest {
     private fun renderOperation(rustCrate: RustCrate) {
         inputShape.renderWithModelBuilder(model, symbolProvider, rustCrate)
         rustCrate.withModule(ClientRustModule.Input) {
-            val codegenContext = testCodegenContext(model)
+            val codegenContext = testClientCodegenContext(model)
             val bindingGen = RequestBindingGenerator(
                 codegenContext,
                 // Any protocol is fine for this test.

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/http/ResponseBindingGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/http/ResponseBindingGeneratorTest.kt
@@ -9,10 +9,9 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
-import software.amazon.smithy.rust.codegen.client.testutil.testCodegenContext
+import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
-import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpTraitHttpBindingResolver
@@ -67,7 +66,7 @@ class ResponseBindingGeneratorTest {
     """.asSmithyModel()
     private val model = OperationNormalizer.transform(baseModel)
     private val operationShape = model.expectShape(ShapeId.from("smithy.example#PutObject"), OperationShape::class.java)
-    private val codegenContext: CodegenContext = testCodegenContext(model)
+    private val codegenContext = testClientCodegenContext(model)
     private val symbolProvider = codegenContext.symbolProvider
 
     private fun RustCrate.renderOperation() {

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamBaseRequirements.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamBaseRequirements.kt
@@ -18,7 +18,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.CombinedClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.error.ErrorGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.error.OperationErrorGenerator
-import software.amazon.smithy.rust.codegen.client.testutil.clientTestRustSettings
+import software.amazon.smithy.rust.codegen.client.testutil.testClientRustSettings
 import software.amazon.smithy.rust.codegen.client.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.implBlock
@@ -47,7 +47,7 @@ abstract class ClientEventStreamBaseRequirements : EventStreamTestRequirements<C
         testSymbolProvider(model),
         serviceShape,
         protocolShapeId,
-        clientTestRustSettings(),
+        testClientRustSettings(),
         CombinedClientCodegenDecorator(emptyList()),
     )
 

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperationsTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/transformers/RemoveEventStreamOperationsTest.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.Shape
 import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenConfig
-import software.amazon.smithy.rust.codegen.client.testutil.clientTestRustSettings
+import software.amazon.smithy.rust.codegen.client.testutil.testClientRustSettings
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import java.util.Optional
 
@@ -49,7 +49,7 @@ internal class RemoveEventStreamOperationsTest {
     fun `remove event stream ops from services that are not in the allow list`() {
         val transformed = RemoveEventStreamOperations.transform(
             model,
-            clientTestRustSettings(
+            testClientRustSettings(
                 codegenConfig = ClientCodegenConfig(eventStreamAllowList = setOf("not-test-module")),
             ),
         )
@@ -61,7 +61,7 @@ internal class RemoveEventStreamOperationsTest {
     fun `keep event stream ops from services that are in the allow list`() {
         val transformed = RemoveEventStreamOperations.transform(
             model,
-            clientTestRustSettings(
+            testClientRustSettings(
                 codegenConfig = ClientCodegenConfig(eventStreamAllowList = setOf("test-module")),
             ),
         )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/testutil/Rust.kt
@@ -111,18 +111,20 @@ object TestWorkspace {
         }
     }
 
-    fun testProject(debugMode: Boolean = false): TestWriterDelegator =
-        testProject(ModelAssembler().assemble().unwrap(), debugMode)
+    fun testProject(
+        model: Model = ModelAssembler().assemble().unwrap(),
+        codegenConfig: CoreCodegenConfig = CoreCodegenConfig(),
+    ): TestWriterDelegator = testProject(testSymbolProvider(model), codegenConfig)
 
-    fun testProject(model: Model, debugMode: Boolean = false): TestWriterDelegator =
-        testProject(testSymbolProvider(model), debugMode)
-
-    fun testProject(symbolProvider: RustSymbolProvider, debugMode: Boolean = false): TestWriterDelegator {
+    fun testProject(
+        symbolProvider: RustSymbolProvider,
+        codegenConfig: CoreCodegenConfig = CoreCodegenConfig(),
+    ): TestWriterDelegator {
         val subprojectDir = subproject()
         return TestWriterDelegator(
             FileManifest.create(subprojectDir.toPath()),
             symbolProvider,
-            CoreCodegenConfig(debugMode = debugMode),
+            codegenConfig,
         ).apply {
             lib {
                 // If the test fails before the crate is finalized, we'll end up with a broken crate.

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedMapGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedMapGeneratorTest.kt
@@ -8,6 +8,7 @@ package software.amazon.smithy.rust.codegen.server.smithy.generators
 import org.junit.jupiter.api.Test
 import software.amazon.smithy.model.shapes.MapShape
 import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.smithy.CoreCodegenConfig
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
@@ -52,7 +53,7 @@ class UnconstrainedMapGeneratorTest {
         val mapA = model.lookup<MapShape>("test#MapA")
         val mapB = model.lookup<MapShape>("test#MapB")
 
-        val project = TestWorkspace.testProject(symbolProvider, debugMode = true)
+        val project = TestWorkspace.testProject(symbolProvider, CoreCodegenConfig(debugMode = true))
 
         project.withModule(Model) {
             model.lookup<StructureShape>("test#StructureC").serverRenderWithModelBuilder(project, model, symbolProvider, this)


### PR DESCRIPTION
## Motivation and Context
This PR reorganizes the types/modules/primitives modules to match [RFC-26](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0026_client_crate_organization.md) behind the feature flag.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
