### PR TITLE
Fix Inaccurate documentation on ProfileFileCredentialsProvider

### DIFF
--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -61,9 +61,8 @@ impl ProvideCredentials for ProfileFileCredentialsProvider {
 /// let provider = ProfileFileCredentialsProvider::builder().build();
 /// ```
 ///
-/// _Note: Profile providers to not implement any caching. They will reload and reparse the profile
-/// from the file system when called. See [CredentialsCache](aws_credential_types::cache::CredentialsCache) for
-/// more information about caching._
+/// _Note: Profile providers, when called, will load and parse the profile from the file system
+/// only once. Parsed file contents will be cached indefinitely._
 ///
 /// This provider supports several different credentials formats:
 /// ### Credentials defined explicitly within the file


### PR DESCRIPTION
## Motivation and Context
Fixes https://github.com/awslabs/aws-sdk-rust/issues/746.

## Description
The doc previously described that `ProfileFileCredentialsProvider` would reload and reparse the profile from the file system every time it was called. The current behavior is loading & parsing happen only for the first the provider is called and the parsed file contents will be [cached indefinitely](https://github.com/awslabs/smithy-rs/blob/main/aws/rust-runtime/aws-config/src/provider_config.rs#L46).

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
