### PR TITLE
Fix test failure in `no-default-features`

### DIFF
--- a/aws/sdk/integration-tests/no-default-features/Cargo.toml
+++ b/aws/sdk/integration-tests/no-default-features/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 [dev-dependencies]
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config", default-features = false }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", default-features = false }
+aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["rt-tokio"] }
 futures = "0.3.25"
 tokio = { version = "1.8.4", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/no-default-features/Cargo.toml
+++ b/aws/sdk/integration-tests/no-default-features/Cargo.toml
@@ -16,7 +16,7 @@ publish = false
 [dev-dependencies]
 aws-config = { path = "../../build/aws-sdk/sdk/aws-config", default-features = false }
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", default-features = false }
-aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["rt-tokio"] }
+aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async" }
 futures = "0.3.25"
 tokio = { version = "1.8.4", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/no-default-features/tests/client-construction.rs
+++ b/aws/sdk/integration-tests/no-default-features/tests/client-construction.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use aws_smithy_async::rt::sleep::default_async_sleep;
+
 // This will fail due to lack of a connector when constructing the SDK Config
 #[tokio::test]
 #[should_panic(
@@ -13,12 +15,14 @@ async fn test_clients_from_sdk_config() {
 }
 
 // This will fail due to lack of a connector when constructing the service client
-#[test]
+#[tokio::test]
 #[should_panic(
     expected = "No HTTP connector was available. Enable the `rustls` or `native-tls` crate feature or set a connector to fix this."
 )]
-fn test_clients_from_service_config() {
-    let config = aws_sdk_s3::Config::builder().build();
+async fn test_clients_from_service_config() {
+    let config = aws_sdk_s3::Config::builder()
+        .sleep_impl(default_async_sleep().unwrap())
+        .build();
     // This will panic due to the lack of an HTTP connector
     aws_sdk_s3::Client::from_conf(config);
 }


### PR DESCRIPTION
## Motivation and Context
This PR fixes a test failure from `test_clients_from_sdk_config`. The test failure has prevented us from releasing a new version of `aws-sdk-rust`.

## Description
It is a negative test expecting a panic, but it failed because it panicked for a different reason, i.e. `no default sleep implementation available` instead of `No HTTP connector was available...`. The fix will add a default async sleep to a service config to ensure that the panic occurs for the expected reason.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
