### PR TITLE
Move using-native-tls-instead-of-rustls to smithy-rs

### DIFF
--- a/aws/sdk/integration-tests/Cargo.toml
+++ b/aws/sdk/integration-tests/Cargo.toml
@@ -15,4 +15,5 @@ members = [
     "s3control",
     "sts",
     "transcribestreaming",
+    "using-native-tls-instead-of-rustls",
 ]

--- a/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/Cargo.toml
+++ b/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/Cargo.toml
@@ -17,8 +17,4 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config", default-features = f
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", default-features = false, features = [
   "native-tls",
 ] }
-# aws-sdk-sts is the same as aws-sdk-s3
-aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts", default-features = false, features = [
-  "native-tls",
-] }
-tokio = { version = "1.20.1", features = ["full"] }
+tokio = { version = "1.20.1", features = ["rt", "macros"] }

--- a/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/Cargo.toml
+++ b/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "using-native-tls-instead-of-rustls"
+version = "0.1.0"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+# aws-config pulls in rustls and several other things by default. We have to disable defaults in order to use native-tls
+# and then manually bring the other defaults back
+aws-config = { path = "../../build/aws-sdk/sdk/aws-config", default-features = false, features = [
+  "native-tls",
+  "rt-tokio",
+] }
+# aws-sdk-s3 brings in rustls by default so we disable that in order to use native-tls only
+aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", default-features = false, features = [
+  "native-tls",
+] }
+# aws-sdk-sts is the same as aws-sdk-s3
+aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts", default-features = false, features = [
+  "native-tls",
+] }
+tokio = { version = "1.20.1", features = ["full"] }

--- a/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
+++ b/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
@@ -1,6 +1,6 @@
 /*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * SPDX-License-Identifier: Apache-2.0.
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /// The SDK defaults to using RusTLS by default but you can also use [`native_tls`](https://github.com/sfackler/rust-native-tls)

--- a/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
+++ b/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
@@ -11,11 +11,7 @@ async fn list_buckets() -> Result<(), aws_sdk_s3::Error> {
     let sdk_config = aws_config::load_from_env().await;
     let client = aws_sdk_s3::Client::new(&sdk_config);
 
-    let resp = client.list_buckets().send().await?;
-
-    for bucket in resp.buckets().unwrap_or_default() {
-        println!("bucket: {:?}", bucket.name().unwrap_or_default())
-    }
+    let _resp = client.list_buckets().send().await?;
 
     Ok(())
 }

--- a/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
+++ b/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
+ */
+
+/// The SDK defaults to using RusTLS by default but you can also use [`native_tls`](https://github.com/sfackler/rust-native-tls)
+/// which will choose a TLS implementation appropriate for your platform. This test looks much like
+/// any other. Activating and deactivating `features` in your app's `Cargo.toml` is all that's needed.
+
+async fn list_buckets() -> Result<(), aws_sdk_s3::Error> {
+    let shared_config = aws_config::load_from_env().await;
+
+    let s3_config = aws_sdk_s3::Config::from(&shared_config);
+    let client = aws_sdk_s3::Client::from_conf(s3_config);
+
+    let resp = client.list_buckets().send().await?;
+
+    for bucket in resp.buckets().unwrap_or_default() {
+        println!("bucket: {:?}", bucket.name().unwrap_or_default())
+    }
+
+    Ok(())
+}
+
+/// You can run this test to ensure that it is only using `native-tls` and
+/// that nothing is pulling in `rustls` as a dependency
+#[test]
+#[should_panic = "error: package ID specification `rustls` did not match any packages"]
+fn test_rustls_is_not_in_dependency_tree() {
+    let cargo_location = std::env::var("CARGO").unwrap();
+    let cargo_command = std::process::Command::new(&cargo_location)
+        .arg("tree")
+        .arg("--invert")
+        .arg("rustls")
+        .output()
+        .expect("failed to run 'cargo tree'");
+
+    let stderr = String::from_utf8_lossy(&cargo_command.stderr);
+
+    // We expect the call to `cargo tree` to error out. If it did, we panic with the resulting
+    // message here. In the case that no error message is set, that's bad.
+    if !stderr.is_empty() {
+        panic!("{}", stderr);
+    }
+
+    // Uh oh. We expected an error message but got none, likely because `cargo tree` found
+    // `rustls` in our dependencies. We'll print out the message we got to see what went wrong.
+    let stdout = String::from_utf8_lossy(&cargo_command.stdout);
+
+    println!("{}", stdout)
+}
+
+// NOTE: not currently run in CI, separate PR will set up a with-creds CI runner
+#[tokio::test]
+#[ignore]
+async fn needs_creds_native_tls_works() {
+    list_buckets().await.expect("should succeed")
+}

--- a/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
+++ b/aws/sdk/integration-tests/using-native-tls-instead-of-rustls/tests/no-rustls-in-dependency.rs
@@ -8,10 +8,8 @@
 /// any other. Activating and deactivating `features` in your app's `Cargo.toml` is all that's needed.
 
 async fn list_buckets() -> Result<(), aws_sdk_s3::Error> {
-    let shared_config = aws_config::load_from_env().await;
-
-    let s3_config = aws_sdk_s3::Config::from(&shared_config);
-    let client = aws_sdk_s3::Client::from_conf(s3_config);
+    let sdk_config = aws_config::load_from_env().await;
+    let client = aws_sdk_s3::Client::new(&sdk_config);
 
     let resp = client.list_buckets().send().await?;
 


### PR DESCRIPTION
## Motivation and Context
Moves a `native-tls/rustls`-related test, `using-native-tls-instead-of-rustls` from `aws-doc-sdk-examples` to `smithy-rs`.

## Description
The test was previously in `aws-doc-sdk-examples` but it can be more useful to be in `smithy-rs` so it can catch a test failure early prior to cutting a release.

(`using-native-tls-instead-of-rustls` has been deleted from `aws-doc-sdk-examples` as part of [this PR](https://github.com/awsdocs/aws-doc-sdk-examples/pull/4469))

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
