### PR TITLE
Split the `types` and `builders` modules into per-shape private modules

### DIFF
--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamBaseRequirements.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/eventstream/ClientEventStreamBaseRequirements.kt
@@ -81,13 +81,18 @@ abstract class ClientEventStreamBaseRequirements : EventStreamTestRequirements<C
         shape: StructureShape,
     ) {
         val errorTrait = shape.expectTrait<ErrorTrait>()
-        ErrorGenerator(
-            rustCrate,
+        val errorGenerator = ErrorGenerator(
             codegenContext.model,
             codegenContext.symbolProvider,
             shape,
             errorTrait,
             emptyList(),
-        ).render()
+        )
+        rustCrate.useShapeWriter(shape) {
+            errorGenerator.renderStruct(this)
+        }
+        rustCrate.withModule(codegenContext.symbolProvider.moduleForBuilder(shape)) {
+            errorGenerator.renderBuilder(this)
+        }
     }
 }


### PR DESCRIPTION
## Motivation and Context
This PR, behind the `enableNewCrateOrganizationScheme` feature flag, splits up the `types` and `builders` modules so that there is one private module per structure/enum/union shape, with the generated types being re-exported into the correct module. This significantly reduces file sizes which should improve IDE support (see aws-sdk-rust#716).

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
