### PR TITLE
Remove `{Service}::layer` in favour of `PluginPipeline::http_layer`

### DIFF
--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service-tls.rs
@@ -62,8 +62,12 @@ struct Args {
 pub async fn main() {
     let args = Args::parse();
     setup_tracing();
-    // Apply the `PrintPlugin` defined in `plugin.rs`
-    let plugins = PluginPipeline::new().print();
+    let state_layer = AddExtensionLayer::new(Arc::new(State::default()));
+    let plugins = PluginPipeline::new()
+        // Apply a layer injecting `State`.
+        .http_layer(&state_layer)
+        // Apply the `PrintPlugin` defined in `plugin.rs`
+        .print();
     let app = PokemonService::builder_with_plugins(plugins)
         // Build a registry containing implementations to all the operations in the service. These
         // are async functions or async closures that take as input the operation's input and
@@ -75,9 +79,7 @@ pub async fn main() {
         .do_nothing(do_nothing)
         .check_health(check_health)
         .build()
-        .expect("failed to build an instance of PokemonService")
-        // Set up shared state and middlewares.
-        .layer(&AddExtensionLayer::new(Arc::new(State::default())));
+        .expect("failed to build an instance of PokemonService");
 
     let addr: SocketAddr = format!("{}:{}", args.address, args.port)
         .parse()

--- a/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service.rs
+++ b/rust-runtime/aws-smithy-http-server/examples/pokemon-service/src/bin/pokemon-service.rs
@@ -29,7 +29,10 @@ struct Args {
 pub async fn main() {
     let args = Args::parse();
     setup_tracing();
+    let state_layer = AddExtensionLayer::new(Arc::new(State::default()));
     let plugins = PluginPipeline::new()
+        // Apply a layer injecting `State`.
+        .http_layer(&state_layer)
         // Apply the `PrintPlugin` defined in `plugin.rs`
         .print()
         // Apply the `OperationExtensionPlugin` defined in `aws_smithy_http_server::extension`. This allows other
@@ -47,9 +50,7 @@ pub async fn main() {
         .do_nothing(do_nothing)
         .check_health(check_health)
         .build()
-        .expect("failed to build an instance of PokemonService")
-        // Setup shared state and middlewares.
-        .layer(&AddExtensionLayer::new(Arc::new(State::default())));
+        .expect("failed to build an instance of PokemonService");
 
     // Start the [`hyper::Server`].
     let bind: SocketAddr = format!("{}:{}", args.address, args.port)

--- a/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
@@ -10,16 +10,13 @@ use crate::operation::Operation;
 use super::Plugin;
 
 /// A [`Plugin`] which appends a HTTP [`Layer`](tower::Layer) `L` to the existing `Layer` in [`Operation<S, Layer>`](Operation).
-pub struct HttpLayer<L>(pub L);
+pub struct HttpLayer<'a, L>(pub &'a L);
 
-impl<P, Op, S, ExistingLayer, NewLayer> Plugin<P, Op, S, ExistingLayer> for HttpLayer<NewLayer>
-where
-    NewLayer: Clone,
-{
+impl<'a, P, Op, S, ExistingLayer, NewLayer> Plugin<P, Op, S, ExistingLayer> for HttpLayer<'a, NewLayer> {
     type Service = S;
-    type Layer = Stack<ExistingLayer, NewLayer>;
+    type Layer = Stack<ExistingLayer, &'a NewLayer>;
 
     fn map(&self, input: Operation<S, ExistingLayer>) -> Operation<Self::Service, Self::Layer> {
-        input.layer(self.0.clone())
+        input.layer(self.0)
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/plugin/pipeline.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/pipeline.rs
@@ -6,6 +6,8 @@
 use crate::operation::Operation;
 use crate::plugin::{IdentityPlugin, Plugin, PluginStack};
 
+use super::HttpLayer;
+
 /// A wrapper struct for composing [`Plugin`]s.
 /// It is used as input for the `builder_with_plugins` method on the generate service struct
 /// (e.g. `PokemonService::builder_with_plugins`).
@@ -167,6 +169,11 @@ impl<P> PluginPipeline<P> {
     /// in registration order.
     pub fn push<NewPlugin>(self, new_plugin: NewPlugin) -> PluginPipeline<PluginStack<NewPlugin, P>> {
         PluginPipeline(PluginStack::new(new_plugin, self.0))
+    }
+
+    /// Applies a single [`Layer`] to all operations _before_ they are deserialized.
+    pub fn http_layer<L>(self, layer: &L) -> PluginPipeline<PluginStack<HttpLayer<L>, P>> {
+        PluginPipeline(PluginStack::new(HttpLayer(&layer), self.0))
     }
 }
 


### PR DESCRIPTION
## Motivation and Context

The current schematic for middleware for the `smithy-rs` is given in the [Applying Middleware](https://github.com/awslabs/smithy-rs/blob/9d31b6c4a7ba17d38919ddc8f931725f102efb2f/design/src/server/middleware.md#applying-middleware) section of the [Middleware document](https://github.com/awslabs/smithy-rs/blob/main/design/src/server/middleware.md).

Within the document 4 middleware groups are described. Both A and B were present prior to the [service builder refactor](https://github.com/awslabs/smithy-rs/blob/main/design/src/rfcs/rfc0020_service_builder.md) while C and D were added during it. The group B survived the refactor mainly because the lack of infrastructure around C at the time and an attempt to smooth out the breaking changes.

B and C are however nearly identical positions to apply middleware. The API for applying to C is more flexible in the sense that we can use `Plugin`s and `Operation::layer` to apply individualized `Layer`s to each operation - however a blanket application of one `Layer` to every operation is just a special case of this. The only real difference is that B is applied _after_ we `Route::new` and `C` is applied just _before_ we `Route::new`.

**Pros**

- Remove redundant middleware surface
- Simplify types
- The order of `Plugin`s and `Layer`s are now explicit in `PluginPipeline` method chain

**Cons**

- Breaking change and everyone is using `{Service}::layer`.

## Description

- Remove middleware position B by removing `{Service}::layer` and `{Service}::boxed`.
- Add `PluginPipeline::http_layer` which plays the role of `{Service}::layer`.

