### PR TITLE
Address clippy warnings in pokemon-service

### DIFF
--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs
@@ -226,8 +226,8 @@ pub async fn capture_pokemon(
                     Some(event) => {
                         let capturing_event = event.as_event();
                         if let Ok(attempt) = capturing_event {
-                            let payload = attempt.payload.clone().unwrap_or(CapturingPayload::builder().build());
-                            let pokeball = payload.pokeball.as_ref().map(|ball| ball.as_str()).unwrap_or("");
+                            let payload = attempt.payload.clone().unwrap_or_else(|| CapturingPayload::builder().build());
+                            let pokeball = payload.pokeball.as_deref().unwrap_or("");
                             if ! matches!(pokeball, "Master Ball" | "Great Ball" | "Fast Ball") {
                                 yield Err(
                                     crate::error::CapturePokemonEventsError::InvalidPokeballError(
@@ -250,8 +250,7 @@ pub async fn capture_pokemon(
                                     let shiny = rand::thread_rng().gen_range(0..4096) == 0;
                                     let pokemon = payload
                                         .name
-                                        .as_ref()
-                                        .map(|name| name.as_str())
+                                        .as_deref()
                                         .unwrap_or("")
                                         .to_string();
                                     let pokedex: Vec<u8> = (0..255).collect();


### PR DESCRIPTION
## Motivation and Context
This PR will fix the clippy warnings that appeared in [CI for a recent PR](https://github.com/awslabs/smithy-rs/actions/runs/4235675704/jobs/7359616902). The warnings originated in `smithy-rs/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/lib.rs`.

## Description
The clippy warnings in question include `clippy::or_fun_call` and `clippy::option_as_ref_deref`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
