### PR TITLE
Remove uncessary type parameter and constraints from `Upgrade` service

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -239,3 +239,9 @@ message = "`SdkError` variants can now be constructed for easier unit testing."
 references = ["smithy-rs#2428", "smithy-rs#2208"]
 meta = { "breaking" = false, "tada" = true, "bug" = false, "target" = "client" }
 author = "jdisanti"
+
+[[smithy-rs]]
+message = "Remove unnecessary type parameter `B` from `Upgrade` service."
+references = ["smithy-rs#2436"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
+author = "hlbarber"

--- a/design/src/server/anatomy.md
+++ b/design/src/server/anatomy.md
@@ -301,7 +301,7 @@ where
 
 When we `GetPokemonService::from_handler` or `GetPokemonService::from_service`, the model service produced, `S`, will meet the constraints above.
 
-There is an associated `Layer`, `UpgradeLayer<P, Op, B>` which constructs `Upgrade` from a service.
+There is an associated `Layer`, `UpgradeLayer<P, Op>` which constructs `Upgrade` from a service.
 
 The upgrade procedure is finalized by the application of the `Layer` `L`, referenced in `Operation<S, L>`. In this way the entire upgrade procedure takes an `Operation<S, L>` and returns a HTTP service.
 

--- a/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
@@ -247,13 +247,9 @@ where
     // The modified Layer applies correctly to `Upgrade<P, Op, Exts, S>`
     Pl::Layer: Layer<Upgrade<P, Op, Exts, Pl::Service>>,
 
-    // The signature of the output is correct
-    <Pl::Layer as Layer<Upgrade<P, Op, Exts, Pl::Service>>>::Service:
-        Service<http::Request<B>, Response = http::Response<BoxBody>>,
-
     // For `Route::new` for the resulting service
-    <Pl::Layer as Layer<Upgrade<P, Op, Exts, Pl::Service>>>::Service: Service<http::Request<B>, Error = Infallible>,
-    UpgradedService<Pl, P, Op, Exts, S, L>: Clone + Send + 'static,
+    UpgradedService<Pl, P, Op, Exts, S, L>:
+        Service<http::Request<B>, Response = http::Response<BoxBody>, Error = Infallible> + Clone + Send + 'static,
     <UpgradedService<Pl, P, Op, Exts, S, L> as Service<http::Request<B>>>::Future: Send + 'static,
 {
     /// Takes the [`Operation<S, L>`](Operation), applies [`Plugin`], then applies [`UpgradeLayer`] to

--- a/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
@@ -32,39 +32,36 @@ use super::{Operation, OperationError, OperationShape};
 ///
 /// See [`Upgrade`].
 #[derive(Debug, Clone)]
-pub struct UpgradeLayer<Protocol, Operation, Exts, B> {
+pub struct UpgradeLayer<Protocol, Operation, Exts> {
     _protocol: PhantomData<Protocol>,
     _operation: PhantomData<Operation>,
     _exts: PhantomData<Exts>,
-    _body: PhantomData<B>,
 }
 
-impl<P, Op, E, B> Default for UpgradeLayer<P, Op, E, B> {
+impl<P, Op, E> Default for UpgradeLayer<P, Op, E> {
     fn default() -> Self {
         Self {
             _protocol: PhantomData,
             _operation: PhantomData,
             _exts: PhantomData,
-            _body: PhantomData,
         }
     }
 }
 
-impl<Protocol, Operation, Exts, B> UpgradeLayer<Protocol, Operation, Exts, B> {
+impl<Protocol, Operation, Exts> UpgradeLayer<Protocol, Operation, Exts> {
     /// Creates a new [`UpgradeLayer`].
     pub fn new() -> Self {
         Self::default()
     }
 }
 
-impl<S, P, Op, E, B> Layer<S> for UpgradeLayer<P, Op, E, B> {
-    type Service = Upgrade<P, Op, E, B, S>;
+impl<S, P, Op, E> Layer<S> for UpgradeLayer<P, Op, E> {
+    type Service = Upgrade<P, Op, E, S>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Upgrade {
             _protocol: PhantomData,
             _operation: PhantomData,
-            _body: PhantomData,
             _exts: PhantomData,
             inner,
         }
@@ -73,15 +70,14 @@ impl<S, P, Op, E, B> Layer<S> for UpgradeLayer<P, Op, E, B> {
 
 /// A [`Service`] responsible for wrapping an operation [`Service`] accepting and returning Smithy
 /// types, and converting it into a [`Service`] accepting and returning [`http`] types.
-pub struct Upgrade<Protocol, Operation, Exts, B, S> {
+pub struct Upgrade<Protocol, Operation, Exts, S> {
     _protocol: PhantomData<Protocol>,
     _operation: PhantomData<Operation>,
     _exts: PhantomData<Exts>,
-    _body: PhantomData<B>,
     inner: S,
 }
 
-impl<P, Op, E, B, S> Clone for Upgrade<P, Op, E, B, S>
+impl<P, Op, E, S> Clone for Upgrade<P, Op, E, S>
 where
     S: Clone,
 {
@@ -89,7 +85,6 @@ where
         Self {
             _protocol: PhantomData,
             _operation: PhantomData,
-            _body: PhantomData,
             _exts: PhantomData,
             inner: self.inner.clone(),
         }
@@ -177,7 +172,7 @@ where
     }
 }
 
-impl<P, Op, Exts, B, S, PollError, OpError> Service<http::Request<B>> for Upgrade<P, Op, Exts, B, S>
+impl<P, Op, Exts, B, S, PollError, OpError> Service<http::Request<B>> for Upgrade<P, Op, Exts, S>
 where
     // `Op` is used to specify the operation shape
     Op: OperationShape,
@@ -225,9 +220,8 @@ pub trait Upgradable<Protocol, Operation, Exts, B, Plugin> {
     fn upgrade(self, plugin: &Plugin) -> Route<B>;
 }
 
-type UpgradedService<Pl, P, Op, Exts, B, S, L> = <<Pl as Plugin<P, Op, S, L>>::Layer as Layer<
-    Upgrade<P, Op, Exts, B, <Pl as Plugin<P, Op, S, L>>::Service>,
->>::Service;
+type UpgradedService<Pl, P, Op, Exts, S, L> =
+    <<Pl as Plugin<P, Op, S, L>>::Layer as Layer<Upgrade<P, Op, Exts, <Pl as Plugin<P, Op, S, L>>::Service>>>::Service;
 
 impl<P, Op, Exts, B, Pl, S, L, PollError> Upgradable<P, Op, Exts, B, Pl> for Operation<S, L>
 where
@@ -250,17 +244,17 @@ where
     // The plugin takes this operation as input
     Pl: Plugin<P, Op, S, L>,
 
-    // The modified Layer applies correctly to `Upgrade<P, Op, Exts, B, S>`
-    Pl::Layer: Layer<Upgrade<P, Op, Exts, B, Pl::Service>>,
+    // The modified Layer applies correctly to `Upgrade<P, Op, Exts, S>`
+    Pl::Layer: Layer<Upgrade<P, Op, Exts, Pl::Service>>,
 
     // The signature of the output is correct
-    <Pl::Layer as Layer<Upgrade<P, Op, Exts, B, Pl::Service>>>::Service:
+    <Pl::Layer as Layer<Upgrade<P, Op, Exts, Pl::Service>>>::Service:
         Service<http::Request<B>, Response = http::Response<BoxBody>>,
 
     // For `Route::new` for the resulting service
-    <Pl::Layer as Layer<Upgrade<P, Op, Exts, B, Pl::Service>>>::Service: Service<http::Request<B>, Error = Infallible>,
-    UpgradedService<Pl, P, Op, Exts, B, S, L>: Clone + Send + 'static,
-    <UpgradedService<Pl, P, Op, Exts, B, S, L> as Service<http::Request<B>>>::Future: Send + 'static,
+    <Pl::Layer as Layer<Upgrade<P, Op, Exts, Pl::Service>>>::Service: Service<http::Request<B>, Error = Infallible>,
+    UpgradedService<Pl, P, Op, Exts, S, L>: Clone + Send + 'static,
+    <UpgradedService<Pl, P, Op, Exts, S, L> as Service<http::Request<B>>>::Future: Send + 'static,
 {
     /// Takes the [`Operation<S, L>`](Operation), applies [`Plugin`], then applies [`UpgradeLayer`] to
     /// the modified `S`, then finally applies the modified `L`.


### PR DESCRIPTION
## Motivation and Context

The type parameter `B` was not only redundant but also removed a degree of freedom from the API.

## Description

- Remove type parameter `B` from `Upgrade` and related code.
- Remove repeated constraint on the upgraded service.
