### PR TITLE
Add hook for CodegenDecorators to insert a custom symbol provider

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientCodegenVisitor.kt
@@ -98,7 +98,7 @@ class ClientCodegenVisitor(
         model = codegenDecorator.transformModel(untransformedService, baseModel)
         // the model transformer _might_ change the service shape
         val service = settings.getService(model)
-        symbolProvider = RustClientCodegenPlugin.baseSymbolProvider(settings, model, service, rustSymbolProviderConfig)
+        symbolProvider = RustClientCodegenPlugin.baseSymbolProvider(settings, model, service, rustSymbolProviderConfig, codegenDecorator)
 
         codegenContext = ClientCodegenContext(model, symbolProvider, service, protocol, settings, codegenDecorator)
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -94,6 +94,6 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
                 // Allows decorators to inject a custom symbol provider
-                .let { codegenDecorator.symbolProvider(it, model) }
+                .let { codegenDecorator.symbolProvider(it) }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -79,6 +79,7 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
             model: Model,
             serviceShape: ServiceShape,
             rustSymbolProviderConfig: RustSymbolProviderConfig,
+            codegenDecorator: ClientCodegenDecorator,
         ) =
             SymbolVisitor(settings, model, serviceShape = serviceShape, config = rustSymbolProviderConfig)
                 // Generate different types for EventStream shapes (e.g. transcribe streaming)
@@ -92,5 +93,7 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
                 // Rename shapes that clash with Rust reserved words & and other SDK specific features e.g. `send()` cannot
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
+                // Allows decorators to inject a custom symbol provider
+                .let { codegenDecorator.extraSymbolProvider(it, model) }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/RustClientCodegenPlugin.kt
@@ -94,6 +94,6 @@ class RustClientCodegenPlugin : ClientDecoratableBuildPlugin() {
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
                 // Allows decorators to inject a custom symbol provider
-                .let { codegenDecorator.extraSymbolProvider(it, model) }
+                .let { codegenDecorator.symbolProvider(it, model) }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestHelpers.kt
@@ -56,12 +56,18 @@ val TestClientRustSymbolProviderConfig = RustSymbolProviderConfig(
     moduleProvider = OldModuleSchemeClientModuleProvider,
 )
 
+private class ClientTestCodegenDecorator : ClientCodegenDecorator {
+    override val name = "test"
+    override val order: Byte = 0
+}
+
 fun testSymbolProvider(model: Model, serviceShape: ServiceShape? = null): RustSymbolProvider =
     RustClientCodegenPlugin.baseSymbolProvider(
         testClientRustSettings(),
         model,
         serviceShape ?: ServiceShape.builder().version("test").id("test#Service").build(),
         TestClientRustSymbolProviderConfig,
+        ClientTestCodegenDecorator(),
     )
 
 fun testClientCodegenContext(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.build.PluginContext
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.ManifestCustomizations
@@ -94,6 +95,11 @@ interface CoreCodegenDecorator<CodegenContext> {
      * Extra sections allow one decorator to influence another. This is intended to be used by querying the `rootDecorator`
      */
     fun extraSections(codegenContext: CodegenContext): List<AdHocCustomization> = listOf()
+
+    /**
+     * Hook for customizing symbols by inserting an additional symbol provider.
+     */
+    fun extraSymbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider = base
 }
 
 /**
@@ -149,6 +155,11 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
 
     final override fun extraSections(codegenContext: CodegenContext): List<AdHocCustomization> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
+
+    final override fun extraSymbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider =
+        combineCustomizations(base) { decorator, otherProvider ->
+            decorator.extraSymbolProvider(otherProvider, model)
+        }
 
     /**
      * Combines customizations from multiple ordered codegen decorators.

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -99,7 +99,7 @@ interface CoreCodegenDecorator<CodegenContext> {
     /**
      * Hook for customizing symbols by inserting an additional symbol provider.
      */
-    fun symbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider = base
+    fun symbolProvider(base: RustSymbolProvider): RustSymbolProvider = base
 }
 
 /**
@@ -156,9 +156,9 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
     final override fun extraSections(codegenContext: CodegenContext): List<AdHocCustomization> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
-    final override fun symbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider =
+    final override fun symbolProvider(base: RustSymbolProvider): RustSymbolProvider =
         combineCustomizations(base) { decorator, otherProvider ->
-            decorator.symbolProvider(otherProvider, model)
+            decorator.symbolProvider(otherProvider)
         }
 
     /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/CoreCodegenDecorator.kt
@@ -99,7 +99,7 @@ interface CoreCodegenDecorator<CodegenContext> {
     /**
      * Hook for customizing symbols by inserting an additional symbol provider.
      */
-    fun extraSymbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider = base
+    fun symbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider = base
 }
 
 /**
@@ -156,9 +156,9 @@ abstract class CombinedCoreCodegenDecorator<CodegenContext, Decorator : CoreCode
     final override fun extraSections(codegenContext: CodegenContext): List<AdHocCustomization> =
         addCustomizations { decorator -> decorator.extraSections(codegenContext) }
 
-    final override fun extraSymbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider =
+    final override fun symbolProvider(base: RustSymbolProvider, model: Model): RustSymbolProvider =
         combineCustomizations(base) { decorator, otherProvider ->
-            decorator.extraSymbolProvider(otherProvider, model)
+            decorator.symbolProvider(otherProvider, model)
         }
 
     /**

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -81,7 +81,8 @@ class PythonServerCodegenVisitor(
             rustSymbolProviderConfig: RustSymbolProviderConfig,
             publicConstrainedTypes: Boolean,
             includeConstraintShapeProvider: Boolean,
-        ) = RustServerCodegenPythonPlugin.baseSymbolProvider(settings, model, serviceShape, rustSymbolProviderConfig, publicConstrainedTypes)
+            codegenDecorator: ServerCodegenDecorator,
+        ) = RustServerCodegenPythonPlugin.baseSymbolProvider(settings, model, serviceShape, rustSymbolProviderConfig, publicConstrainedTypes, codegenDecorator)
 
         val serverSymbolProviders = ServerSymbolProviders.from(
             settings,
@@ -89,6 +90,7 @@ class PythonServerCodegenVisitor(
             service,
             rustSymbolProviderConfig,
             settings.codegenConfig.publicConstrainedTypes,
+            codegenDecorator,
             ::baseSymbolProviderFactory,
         )
 

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
@@ -100,6 +100,6 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
                 // Allows decorators to inject a custom symbol provider
-                .let { codegenDecorator.symbolProvider(it, model) }
+                .let { codegenDecorator.symbolProvider(it) }
     }
 }

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
@@ -24,6 +24,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.customizations.CustomVa
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.ServerRequiredCustomizations
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionDecorator
 import software.amazon.smithy.rust.codegen.server.smithy.customize.CombinedServerCodegenDecorator
+import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -73,6 +74,7 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
             model: Model,
             serviceShape: ServiceShape,
             rustSymbolProviderConfig: RustSymbolProviderConfig,
+            codegenDecorator: ServerCodegenDecorator,
             constrainedTypes: Boolean = true,
         ) =
             // Rename a set of symbols that do not implement `PyClass` and have been wrapped in
@@ -97,5 +99,7 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
                 // Rename shapes that clash with Rust reserved words & and other SDK specific features e.g. `send()` cannot
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
+                // Allows decorators to inject a custom symbol provider
+                .let { codegenDecorator.extraSymbolProvider(it, model) }
     }
 }

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
@@ -74,8 +74,8 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
             model: Model,
             serviceShape: ServiceShape,
             rustSymbolProviderConfig: RustSymbolProviderConfig,
-            codegenDecorator: ServerCodegenDecorator,
             constrainedTypes: Boolean = true,
+            codegenDecorator: ServerCodegenDecorator,
         ) =
             // Rename a set of symbols that do not implement `PyClass` and have been wrapped in
             // `aws_smithy_http_server_python::types`.

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/RustServerCodegenPythonPlugin.kt
@@ -100,6 +100,6 @@ class RustServerCodegenPythonPlugin : SmithyBuildPlugin {
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
                 // Allows decorators to inject a custom symbol provider
-                .let { codegenDecorator.extraSymbolProvider(it, model) }
+                .let { codegenDecorator.symbolProvider(it, model) }
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
@@ -92,6 +92,6 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
                 // Allows decorators to inject a custom symbol provider
-                .let { codegenDecorator.extraSymbolProvider(it, model) }
+                .let { codegenDecorator.symbolProvider(it, model) }
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
@@ -92,6 +92,6 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
                 // Allows decorators to inject a custom symbol provider
-                .let { codegenDecorator.symbolProvider(it, model) }
+                .let { codegenDecorator.symbolProvider(it) }
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/RustServerCodegenPlugin.kt
@@ -69,6 +69,7 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
             rustSymbolProviderConfig: RustSymbolProviderConfig,
             constrainedTypes: Boolean = true,
             includeConstrainedShapeProvider: Boolean = true,
+            codegenDecorator: ServerCodegenDecorator,
         ) =
             SymbolVisitor(settings, model, serviceShape = serviceShape, config = rustSymbolProviderConfig)
                 // Generate public constrained types for directly constrained shapes.
@@ -90,5 +91,7 @@ class RustServerCodegenPlugin : ServerDecoratableBuildPlugin() {
                 // Rename shapes that clash with Rust reserved words & and other SDK specific features e.g. `send()` cannot
                 // be the name of an operation input
                 .let { RustReservedWordSymbolProvider(it) }
+                // Allows decorators to inject a custom symbol provider
+                .let { codegenDecorator.extraSymbolProvider(it, model) }
     }
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCodegenVisitor.kt
@@ -132,6 +132,7 @@ open class ServerCodegenVisitor(
             service,
             rustSymbolProviderConfig,
             settings.codegenConfig.publicConstrainedTypes,
+            codegenDecorator,
             RustServerCodegenPlugin::baseSymbolProvider,
         )
 

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
@@ -31,9 +31,9 @@ class ServerSymbolProviders private constructor(
             rustSymbolProviderConfig: RustSymbolProviderConfig,
             publicConstrainedTypes: Boolean,
             codegenDecorator: ServerCodegenDecorator,
-            baseSymbolProviderFactory: (model: Model, service: ServiceShape, symbolVisitorConfig: SymbolVisitorConfig, publicConstrainedTypes: Boolean, includeConstraintShapeProvider: Boolean, codegenDecorator: ServerCodegenDecorator) -> RustSymbolProvider,
+            baseSymbolProviderFactory: (settings: ServerRustSettings, model: Model, service: ServiceShape, rustSymbolProviderConfig: RustSymbolProviderConfig, publicConstrainedTypes: Boolean, includeConstraintShapeProvider: Boolean, codegenDecorator: ServerCodegenDecorator) -> RustSymbolProvider,
         ): ServerSymbolProviders {
-            val baseSymbolProvider = baseSymbolProviderFactory(model, service, symbolVisitorConfig, publicConstrainedTypes, publicConstrainedTypes, codegenDecorator)
+            val baseSymbolProvider = baseSymbolProviderFactory(settings, model, service, rustSymbolProviderConfig, publicConstrainedTypes, publicConstrainedTypes, codegenDecorator)
             return ServerSymbolProviders(
                 symbolProvider = baseSymbolProvider,
                 constrainedShapeSymbolProvider = baseSymbolProviderFactory(

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerSymbolProviders.kt
@@ -9,6 +9,7 @@ import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProviderConfig
+import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
 
 /**
  * Just a handy class to centralize initialization all the symbol providers required by the server code generators, to
@@ -29,9 +30,10 @@ class ServerSymbolProviders private constructor(
             service: ServiceShape,
             rustSymbolProviderConfig: RustSymbolProviderConfig,
             publicConstrainedTypes: Boolean,
-            baseSymbolProviderFactory: (settings: ServerRustSettings, model: Model, service: ServiceShape, rustSymbolProviderConfig: RustSymbolProviderConfig, publicConstrainedTypes: Boolean, includeConstraintShapeProvider: Boolean) -> RustSymbolProvider,
+            codegenDecorator: ServerCodegenDecorator,
+            baseSymbolProviderFactory: (model: Model, service: ServiceShape, symbolVisitorConfig: SymbolVisitorConfig, publicConstrainedTypes: Boolean, includeConstraintShapeProvider: Boolean, codegenDecorator: ServerCodegenDecorator) -> RustSymbolProvider,
         ): ServerSymbolProviders {
-            val baseSymbolProvider = baseSymbolProviderFactory(settings, model, service, rustSymbolProviderConfig, publicConstrainedTypes, publicConstrainedTypes)
+            val baseSymbolProvider = baseSymbolProviderFactory(model, service, symbolVisitorConfig, publicConstrainedTypes, publicConstrainedTypes, codegenDecorator)
             return ServerSymbolProviders(
                 symbolProvider = baseSymbolProvider,
                 constrainedShapeSymbolProvider = baseSymbolProviderFactory(
@@ -41,6 +43,7 @@ class ServerSymbolProviders private constructor(
                     rustSymbolProviderConfig,
                     publicConstrainedTypes,
                     true,
+                    codegenDecorator,
                 ),
                 unconstrainedShapeSymbolProvider = UnconstrainedShapeSymbolProvider(
                     baseSymbolProviderFactory(
@@ -50,6 +53,7 @@ class ServerSymbolProviders private constructor(
                         rustSymbolProviderConfig,
                         false,
                         false,
+                        codegenDecorator,
                     ),
                     publicConstrainedTypes, service,
                 ),

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/testutil/ServerTestHelpers.kt
@@ -26,6 +26,7 @@ import software.amazon.smithy.rust.codegen.server.smithy.ServerModuleProvider
 import software.amazon.smithy.rust.codegen.server.smithy.ServerRustSettings
 import software.amazon.smithy.rust.codegen.server.smithy.ServerSymbolProviders
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.SmithyValidationExceptionConversionGenerator
+import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
 import software.amazon.smithy.rust.codegen.server.smithy.generators.ServerBuilderGenerator
 
 // These are the settings we default to if the user does not override them in their `smithy-build.json`.
@@ -42,6 +43,11 @@ private fun testServiceShapeFor(model: Model) =
 fun serverTestSymbolProvider(model: Model, serviceShape: ServiceShape? = null) =
     serverTestSymbolProviders(model, serviceShape).symbolProvider
 
+private class ServerTestCodegenDecorator : ServerCodegenDecorator {
+    override val name = "test"
+    override val order: Byte = 0
+}
+
 fun serverTestSymbolProviders(
     model: Model,
     serviceShape: ServiceShape? = null,
@@ -57,6 +63,7 @@ fun serverTestSymbolProviders(
                 (serviceShape ?: testServiceShapeFor(model)).id,
             )
             ).codegenConfig.publicConstrainedTypes,
+        ServerTestCodegenDecorator(),
         RustServerCodegenPlugin::baseSymbolProvider,
     )
 
@@ -103,6 +110,7 @@ fun serverTestCodegenContext(
         service,
         ServerTestRustSymbolProviderConfig,
         settings.codegenConfig.publicConstrainedTypes,
+        ServerTestCodegenDecorator(),
         RustServerCodegenPlugin::baseSymbolProvider,
     )
 


### PR DESCRIPTION
## Motivation and Context
https://github.com/awslabs/smithy-rs/issues/2158

## Description
This provides a new hook on the `CoreCodegenDecorator` interface. This allows authors of custom decorators (like myself) to manipulate symbols when they are being built.

For example -- this allows me to insert extra derives (such as `serde::Deserialize`).

## Testing
* Ensured all tests are passing locally `./gradlew test`
* Rebuilt the package with my custom decorator and verified my decorator receives the expected callback.

## Checklist
No updates to changelog. This is an internal change that shouldn't affect most users.


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
