### PR TITLE
update: enable presigned S3 HeadObject requests

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -263,3 +263,9 @@ message = "Add more client re-exports. Specifically, it re-exports `aws_smithy_h
 references = ["smithy-rs#2437", "aws-sdk-rust#600"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "Enable presigning for S3's `HeadObject` operation."
+references = ["aws-sdk-rust#753"]
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+author = "Velfi"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -266,7 +266,7 @@ author = "ysaito1001"
 
 [[aws-sdk-rust]]
 message = "Enable presigning for S3's `HeadObject` operation."
-references = ["aws-sdk-rust#753"]
+references = ["aws-sdk-rust#753", "smithy-rs#2451"]
 meta = { "breaking" = false, "tada" = true, "bug" = false }
 author = "Velfi"
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -62,6 +62,7 @@ internal val PRESIGNABLE_OPERATIONS by lazy {
     mapOf(
         // S3
         // TODO(https://github.com/awslabs/aws-sdk-rust/issues/488) Technically, all S3 operations support presigning
+        ShapeId.from("com.amazonaws.s3#HeadObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#GetObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#PutObject") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),
         ShapeId.from("com.amazonaws.s3#UploadPart") to PresignableOperation(PayloadSigningType.UNSIGNED_PAYLOAD),

--- a/aws/sdk/integration-tests/s3/tests/presigning.rs
+++ b/aws/sdk/integration-tests/s3/tests/presigning.rs
@@ -142,3 +142,18 @@ async fn test_presigning_object_lambda() -> Result<(), Box<dyn Error>> {
     assert_eq!(presigned.uri().to_string(), "https://my-banner-ap-name-123456789012.s3-object-lambda.us-west-2.amazonaws.com/test2.txt?x-id=GetObject&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F20090213%2Fus-west-2%2Fs3-object-lambda%2Faws4_request&X-Amz-Date=20090213T233131Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=027976453050b6f9cca7af80a59c05ee572b462e0fc1ef564c59412b903fcdf2&X-Amz-Security-Token=notarealsessiontoken");
     Ok(())
 }
+
+#[tokio::test]
+async fn test_presigned_head_object() -> Result<(), Box<dyn Error>> {
+    let presigned = presign_input!(s3::input::HeadObjectInput::builder()
+        .bucket("bucket")
+        .key("key")
+        .build()?);
+
+    assert_eq!("HEAD", presigned.method().as_str());
+    assert_eq!(
+        presigned.uri().to_string(),
+        "https://bucket.s3.us-east-1.amazonaws.com/key?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ANOTREAL%2F20090213%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20090213T233131Z&X-Amz-Expires=30&X-Amz-SignedHeaders=host&X-Amz-Signature=6b97012e70d5ee3528b5591e0e90c0f45e0fa303506f854eff50ff922751a193&X-Amz-Security-Token=notarealsessiontoken",
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
https://github.com/awslabs/aws-sdk-rust/issues/753

## Description
<!--- Describe your changes in detail -->
This add `HeadObject` to the list of S3 operations that support presigning.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added a test.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
