### PR TITLE
Remove InvalidUri from external-types.toml

### DIFF
--- a/aws/rust-runtime/aws-config/external-types.toml
+++ b/aws/rust-runtime/aws-config/external-types.toml
@@ -29,9 +29,6 @@ allowed_external_types = [
    "http::uri::Uri",
    "tower_service::Service",
 
-   # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Decide if `InvalidUri` should be exposed
-   "http::uri::InvalidUri",
-
    # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Decide if the following should be exposed
    "hyper::client::connect::Connection",
    "tokio::io::async_read::AsyncRead",

--- a/rust-runtime/aws-smithy-http/external-types.toml
+++ b/rust-runtime/aws-smithy-http/external-types.toml
@@ -26,9 +26,6 @@ allowed_external_types = [
     # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Feature gate references to Tokio `File`
     "tokio::fs::file::File",
 
-    # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Decide if `InvalidUri` should be exposed
-    "http::uri::InvalidUri",
-
     # TODO(https://github.com/awslabs/smithy-rs/issues/1193): Don't expose `once_cell` in public API
     "once_cell::sync::Lazy",
 


### PR DESCRIPTION
## Motivation and Context
`InvalidUri` does not seem be exposed in public API anymore, updating `external-types.toml` for `aws-config` and `aws-smithy-http` accordingly.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
