### PR TITLE
Fix SDK codegen against the latest SDK models

### DIFF
--- a/aws/sdk/aws-models/config.json
+++ b/aws/sdk/aws-models/config.json
@@ -12896,7 +12896,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -12925,15 +12925,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -12942,7 +12994,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -12952,22 +13004,182 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://config-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        "aws-us-gov",
+                                                                                        {
+                                                                                            "fn": "getAttr",
+                                                                                            "argv": [
+                                                                                                {
+                                                                                                    "ref": "PartitionResult"
+                                                                                                },
+                                                                                                "name"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://config.{Region}.amazonaws.com",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://config-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -12980,223 +13192,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
-                                                        },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://config-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
                                                     "type": "tree",
                                                     "rules": [
                                                         {
                                                             "conditions": [
                                                                 {
-                                                                    "fn": "stringEquals",
+                                                                    "fn": "booleanEquals",
                                                                     "argv": [
-                                                                        "aws-us-gov",
+                                                                        true,
                                                                         {
                                                                             "fn": "getAttr",
                                                                             "argv": [
                                                                                 {
                                                                                     "ref": "PartitionResult"
                                                                                 },
-                                                                                "name"
+                                                                                "supportsDualStack"
                                                                             ]
                                                                         }
                                                                     ]
                                                                 }
                                                             ],
-                                                            "endpoint": {
-                                                                "url": "https://config.{Region}.amazonaws.com",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://config.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
                                                         {
                                                             "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://config-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
                                                 },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -13204,7 +13245,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://config.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "url": "https://config.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -13213,28 +13254,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://config.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -13243,16 +13269,16 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.sa-east-1.amazonaws.com"
+                                    "url": "https://config.af-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "af-south-1",
                                 "UseDualStack": false,
-                                "Region": "sa-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13263,165 +13289,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-east-1",
                                 "UseDualStack": false,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.af-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-south-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13432,9 +13302,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13445,9 +13315,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-2",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13458,87 +13328,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-3",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-3"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.us-east-1.amazonaws.com"
+                                    "url": "https://config.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-south-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config-fips.us-east-1.amazonaws.com"
+                                    "url": "https://config.ap-southeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "ap-southeast-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.eu-west-1.amazonaws.com"
+                                    "url": "https://config.ap-southeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-southeast-2",
                                 "UseDualStack": false,
-                                "Region": "eu-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.eu-west-2.amazonaws.com"
+                                    "url": "https://config.ap-southeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-southeast-3",
                                 "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.eu-west-3.amazonaws.com"
+                                    "url": "https://config.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ca-central-1",
                                 "UseDualStack": false,
-                                "Region": "eu-west-3"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.me-south-1.amazonaws.com"
+                                    "url": "https://config.eu-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-central-1",
                                 "UseDualStack": false,
-                                "Region": "me-south-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13549,9 +13419,113 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-north-1",
                                 "UseDualStack": false,
-                                "Region": "eu-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -13562,9 +13536,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13575,9 +13549,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -13588,9 +13614,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -13601,126 +13627,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://config.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13731,9 +13640,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13744,9 +13666,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -13757,9 +13679,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -13770,22 +13692,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://config.us-iso-west-1.c2s.ic.gov"
+                                    "url": "https://config.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-gov-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-west-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13796,9 +13783,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -13809,22 +13809,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://config-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -13834,9 +13873,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -13846,9 +13885,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
                                 "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         }

--- a/aws/sdk/aws-models/dynamodb.json
+++ b/aws/sdk/aws-models/dynamodb.json
@@ -44,7 +44,7 @@
                 "ArchivalReason": {
                     "target": "com.amazonaws.dynamodb#ArchivalReason",
                     "traits": {
-                        "smithy.api#documentation": "<p>The reason DynamoDB archived the table. Currently, the only possible value is:</p>\n\n        <ul>\n            <li>\n                <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS</code> - The table was archived due\n                    to the table's KMS key being inaccessible for more than seven\n                    days. An On-Demand backup was created at the archival time.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The reason DynamoDB archived the table. Currently, the only possible value is:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS</code> - The table was archived due\n                    to the table's KMS key being inaccessible for more than seven\n                    days. An On-Demand backup was created at the archival time.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ArchivalBackupArn": {
@@ -94,7 +94,7 @@
                 "AttributeType": {
                     "target": "com.amazonaws.dynamodb#ScalarAttributeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The data type for the attribute, where:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>S</code> - the attribute is of type String</p>\n            </li>\n            <li>\n                <p>\n                    <code>N</code> - the attribute is of type Number</p>\n            </li>\n            <li>\n                <p>\n                    <code>B</code> - the attribute is of type Binary</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The data type for the attribute, where:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>S</code> - the attribute is of type String</p>\n            </li>\n            <li>\n               <p>\n                  <code>N</code> - the attribute is of type Number</p>\n            </li>\n            <li>\n               <p>\n                  <code>B</code> - the attribute is of type Binary</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
@@ -153,66 +153,66 @@
                 "S": {
                     "target": "com.amazonaws.dynamodb#StringAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type String. For example:</p>\n        <p>\n            <code>\"S\": \"Hello\"</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type String. For example:</p>\n         <p>\n            <code>\"S\": \"Hello\"</code>\n         </p>"
                     }
                 },
                 "N": {
                     "target": "com.amazonaws.dynamodb#NumberAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Number. For example:</p>\n        <p>\n            <code>\"N\": \"123.45\"</code>\n         </p>\n        <p>Numbers are sent across the network to DynamoDB as strings, to maximize compatibility\n            across languages and libraries. However, DynamoDB treats them as number type attributes\n            for mathematical operations.</p>"
+                        "smithy.api#documentation": "<p>An attribute of type Number. For example:</p>\n         <p>\n            <code>\"N\": \"123.45\"</code>\n         </p>\n         <p>Numbers are sent across the network to DynamoDB as strings, to maximize compatibility\n            across languages and libraries. However, DynamoDB treats them as number type attributes\n            for mathematical operations.</p>"
                     }
                 },
                 "B": {
                     "target": "com.amazonaws.dynamodb#BinaryAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Binary. For example:</p>\n        <p>\n            <code>\"B\": \"dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk\"</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type Binary. For example:</p>\n         <p>\n            <code>\"B\": \"dGhpcyB0ZXh0IGlzIGJhc2U2NC1lbmNvZGVk\"</code>\n         </p>"
                     }
                 },
                 "SS": {
                     "target": "com.amazonaws.dynamodb#StringSetAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type String Set. For example:</p>\n        <p>\n            <code>\"SS\": [\"Giraffe\", \"Hippo\" ,\"Zebra\"]</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type String Set. For example:</p>\n         <p>\n            <code>\"SS\": [\"Giraffe\", \"Hippo\" ,\"Zebra\"]</code>\n         </p>"
                     }
                 },
                 "NS": {
                     "target": "com.amazonaws.dynamodb#NumberSetAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Number Set. For example:</p>\n        <p>\n            <code>\"NS\": [\"42.2\", \"-19\", \"7.5\", \"3.14\"]</code>\n         </p>\n        <p>Numbers are sent across the network to DynamoDB as strings, to maximize compatibility\n            across languages and libraries. However, DynamoDB treats them as number type attributes\n            for mathematical operations.</p>"
+                        "smithy.api#documentation": "<p>An attribute of type Number Set. For example:</p>\n         <p>\n            <code>\"NS\": [\"42.2\", \"-19\", \"7.5\", \"3.14\"]</code>\n         </p>\n         <p>Numbers are sent across the network to DynamoDB as strings, to maximize compatibility\n            across languages and libraries. However, DynamoDB treats them as number type attributes\n            for mathematical operations.</p>"
                     }
                 },
                 "BS": {
                     "target": "com.amazonaws.dynamodb#BinarySetAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Binary Set. For example:</p>\n        <p>\n            <code>\"BS\": [\"U3Vubnk=\", \"UmFpbnk=\", \"U25vd3k=\"]</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type Binary Set. For example:</p>\n         <p>\n            <code>\"BS\": [\"U3Vubnk=\", \"UmFpbnk=\", \"U25vd3k=\"]</code>\n         </p>"
                     }
                 },
                 "M": {
                     "target": "com.amazonaws.dynamodb#MapAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Map. For example:</p>\n        <p>\n            <code>\"M\": {\"Name\": {\"S\": \"Joe\"}, \"Age\": {\"N\": \"35\"}}</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type Map. For example:</p>\n         <p>\n            <code>\"M\": {\"Name\": {\"S\": \"Joe\"}, \"Age\": {\"N\": \"35\"}}</code>\n         </p>"
                     }
                 },
                 "L": {
                     "target": "com.amazonaws.dynamodb#ListAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type List. For example:</p>\n        <p>\n            <code>\"L\": [ {\"S\": \"Cookies\"} , {\"S\": \"Coffee\"}, {\"N\": \"3.14159\"}]</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type List. For example:</p>\n         <p>\n            <code>\"L\": [ {\"S\": \"Cookies\"} , {\"S\": \"Coffee\"}, {\"N\": \"3.14159\"}]</code>\n         </p>"
                     }
                 },
                 "NULL": {
                     "target": "com.amazonaws.dynamodb#NullAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Null. For example:</p>\n        <p>\n            <code>\"NULL\": true</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type Null. For example:</p>\n         <p>\n            <code>\"NULL\": true</code>\n         </p>"
                     }
                 },
                 "BOOL": {
                     "target": "com.amazonaws.dynamodb#BooleanAttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>An attribute of type Boolean. For example:</p>\n        <p>\n            <code>\"BOOL\": true</code>\n         </p>"
+                        "smithy.api#documentation": "<p>An attribute of type Boolean. For example:</p>\n         <p>\n            <code>\"BOOL\": true</code>\n         </p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the data for an attribute.</p>\n        <p>Each attribute value is described as a name-value pair. The name is the data type, and\n            the value is the data itself.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes\">Data Types</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Represents the data for an attribute.</p>\n         <p>Each attribute value is described as a name-value pair. The name is the data type, and\n            the value is the data itself.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes\">Data Types</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#AttributeValueList": {
@@ -227,18 +227,18 @@
                 "Value": {
                     "target": "com.amazonaws.dynamodb#AttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the data for an attribute.</p>\n        <p>Each attribute value is described as a name-value pair. The name is the data type, and\n            the value is the data itself.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes\">Data Types</a> in the <i>Amazon DynamoDB Developer Guide</i>.\n        </p>"
+                        "smithy.api#documentation": "<p>Represents the data for an attribute.</p>\n         <p>Each attribute value is described as a name-value pair. The name is the data type, and\n            the value is the data itself.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes\">Data Types</a> in the <i>Amazon DynamoDB Developer Guide</i>.\n        </p>"
                     }
                 },
                 "Action": {
                     "target": "com.amazonaws.dynamodb#AttributeAction",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies how to perform the update. Valid values are <code>PUT</code> (default),\n                <code>DELETE</code>, and <code>ADD</code>. The behavior depends on whether the\n            specified primary key already exists in the table.</p>\n\n        <p>\n            <b>If an item with the specified <i>Key</i> is found in\n                the table:</b>\n        </p>\n\n        <ul>\n            <li>\n                <p>\n                    <code>PUT</code> - Adds the specified attribute to the item. If the attribute\n                    already exists, it is replaced by the new value. </p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETE</code> - If no value is specified, the attribute and its value are\n                    removed from the item. The data type of the specified value must match the\n                    existing value's data type.</p>\n                <p>If a <i>set</i> of values is specified, then those values are\n                    subtracted from the old set. For example, if the attribute value was the set\n                        <code>[a,b,c]</code> and the <code>DELETE</code> action specified\n                        <code>[a,c]</code>, then the final attribute value would be\n                    <code>[b]</code>. Specifying an empty set is an error.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ADD</code> - If the attribute does not already exist, then the attribute\n                    and its values are added to the item. If the attribute does exist, then the\n                    behavior of <code>ADD</code> depends on the data type of the attribute:</p>\n                <ul>\n                  <li>\n                        <p>If the existing attribute is a number, and if <code>Value</code> is\n                            also a number, then the <code>Value</code> is mathematically added to\n                            the existing attribute. If <code>Value</code> is a negative number, then\n                            it is subtracted from the existing attribute.</p>\n                        <note>\n                            <p> If you use <code>ADD</code> to increment or decrement a number\n                                value for an item that doesn't exist before the update, DynamoDB\n                                uses 0 as the initial value.</p>\n                            <p>In addition, if you use <code>ADD</code> to update an existing\n                                item, and intend to increment or decrement an attribute value which\n                                does not yet exist, DynamoDB uses <code>0</code> as the initial\n                                value. For example, suppose that the item you want to update does\n                                not yet have an attribute named <i>itemcount</i>, but\n                                you decide to <code>ADD</code> the number <code>3</code> to this\n                                attribute anyway, even though it currently does not exist. DynamoDB\n                                will create the <i>itemcount</i> attribute, set its\n                                initial value to <code>0</code>, and finally add <code>3</code> to\n                                it. The result will be a new <i>itemcount</i>\n                                attribute in the item, with a value of <code>3</code>.</p>\n                        </note>\n                    </li>\n                  <li>\n                        <p>If the existing data type is a set, and if the <code>Value</code> is\n                            also a set, then the <code>Value</code> is added to the existing set.\n                            (This is a <i>set</i> operation, not mathematical\n                            addition.) For example, if the attribute value was the set\n                                <code>[1,2]</code>, and the <code>ADD</code> action specified\n                                <code>[3]</code>, then the final attribute value would be\n                                <code>[1,2,3]</code>. An error occurs if an Add action is specified\n                            for a set attribute and the attribute type specified does not match the\n                            existing set type. </p>\n                        <p>Both sets must have the same primitive data type. For example, if the\n                            existing data type is a set of strings, the <code>Value</code> must also\n                            be a set of strings. The same holds true for number sets and binary\n                            sets.</p>\n                    </li>\n               </ul>\n                <p>This action is only valid for an existing attribute whose data type is number\n                    or is a set. Do not use <code>ADD</code> for any other data types.</p>\n            </li>\n         </ul>\n\n        <p>\n            <b>If no item with the specified <i>Key</i> is\n                found:</b>\n        </p>\n\n        <ul>\n            <li>\n                <p>\n                    <code>PUT</code> - DynamoDB creates a new item with the specified primary key,\n                    and then adds the attribute. </p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETE</code> - Nothing happens; there is no attribute to delete.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ADD</code> - DynamoDB creates a new item with the supplied primary key and\n                    number (or set) for the attribute value. The only data types allowed are number,\n                    number set, string set or binary set.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Specifies how to perform the update. Valid values are <code>PUT</code> (default),\n                <code>DELETE</code>, and <code>ADD</code>. The behavior depends on whether the\n            specified primary key already exists in the table.</p>\n         <p>\n            <b>If an item with the specified <i>Key</i> is found in\n                the table:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>PUT</code> - Adds the specified attribute to the item. If the attribute\n                    already exists, it is replaced by the new value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE</code> - If no value is specified, the attribute and its value are\n                    removed from the item. The data type of the specified value must match the\n                    existing value's data type.</p>\n               <p>If a <i>set</i> of values is specified, then those values are\n                    subtracted from the old set. For example, if the attribute value was the set\n                        <code>[a,b,c]</code> and the <code>DELETE</code> action specified\n                        <code>[a,c]</code>, then the final attribute value would be\n                    <code>[b]</code>. Specifying an empty set is an error.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ADD</code> - If the attribute does not already exist, then the attribute\n                    and its values are added to the item. If the attribute does exist, then the\n                    behavior of <code>ADD</code> depends on the data type of the attribute:</p>\n               <ul>\n                  <li>\n                     <p>If the existing attribute is a number, and if <code>Value</code> is\n                            also a number, then the <code>Value</code> is mathematically added to\n                            the existing attribute. If <code>Value</code> is a negative number, then\n                            it is subtracted from the existing attribute.</p>\n                     <note>\n                        <p> If you use <code>ADD</code> to increment or decrement a number\n                                value for an item that doesn't exist before the update, DynamoDB\n                                uses 0 as the initial value.</p>\n                        <p>In addition, if you use <code>ADD</code> to update an existing\n                                item, and intend to increment or decrement an attribute value which\n                                does not yet exist, DynamoDB uses <code>0</code> as the initial\n                                value. For example, suppose that the item you want to update does\n                                not yet have an attribute named <i>itemcount</i>, but\n                                you decide to <code>ADD</code> the number <code>3</code> to this\n                                attribute anyway, even though it currently does not exist. DynamoDB\n                                will create the <i>itemcount</i> attribute, set its\n                                initial value to <code>0</code>, and finally add <code>3</code> to\n                                it. The result will be a new <i>itemcount</i>\n                                attribute in the item, with a value of <code>3</code>.</p>\n                     </note>\n                  </li>\n                  <li>\n                     <p>If the existing data type is a set, and if the <code>Value</code> is\n                            also a set, then the <code>Value</code> is added to the existing set.\n                            (This is a <i>set</i> operation, not mathematical\n                            addition.) For example, if the attribute value was the set\n                                <code>[1,2]</code>, and the <code>ADD</code> action specified\n                                <code>[3]</code>, then the final attribute value would be\n                                <code>[1,2,3]</code>. An error occurs if an Add action is specified\n                            for a set attribute and the attribute type specified does not match the\n                            existing set type. </p>\n                     <p>Both sets must have the same primitive data type. For example, if the\n                            existing data type is a set of strings, the <code>Value</code> must also\n                            be a set of strings. The same holds true for number sets and binary\n                            sets.</p>\n                  </li>\n               </ul>\n               <p>This action is only valid for an existing attribute whose data type is number\n                    or is a set. Do not use <code>ADD</code> for any other data types.</p>\n            </li>\n         </ul>\n         <p>\n            <b>If no item with the specified <i>Key</i> is\n                found:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>PUT</code> - DynamoDB creates a new item with the specified primary key,\n                    and then adds the attribute. </p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE</code> - Nothing happens; there is no attribute to delete.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ADD</code> - DynamoDB creates a new item with the supplied primary key and\n                    number (or set) for the attribute value. The only data types allowed are number,\n                    number set, string set or binary set.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>For the <code>UpdateItem</code> operation, represents the attributes to be modified,\n            the action to perform on each, and the new value for each.</p>\n        <note>\n            <p>You cannot use <code>UpdateItem</code> to update any primary key attributes.\n                Instead, you will need to delete the item, and then use <code>PutItem</code> to\n                create a new item with new attributes.</p>\n        </note>\n        <p>Attribute values cannot be null; string and binary type attributes must have lengths\n            greater than zero; and set type attributes must not be empty. Requests with empty values\n            will be rejected with a <code>ValidationException</code> exception.</p>"
+                "smithy.api#documentation": "<p>For the <code>UpdateItem</code> operation, represents the attributes to be modified,\n            the action to perform on each, and the new value for each.</p>\n         <note>\n            <p>You cannot use <code>UpdateItem</code> to update any primary key attributes.\n                Instead, you will need to delete the item, and then use <code>PutItem</code> to\n                create a new item with new attributes.</p>\n         </note>\n         <p>Attribute values cannot be null; string and binary type attributes must have lengths\n            greater than zero; and set type attributes must not be empty. Requests with empty values\n            will be rejected with a <code>ValidationException</code> exception.</p>"
             }
         },
         "com.amazonaws.dynamodb#AutoScalingPolicyDescription": {
@@ -406,7 +406,7 @@
                     }
                 },
                 "TargetValue": {
-                    "target": "com.amazonaws.dynamodb#Double",
+                    "target": "com.amazonaws.dynamodb#DoubleObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The target value for the metric. The range is 8.515920e-109 to 1.174271e+108 (Base 10)\n            or 2e-360 to 2e360 (Base 2).</p>",
                         "smithy.api#required": {}
@@ -439,7 +439,7 @@
                     }
                 },
                 "TargetValue": {
-                    "target": "com.amazonaws.dynamodb#Double",
+                    "target": "com.amazonaws.dynamodb#DoubleObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The target value for the metric. The range is 8.515920e-109 to 1.174271e+108 (Base 10)\n            or 2e-360 to 2e360 (Base 2).</p>",
                         "smithy.api#required": {}
@@ -524,7 +524,7 @@
                 "BackupType": {
                     "target": "com.amazonaws.dynamodb#BackupType",
                     "traits": {
-                        "smithy.api#documentation": "<p>BackupType:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>USER</code> - You create and manage these using the on-demand backup\n                    feature.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SYSTEM</code> - If you delete a table with point-in-time recovery enabled,\n                    a <code>SYSTEM</code> backup is automatically created and is retained for 35\n                    days (at no additional cost). System backups allow you to restore the deleted\n                    table to the state it was in just before the point of deletion. </p>\n            </li>\n            <li>\n                <p>\n                    <code>AWS_BACKUP</code> - On-demand backup created by you from Backup service.</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>BackupType:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>USER</code> - You create and manage these using the on-demand backup\n                    feature.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SYSTEM</code> - If you delete a table with point-in-time recovery enabled,\n                    a <code>SYSTEM</code> backup is automatically created and is retained for 35\n                    days (at no additional cost). System backups allow you to restore the deleted\n                    table to the state it was in just before the point of deletion. </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_BACKUP</code> - On-demand backup created by you from Backup service.</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
@@ -671,7 +671,7 @@
                 "BackupType": {
                     "target": "com.amazonaws.dynamodb#BackupType",
                     "traits": {
-                        "smithy.api#documentation": "<p>BackupType:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>USER</code> - You create and manage these using the on-demand backup\n                    feature.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SYSTEM</code> - If you delete a table with point-in-time recovery enabled,\n                    a <code>SYSTEM</code> backup is automatically created and is retained for 35\n                    days (at no additional cost). System backups allow you to restore the deleted\n                    table to the state it was in just before the point of deletion. </p>\n            </li>\n            <li>\n                <p>\n                    <code>AWS_BACKUP</code> - On-demand backup created by you from Backup service.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>BackupType:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>USER</code> - You create and manage these using the on-demand backup\n                    feature.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SYSTEM</code> - If you delete a table with point-in-time recovery enabled,\n                    a <code>SYSTEM</code> backup is automatically created and is retained for 35\n                    days (at no additional cost). System backups allow you to restore the deleted\n                    table to the state it was in just before the point of deletion. </p>\n            </li>\n            <li>\n               <p>\n                  <code>AWS_BACKUP</code> - On-demand backup created by you from Backup service.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "BackupSizeBytes": {
@@ -763,7 +763,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>This operation allows you to perform batch reads or writes on data stored in DynamoDB,\n            using PartiQL. Each read statement in a <code>BatchExecuteStatement</code> must specify\n            an equality condition on all key attributes. This enforces that each <code>SELECT</code>\n            statement in a batch returns at most a single item.</p>\n        <note>\n            <p>The entire batch must consist of either read statements or write statements, you\n                cannot mix both in one batch.</p>\n        </note>\n        <important>\n            <p>A HTTP 200 response does not mean that all statements in the BatchExecuteStatement\n                succeeded. Error details for individual statements can be found under the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchStatementResponse.html#DDB-Type-BatchStatementResponse-Error\">Error</a> field of the <code>BatchStatementResponse</code> for each\n                statement.</p>\n        </important>"
+                "smithy.api#documentation": "<p>This operation allows you to perform batch reads or writes on data stored in DynamoDB,\n            using PartiQL. Each read statement in a <code>BatchExecuteStatement</code> must specify\n            an equality condition on all key attributes. This enforces that each <code>SELECT</code>\n            statement in a batch returns at most a single item.</p>\n         <note>\n            <p>The entire batch must consist of either read statements or write statements, you\n                cannot mix both in one batch.</p>\n         </note>\n         <important>\n            <p>A HTTP 200 response does not mean that all statements in the BatchExecuteStatement\n                succeeded. Error details for individual statements can be found under the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchStatementResponse.html#DDB-Type-BatchStatementResponse-Error\">Error</a> field of the <code>BatchStatementResponse</code> for each\n                statement.</p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#BatchExecuteStatementInput": {
@@ -779,6 +779,9 @@
                 "ReturnConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ReturnConsumedCapacity"
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#BatchExecuteStatementOutput": {
@@ -796,6 +799,9 @@
                         "smithy.api#documentation": "<p>The capacity units consumed by the entire operation. The values of the list are\n            ordered according to the ordering of the statements.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#BatchGetItem": {
@@ -827,7 +833,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>BatchGetItem</code> operation returns the attributes of one or more items\n            from one or more tables. You identify requested items by primary key.</p>\n        <p>A single operation can retrieve up to 16 MB of data, which can contain as many as 100\n            items. <code>BatchGetItem</code> returns a partial result if the response size limit is\n            exceeded, the table's provisioned throughput is exceeded, or an internal processing\n            failure occurs. If a partial result is returned, the operation returns a value for\n                <code>UnprocessedKeys</code>. You can use this value to retry the operation starting\n            with the next item to get.</p>\n        <important>\n            <p>If you request more than 100 items, <code>BatchGetItem</code> returns a\n                    <code>ValidationException</code> with the message \"Too many items requested for\n                the BatchGetItem call.\"</p>\n        </important>\n        <p>For example, if you ask to retrieve 100 items, but each individual item is 300 KB in\n            size, the system returns 52 items (so as not to exceed the 16 MB limit). It also returns\n            an appropriate <code>UnprocessedKeys</code> value so you can get the next page of\n            results. If desired, your application can include its own logic to assemble the pages of\n            results into one dataset.</p>\n        <p>If <i>none</i> of the items can be processed due to insufficient\n            provisioned throughput on all of the tables in the request, then\n                <code>BatchGetItem</code> returns a\n                <code>ProvisionedThroughputExceededException</code>. If <i>at least\n                one</i> of the items is successfully processed, then\n                <code>BatchGetItem</code> completes successfully, while returning the keys of the\n            unread items in <code>UnprocessedKeys</code>.</p>\n        <important>\n            <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on\n                those items. However, <i>we strongly recommend that you use an exponential\n                    backoff algorithm</i>. If you retry the batch operation immediately, the\n                underlying read or write requests can still fail due to throttling on the individual\n                tables. If you delay the batch operation using exponential backoff, the individual\n                requests in the batch are much more likely to succeed.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#BatchOperations\">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB\n                    Developer Guide</i>.</p>\n        </important>\n        <p>By default, <code>BatchGetItem</code> performs eventually consistent reads on every\n            table in the request. If you want strongly consistent reads instead, you can set\n                <code>ConsistentRead</code> to <code>true</code> for any or all tables.</p>\n        <p>In order to minimize response latency, <code>BatchGetItem</code> retrieves items in\n            parallel.</p>\n        <p>When designing your application, keep in mind that DynamoDB does not return items in\n            any particular order. To help parse the response by item, include the primary key values\n            for the items in your request in the <code>ProjectionExpression</code> parameter.</p>\n        <p>If a requested item does not exist, it is not returned in the result. Requests for\n            nonexistent items consume the minimum read capacity units according to the type of read.\n            For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations\">Working with Tables</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                "smithy.api#documentation": "<p>The <code>BatchGetItem</code> operation returns the attributes of one or more items\n            from one or more tables. You identify requested items by primary key.</p>\n         <p>A single operation can retrieve up to 16 MB of data, which can contain as many as 100\n            items. <code>BatchGetItem</code> returns a partial result if the response size limit is\n            exceeded, the table's provisioned throughput is exceeded, or an internal processing\n            failure occurs. If a partial result is returned, the operation returns a value for\n                <code>UnprocessedKeys</code>. You can use this value to retry the operation starting\n            with the next item to get.</p>\n         <important>\n            <p>If you request more than 100 items, <code>BatchGetItem</code> returns a\n                    <code>ValidationException</code> with the message \"Too many items requested for\n                the BatchGetItem call.\"</p>\n         </important>\n         <p>For example, if you ask to retrieve 100 items, but each individual item is 300 KB in\n            size, the system returns 52 items (so as not to exceed the 16 MB limit). It also returns\n            an appropriate <code>UnprocessedKeys</code> value so you can get the next page of\n            results. If desired, your application can include its own logic to assemble the pages of\n            results into one dataset.</p>\n         <p>If <i>none</i> of the items can be processed due to insufficient\n            provisioned throughput on all of the tables in the request, then\n                <code>BatchGetItem</code> returns a\n                <code>ProvisionedThroughputExceededException</code>. If <i>at least\n                one</i> of the items is successfully processed, then\n                <code>BatchGetItem</code> completes successfully, while returning the keys of the\n            unread items in <code>UnprocessedKeys</code>.</p>\n         <important>\n            <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on\n                those items. However, <i>we strongly recommend that you use an exponential\n                    backoff algorithm</i>. If you retry the batch operation immediately, the\n                underlying read or write requests can still fail due to throttling on the individual\n                tables. If you delay the batch operation using exponential backoff, the individual\n                requests in the batch are much more likely to succeed.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#BatchOperations\">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB\n                    Developer Guide</i>.</p>\n         </important>\n         <p>By default, <code>BatchGetItem</code> performs eventually consistent reads on every\n            table in the request. If you want strongly consistent reads instead, you can set\n                <code>ConsistentRead</code> to <code>true</code> for any or all tables.</p>\n         <p>In order to minimize response latency, <code>BatchGetItem</code> retrieves items in\n            parallel.</p>\n         <p>When designing your application, keep in mind that DynamoDB does not return items in\n            any particular order. To help parse the response by item, include the primary key values\n            for the items in your request in the <code>ProjectionExpression</code> parameter.</p>\n         <p>If a requested item does not exist, it is not returned in the result. Requests for\n            nonexistent items consume the minimum read capacity units according to the type of read.\n            For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#CapacityUnitCalculations\">Working with Tables</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#BatchGetItemInput": {
@@ -836,7 +842,7 @@
                 "RequestItems": {
                     "target": "com.amazonaws.dynamodb#BatchGetRequestMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of one or more table names and, for each table, a map that describes one or more\n            items to retrieve from that table. Each table name can be used only once per\n                <code>BatchGetItem</code> request.</p>\n        <p>Each element in the map of items to retrieve consists of the following:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ConsistentRead</code> - If <code>true</code>, a strongly consistent read\n                    is used; if <code>false</code> (the default), an eventually consistent read is\n                    used.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ExpressionAttributeNames</code> - One or more substitution tokens for\n                    attribute names in the <code>ProjectionExpression</code> parameter. The\n                    following are some use cases for using\n                    <code>ExpressionAttributeNames</code>:</p>\n                <ul>\n                  <li>\n                        <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                            word.</p>\n                    </li>\n                  <li>\n                        <p>To create a placeholder for repeating occurrences of an attribute name\n                            in an expression.</p>\n                    </li>\n                  <li>\n                        <p>To prevent special characters in an attribute name from being\n                            misinterpreted in an expression.</p>\n                    </li>\n               </ul>\n                <p>Use the <b>#</b> character in an expression to\n                    dereference an attribute name. For example, consider the following attribute\n                    name:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>Percentile</code>\n                        </p>\n                    </li>\n               </ul>\n                <p>The name of this attribute conflicts with a reserved word, so it cannot be\n                    used directly in an expression. (For the complete list of reserved words, see\n                        <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved\n                        Words</a> in the <i>Amazon DynamoDB Developer Guide</i>).\n                    To work around this, you could specify the following for\n                        <code>ExpressionAttributeNames</code>:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>{\"#P\":\"Percentile\"}</code>\n                        </p>\n                    </li>\n               </ul>\n                <p>You could then use this substitution in an expression, as in this\n                    example:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>#P = :val</code>\n                        </p>\n                    </li>\n               </ul>\n                <note>\n                    <p>Tokens that begin with the <b>:</b> character\n                        are <i>expression attribute values</i>, which are placeholders\n                        for the actual value at runtime.</p>\n                </note>\n                <p>For more information about expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB\n                        Developer Guide</i>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Keys</code> - An array of primary key attribute values that define\n                    specific items in the table. For each primary key, you must provide\n                        <i>all</i> of the key attributes. For example, with a simple\n                    primary key, you only need to provide the partition key value. For a composite\n                    key, you must provide <i>both</i> the partition key value and the\n                    sort key value.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ProjectionExpression</code> - A string that identifies one or more\n                    attributes to retrieve from the table. These attributes can include scalars,\n                    sets, or elements of a JSON document. The attributes in the expression must be\n                    separated by commas.</p>\n                <p>If no attribute names are specified, then all attributes are returned. If any\n                    of the requested attributes are not found, they do not appear in the\n                    result.</p>\n                <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB\n                        Developer Guide</i>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>AttributesToGet</code> - This is a legacy parameter. Use\n                        <code>ProjectionExpression</code> instead. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html\">AttributesToGet</a> in the <i>Amazon DynamoDB Developer\n                        Guide</i>. </p>\n\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>A map of one or more table names and, for each table, a map that describes one or more\n            items to retrieve from that table. Each table name can be used only once per\n                <code>BatchGetItem</code> request.</p>\n         <p>Each element in the map of items to retrieve consists of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ConsistentRead</code> - If <code>true</code>, a strongly consistent read\n                    is used; if <code>false</code> (the default), an eventually consistent read is\n                    used.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ExpressionAttributeNames</code> - One or more substitution tokens for\n                    attribute names in the <code>ProjectionExpression</code> parameter. The\n                    following are some use cases for using\n                    <code>ExpressionAttributeNames</code>:</p>\n               <ul>\n                  <li>\n                     <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                            word.</p>\n                  </li>\n                  <li>\n                     <p>To create a placeholder for repeating occurrences of an attribute name\n                            in an expression.</p>\n                  </li>\n                  <li>\n                     <p>To prevent special characters in an attribute name from being\n                            misinterpreted in an expression.</p>\n                  </li>\n               </ul>\n               <p>Use the <b>#</b> character in an expression to\n                    dereference an attribute name. For example, consider the following attribute\n                    name:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>Percentile</code>\n                     </p>\n                  </li>\n               </ul>\n               <p>The name of this attribute conflicts with a reserved word, so it cannot be\n                    used directly in an expression. (For the complete list of reserved words, see\n                        <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved\n                        Words</a> in the <i>Amazon DynamoDB Developer Guide</i>).\n                    To work around this, you could specify the following for\n                        <code>ExpressionAttributeNames</code>:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>{\"#P\":\"Percentile\"}</code>\n                     </p>\n                  </li>\n               </ul>\n               <p>You could then use this substitution in an expression, as in this\n                    example:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>#P = :val</code>\n                     </p>\n                  </li>\n               </ul>\n               <note>\n                  <p>Tokens that begin with the <b>:</b> character\n                        are <i>expression attribute values</i>, which are placeholders\n                        for the actual value at runtime.</p>\n               </note>\n               <p>For more information about expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB\n                        Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Keys</code> - An array of primary key attribute values that define\n                    specific items in the table. For each primary key, you must provide\n                        <i>all</i> of the key attributes. For example, with a simple\n                    primary key, you only need to provide the partition key value. For a composite\n                    key, you must provide <i>both</i> the partition key value and the\n                    sort key value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ProjectionExpression</code> - A string that identifies one or more\n                    attributes to retrieve from the table. These attributes can include scalars,\n                    sets, or elements of a JSON document. The attributes in the expression must be\n                    separated by commas.</p>\n               <p>If no attribute names are specified, then all attributes are returned. If any\n                    of the requested attributes are not found, they do not appear in the\n                    result.</p>\n               <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB\n                        Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AttributesToGet</code> - This is a legacy parameter. Use\n                        <code>ProjectionExpression</code> instead. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.AttributesToGet.html\">AttributesToGet</a> in the <i>Amazon DynamoDB Developer\n                        Guide</i>. </p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
@@ -845,7 +851,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>BatchGetItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>BatchGetItem</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#BatchGetItemOutput": {
@@ -860,18 +867,19 @@
                 "UnprocessedKeys": {
                     "target": "com.amazonaws.dynamodb#BatchGetRequestMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of tables and their respective keys that were not processed with the current\n            response. The <code>UnprocessedKeys</code> value is in the same form as\n                <code>RequestItems</code>, so the value can be provided directly to a subsequent\n                <code>BatchGetItem</code> operation. For more information, see\n                <code>RequestItems</code> in the Request Parameters section.</p>\n        <p>Each element consists of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Keys</code> - An array of primary key attribute values that define\n                    specific items in the table.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ProjectionExpression</code> - One or more attributes to be retrieved from\n                    the table or index. By default, all attributes are returned. If a requested\n                    attribute is not found, it does not appear in the result.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ConsistentRead</code> - The consistency of a read operation. If set to\n                        <code>true</code>, then a strongly consistent read is used; otherwise, an\n                    eventually consistent read is used.</p>\n            </li>\n         </ul>\n        <p>If there are no unprocessed keys remaining, the response contains an empty\n                <code>UnprocessedKeys</code> map.</p>"
+                        "smithy.api#documentation": "<p>A map of tables and their respective keys that were not processed with the current\n            response. The <code>UnprocessedKeys</code> value is in the same form as\n                <code>RequestItems</code>, so the value can be provided directly to a subsequent\n                <code>BatchGetItem</code> operation. For more information, see\n                <code>RequestItems</code> in the Request Parameters section.</p>\n         <p>Each element consists of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Keys</code> - An array of primary key attribute values that define\n                    specific items in the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ProjectionExpression</code> - One or more attributes to be retrieved from\n                    the table or index. By default, all attributes are returned. If a requested\n                    attribute is not found, it does not appear in the result.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ConsistentRead</code> - The consistency of a read operation. If set to\n                        <code>true</code>, then a strongly consistent read is used; otherwise, an\n                    eventually consistent read is used.</p>\n            </li>\n         </ul>\n         <p>If there are no unprocessed keys remaining, the response contains an empty\n                <code>UnprocessedKeys</code> map.</p>"
                     }
                 },
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacityMultiple",
                     "traits": {
-                        "smithy.api#documentation": "<p>The read capacity units consumed by the entire <code>BatchGetItem</code>\n            operation.</p>\n        <p>Each element consists of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>TableName</code> - The table that consumed the provisioned\n                    throughput.</p>\n            </li>\n            <li>\n                <p>\n                    <code>CapacityUnits</code> - The total number of capacity units consumed.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The read capacity units consumed by the entire <code>BatchGetItem</code>\n            operation.</p>\n         <p>Each element consists of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TableName</code> - The table that consumed the provisioned\n                    throughput.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CapacityUnits</code> - The total number of capacity units consumed.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>BatchGetItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>BatchGetItem</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#BatchGetRequestMap": {
@@ -1074,7 +1082,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>BatchWriteItem</code> operation puts or deletes multiple items in one or\n            more tables. A single call to <code>BatchWriteItem</code> can transmit up to 16MB of\n            data over the network, consisting of up to 25 item put or delete operations. While\n            individual items can be up to 400 KB once stored, it's important to note that an item's\n            representation might be greater than 400KB while being sent in DynamoDB's JSON format\n            for the API call. For more details on this distinction, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html\">Naming Rules and Data Types</a>.</p>\n        <note>\n            <p>\n                <code>BatchWriteItem</code> cannot update items. If you perform a <code>BatchWriteItem</code>\n                operation on an existing item, that item's values will be overwritten by the\n                operation and it will appear like it was updated. To update items, we recommend you\n                use the <code>UpdateItem</code> action.</p>\n        </note>\n        <p>The individual <code>PutItem</code> and <code>DeleteItem</code> operations specified\n            in <code>BatchWriteItem</code> are atomic; however <code>BatchWriteItem</code> as a\n            whole is not. If any requested operations fail because the table's provisioned\n            throughput is exceeded or an internal processing failure occurs, the failed operations\n            are returned in the <code>UnprocessedItems</code> response parameter. You can\n            investigate and optionally resend the requests. Typically, you would call\n                <code>BatchWriteItem</code> in a loop. Each iteration would check for unprocessed\n            items and submit a new <code>BatchWriteItem</code> request with those unprocessed items\n            until all items have been processed.</p>\n        <p>If <i>none</i> of the items can be processed due to insufficient\n            provisioned throughput on all of the tables in the request, then\n                <code>BatchWriteItem</code> returns a\n                <code>ProvisionedThroughputExceededException</code>.</p>\n        <important>\n            <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on\n                those items. However, <i>we strongly recommend that you use an exponential\n                    backoff algorithm</i>. If you retry the batch operation immediately, the\n                underlying read or write requests can still fail due to throttling on the individual\n                tables. If you delay the batch operation using exponential backoff, the individual\n                requests in the batch are much more likely to succeed.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#Programming.Errors.BatchOperations\">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB\n                    Developer Guide</i>.</p>\n        </important>\n\n        <p>With <code>BatchWriteItem</code>, you can efficiently write or delete large amounts of\n            data, such as from Amazon EMR, or copy data from another database into DynamoDB. In\n            order to improve performance with these large-scale operations,\n                <code>BatchWriteItem</code> does not behave in the same way as individual\n                <code>PutItem</code> and <code>DeleteItem</code> calls would. For example, you\n            cannot specify conditions on individual put and delete requests, and\n                <code>BatchWriteItem</code> does not return deleted items in the response.</p>\n        <p>If you use a programming language that supports concurrency, you can use threads to\n            write items in parallel. Your application must include the necessary logic to manage the\n            threads. With languages that don't support threading, you must update or delete the\n            specified items one at a time. In both situations, <code>BatchWriteItem</code> performs\n            the specified put and delete operations in parallel, giving you the power of the thread\n            pool approach without having to introduce complexity into your application.</p>\n        <p>Parallel processing reduces latency, but each specified put and delete request\n            consumes the same number of write capacity units whether it is processed in parallel or\n            not. Delete operations on nonexistent items consume one write capacity unit.</p>\n        <p>If one or more of the following is true, DynamoDB rejects the entire batch write\n            operation:</p>\n        <ul>\n            <li>\n                <p>One or more tables specified in the <code>BatchWriteItem</code> request does\n                    not exist.</p>\n            </li>\n            <li>\n                <p>Primary key attributes specified on an item in the request do not match those\n                    in the corresponding table's primary key schema.</p>\n            </li>\n            <li>\n                <p>You try to perform multiple operations on the same item in the same\n                        <code>BatchWriteItem</code> request. For example, you cannot put and delete\n                    the same item in the same <code>BatchWriteItem</code> request. </p>\n            </li>\n            <li>\n                <p> Your request contains at least two items with identical hash and range keys\n                    (which essentially is two put operations). </p>\n            </li>\n            <li>\n                <p>There are more than 25 requests in the batch.</p>\n            </li>\n            <li>\n                <p>Any individual item in a batch exceeds 400 KB.</p>\n            </li>\n            <li>\n                <p>The total request size exceeds 16 MB.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>The <code>BatchWriteItem</code> operation puts or deletes multiple items in one or\n            more tables. A single call to <code>BatchWriteItem</code> can transmit up to 16MB of\n            data over the network, consisting of up to 25 item put or delete operations. While\n            individual items can be up to 400 KB once stored, it's important to note that an item's\n            representation might be greater than 400KB while being sent in DynamoDB's JSON format\n            for the API call. For more details on this distinction, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html\">Naming Rules and Data Types</a>.</p>\n         <note>\n            <p>\n               <code>BatchWriteItem</code> cannot update items. If you perform a <code>BatchWriteItem</code>\n                operation on an existing item, that item's values will be overwritten by the\n                operation and it will appear like it was updated. To update items, we recommend you\n                use the <code>UpdateItem</code> action.</p>\n         </note>\n         <p>The individual <code>PutItem</code> and <code>DeleteItem</code> operations specified\n            in <code>BatchWriteItem</code> are atomic; however <code>BatchWriteItem</code> as a\n            whole is not. If any requested operations fail because the table's provisioned\n            throughput is exceeded or an internal processing failure occurs, the failed operations\n            are returned in the <code>UnprocessedItems</code> response parameter. You can\n            investigate and optionally resend the requests. Typically, you would call\n                <code>BatchWriteItem</code> in a loop. Each iteration would check for unprocessed\n            items and submit a new <code>BatchWriteItem</code> request with those unprocessed items\n            until all items have been processed.</p>\n         <p>If <i>none</i> of the items can be processed due to insufficient\n            provisioned throughput on all of the tables in the request, then\n                <code>BatchWriteItem</code> returns a\n                <code>ProvisionedThroughputExceededException</code>.</p>\n         <important>\n            <p>If DynamoDB returns any unprocessed items, you should retry the batch operation on\n                those items. However, <i>we strongly recommend that you use an exponential\n                    backoff algorithm</i>. If you retry the batch operation immediately, the\n                underlying read or write requests can still fail due to throttling on the individual\n                tables. If you delay the batch operation using exponential backoff, the individual\n                requests in the batch are much more likely to succeed.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ErrorHandling.html#Programming.Errors.BatchOperations\">Batch Operations and Error Handling</a> in the <i>Amazon DynamoDB\n                    Developer Guide</i>.</p>\n         </important>\n         <p>With <code>BatchWriteItem</code>, you can efficiently write or delete large amounts of\n            data, such as from Amazon EMR, or copy data from another database into DynamoDB. In\n            order to improve performance with these large-scale operations,\n                <code>BatchWriteItem</code> does not behave in the same way as individual\n                <code>PutItem</code> and <code>DeleteItem</code> calls would. For example, you\n            cannot specify conditions on individual put and delete requests, and\n                <code>BatchWriteItem</code> does not return deleted items in the response.</p>\n         <p>If you use a programming language that supports concurrency, you can use threads to\n            write items in parallel. Your application must include the necessary logic to manage the\n            threads. With languages that don't support threading, you must update or delete the\n            specified items one at a time. In both situations, <code>BatchWriteItem</code> performs\n            the specified put and delete operations in parallel, giving you the power of the thread\n            pool approach without having to introduce complexity into your application.</p>\n         <p>Parallel processing reduces latency, but each specified put and delete request\n            consumes the same number of write capacity units whether it is processed in parallel or\n            not. Delete operations on nonexistent items consume one write capacity unit.</p>\n         <p>If one or more of the following is true, DynamoDB rejects the entire batch write\n            operation:</p>\n         <ul>\n            <li>\n               <p>One or more tables specified in the <code>BatchWriteItem</code> request does\n                    not exist.</p>\n            </li>\n            <li>\n               <p>Primary key attributes specified on an item in the request do not match those\n                    in the corresponding table's primary key schema.</p>\n            </li>\n            <li>\n               <p>You try to perform multiple operations on the same item in the same\n                        <code>BatchWriteItem</code> request. For example, you cannot put and delete\n                    the same item in the same <code>BatchWriteItem</code> request. </p>\n            </li>\n            <li>\n               <p> Your request contains at least two items with identical hash and range keys\n                    (which essentially is two put operations). </p>\n            </li>\n            <li>\n               <p>There are more than 25 requests in the batch.</p>\n            </li>\n            <li>\n               <p>Any individual item in a batch exceeds 400 KB.</p>\n            </li>\n            <li>\n               <p>The total request size exceeds 16 MB.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#BatchWriteItemInput": {
@@ -1083,7 +1091,7 @@
                 "RequestItems": {
                     "target": "com.amazonaws.dynamodb#BatchWriteItemRequestMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of one or more table names and, for each table, a list of operations to be\n            performed (<code>DeleteRequest</code> or <code>PutRequest</code>). Each element in the\n            map consists of the following:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>DeleteRequest</code> - Perform a <code>DeleteItem</code> operation on the\n                    specified item. The item to be deleted is identified by a <code>Key</code>\n                    subelement:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>Key</code> - A map of primary key attribute values that uniquely\n                            identify the item. Each entry in this map consists of an attribute name\n                            and an attribute value. For each primary key, you must provide\n                                <i>all</i> of the key attributes. For example, with a\n                            simple primary key, you only need to provide a value for the partition\n                            key. For a composite primary key, you must provide values for\n                                <i>both</i> the partition key and the sort key.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>\n                    <code>PutRequest</code> - Perform a <code>PutItem</code> operation on the\n                    specified item. The item to be put is identified by an <code>Item</code>\n                    subelement:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>Item</code> - A map of attributes and their values. Each entry in\n                            this map consists of an attribute name and an attribute value. Attribute\n                            values must not be null; string and binary type attributes must have\n                            lengths greater than zero; and set type attributes must not be empty.\n                            Requests that contain empty values are rejected with a\n                                <code>ValidationException</code> exception.</p>\n                        <p>If you specify any attributes that are part of an index key, then the\n                            data types for those attributes must match those of the schema in the\n                            table's attribute definition.</p>\n                    </li>\n               </ul>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>A map of one or more table names and, for each table, a list of operations to be\n            performed (<code>DeleteRequest</code> or <code>PutRequest</code>). Each element in the\n            map consists of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DeleteRequest</code> - Perform a <code>DeleteItem</code> operation on the\n                    specified item. The item to be deleted is identified by a <code>Key</code>\n                    subelement:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>Key</code> - A map of primary key attribute values that uniquely\n                            identify the item. Each entry in this map consists of an attribute name\n                            and an attribute value. For each primary key, you must provide\n                                <i>all</i> of the key attributes. For example, with a\n                            simple primary key, you only need to provide a value for the partition\n                            key. For a composite primary key, you must provide values for\n                                <i>both</i> the partition key and the sort key.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>PutRequest</code> - Perform a <code>PutItem</code> operation on the\n                    specified item. The item to be put is identified by an <code>Item</code>\n                    subelement:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>Item</code> - A map of attributes and their values. Each entry in\n                            this map consists of an attribute name and an attribute value. Attribute\n                            values must not be null; string and binary type attributes must have\n                            lengths greater than zero; and set type attributes must not be empty.\n                            Requests that contain empty values are rejected with a\n                                <code>ValidationException</code> exception.</p>\n                     <p>If you specify any attributes that are part of an index key, then the\n                            data types for those attributes must match those of the schema in the\n                            table's attribute definition.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
@@ -1098,7 +1106,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>BatchWriteItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>BatchWriteItem</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#BatchWriteItemOutput": {
@@ -1107,24 +1116,25 @@
                 "UnprocessedItems": {
                     "target": "com.amazonaws.dynamodb#BatchWriteItemRequestMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of tables and requests against those tables that were not processed. The\n                <code>UnprocessedItems</code> value is in the same form as\n            <code>RequestItems</code>, so you can provide this value directly to a subsequent\n                <code>BatchWriteItem</code> operation. For more information, see\n                <code>RequestItems</code> in the Request Parameters section.</p>\n        <p>Each <code>UnprocessedItems</code> entry consists of a table name and, for that table,\n            a list of operations to perform (<code>DeleteRequest</code> or\n            <code>PutRequest</code>).</p>\n        <ul>\n            <li>\n                <p>\n                    <code>DeleteRequest</code> - Perform a <code>DeleteItem</code> operation on the\n                    specified item. The item to be deleted is identified by a <code>Key</code>\n                    subelement:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>Key</code> - A map of primary key attribute values that uniquely\n                            identify the item. Each entry in this map consists of an attribute name\n                            and an attribute value.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>\n                    <code>PutRequest</code> - Perform a <code>PutItem</code> operation on the\n                    specified item. The item to be put is identified by an <code>Item</code>\n                    subelement:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>Item</code> - A map of attributes and their values. Each entry in\n                            this map consists of an attribute name and an attribute value. Attribute\n                            values must not be null; string and binary type attributes must have\n                            lengths greater than zero; and set type attributes must not be empty.\n                            Requests that contain empty values will be rejected with a\n                                <code>ValidationException</code> exception.</p>\n                        <p>If you specify any attributes that are part of an index key, then the\n                            data types for those attributes must match those of the schema in the\n                            table's attribute definition.</p>\n                    </li>\n               </ul>\n            </li>\n         </ul>\n        <p>If there are no unprocessed items remaining, the response contains an empty\n                <code>UnprocessedItems</code> map.</p>"
+                        "smithy.api#documentation": "<p>A map of tables and requests against those tables that were not processed. The\n                <code>UnprocessedItems</code> value is in the same form as\n            <code>RequestItems</code>, so you can provide this value directly to a subsequent\n                <code>BatchWriteItem</code> operation. For more information, see\n                <code>RequestItems</code> in the Request Parameters section.</p>\n         <p>Each <code>UnprocessedItems</code> entry consists of a table name and, for that table,\n            a list of operations to perform (<code>DeleteRequest</code> or\n            <code>PutRequest</code>).</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DeleteRequest</code> - Perform a <code>DeleteItem</code> operation on the\n                    specified item. The item to be deleted is identified by a <code>Key</code>\n                    subelement:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>Key</code> - A map of primary key attribute values that uniquely\n                            identify the item. Each entry in this map consists of an attribute name\n                            and an attribute value.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>PutRequest</code> - Perform a <code>PutItem</code> operation on the\n                    specified item. The item to be put is identified by an <code>Item</code>\n                    subelement:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>Item</code> - A map of attributes and their values. Each entry in\n                            this map consists of an attribute name and an attribute value. Attribute\n                            values must not be null; string and binary type attributes must have\n                            lengths greater than zero; and set type attributes must not be empty.\n                            Requests that contain empty values will be rejected with a\n                                <code>ValidationException</code> exception.</p>\n                     <p>If you specify any attributes that are part of an index key, then the\n                            data types for those attributes must match those of the schema in the\n                            table's attribute definition.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>If there are no unprocessed items remaining, the response contains an empty\n                <code>UnprocessedItems</code> map.</p>"
                     }
                 },
                 "ItemCollectionMetrics": {
                     "target": "com.amazonaws.dynamodb#ItemCollectionMetricsPerTable",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of tables that were processed by <code>BatchWriteItem</code> and, for each\n            table, information about any item collections that were affected by individual\n                <code>DeleteItem</code> or <code>PutItem</code> operations.</p>\n        <p>Each entry consists of the following subelements:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SizeEstimateRangeGB</code> - An estimate of item collection size,\n                    expressed in GB. This is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on the table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n                <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>A list of tables that were processed by <code>BatchWriteItem</code> and, for each\n            table, information about any item collections that were affected by individual\n                <code>DeleteItem</code> or <code>PutItem</code> operations.</p>\n         <p>Each entry consists of the following subelements:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SizeEstimateRangeGB</code> - An estimate of item collection size,\n                    expressed in GB. This is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on the table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n               <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacityMultiple",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity units consumed by the entire <code>BatchWriteItem</code>\n            operation.</p>\n        <p>Each element consists of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>TableName</code> - The table that consumed the provisioned\n                    throughput.</p>\n            </li>\n            <li>\n                <p>\n                    <code>CapacityUnits</code> - The total number of capacity units consumed.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The capacity units consumed by the entire <code>BatchWriteItem</code>\n            operation.</p>\n         <p>Each element consists of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>TableName</code> - The table that consumed the provisioned\n                    throughput.</p>\n            </li>\n            <li>\n               <p>\n                  <code>CapacityUnits</code> - The total number of capacity units consumed.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>BatchWriteItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>BatchWriteItem</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#BatchWriteItemRequestMap": {
@@ -1173,7 +1183,7 @@
                 "BillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>PROVISIONED</code> - Sets the read/write capacity mode to\n                        <code>PROVISIONED</code>. We recommend using <code>PROVISIONED</code> for\n                    predictable workloads.</p>\n            </li>\n            <li>\n                <p>\n                    <code>PAY_PER_REQUEST</code> - Sets the read/write capacity mode to\n                        <code>PAY_PER_REQUEST</code>. We recommend using\n                        <code>PAY_PER_REQUEST</code> for unpredictable workloads. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - Sets the read/write capacity mode to\n                        <code>PROVISIONED</code>. We recommend using <code>PROVISIONED</code> for\n                    predictable workloads.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - Sets the read/write capacity mode to\n                        <code>PAY_PER_REQUEST</code>. We recommend using\n                        <code>PAY_PER_REQUEST</code> for unpredictable workloads. </p>\n            </li>\n         </ul>"
                     }
                 },
                 "LastUpdateToPayPerRequestDateTime": {
@@ -1184,7 +1194,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the details for the read/write capacity mode. This page talks about\n                <code>PROVISIONED</code> and <code>PAY_PER_REQUEST</code> billing modes. For more\n            information about these modes, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html\">Read/write capacity mode</a>.</p>\n        <note>\n            <p>You may need to switch to on-demand mode at least once in order to return a\n                    <code>BillingModeSummary</code> response.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Contains the details for the read/write capacity mode. This page talks about\n                <code>PROVISIONED</code> and <code>PAY_PER_REQUEST</code> billing modes. For more\n            information about these modes, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html\">Read/write capacity mode</a>.</p>\n         <note>\n            <p>You may need to switch to on-demand mode at least once in order to return a\n                    <code>BillingModeSummary</code> response.</p>\n         </note>"
             }
         },
         "com.amazonaws.dynamodb#BinaryAttributeValue": {
@@ -1382,19 +1392,19 @@
                 "AttributeValueList": {
                     "target": "com.amazonaws.dynamodb#AttributeValueList",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values to evaluate against the supplied attribute. The number of values in\n            the list depends on the <code>ComparisonOperator</code> being used.</p>\n        <p>For type Number, value comparisons are numeric.</p>\n        <p>String value comparisons for greater than, equals, or less than are based on ASCII\n            character code values. For example, <code>a</code> is greater than <code>A</code>, and\n                <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p>\n        <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it\n            compares binary values.</p>"
+                        "smithy.api#documentation": "<p>One or more values to evaluate against the supplied attribute. The number of values in\n            the list depends on the <code>ComparisonOperator</code> being used.</p>\n         <p>For type Number, value comparisons are numeric.</p>\n         <p>String value comparisons for greater than, equals, or less than are based on ASCII\n            character code values. For example, <code>a</code> is greater than <code>A</code>, and\n                <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p>\n         <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it\n            compares binary values.</p>"
                     }
                 },
                 "ComparisonOperator": {
                     "target": "com.amazonaws.dynamodb#ComparisonOperator",
                     "traits": {
-                        "smithy.api#documentation": "<p>A comparator for evaluating attributes. For example, equals, greater than, less than,\n            etc.</p>\n        <p>The following comparison operators are available:</p>\n        <p>\n            <code>EQ | NE | LE | LT | GE | GT | NOT_NULL | NULL | CONTAINS | NOT_CONTAINS |\n                BEGINS_WITH | IN | BETWEEN</code>\n        </p>\n        <p>The following are descriptions of each comparison operator.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>EQ</code> : Equal. <code>EQ</code> is supported for all data types,\n                    including lists and maps.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, Binary, String Set, Number Set, or Binary Set.\n                    If an item contains an <code>AttributeValue</code> element of a different type\n                    than the one provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>NE</code> : Not equal. <code>NE</code> is supported for all data types,\n                    including lists and maps.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, Binary, String Set, Number Set, or Binary Set. If an\n                    item contains an <code>AttributeValue</code> of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>LE</code> : Less than or equal. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>LT</code> : Less than. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, or Binary (not a set type). If an item contains an\n                        <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>GE</code> : Greater than or equal. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>GT</code> : Greater than. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>NOT_NULL</code> : The attribute exists. <code>NOT_NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n                <note>\n                    <p>This operator tests for the existence of an attribute, not its data type.\n                        If the data type of attribute \"<code>a</code>\" is null, and you evaluate it\n                        using <code>NOT_NULL</code>, the result is a Boolean <code>true</code>. This\n                        result is because the attribute \"<code>a</code>\" exists; its data type is\n                        not relevant to the <code>NOT_NULL</code> comparison operator.</p>\n                </note>\n            </li>\n            <li>\n                <p>\n                    <code>NULL</code> : The attribute does not exist. <code>NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n                <note>\n                    <p>This operator tests for the nonexistence of an attribute, not its data\n                        type. If the data type of attribute \"<code>a</code>\" is null, and you\n                        evaluate it using <code>NULL</code>, the result is a Boolean\n                            <code>false</code>. This is because the attribute \"<code>a</code>\"\n                        exists; its data type is not relevant to the <code>NULL</code> comparison\n                        operator.</p>\n                </note>\n            </li>\n            <li>\n                <p>\n                    <code>CONTAINS</code> : Checks for a subsequence, or value in a set.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is of type String, then the operator checks for a\n                    substring match. If the target attribute of the comparison is of type Binary,\n                    then the operator looks for a subsequence of the target that matches the input.\n                    If the target attribute of the comparison is a set (\"<code>SS</code>\",\n                        \"<code>NS</code>\", or \"<code>BS</code>\"), then the operator evaluates to\n                    true if it finds an exact match with any member of the set.</p>\n                <p>CONTAINS is supported for lists: When evaluating \"<code>a CONTAINS b</code>\",\n                        \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot be a set, a\n                    map, or a list.</p>\n            </li>\n            <li>\n                <p>\n                    <code>NOT_CONTAINS</code> : Checks for absence of a subsequence, or absence of a\n                    value in a set.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is a String, then the operator checks for the\n                    absence of a substring match. If the target attribute of the comparison is\n                    Binary, then the operator checks for the absence of a subsequence of the target\n                    that matches the input. If the target attribute of the comparison is a set\n                        (\"<code>SS</code>\", \"<code>NS</code>\", or \"<code>BS</code>\"), then the\n                    operator evaluates to true if it <i>does not</i> find an exact\n                    match with any member of the set.</p>\n                <p>NOT_CONTAINS is supported for lists: When evaluating \"<code>a NOT CONTAINS\n                        b</code>\", \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot\n                    be a set, a map, or a list.</p>\n            </li>\n            <li>\n                <p>\n                    <code>BEGINS_WITH</code> : Checks for a prefix. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String or Binary (not a Number or a set type). The target attribute of\n                    the comparison must be of type String or Binary (not a Number or a set\n                    type).</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>IN</code> : Checks for matching elements in a list.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain one or more\n                        <code>AttributeValue</code> elements of type String, Number, or Binary.\n                    These attributes are compared against an existing attribute of an item. If any\n                    elements of the input are equal to the item attribute, the expression evaluates\n                    to true.</p>\n            </li>\n            <li>\n                <p>\n                    <code>BETWEEN</code> : Greater than or equal to the first value, and less than\n                    or equal to the second value. </p>\n                <p>\n                    <code>AttributeValueList</code> must contain two <code>AttributeValue</code>\n                    elements of the same type, either String, Number, or Binary (not a set type). A\n                    target attribute matches if the target value is greater than, or equal to, the\n                    first element and less than, or equal to, the second element. If an item\n                    contains an <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not compare to <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>\n                </p>\n            </li>\n         </ul>\n        <p>For usage examples of <code>AttributeValueList</code> and\n                <code>ComparisonOperator</code>, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html\">Legacy\n                Conditional Parameters</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>A comparator for evaluating attributes. For example, equals, greater than, less than,\n            etc.</p>\n         <p>The following comparison operators are available:</p>\n         <p>\n            <code>EQ | NE | LE | LT | GE | GT | NOT_NULL | NULL | CONTAINS | NOT_CONTAINS |\n                BEGINS_WITH | IN | BETWEEN</code>\n         </p>\n         <p>The following are descriptions of each comparison operator.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>EQ</code> : Equal. <code>EQ</code> is supported for all data types,\n                    including lists and maps.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, Binary, String Set, Number Set, or Binary Set.\n                    If an item contains an <code>AttributeValue</code> element of a different type\n                    than the one provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>NE</code> : Not equal. <code>NE</code> is supported for all data types,\n                    including lists and maps.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, Binary, String Set, Number Set, or Binary Set. If an\n                    item contains an <code>AttributeValue</code> of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>LE</code> : Less than or equal. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>LT</code> : Less than. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, or Binary (not a set type). If an item contains an\n                        <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>GE</code> : Greater than or equal. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>GT</code> : Greater than. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_NULL</code> : The attribute exists. <code>NOT_NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n               <note>\n                  <p>This operator tests for the existence of an attribute, not its data type.\n                        If the data type of attribute \"<code>a</code>\" is null, and you evaluate it\n                        using <code>NOT_NULL</code>, the result is a Boolean <code>true</code>. This\n                        result is because the attribute \"<code>a</code>\" exists; its data type is\n                        not relevant to the <code>NOT_NULL</code> comparison operator.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>NULL</code> : The attribute does not exist. <code>NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n               <note>\n                  <p>This operator tests for the nonexistence of an attribute, not its data\n                        type. If the data type of attribute \"<code>a</code>\" is null, and you\n                        evaluate it using <code>NULL</code>, the result is a Boolean\n                            <code>false</code>. This is because the attribute \"<code>a</code>\"\n                        exists; its data type is not relevant to the <code>NULL</code> comparison\n                        operator.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>CONTAINS</code> : Checks for a subsequence, or value in a set.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is of type String, then the operator checks for a\n                    substring match. If the target attribute of the comparison is of type Binary,\n                    then the operator looks for a subsequence of the target that matches the input.\n                    If the target attribute of the comparison is a set (\"<code>SS</code>\",\n                        \"<code>NS</code>\", or \"<code>BS</code>\"), then the operator evaluates to\n                    true if it finds an exact match with any member of the set.</p>\n               <p>CONTAINS is supported for lists: When evaluating \"<code>a CONTAINS b</code>\",\n                        \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot be a set, a\n                    map, or a list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_CONTAINS</code> : Checks for absence of a subsequence, or absence of a\n                    value in a set.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is a String, then the operator checks for the\n                    absence of a substring match. If the target attribute of the comparison is\n                    Binary, then the operator checks for the absence of a subsequence of the target\n                    that matches the input. If the target attribute of the comparison is a set\n                        (\"<code>SS</code>\", \"<code>NS</code>\", or \"<code>BS</code>\"), then the\n                    operator evaluates to true if it <i>does not</i> find an exact\n                    match with any member of the set.</p>\n               <p>NOT_CONTAINS is supported for lists: When evaluating \"<code>a NOT CONTAINS\n                        b</code>\", \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot\n                    be a set, a map, or a list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BEGINS_WITH</code> : Checks for a prefix. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String or Binary (not a Number or a set type). The target attribute of\n                    the comparison must be of type String or Binary (not a Number or a set\n                    type).</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>IN</code> : Checks for matching elements in a list.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain one or more\n                        <code>AttributeValue</code> elements of type String, Number, or Binary.\n                    These attributes are compared against an existing attribute of an item. If any\n                    elements of the input are equal to the item attribute, the expression evaluates\n                    to true.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BETWEEN</code> : Greater than or equal to the first value, and less than\n                    or equal to the second value. </p>\n               <p>\n                  <code>AttributeValueList</code> must contain two <code>AttributeValue</code>\n                    elements of the same type, either String, Number, or Binary (not a set type). A\n                    target attribute matches if the target value is greater than, or equal to, the\n                    first element and less than, or equal to, the second element. If an item\n                    contains an <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not compare to <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>\n               </p>\n            </li>\n         </ul>\n         <p>For usage examples of <code>AttributeValueList</code> and\n                <code>ComparisonOperator</code>, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html\">Legacy\n                Conditional Parameters</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the selection criteria for a <code>Query</code> or <code>Scan</code>\n            operation:</p>\n        <ul>\n            <li>\n                <p>For a <code>Query</code> operation, <code>Condition</code> is used for\n                    specifying the <code>KeyConditions</code> to use when querying a table or an\n                    index. For <code>KeyConditions</code>, only the following comparison operators\n                    are supported:</p>\n                <p>\n                    <code>EQ | LE | LT | GE | GT | BEGINS_WITH | BETWEEN</code>\n                </p>\n                <p>\n                    <code>Condition</code> is also used in a <code>QueryFilter</code>, which\n                    evaluates the query results and returns only the desired values.</p>\n            </li>\n            <li>\n                <p>For a <code>Scan</code> operation, <code>Condition</code> is used in a\n                        <code>ScanFilter</code>, which evaluates the scan results and returns only\n                    the desired values.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Represents the selection criteria for a <code>Query</code> or <code>Scan</code>\n            operation:</p>\n         <ul>\n            <li>\n               <p>For a <code>Query</code> operation, <code>Condition</code> is used for\n                    specifying the <code>KeyConditions</code> to use when querying a table or an\n                    index. For <code>KeyConditions</code>, only the following comparison operators\n                    are supported:</p>\n               <p>\n                  <code>EQ | LE | LT | GE | GT | BEGINS_WITH | BETWEEN</code>\n               </p>\n               <p>\n                  <code>Condition</code> is also used in a <code>QueryFilter</code>, which\n                    evaluates the query results and returns only the desired values.</p>\n            </li>\n            <li>\n               <p>For a <code>Scan</code> operation, <code>Condition</code> is used in a\n                        <code>ScanFilter</code>, which evaluates the scan results and returns only\n                    the desired values.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#ConditionCheck": {
@@ -1417,20 +1427,20 @@
                 "ConditionExpression": {
                     "target": "com.amazonaws.dynamodb#ConditionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional update to\n            succeed.</p>",
+                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional update to\n            succeed. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html\">Condition expressions</a> in the <i>Amazon DynamoDB Developer\n                    Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. For more information, see\n            <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ExpressionAttributeNames.html\">Expression attribute names</a> \n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeValues": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeValueMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>"
+                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html\">Condition expressions</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
                     }
                 },
                 "ReturnValuesOnConditionCheckFailure": {
@@ -1722,7 +1732,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Creates a backup for an existing table.</p>\n        <p> Each time you create an on-demand backup, the entire table data is backed up. There\n            is no limit to the number of on-demand backups that can be taken. </p>\n        <p> When you create an on-demand backup, a time marker of the request is cataloged, and\n            the backup is created asynchronously, by applying all changes until the time of the\n            request to the last full table snapshot. Backup requests are processed instantaneously\n            and become available for restore within minutes. </p>\n        <p>You can call <code>CreateBackup</code> at a maximum rate of 50 times per\n            second.</p>\n        <p>All backups in DynamoDB work without consuming any provisioned throughput on the\n            table.</p>\n        <p> If you submit a backup request on 2018-12-14 at 14:25:00, the backup is guaranteed to\n            contain all data committed to the table up to 14:24:00, and data committed after\n            14:26:00 will not be. The backup might contain data modifications made between 14:24:00\n            and 14:26:00. On-demand backup does not support causal consistency. </p>\n        <p> Along with data, the following are also included on the backups: </p>\n        <ul>\n            <li>\n                <p>Global secondary indexes (GSIs)</p>\n            </li>\n            <li>\n                <p>Local secondary indexes (LSIs)</p>\n            </li>\n            <li>\n                <p>Streams</p>\n            </li>\n            <li>\n                <p>Provisioned read and write capacity</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Creates a backup for an existing table.</p>\n         <p> Each time you create an on-demand backup, the entire table data is backed up. There\n            is no limit to the number of on-demand backups that can be taken. </p>\n         <p> When you create an on-demand backup, a time marker of the request is cataloged, and\n            the backup is created asynchronously, by applying all changes until the time of the\n            request to the last full table snapshot. Backup requests are processed instantaneously\n            and become available for restore within minutes. </p>\n         <p>You can call <code>CreateBackup</code> at a maximum rate of 50 times per\n            second.</p>\n         <p>All backups in DynamoDB work without consuming any provisioned throughput on the\n            table.</p>\n         <p> If you submit a backup request on 2018-12-14 at 14:25:00, the backup is guaranteed to\n            contain all data committed to the table up to 14:24:00, and data committed after\n            14:26:00 will not be. The backup might contain data modifications made between 14:24:00\n            and 14:26:00. On-demand backup does not support causal consistency. </p>\n         <p> Along with data, the following are also included on the backups: </p>\n         <ul>\n            <li>\n               <p>Global secondary indexes (GSIs)</p>\n            </li>\n            <li>\n               <p>Local secondary indexes (LSIs)</p>\n            </li>\n            <li>\n               <p>Streams</p>\n            </li>\n            <li>\n               <p>Provisioned read and write capacity</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#CreateBackupInput": {
@@ -1742,6 +1752,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#CreateBackupOutput": {
@@ -1753,6 +1766,9 @@
                         "smithy.api#documentation": "<p>Contains the details of the backup created for the table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#CreateGlobalSecondaryIndexAction": {
@@ -1782,7 +1798,7 @@
                 "ProvisionedThroughput": {
                     "target": "com.amazonaws.dynamodb#ProvisionedThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n        <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
@@ -1819,7 +1835,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Creates a global table from an existing table. A global table creates a replication\n            relationship between two or more DynamoDB tables with the same table name in the\n            provided Regions. </p>\n        <note>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                    2017.11.29</a> of global tables.</p>\n        </note>\n\n        <p>If you want to add a new replica table to a global table, each of the following\n            conditions must be true:</p>\n        <ul>\n            <li>\n                <p>The table must have the same primary key as all of the other replicas.</p>\n            </li>\n            <li>\n                <p>The table must have the same name as all of the other replicas.</p>\n            </li>\n            <li>\n                <p>The table must have DynamoDB Streams enabled, with the stream containing both\n                    the new and the old images of the item.</p>\n            </li>\n            <li>\n                <p>None of the replica tables in the global table can contain any data.</p>\n            </li>\n         </ul>\n        <p> If global secondary indexes are specified, then the following conditions must also be\n            met: </p>\n        <ul>\n            <li>\n                <p> The global secondary indexes must have the same name. </p>\n            </li>\n            <li>\n                <p> The global secondary indexes must have the same hash key and sort key (if\n                    present). </p>\n            </li>\n         </ul>\n        <p> If local secondary indexes are specified, then the following conditions must also be\n            met: </p>\n        <ul>\n            <li>\n                <p> The local secondary indexes must have the same name. </p>\n            </li>\n            <li>\n                <p> The local secondary indexes must have the same hash key and sort key (if\n                    present). </p>\n            </li>\n         </ul>\n\n        <important>\n            <p> Write capacity settings should be set consistently across your replica tables and\n                secondary indexes. DynamoDB strongly recommends enabling auto scaling to manage the\n                write capacity settings for all of your global tables replicas and indexes. </p>\n            <p> If you prefer to manage write capacity settings manually, you should provision\n                equal replicated write capacity units to your replica tables. You should also\n                provision equal replicated write capacity units to matching secondary indexes across\n                your global table. </p>\n        </important>"
+                "smithy.api#documentation": "<p>Creates a global table from an existing table. A global table creates a replication\n            relationship between two or more DynamoDB tables with the same table name in the\n            provided Regions. </p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                2017.11.29 (Legacy)</a> of global tables. We recommend using\n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                when creating new global tables, as it provides greater flexibility, higher efficiency and consumes less write capacity than \n                2017.11.29 (Legacy). To determine which version you are using, see \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.DetermineVersion.html\">Determining the version</a>. \n                To update existing global tables from version 2017.11.29 (Legacy) to version\n                2019.11.21 (Current), see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_upgrade.html\">\n                    Updating global tables</a>.\n            </p>\n         </important>\n         <p>If you want to add a new replica table to a global table, each of the following\n            conditions must be true:</p>\n         <ul>\n            <li>\n               <p>The table must have the same primary key as all of the other replicas.</p>\n            </li>\n            <li>\n               <p>The table must have the same name as all of the other replicas.</p>\n            </li>\n            <li>\n               <p>The table must have DynamoDB Streams enabled, with the stream containing both\n                    the new and the old images of the item.</p>\n            </li>\n            <li>\n               <p>None of the replica tables in the global table can contain any data.</p>\n            </li>\n         </ul>\n         <p> If global secondary indexes are specified, then the following conditions must also be\n            met: </p>\n         <ul>\n            <li>\n               <p> The global secondary indexes must have the same name. </p>\n            </li>\n            <li>\n               <p> The global secondary indexes must have the same hash key and sort key (if\n                    present). </p>\n            </li>\n         </ul>\n         <p> If local secondary indexes are specified, then the following conditions must also be\n            met: </p>\n         <ul>\n            <li>\n               <p> The local secondary indexes must have the same name. </p>\n            </li>\n            <li>\n               <p> The local secondary indexes must have the same hash key and sort key (if\n                    present). </p>\n            </li>\n         </ul>\n         <important>\n            <p> Write capacity settings should be set consistently across your replica tables and\n                secondary indexes. DynamoDB strongly recommends enabling auto scaling to manage the\n                write capacity settings for all of your global tables replicas and indexes. </p>\n            <p> If you prefer to manage write capacity settings manually, you should provision\n                equal replicated write capacity units to your replica tables. You should also\n                provision equal replicated write capacity units to matching secondary indexes across\n                your global table. </p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#CreateGlobalTableInput": {
@@ -1839,6 +1855,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#CreateGlobalTableOutput": {
@@ -1850,6 +1869,9 @@
                         "smithy.api#documentation": "<p>Contains the details of the global table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#CreateReplicaAction": {
@@ -1932,7 +1954,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>CreateTable</code> operation adds a new table to your account. In an Amazon Web Services account, table names must be unique within each Region. That is, you can\n            have two tables with same name if you create the tables in different Regions.</p>\n        <p>\n            <code>CreateTable</code> is an asynchronous operation. Upon receiving a\n                <code>CreateTable</code> request, DynamoDB immediately returns a response with a\n                <code>TableStatus</code> of <code>CREATING</code>. After the table is created,\n            DynamoDB sets the <code>TableStatus</code> to <code>ACTIVE</code>. You can perform read\n            and write operations only on an <code>ACTIVE</code> table. </p>\n        <p>You can optionally define secondary indexes on the new table, as part of the\n                <code>CreateTable</code> operation. If you want to create multiple tables with\n            secondary indexes on them, you must create the tables sequentially. Only one table with\n            secondary indexes can be in the <code>CREATING</code> state at any given time.</p>\n        <p>You can use the <code>DescribeTable</code> action to check the table status.</p>"
+                "smithy.api#documentation": "<p>The <code>CreateTable</code> operation adds a new table to your account. In an Amazon Web Services account, table names must be unique within each Region. That is, you can\n            have two tables with same name if you create the tables in different Regions.</p>\n         <p>\n            <code>CreateTable</code> is an asynchronous operation. Upon receiving a\n                <code>CreateTable</code> request, DynamoDB immediately returns a response with a\n                <code>TableStatus</code> of <code>CREATING</code>. After the table is created,\n            DynamoDB sets the <code>TableStatus</code> to <code>ACTIVE</code>. You can perform read\n            and write operations only on an <code>ACTIVE</code> table. </p>\n         <p>You can optionally define secondary indexes on the new table, as part of the\n                <code>CreateTable</code> operation. If you want to create multiple tables with\n            secondary indexes on them, you must create the tables sequentially. Only one table with\n            secondary indexes can be in the <code>CREATING</code> state at any given time.</p>\n         <p>You can use the <code>DescribeTable</code> action to check the table status.</p>"
             }
         },
         "com.amazonaws.dynamodb#CreateTableInput": {
@@ -1955,38 +1977,38 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the attributes that make up the primary key for a table or an index. The\n            attributes in <code>KeySchema</code> must also be defined in the\n                <code>AttributeDefinitions</code> array. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html\">Data\n                Model</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>\n        <p>Each <code>KeySchemaElement</code> in the array is composed of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>AttributeName</code> - The name of this key attribute.</p>\n            </li>\n            <li>\n                <p>\n                    <code>KeyType</code> - The role that the key attribute will assume:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>HASH</code> - partition key</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>RANGE</code> - sort key</p>\n                    </li>\n               </ul>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from the DynamoDB usage\n                of an internal hash function to evenly distribute data items across partitions,\n                based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>\n\n        <p>For a simple primary key (partition key), you must provide exactly one element with a\n                <code>KeyType</code> of <code>HASH</code>.</p>\n        <p>For a composite primary key (partition key and sort key), you must provide exactly two\n            elements, in this order: The first element must have a <code>KeyType</code> of\n                <code>HASH</code>, and the second element must have a <code>KeyType</code> of\n                <code>RANGE</code>.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#WorkingWithTables.primary.key\">Working with Tables</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>Specifies the attributes that make up the primary key for a table or an index. The\n            attributes in <code>KeySchema</code> must also be defined in the\n                <code>AttributeDefinitions</code> array. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html\">Data\n                Model</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>\n         <p>Each <code>KeySchemaElement</code> in the array is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AttributeName</code> - The name of this key attribute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeyType</code> - The role that the key attribute will assume:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>HASH</code> - partition key</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RANGE</code> - sort key</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from the DynamoDB usage\n                of an internal hash function to evenly distribute data items across partitions,\n                based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>\n         <p>For a simple primary key (partition key), you must provide exactly one element with a\n                <code>KeyType</code> of <code>HASH</code>.</p>\n         <p>For a composite primary key (partition key and sort key), you must provide exactly two\n            elements, in this order: The first element must have a <code>KeyType</code> of\n                <code>HASH</code>, and the second element must have a <code>KeyType</code> of\n                <code>RANGE</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#WorkingWithTables.primary.key\">Working with Tables</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "LocalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#LocalSecondaryIndexList",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more local secondary indexes (the maximum is 5) to be created on the table.\n            Each index is scoped to a given partition key value. There is a 10 GB size limit per\n            partition key value; otherwise, the size of a local secondary index is\n            unconstrained.</p>\n        <p>Each local secondary index in the array includes the following:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>IndexName</code> - The name of the local secondary index. Must be unique\n                    only for this table.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>KeySchema</code> - Specifies the key schema for the local secondary index.\n                    The key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>ProjectionType</code> - One of the following:</p>\n                        <ul>\n                        <li>\n                                <p>\n                                    <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                            </li>\n                     </ul>\n                    </li>\n                  <li>\n                        <p>\n                            <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                    </li>\n               </ul>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>One or more local secondary indexes (the maximum is 5) to be created on the table.\n            Each index is scoped to a given partition key value. There is a 10 GB size limit per\n            partition key value; otherwise, the size of a local secondary index is\n            unconstrained.</p>\n         <p>Each local secondary index in the array includes the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index. Must be unique\n                    only for this table.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the key schema for the local secondary index.\n                    The key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
                     }
                 },
                 "GlobalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#GlobalSecondaryIndexList",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more global secondary indexes (the maximum is 20) to be created on the table.\n            Each global secondary index in the array includes the following:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>IndexName</code> - The name of the global secondary index. Must be unique\n                    only for this table.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>KeySchema</code> - Specifies the key schema for the global secondary\n                    index.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>ProjectionType</code> - One of the following:</p>\n                        <ul>\n                        <li>\n                                <p>\n                                    <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                            </li>\n                     </ul>\n                    </li>\n                  <li>\n                        <p>\n                            <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>\n                    <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>One or more global secondary indexes (the maximum is 20) to be created on the table.\n            Each global secondary index in the array includes the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index. Must be unique\n                    only for this table.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the key schema for the global secondary\n                    index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "BillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual\">Provisioned Mode</a>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand\">On-Demand Mode</a>. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual\">Provisioned Mode</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand\">On-Demand Mode</a>. </p>\n            </li>\n         </ul>"
                     }
                 },
                 "ProvisionedThroughput": {
                     "target": "com.amazonaws.dynamodb#ProvisionedThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for a specified table or index. The\n            settings can be modified using the <code>UpdateTable</code> operation.</p>\n        <p> If you set BillingMode as <code>PROVISIONED</code>, you must specify this property.\n            If you set BillingMode as <code>PAY_PER_REQUEST</code>, you cannot specify this\n            property.</p>\n        <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for a specified table or index. The\n            settings can be modified using the <code>UpdateTable</code> operation.</p>\n         <p> If you set BillingMode as <code>PROVISIONED</code>, you must specify this property.\n            If you set BillingMode as <code>PAY_PER_REQUEST</code>, you cannot specify this\n            property.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "StreamSpecification": {
                     "target": "com.amazonaws.dynamodb#StreamSpecification",
                     "traits": {
-                        "smithy.api#documentation": "<p>The settings for DynamoDB Streams on the table. These settings consist of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>StreamEnabled</code> - Indicates whether DynamoDB Streams is to be enabled\n                    (true) or disabled (false).</p>\n            </li>\n            <li>\n                <p>\n                    <code>StreamViewType</code> - When an item in the table is modified,\n                        <code>StreamViewType</code> determines what information is written to the\n                    table's stream. Valid values for <code>StreamViewType</code> are:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>KEYS_ONLY</code> - Only the key attributes of the modified item\n                            are written to the stream.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>NEW_IMAGE</code> - The entire item, as it appears after it was\n                            modified, is written to the stream.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>OLD_IMAGE</code> - The entire item, as it appeared before it was\n                            modified, is written to the stream.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>NEW_AND_OLD_IMAGES</code> - Both the new and the old item images\n                            of the item are written to the stream.</p>\n                    </li>\n               </ul>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The settings for DynamoDB Streams on the table. These settings consist of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>StreamEnabled</code> - Indicates whether DynamoDB Streams is to be enabled\n                    (true) or disabled (false).</p>\n            </li>\n            <li>\n               <p>\n                  <code>StreamViewType</code> - When an item in the table is modified,\n                        <code>StreamViewType</code> determines what information is written to the\n                    table's stream. Valid values for <code>StreamViewType</code> are:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>KEYS_ONLY</code> - Only the key attributes of the modified item\n                            are written to the stream.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NEW_IMAGE</code> - The entire item, as it appears after it was\n                            modified, is written to the stream.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>OLD_IMAGE</code> - The entire item, as it appeared before it was\n                            modified, is written to the stream.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NEW_AND_OLD_IMAGES</code> - Both the new and the old item images\n                            of the item are written to the stream.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
                     }
                 },
                 "SSESpecification": {
@@ -2006,10 +2028,17 @@
                     "traits": {
                         "smithy.api#documentation": "<p>The table class of the new table. Valid values are <code>STANDARD</code> and\n                <code>STANDARD_INFREQUENT_ACCESS</code>.</p>"
                     }
+                },
+                "DeletionProtectionEnabled": {
+                    "target": "com.amazonaws.dynamodb#DeletionProtectionEnabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether deletion protection is to be enabled (true) or disabled (false) on the table.</p>"
+                    }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>CreateTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>CreateTable</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#CreateTableOutput": {
@@ -2023,7 +2052,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>CreateTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>CreateTable</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#CsvDelimiter": {
@@ -2156,7 +2186,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Deletes an existing backup of a table.</p>\n        <p>You can call <code>DeleteBackup</code> at a maximum rate of 10 times per\n            second.</p>"
+                "smithy.api#documentation": "<p>Deletes an existing backup of a table.</p>\n         <p>You can call <code>DeleteBackup</code> at a maximum rate of 10 times per\n            second.</p>"
             }
         },
         "com.amazonaws.dynamodb#DeleteBackupInput": {
@@ -2169,6 +2199,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DeleteBackupOutput": {
@@ -2180,6 +2213,9 @@
                         "smithy.api#documentation": "<p>Contains the description of the backup created for the table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DeleteGlobalSecondaryIndexAction": {
@@ -2235,7 +2271,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Deletes a single item in a table by primary key. You can perform a conditional delete\n            operation that deletes the item if it exists, or if it has an expected attribute\n            value.</p>\n        <p>In addition to deleting an item, you can also return the item's attribute values in\n            the same operation, using the <code>ReturnValues</code> parameter.</p>\n        <p>Unless you specify conditions, the <code>DeleteItem</code> is an idempotent operation;\n            running it multiple times on the same item or attribute does <i>not</i>\n            result in an error response.</p>\n        <p>Conditional deletes are useful for deleting items only if specific conditions are met.\n            If those conditions are met, DynamoDB performs the delete. Otherwise, the item is not\n            deleted.</p>"
+                "smithy.api#documentation": "<p>Deletes a single item in a table by primary key. You can perform a conditional delete\n            operation that deletes the item if it exists, or if it has an expected attribute\n            value.</p>\n         <p>In addition to deleting an item, you can also return the item's attribute values in\n            the same operation, using the <code>ReturnValues</code> parameter.</p>\n         <p>Unless you specify conditions, the <code>DeleteItem</code> is an idempotent operation;\n            running it multiple times on the same item or attribute does <i>not</i>\n            result in an error response.</p>\n         <p>Conditional deletes are useful for deleting items only if specific conditions are met.\n            If those conditions are met, DynamoDB performs the delete. Otherwise, the item is not\n            deleted.</p>"
             }
         },
         "com.amazonaws.dynamodb#DeleteItemInput": {
@@ -2251,7 +2287,7 @@
                 "Key": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of attribute names to <code>AttributeValue</code> objects, representing the\n            primary key of the item to delete.</p>\n        <p>For the primary key, you must provide all of the attributes. For example, with a\n            simple primary key, you only need to provide a value for the partition key. For a\n            composite primary key, you must provide values for both the partition key and the sort\n            key.</p>",
+                        "smithy.api#documentation": "<p>A map of attribute names to <code>AttributeValue</code> objects, representing the\n            primary key of the item to delete.</p>\n         <p>For the primary key, you must provide all of the key attributes. For example, with a\n            simple primary key, you only need to provide a value for the partition key. For a\n            composite primary key, you must provide values for both the partition key and the sort\n            key.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2270,7 +2306,7 @@
                 "ReturnValues": {
                     "target": "com.amazonaws.dynamodb#ReturnValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>Use <code>ReturnValues</code> if you want to get the item attributes as they appeared\n            before they were deleted. For <code>DeleteItem</code>, the valid values are:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>NONE</code> - If <code>ReturnValues</code> is not specified, or if its\n                    value is <code>NONE</code>, then nothing is returned. (This setting is the\n                    default for <code>ReturnValues</code>.)</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL_OLD</code> - The content of the old item is returned.</p>\n            </li>\n         </ul>\n        <p>There is no additional cost associated with requesting a return value aside from the\n            small network and processing overhead of receiving a larger response. No read capacity\n            units are consumed.</p>\n        <note>\n            <p>The <code>ReturnValues</code> parameter is used by several DynamoDB operations;\n                however, <code>DeleteItem</code> does not recognize any values other than\n                    <code>NONE</code> or <code>ALL_OLD</code>.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>Use <code>ReturnValues</code> if you want to get the item attributes as they appeared\n            before they were deleted. For <code>DeleteItem</code>, the valid values are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NONE</code> - If <code>ReturnValues</code> is not specified, or if its\n                    value is <code>NONE</code>, then nothing is returned. (This setting is the\n                    default for <code>ReturnValues</code>.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL_OLD</code> - The content of the old item is returned.</p>\n            </li>\n         </ul>\n         <p>There is no additional cost associated with requesting a return value aside from the\n            small network and processing overhead of receiving a larger response. No read capacity\n            units are consumed.</p>\n         <note>\n            <p>The <code>ReturnValues</code> parameter is used by several DynamoDB operations;\n                however, <code>DeleteItem</code> does not recognize any values other than\n                    <code>NONE</code> or <code>ALL_OLD</code>.</p>\n         </note>"
                     }
                 },
                 "ReturnConsumedCapacity": {
@@ -2285,24 +2321,25 @@
                 "ConditionExpression": {
                     "target": "com.amazonaws.dynamodb#ConditionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional <code>DeleteItem</code>\n            to succeed.</p>\n        <p>An expression can contain any of the following:</p>\n        <ul>\n            <li>\n                <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type |\n                        contains | begins_with | size</code>\n                </p>\n                <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n                <p>Comparison operators: <code>= | <> |\n            < | > | <= | >= |\n            BETWEEN | IN </code>\n                </p>\n            </li>\n            <li>\n                <p> Logical operators: <code>AND | OR | NOT</code>\n                </p>\n            </li>\n         </ul>\n        <p>For more information about condition expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional <code>DeleteItem</code>\n            to succeed.</p>\n         <p>An expression can contain any of the following:</p>\n         <ul>\n            <li>\n               <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type |\n                        contains | begins_with | size</code>\n               </p>\n               <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Comparison operators: <code>= | <> |\n            < | > | <= | >= |\n            BETWEEN | IN </code>\n               </p>\n            </li>\n            <li>\n               <p> Logical operators: <code>AND | OR | NOT</code>\n               </p>\n            </li>\n         </ul>\n         <p>For more information about condition expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeValues": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeValueMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n        <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <i>ProductStatus</i> attribute was one of the following: </p>\n        <p>\n            <code>Available | Backordered | Discontinued</code>\n        </p>\n        <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n        <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n        </p>\n        <p>You could then use these values in an expression, such as this:</p>\n        <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n        </p>\n        <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n         <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <i>ProductStatus</i> attribute was one of the following: </p>\n         <p>\n            <code>Available | Backordered | Discontinued</code>\n         </p>\n         <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n         <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n         </p>\n         <p>You could then use these values in an expression, such as this:</p>\n         <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n         </p>\n         <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>DeleteItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>DeleteItem</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DeleteItemOutput": {
@@ -2317,18 +2354,19 @@
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacity",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>DeleteItem</code> operation. The data\n            returned includes the total provisioned throughput consumed, along with statistics for\n            the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is\n            only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For\n            more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Mode</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>DeleteItem</code> operation. The data\n            returned includes the total provisioned throughput consumed, along with statistics for\n            the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is\n            only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For\n            more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ItemCollectionMetrics": {
                     "target": "com.amazonaws.dynamodb#ItemCollectionMetrics",
                     "traits": {
-                        "smithy.api#documentation": "<p>Information about item collections, if any, that were affected by the\n                <code>DeleteItem</code> operation. <code>ItemCollectionMetrics</code> is only\n            returned if the <code>ReturnItemCollectionMetrics</code> parameter was specified. If the\n            table does not have any local secondary indexes, this information is not returned in the\n            response.</p>\n        <p>Each <code>ItemCollectionMetrics</code> element consists of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item itself.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SizeEstimateRangeGB</code> - An estimate of item collection size, in\n                    gigabytes. This value is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on that table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n                <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Information about item collections, if any, that were affected by the\n                <code>DeleteItem</code> operation. <code>ItemCollectionMetrics</code> is only\n            returned if the <code>ReturnItemCollectionMetrics</code> parameter was specified. If the\n            table does not have any local secondary indexes, this information is not returned in the\n            response.</p>\n         <p>Each <code>ItemCollectionMetrics</code> element consists of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item itself.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SizeEstimateRangeGB</code> - An estimate of item collection size, in\n                    gigabytes. This value is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on that table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n               <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>DeleteItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>DeleteItem</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DeleteReplicaAction": {
@@ -2405,7 +2443,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>DeleteTable</code> operation deletes a table and all of its items. After a\n                <code>DeleteTable</code> request, the specified table is in the\n                <code>DELETING</code> state until DynamoDB completes the deletion. If the table is\n            in the <code>ACTIVE</code> state, you can delete it. If a table is in\n                <code>CREATING</code> or <code>UPDATING</code> states, then DynamoDB returns a\n                <code>ResourceInUseException</code>. If the specified table does not exist, DynamoDB\n            returns a <code>ResourceNotFoundException</code>. If table is already in the\n                <code>DELETING</code> state, no error is returned. </p>\n        <note>\n            <p>DynamoDB might continue to accept data read and write operations, such as\n                    <code>GetItem</code> and <code>PutItem</code>, on a table in the\n                    <code>DELETING</code> state until the table deletion is complete.</p>\n        </note>\n        <p>When you delete a table, any indexes on that table are also deleted.</p>\n        <p>If you have DynamoDB Streams enabled on the table, then the corresponding stream on\n            that table goes into the <code>DISABLED</code> state, and the stream is automatically\n            deleted after 24 hours.</p>\n\n        <p>Use the <code>DescribeTable</code> action to check the status of the table. </p>"
+                "smithy.api#documentation": "<p>The <code>DeleteTable</code> operation deletes a table and all of its items. After a\n                <code>DeleteTable</code> request, the specified table is in the\n                <code>DELETING</code> state until DynamoDB completes the deletion. If the table is\n            in the <code>ACTIVE</code> state, you can delete it. If a table is in\n                <code>CREATING</code> or <code>UPDATING</code> states, then DynamoDB returns a\n                <code>ResourceInUseException</code>. If the specified table does not exist, DynamoDB\n            returns a <code>ResourceNotFoundException</code>. If table is already in the\n                <code>DELETING</code> state, no error is returned. </p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a> \n                of global tables.\n            </p>\n         </important>\n         <note>\n            <p>DynamoDB might continue to accept data read and write operations, such as\n                    <code>GetItem</code> and <code>PutItem</code>, on a table in the\n                    <code>DELETING</code> state until the table deletion is complete.</p>\n         </note>\n         <p>When you delete a table, any indexes on that table are also deleted.</p>\n         <p>If you have DynamoDB Streams enabled on the table, then the corresponding stream on\n            that table goes into the <code>DISABLED</code> state, and the stream is automatically\n            deleted after 24 hours.</p>\n         <p>Use the <code>DescribeTable</code> action to check the status of the table. </p>"
             }
         },
         "com.amazonaws.dynamodb#DeleteTableInput": {
@@ -2420,7 +2458,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>DeleteTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>DeleteTable</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DeleteTableOutput": {
@@ -2434,8 +2473,12 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>DeleteTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>DeleteTable</code> operation.</p>",
+                "smithy.api#output": {}
             }
+        },
+        "com.amazonaws.dynamodb#DeletionProtectionEnabled": {
+            "type": "boolean"
         },
         "com.amazonaws.dynamodb#DescribeBackup": {
             "type": "operation",
@@ -2460,7 +2503,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Describes an existing backup of a table.</p>\n        <p>You can call <code>DescribeBackup</code> at a maximum rate of 10 times per\n            second.</p>"
+                "smithy.api#documentation": "<p>Describes an existing backup of a table.</p>\n         <p>You can call <code>DescribeBackup</code> at a maximum rate of 10 times per\n            second.</p>"
             }
         },
         "com.amazonaws.dynamodb#DescribeBackupInput": {
@@ -2473,6 +2516,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeBackupOutput": {
@@ -2484,6 +2530,9 @@
                         "smithy.api#documentation": "<p>Contains the description of the backup created for the table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeContinuousBackups": {
@@ -2509,7 +2558,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Checks the status of continuous backups and point in time recovery on the specified\n            table. Continuous backups are <code>ENABLED</code> on all tables at table creation. If\n            point in time recovery is enabled, <code>PointInTimeRecoveryStatus</code> will be set to\n            ENABLED.</p>\n        <p> After continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n        <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time during the last 35 days. </p>\n        <p>You can call <code>DescribeContinuousBackups</code> at a maximum rate of 10 times per\n            second.</p>"
+                "smithy.api#documentation": "<p>Checks the status of continuous backups and point in time recovery on the specified\n            table. Continuous backups are <code>ENABLED</code> on all tables at table creation. If\n            point in time recovery is enabled, <code>PointInTimeRecoveryStatus</code> will be set to\n            ENABLED.</p>\n         <p> After continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n         <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time during the last 35 days. </p>\n         <p>You can call <code>DescribeContinuousBackups</code> at a maximum rate of 10 times per\n            second.</p>"
             }
         },
         "com.amazonaws.dynamodb#DescribeContinuousBackupsInput": {
@@ -2522,6 +2571,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeContinuousBackupsOutput": {
@@ -2533,6 +2585,9 @@
                         "smithy.api#documentation": "<p>Represents the continuous backups and point in time recovery settings on the\n            table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeContributorInsights": {
@@ -2552,7 +2607,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns information about contributor insights, for a given table or global secondary\n            index.</p>"
+                "smithy.api#documentation": "<p>Returns information about contributor insights for a given table or global secondary\n            index.</p>"
             }
         },
         "com.amazonaws.dynamodb#DescribeContributorInsightsInput": {
@@ -2571,6 +2626,9 @@
                         "smithy.api#documentation": "<p>The name of the global secondary index to describe, if applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeContributorInsightsOutput": {
@@ -2609,9 +2667,12 @@
                 "FailureException": {
                     "target": "com.amazonaws.dynamodb#FailureException",
                     "traits": {
-                        "smithy.api#documentation": "<p>Returns information about the last failure that was encountered.</p>\n        <p>The most common exceptions for a FAILED status are:</p>\n        <ul>\n            <li>\n                <p>LimitExceededException - Per-account Amazon CloudWatch Contributor Insights\n                    rule limit reached. Please disable Contributor Insights for other tables/indexes\n                    OR disable Contributor Insights rules before retrying.</p>\n            </li>\n            <li>\n                <p>AccessDeniedException - Amazon CloudWatch Contributor Insights rules cannot be\n                    modified due to insufficient permissions.</p>\n            </li>\n            <li>\n                <p>AccessDeniedException - Failed to create service-linked role for Contributor\n                    Insights due to insufficient permissions.</p>\n            </li>\n            <li>\n                <p>InternalServerError - Failed to create Amazon CloudWatch Contributor Insights\n                    rules. Please retry request.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Returns information about the last failure that was encountered.</p>\n         <p>The most common exceptions for a FAILED status are:</p>\n         <ul>\n            <li>\n               <p>LimitExceededException - Per-account Amazon CloudWatch Contributor Insights\n                    rule limit reached. Please disable Contributor Insights for other tables/indexes\n                    OR disable Contributor Insights rules before retrying.</p>\n            </li>\n            <li>\n               <p>AccessDeniedException - Amazon CloudWatch Contributor Insights rules cannot be\n                    modified due to insufficient permissions.</p>\n            </li>\n            <li>\n               <p>AccessDeniedException - Failed to create service-linked role for Contributor\n                    Insights due to insufficient permissions.</p>\n            </li>\n            <li>\n               <p>InternalServerError - Failed to create Amazon CloudWatch Contributor Insights\n                    rules. Please retry request.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeEndpoints": {
@@ -2623,12 +2684,15 @@
                 "target": "com.amazonaws.dynamodb#DescribeEndpointsResponse"
             },
             "traits": {
-                "smithy.api#documentation": "<p>Returns the regional endpoint information.</p>"
+                "smithy.api#documentation": "<p>Returns the regional endpoint information. This action must be included in your VPC \n            endpoint policies, or access to the DescribeEndpoints API will be denied. For more information \n            on policy permissions, please see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/inter-network-traffic-privacy.html#inter-network-traffic-DescribeEndpoints\">Internetwork traffic privacy</a>.</p>"
             }
         },
         "com.amazonaws.dynamodb#DescribeEndpointsRequest": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.amazonaws.dynamodb#DescribeEndpointsResponse": {
             "type": "structure",
@@ -2640,6 +2704,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeExport": {
@@ -2675,6 +2742,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeExportOutput": {
@@ -2686,6 +2756,9 @@
                         "smithy.api#documentation": "<p>Represents the properties of the export.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeGlobalTable": {
@@ -2711,7 +2784,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Returns information about the specified global table.</p>\n        <note>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                    2017.11.29</a> of global tables. If you are using global tables <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version\n                    2019.11.21</a> you can use <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html\">DescribeTable</a> instead.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Returns information about the specified global table.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                2017.11.29 (Legacy)</a> of global tables. We recommend using \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                when creating new global tables, as it provides greater flexibility, higher efficiency and consumes less write capacity than \n                2017.11.29 (Legacy). To determine which version you are using, see \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.DetermineVersion.html\">Determining the version</a>. \n                To update existing global tables from version 2017.11.29 (Legacy) to version\n                2019.11.21 (Current), see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_upgrade.html\">\n                    Updating global tables</a>.\n            </p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#DescribeGlobalTableInput": {
@@ -2724,6 +2797,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeGlobalTableOutput": {
@@ -2735,6 +2811,9 @@
                         "smithy.api#documentation": "<p>Contains the details of the global table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeGlobalTableSettings": {
@@ -2760,7 +2839,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Describes Region-specific settings for a global table.</p>\n        <note>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                    2017.11.29</a> of global tables.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Describes Region-specific settings for a global table.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                2017.11.29 (Legacy)</a> of global tables. We recommend using\n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                when creating new global tables, as it provides greater flexibility, higher efficiency and consumes less write capacity than \n                2017.11.29 (Legacy). To determine which version you are using, see \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.DetermineVersion.html\">Determining the version</a>. \n                To update existing global tables from version 2017.11.29 (Legacy) to version\n                2019.11.21 (Current), see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_upgrade.html\">\n                    Updating global tables</a>.\n            </p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#DescribeGlobalTableSettingsInput": {
@@ -2773,6 +2852,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeGlobalTableSettingsOutput": {
@@ -2790,6 +2872,9 @@
                         "smithy.api#documentation": "<p>The Region-specific settings for the global table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeImport": {
@@ -2819,6 +2904,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeImportOutput": {
@@ -2831,6 +2919,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeKinesisStreamingDestination": {
@@ -2869,6 +2960,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeKinesisStreamingDestinationOutput": {
@@ -2886,6 +2980,9 @@
                         "smithy.api#documentation": "<p>The list of replica structures for the table being described.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeLimits": {
@@ -2908,14 +3005,15 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Returns the current provisioned-capacity quotas for your Amazon Web Services account in\n            a Region, both for the Region as a whole and for any one DynamoDB table that you create\n            there.</p>\n        <p>When you establish an Amazon Web Services account, the account has initial quotas on\n            the maximum read capacity units and write capacity units that you can provision across\n            all of your DynamoDB tables in a given Region. Also, there are per-table\n            quotas that apply when you create a table there. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> page in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>\n\n        <p>Although you can increase these quotas by filing a case at <a href=\"https://console.aws.amazon.com/support/home#/\">Amazon Web Services Support Center</a>, obtaining the\n            increase is not instantaneous. The <code>DescribeLimits</code> action lets you write\n            code to compare the capacity you are currently using to those quotas imposed by your\n            account so that you have enough time to apply for an increase before you hit a\n            quota.</p>\n\n        <p>For example, you could use one of the Amazon Web Services SDKs to do the\n            following:</p>\n\n        <ol>\n            <li>\n                <p>Call <code>DescribeLimits</code> for a particular Region to obtain your\n                    current account quotas on provisioned capacity there.</p>\n            </li>\n            <li>\n                <p>Create a variable to hold the aggregate read capacity units provisioned for\n                    all your tables in that Region, and one to hold the aggregate write capacity\n                    units. Zero them both.</p>\n            </li>\n            <li>\n                <p>Call <code>ListTables</code> to obtain a list of all your DynamoDB\n                    tables.</p>\n            </li>\n            <li>\n                <p>For each table name listed by <code>ListTables</code>, do the\n                    following:</p>\n                <ul>\n                  <li>\n                        <p>Call <code>DescribeTable</code> with the table name.</p>\n                    </li>\n                  <li>\n                        <p>Use the data returned by <code>DescribeTable</code> to add the read\n                            capacity units and write capacity units provisioned for the table itself\n                            to your variables.</p>\n                    </li>\n                  <li>\n                        <p>If the table has one or more global secondary indexes (GSIs), loop\n                            over these GSIs and add their provisioned capacity values to your\n                            variables as well.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Report the account quotas for that Region returned by\n                        <code>DescribeLimits</code>, along with the total current provisioned\n                    capacity levels you have calculated.</p>\n            </li>\n         </ol>\n\n        <p>This will let you see whether you are getting close to your account-level\n            quotas.</p>\n        <p>The per-table quotas apply only when you are creating a new table. They restrict the\n            sum of the provisioned capacity of the new table itself and all its global secondary\n            indexes.</p>\n        <p>For existing tables and their GSIs, DynamoDB doesn't let you increase provisioned\n            capacity extremely rapidly, but the only quota that applies is that the aggregate\n            provisioned capacity over all your tables and GSIs cannot exceed either of the\n            per-account quotas.</p>\n        <note>\n            <p>\n                <code>DescribeLimits</code> should only be called periodically. You can expect\n                throttling errors if you call it more than once in a minute.</p>\n        </note>\n        <p>The <code>DescribeLimits</code> Request element has no content.</p>"
+                "smithy.api#documentation": "<p>Returns the current provisioned-capacity quotas for your Amazon Web Services account in\n            a Region, both for the Region as a whole and for any one DynamoDB table that you create\n            there.</p>\n         <p>When you establish an Amazon Web Services account, the account has initial quotas on\n            the maximum read capacity units and write capacity units that you can provision across\n            all of your DynamoDB tables in a given Region. Also, there are per-table\n            quotas that apply when you create a table there. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> page in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>\n         <p>Although you can increase these quotas by filing a case at <a href=\"https://console.aws.amazon.com/support/home#/\">Amazon Web Services Support Center</a>, obtaining the\n            increase is not instantaneous. The <code>DescribeLimits</code> action lets you write\n            code to compare the capacity you are currently using to those quotas imposed by your\n            account so that you have enough time to apply for an increase before you hit a\n            quota.</p>\n         <p>For example, you could use one of the Amazon Web Services SDKs to do the\n            following:</p>\n         <ol>\n            <li>\n               <p>Call <code>DescribeLimits</code> for a particular Region to obtain your\n                    current account quotas on provisioned capacity there.</p>\n            </li>\n            <li>\n               <p>Create a variable to hold the aggregate read capacity units provisioned for\n                    all your tables in that Region, and one to hold the aggregate write capacity\n                    units. Zero them both.</p>\n            </li>\n            <li>\n               <p>Call <code>ListTables</code> to obtain a list of all your DynamoDB\n                    tables.</p>\n            </li>\n            <li>\n               <p>For each table name listed by <code>ListTables</code>, do the\n                    following:</p>\n               <ul>\n                  <li>\n                     <p>Call <code>DescribeTable</code> with the table name.</p>\n                  </li>\n                  <li>\n                     <p>Use the data returned by <code>DescribeTable</code> to add the read\n                            capacity units and write capacity units provisioned for the table itself\n                            to your variables.</p>\n                  </li>\n                  <li>\n                     <p>If the table has one or more global secondary indexes (GSIs), loop\n                            over these GSIs and add their provisioned capacity values to your\n                            variables as well.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Report the account quotas for that Region returned by\n                        <code>DescribeLimits</code>, along with the total current provisioned\n                    capacity levels you have calculated.</p>\n            </li>\n         </ol>\n         <p>This will let you see whether you are getting close to your account-level\n            quotas.</p>\n         <p>The per-table quotas apply only when you are creating a new table. They restrict the\n            sum of the provisioned capacity of the new table itself and all its global secondary\n            indexes.</p>\n         <p>For existing tables and their GSIs, DynamoDB doesn't let you increase provisioned\n            capacity extremely rapidly, but the only quota that applies is that the aggregate\n            provisioned capacity over all your tables and GSIs cannot exceed either of the\n            per-account quotas.</p>\n         <note>\n            <p>\n               <code>DescribeLimits</code> should only be called periodically. You can expect\n                throttling errors if you call it more than once in a minute.</p>\n         </note>\n         <p>The <code>DescribeLimits</code> Request element has no content.</p>"
             }
         },
         "com.amazonaws.dynamodb#DescribeLimitsInput": {
             "type": "structure",
             "members": {},
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>DescribeLimits</code> operation. Has no\n            content.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>DescribeLimits</code> operation. Has no\n            content.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeLimitsOutput": {
@@ -2947,7 +3045,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>DescribeLimits</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>DescribeLimits</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeTable": {
@@ -2973,7 +3072,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Returns information about the table, including the current status of the table, when\n            it was created, the primary key schema, and any indexes on the table.</p>\n        <note>\n            <p>If you issue a <code>DescribeTable</code> request immediately after a\n                    <code>CreateTable</code> request, DynamoDB might return a\n                    <code>ResourceNotFoundException</code>. This is because\n                    <code>DescribeTable</code> uses an eventually consistent query, and the metadata\n                for your table might not be available at that moment. Wait for a few seconds, and\n                then try the <code>DescribeTable</code> request again.</p>\n        </note>",
+                "smithy.api#documentation": "<p>Returns information about the table, including the current status of the table, when\n            it was created, the primary key schema, and any indexes on the table.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a> \n                of global tables.\n            </p>\n         </important>\n         <note>\n            <p>If you issue a <code>DescribeTable</code> request immediately after a\n                    <code>CreateTable</code> request, DynamoDB might return a\n                    <code>ResourceNotFoundException</code>. This is because\n                    <code>DescribeTable</code> uses an eventually consistent query, and the metadata\n                for your table might not be available at that moment. Wait for a few seconds, and\n                then try the <code>DescribeTable</code> request again.</p>\n         </note>",
                 "smithy.waiters#waitable": {
                     "TableExists": {
                         "acceptors": [
@@ -3022,7 +3121,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>DescribeTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>DescribeTable</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeTableOutput": {
@@ -3036,7 +3136,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>DescribeTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>DescribeTable</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeTableReplicaAutoScaling": {
@@ -3056,7 +3157,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Describes auto scaling settings across replicas of the global table at once.</p>\n        <note>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version\n                    2019.11.21</a> of global tables.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Describes auto scaling settings across replicas of the global table at once.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n            of global tables.</p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#DescribeTableReplicaAutoScalingInput": {
@@ -3069,6 +3170,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeTableReplicaAutoScalingOutput": {
@@ -3080,6 +3184,9 @@
                         "smithy.api#documentation": "<p>Represents the auto scaling properties of the table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeTimeToLive": {
@@ -3118,6 +3225,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#DescribeTimeToLiveOutput": {
@@ -3129,6 +3239,9 @@
                         "smithy.api#documentation": "<p></p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#DestinationStatus": {
@@ -3198,7 +3311,7 @@
                 "smithy.api#documentation": "<p>Stops replication from the DynamoDB table to the Kinesis data stream. This is done\n            without deleting either of the resources.</p>"
             }
         },
-        "com.amazonaws.dynamodb#Double": {
+        "com.amazonaws.dynamodb#DoubleObject": {
             "type": "double"
         },
         "com.amazonaws.dynamodb#DuplicateItemException": {
@@ -3393,7 +3506,7 @@
                     "name": "dynamodb"
                 },
                 "aws.protocols#awsJson1_0": {},
-                "smithy.api#documentation": "<fullname>Amazon DynamoDB</fullname>\n\n        <p>Amazon DynamoDB is a fully managed NoSQL database service that provides fast\n            and predictable performance with seamless scalability. DynamoDB lets you\n            offload the administrative burdens of operating and scaling a distributed database, so\n            that you don't have to worry about hardware provisioning, setup and configuration,\n            replication, software patching, or cluster scaling.</p>\n\n        <p>With DynamoDB, you can create database tables that can store and retrieve\n            any amount of data, and serve any level of request traffic. You can scale up or scale\n            down your tables' throughput capacity without downtime or performance degradation, and\n            use the Amazon Web Services Management Console to monitor resource utilization and performance\n            metrics.</p>\n\n        <p>DynamoDB automatically spreads the data and traffic for your tables over\n            a sufficient number of servers to handle your throughput and storage requirements, while\n            maintaining consistent and fast performance. All of your data is stored on solid state\n            disks (SSDs) and automatically replicated across multiple Availability Zones in an\n                Amazon Web Services Region, providing built-in high availability and data\n            durability.</p>",
+                "smithy.api#documentation": "<fullname>Amazon DynamoDB</fullname>\n         <p>Amazon DynamoDB is a fully managed NoSQL database service that provides fast\n            and predictable performance with seamless scalability. DynamoDB lets you\n            offload the administrative burdens of operating and scaling a distributed database, so\n            that you don't have to worry about hardware provisioning, setup and configuration,\n            replication, software patching, or cluster scaling.</p>\n         <p>With DynamoDB, you can create database tables that can store and retrieve\n            any amount of data, and serve any level of request traffic. You can scale up or scale\n            down your tables' throughput capacity without downtime or performance degradation, and\n            use the Amazon Web Services Management Console to monitor resource utilization and performance\n            metrics.</p>\n         <p>DynamoDB automatically spreads the data and traffic for your tables over\n            a sufficient number of servers to handle your throughput and storage requirements, while\n            maintaining consistent and fast performance. All of your data is stored on solid state\n            disks (SSDs) and automatically replicated across multiple Availability Zones in an\n                Amazon Web Services Region, providing built-in high availability and data\n            durability.</p>",
                 "smithy.api#title": "Amazon DynamoDB",
                 "smithy.api#xmlNamespace": {
                     "uri": "http://dynamodb.amazonaws.com/doc/2012-08-10/"
@@ -3403,7 +3516,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -3432,15 +3545,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -3449,7 +3614,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -3459,22 +3624,182 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://dynamodb-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        "aws-us-gov",
+                                                                                        {
+                                                                                            "fn": "getAttr",
+                                                                                            "argv": [
+                                                                                                {
+                                                                                                    "ref": "PartitionResult"
+                                                                                                },
+                                                                                                "name"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://dynamodb.{Region}.amazonaws.com",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://dynamodb-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -3487,140 +3812,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
-                                                        },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
                                                     "type": "tree",
                                                     "rules": [
                                                         {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://dynamodb-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
+                                                            "conditions": [
                                                                 {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://dynamodb.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
                                                             ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
+                                                },
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -3630,22 +3867,24 @@
                                                                 {
                                                                     "fn": "stringEquals",
                                                                     "argv": [
-                                                                        "aws-us-gov",
                                                                         {
-                                                                            "fn": "getAttr",
-                                                                            "argv": [
-                                                                                {
-                                                                                    "ref": "PartitionResult"
-                                                                                },
-                                                                                "name"
-                                                                            ]
-                                                                        }
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "local"
                                                                     ]
                                                                 }
                                                             ],
                                                             "endpoint": {
-                                                                "url": "https://dynamodb.{Region}.amazonaws.com",
-                                                                "properties": {},
+                                                                "url": "http://localhost:8000",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "dynamodb",
+                                                                            "signingRegion": "us-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
                                                                 "headers": {}
                                                             },
                                                             "type": "endpoint"
@@ -3653,7 +3892,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://dynamodb-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://dynamodb.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -3662,113 +3901,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://dynamodb.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "local"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "http://localhost:8000",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "dynamodb"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://dynamodb.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -3777,184 +3916,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb-fips.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-northeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-northeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region local with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "dynamodb",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-east-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "http://localhost:8000"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "local"
-                            }
-                        },
-                        {
                             "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -3962,22 +3923,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "af-south-1",
                                 "UseDualStack": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-north-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -3988,100 +3936,126 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-east-1",
                                 "UseDualStack": false,
-                                "Region": "ap-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb.eu-west-1.amazonaws.com"
+                                    "url": "https://dynamodb.ap-northeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "Region": "eu-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb.eu-west-2.amazonaws.com"
+                                    "url": "https://dynamodb.ap-northeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-2",
                                 "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb.eu-west-3.amazonaws.com"
+                                    "url": "https://dynamodb.ap-northeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-3",
                                 "UseDualStack": false,
-                                "Region": "eu-west-3"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                    "url": "https://dynamodb.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-south-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                    "url": "https://dynamodb.ap-southeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "ap-southeast-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb.us-east-2.amazonaws.com"
+                                    "url": "https://dynamodb.ap-southeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-southeast-2",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb-fips.us-east-2.amazonaws.com"
+                                    "url": "https://dynamodb.ap-southeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "ap-southeast-3",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4092,9 +4066,174 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-central-1",
                                 "UseDualStack": false,
-                                "Region": "eu-central-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region local with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "dynamodb",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "http://localhost:8000"
+                                }
+                            },
+                            "params": {
+                                "Region": "local",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4105,9 +4244,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-west-1",
                                 "UseDualStack": false,
-                                "Region": "us-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -4118,9 +4257,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-west-1",
                                 "UseDualStack": false,
-                                "Region": "us-west-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4131,9 +4270,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-west-2",
                                 "UseDualStack": false,
-                                "Region": "us-west-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -4144,9 +4283,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-west-2",
                                 "UseDualStack": false,
-                                "Region": "us-west-2"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4157,9 +4296,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4170,126 +4309,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://dynamodb.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -4300,9 +4322,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -4313,9 +4348,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4326,9 +4361,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -4339,22 +4374,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://dynamodb.us-iso-west-1.c2s.ic.gov"
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-gov-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-west-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -4365,9 +4465,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -4378,22 +4491,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://dynamodb-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -4403,9 +4555,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -4415,9 +4567,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
                                 "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         }
@@ -4540,7 +4692,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>This operation allows you to perform reads and singleton writes on data stored in\n            DynamoDB, using PartiQL.</p>\n        <p>For PartiQL reads (<code>SELECT</code> statement), if the total number of processed\n            items exceeds the maximum dataset size limit of 1 MB, the read stops and results are\n            returned to the user as a <code>LastEvaluatedKey</code> value to continue the read in a\n            subsequent operation. If the filter criteria in <code>WHERE</code> clause does not match\n            any data, the read will return an empty result set.</p>\n        <p>A single <code>SELECT</code> statement response can return up to the maximum number of\n            items (if using the Limit parameter) or a maximum of 1 MB of data (and then apply any\n            filtering to the results using <code>WHERE</code> clause). If\n                <code>LastEvaluatedKey</code> is present in the response, you need to paginate the\n            result set.</p>"
+                "smithy.api#documentation": "<p>This operation allows you to perform reads and singleton writes on data stored in\n            DynamoDB, using PartiQL.</p>\n         <p>For PartiQL reads (<code>SELECT</code> statement), if the total number of processed\n            items exceeds the maximum dataset size limit of 1 MB, the read stops and results are\n            returned to the user as a <code>LastEvaluatedKey</code> value to continue the read in a\n            subsequent operation. If the filter criteria in <code>WHERE</code> clause does not match\n            any data, the read will return an empty result set.</p>\n         <p>A single <code>SELECT</code> statement response can return up to the maximum number of\n            items (if using the Limit parameter) or a maximum of 1 MB of data (and then apply any\n            filtering to the results using <code>WHERE</code> clause). If\n                <code>LastEvaluatedKey</code> is present in the response, you need to paginate the\n            result set. If <code>NextToken</code> is present, you need to paginate the result set and include \n            <code>NextToken</code>.</p>"
             }
         },
         "com.amazonaws.dynamodb#ExecuteStatementInput": {
@@ -4580,6 +4732,9 @@
                         "smithy.api#documentation": "<p>The maximum number of items to evaluate (not necessarily the number of matching\n            items). If DynamoDB processes the number of items up to the limit while processing the\n            results, it stops the operation and returns the matching values up to that point, along\n            with a key in <code>LastEvaluatedKey</code> to apply in a subsequent operation so you\n            can pick up where you left off. Also, if the processed dataset size exceeds 1 MB before\n            DynamoDB reaches this limit, it stops the operation and returns the matching values up\n            to the limit, and a key in <code>LastEvaluatedKey</code> to apply in a subsequent\n            operation to continue the operation. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ExecuteStatementOutput": {
@@ -4606,6 +4761,9 @@
                         "smithy.api#documentation": "<p>The primary key of the item where the operation stopped, inclusive of the previous\n            result set. Use this value to start a new operation, excluding this value in the new\n            request. If <code>LastEvaluatedKey</code> is empty, then the \"last page\" of results has\n            been processed and there is no more data to be retrieved. If\n                <code>LastEvaluatedKey</code> is not empty, it does not necessarily mean that there\n            is more data in the result set. The only way to know when you have reached the end of\n            the result set is when <code>LastEvaluatedKey</code> is empty. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ExecuteTransaction": {
@@ -4640,7 +4798,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>This operation allows you to perform transactional reads or writes on data stored in\n            DynamoDB, using PartiQL.</p>\n        <note>\n            <p>The entire transaction must consist of either read statements or write statements,\n                you cannot mix both in one transaction. The EXISTS function is an exception and can\n                be used to check the condition of specific attributes of the item in a similar\n                manner to <code>ConditionCheck</code> in the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-apis-txwriteitems\">TransactWriteItems</a> API.</p>\n        </note>"
+                "smithy.api#documentation": "<p>This operation allows you to perform transactional reads or writes on data stored in\n            DynamoDB, using PartiQL.</p>\n         <note>\n            <p>The entire transaction must consist of either read statements or write statements,\n                you cannot mix both in one transaction. The EXISTS function is an exception and can\n                be used to check the condition of specific attributes of the item in a similar\n                manner to <code>ConditionCheck</code> in the <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-apis-txwriteitems\">TransactWriteItems</a> API.</p>\n         </note>"
             }
         },
         "com.amazonaws.dynamodb#ExecuteTransactionInput": {
@@ -4666,6 +4824,9 @@
                         "smithy.api#documentation": "<p>Determines the level of detail about either provisioned or on-demand throughput\n            consumption that is returned in the response. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactGetItems.html\">TransactGetItems</a> and <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html\">TransactWriteItems</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ExecuteTransactionOutput": {
@@ -4683,6 +4844,9 @@
                         "smithy.api#documentation": "<p>The capacity units consumed by the entire operation. The values of the list are\n            ordered according to the ordering of the statements.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ExpectedAttributeMap": {
@@ -4700,30 +4864,30 @@
                 "Value": {
                     "target": "com.amazonaws.dynamodb#AttributeValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the data for the expected attribute.</p>\n        <p>Each attribute value is described as a name-value pair. The name is the data type, and\n            the value is the data itself.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes\">Data Types</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Represents the data for the expected attribute.</p>\n         <p>Each attribute value is described as a name-value pair. The name is the data type, and\n            the value is the data itself.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes\">Data Types</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "Exists": {
                     "target": "com.amazonaws.dynamodb#BooleanObject",
                     "traits": {
-                        "smithy.api#documentation": "<p>Causes DynamoDB to evaluate the value before attempting a conditional\n            operation:</p>\n        <ul>\n            <li>\n                <p>If <code>Exists</code> is <code>true</code>, DynamoDB will check to\n                    see if that attribute value already exists in the table. If it is found, then\n                    the operation succeeds. If it is not found, the operation fails with a\n                        <code>ConditionCheckFailedException</code>.</p>\n            </li>\n            <li>\n                <p>If <code>Exists</code> is <code>false</code>, DynamoDB assumes that\n                    the attribute value does not exist in the table. If in fact the value does not\n                    exist, then the assumption is valid and the operation succeeds. If the value is\n                    found, despite the assumption that it does not exist, the operation fails with a\n                        <code>ConditionCheckFailedException</code>.</p>\n            </li>\n         </ul>\n        <p>The default setting for <code>Exists</code> is <code>true</code>. If you supply a\n                <code>Value</code> all by itself, DynamoDB assumes the attribute exists:\n            You don't have to set <code>Exists</code> to <code>true</code>, because it is\n            implied.</p>\n        <p>DynamoDB returns a <code>ValidationException</code> if:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Exists</code> is <code>true</code> but there is no <code>Value</code> to\n                    check. (You expect a value to exist, but don't specify what that value\n                    is.)</p>\n            </li>\n            <li>\n                <p>\n                    <code>Exists</code> is <code>false</code> but you also provide a\n                        <code>Value</code>. (You cannot expect an attribute to have a value, while\n                    also expecting it not to exist.)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Causes DynamoDB to evaluate the value before attempting a conditional\n            operation:</p>\n         <ul>\n            <li>\n               <p>If <code>Exists</code> is <code>true</code>, DynamoDB will check to\n                    see if that attribute value already exists in the table. If it is found, then\n                    the operation succeeds. If it is not found, the operation fails with a\n                        <code>ConditionCheckFailedException</code>.</p>\n            </li>\n            <li>\n               <p>If <code>Exists</code> is <code>false</code>, DynamoDB assumes that\n                    the attribute value does not exist in the table. If in fact the value does not\n                    exist, then the assumption is valid and the operation succeeds. If the value is\n                    found, despite the assumption that it does not exist, the operation fails with a\n                        <code>ConditionCheckFailedException</code>.</p>\n            </li>\n         </ul>\n         <p>The default setting for <code>Exists</code> is <code>true</code>. If you supply a\n                <code>Value</code> all by itself, DynamoDB assumes the attribute exists:\n            You don't have to set <code>Exists</code> to <code>true</code>, because it is\n            implied.</p>\n         <p>DynamoDB returns a <code>ValidationException</code> if:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Exists</code> is <code>true</code> but there is no <code>Value</code> to\n                    check. (You expect a value to exist, but don't specify what that value\n                    is.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>Exists</code> is <code>false</code> but you also provide a\n                        <code>Value</code>. (You cannot expect an attribute to have a value, while\n                    also expecting it not to exist.)</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ComparisonOperator": {
                     "target": "com.amazonaws.dynamodb#ComparisonOperator",
                     "traits": {
-                        "smithy.api#documentation": "<p>A comparator for evaluating attributes in the <code>AttributeValueList</code>. For\n            example, equals, greater than, less than, etc.</p>\n        <p>The following comparison operators are available:</p>\n        <p>\n            <code>EQ | NE | LE | LT | GE | GT | NOT_NULL | NULL | CONTAINS | NOT_CONTAINS |\n                BEGINS_WITH | IN | BETWEEN</code>\n        </p>\n        <p>The following are descriptions of each comparison operator.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>EQ</code> : Equal. <code>EQ</code> is supported for all data types,\n                    including lists and maps.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, Binary, String Set, Number Set, or Binary Set.\n                    If an item contains an <code>AttributeValue</code> element of a different type\n                    than the one provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>NE</code> : Not equal. <code>NE</code> is supported for all data types,\n                    including lists and maps.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, Binary, String Set, Number Set, or Binary Set. If an\n                    item contains an <code>AttributeValue</code> of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>LE</code> : Less than or equal. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>LT</code> : Less than. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, or Binary (not a set type). If an item contains an\n                        <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>GE</code> : Greater than or equal. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>GT</code> : Greater than. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>NOT_NULL</code> : The attribute exists. <code>NOT_NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n                <note>\n                    <p>This operator tests for the existence of an attribute, not its data type.\n                        If the data type of attribute \"<code>a</code>\" is null, and you evaluate it\n                        using <code>NOT_NULL</code>, the result is a Boolean <code>true</code>. This\n                        result is because the attribute \"<code>a</code>\" exists; its data type is\n                        not relevant to the <code>NOT_NULL</code> comparison operator.</p>\n                </note>\n            </li>\n            <li>\n                <p>\n                    <code>NULL</code> : The attribute does not exist. <code>NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n                <note>\n                    <p>This operator tests for the nonexistence of an attribute, not its data\n                        type. If the data type of attribute \"<code>a</code>\" is null, and you\n                        evaluate it using <code>NULL</code>, the result is a Boolean\n                            <code>false</code>. This is because the attribute \"<code>a</code>\"\n                        exists; its data type is not relevant to the <code>NULL</code> comparison\n                        operator.</p>\n                </note>\n            </li>\n            <li>\n                <p>\n                    <code>CONTAINS</code> : Checks for a subsequence, or value in a set.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is of type String, then the operator checks for a\n                    substring match. If the target attribute of the comparison is of type Binary,\n                    then the operator looks for a subsequence of the target that matches the input.\n                    If the target attribute of the comparison is a set (\"<code>SS</code>\",\n                        \"<code>NS</code>\", or \"<code>BS</code>\"), then the operator evaluates to\n                    true if it finds an exact match with any member of the set.</p>\n                <p>CONTAINS is supported for lists: When evaluating \"<code>a CONTAINS b</code>\",\n                        \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot be a set, a\n                    map, or a list.</p>\n            </li>\n            <li>\n                <p>\n                    <code>NOT_CONTAINS</code> : Checks for absence of a subsequence, or absence of a\n                    value in a set.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is a String, then the operator checks for the\n                    absence of a substring match. If the target attribute of the comparison is\n                    Binary, then the operator checks for the absence of a subsequence of the target\n                    that matches the input. If the target attribute of the comparison is a set\n                        (\"<code>SS</code>\", \"<code>NS</code>\", or \"<code>BS</code>\"), then the\n                    operator evaluates to true if it <i>does not</i> find an exact\n                    match with any member of the set.</p>\n                <p>NOT_CONTAINS is supported for lists: When evaluating \"<code>a NOT CONTAINS\n                        b</code>\", \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot\n                    be a set, a map, or a list.</p>\n            </li>\n            <li>\n                <p>\n                    <code>BEGINS_WITH</code> : Checks for a prefix. </p>\n                <p>\n                    <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String or Binary (not a Number or a set type). The target attribute of\n                    the comparison must be of type String or Binary (not a Number or a set\n                    type).</p>\n                <p></p>\n            </li>\n            <li>\n                <p>\n                    <code>IN</code> : Checks for matching elements in a list.</p>\n                <p>\n                    <code>AttributeValueList</code> can contain one or more\n                        <code>AttributeValue</code> elements of type String, Number, or Binary.\n                    These attributes are compared against an existing attribute of an item. If any\n                    elements of the input are equal to the item attribute, the expression evaluates\n                    to true.</p>\n            </li>\n            <li>\n                <p>\n                    <code>BETWEEN</code> : Greater than or equal to the first value, and less than\n                    or equal to the second value. </p>\n                <p>\n                    <code>AttributeValueList</code> must contain two <code>AttributeValue</code>\n                    elements of the same type, either String, Number, or Binary (not a set type). A\n                    target attribute matches if the target value is greater than, or equal to, the\n                    first element and less than, or equal to, the second element. If an item\n                    contains an <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not compare to <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>\n                </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>A comparator for evaluating attributes in the <code>AttributeValueList</code>. For\n            example, equals, greater than, less than, etc.</p>\n         <p>The following comparison operators are available:</p>\n         <p>\n            <code>EQ | NE | LE | LT | GE | GT | NOT_NULL | NULL | CONTAINS | NOT_CONTAINS |\n                BEGINS_WITH | IN | BETWEEN</code>\n         </p>\n         <p>The following are descriptions of each comparison operator.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>EQ</code> : Equal. <code>EQ</code> is supported for all data types,\n                    including lists and maps.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, Binary, String Set, Number Set, or Binary Set.\n                    If an item contains an <code>AttributeValue</code> element of a different type\n                    than the one provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>NE</code> : Not equal. <code>NE</code> is supported for all data types,\n                    including lists and maps.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, Binary, String Set, Number Set, or Binary Set. If an\n                    item contains an <code>AttributeValue</code> of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not equal <code>{\"NS\":[\"6\", \"2\",\n                    \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>LE</code> : Less than or equal. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>LT</code> : Less than. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String, Number, or Binary (not a set type). If an item contains an\n                        <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not equal <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>GE</code> : Greater than or equal. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>GT</code> : Greater than. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If an item contains\n                    an <code>AttributeValue</code> element of a different type than the one provided\n                    in the request, the value does not match. For example, <code>{\"S\":\"6\"}</code>\n                    does not equal <code>{\"N\":\"6\"}</code>. Also, <code>{\"N\":\"6\"}</code> does not\n                    compare to <code>{\"NS\":[\"6\", \"2\", \"1\"]}</code>.</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_NULL</code> : The attribute exists. <code>NOT_NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n               <note>\n                  <p>This operator tests for the existence of an attribute, not its data type.\n                        If the data type of attribute \"<code>a</code>\" is null, and you evaluate it\n                        using <code>NOT_NULL</code>, the result is a Boolean <code>true</code>. This\n                        result is because the attribute \"<code>a</code>\" exists; its data type is\n                        not relevant to the <code>NOT_NULL</code> comparison operator.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>NULL</code> : The attribute does not exist. <code>NULL</code> is supported\n                    for all data types, including lists and maps.</p>\n               <note>\n                  <p>This operator tests for the nonexistence of an attribute, not its data\n                        type. If the data type of attribute \"<code>a</code>\" is null, and you\n                        evaluate it using <code>NULL</code>, the result is a Boolean\n                            <code>false</code>. This is because the attribute \"<code>a</code>\"\n                        exists; its data type is not relevant to the <code>NULL</code> comparison\n                        operator.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>CONTAINS</code> : Checks for a subsequence, or value in a set.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is of type String, then the operator checks for a\n                    substring match. If the target attribute of the comparison is of type Binary,\n                    then the operator looks for a subsequence of the target that matches the input.\n                    If the target attribute of the comparison is a set (\"<code>SS</code>\",\n                        \"<code>NS</code>\", or \"<code>BS</code>\"), then the operator evaluates to\n                    true if it finds an exact match with any member of the set.</p>\n               <p>CONTAINS is supported for lists: When evaluating \"<code>a CONTAINS b</code>\",\n                        \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot be a set, a\n                    map, or a list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NOT_CONTAINS</code> : Checks for absence of a subsequence, or absence of a\n                    value in a set.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    element of type String, Number, or Binary (not a set type). If the target\n                    attribute of the comparison is a String, then the operator checks for the\n                    absence of a substring match. If the target attribute of the comparison is\n                    Binary, then the operator checks for the absence of a subsequence of the target\n                    that matches the input. If the target attribute of the comparison is a set\n                        (\"<code>SS</code>\", \"<code>NS</code>\", or \"<code>BS</code>\"), then the\n                    operator evaluates to true if it <i>does not</i> find an exact\n                    match with any member of the set.</p>\n               <p>NOT_CONTAINS is supported for lists: When evaluating \"<code>a NOT CONTAINS\n                        b</code>\", \"<code>a</code>\" can be a list; however, \"<code>b</code>\" cannot\n                    be a set, a map, or a list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BEGINS_WITH</code> : Checks for a prefix. </p>\n               <p>\n                  <code>AttributeValueList</code> can contain only one <code>AttributeValue</code>\n                    of type String or Binary (not a Number or a set type). The target attribute of\n                    the comparison must be of type String or Binary (not a Number or a set\n                    type).</p>\n               <p></p>\n            </li>\n            <li>\n               <p>\n                  <code>IN</code> : Checks for matching elements in a list.</p>\n               <p>\n                  <code>AttributeValueList</code> can contain one or more\n                        <code>AttributeValue</code> elements of type String, Number, or Binary.\n                    These attributes are compared against an existing attribute of an item. If any\n                    elements of the input are equal to the item attribute, the expression evaluates\n                    to true.</p>\n            </li>\n            <li>\n               <p>\n                  <code>BETWEEN</code> : Greater than or equal to the first value, and less than\n                    or equal to the second value. </p>\n               <p>\n                  <code>AttributeValueList</code> must contain two <code>AttributeValue</code>\n                    elements of the same type, either String, Number, or Binary (not a set type). A\n                    target attribute matches if the target value is greater than, or equal to, the\n                    first element and less than, or equal to, the second element. If an item\n                    contains an <code>AttributeValue</code> element of a different type than the one\n                    provided in the request, the value does not match. For example,\n                        <code>{\"S\":\"6\"}</code> does not compare to <code>{\"N\":\"6\"}</code>. Also,\n                        <code>{\"N\":\"6\"}</code> does not compare to <code>{\"NS\":[\"6\", \"2\",\n                        \"1\"]}</code>\n               </p>\n            </li>\n         </ul>"
                     }
                 },
                 "AttributeValueList": {
                     "target": "com.amazonaws.dynamodb#AttributeValueList",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values to evaluate against the supplied attribute. The number of values in\n            the list depends on the <code>ComparisonOperator</code> being used.</p>\n        <p>For type Number, value comparisons are numeric.</p>\n        <p>String value comparisons for greater than, equals, or less than are based on ASCII\n            character code values. For example, <code>a</code> is greater than <code>A</code>, and\n                <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p>\n        <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it\n            compares binary values.</p>\n        <p>For information on specifying data types in JSON, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataFormat.html\">JSON Data Format</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more values to evaluate against the supplied attribute. The number of values in\n            the list depends on the <code>ComparisonOperator</code> being used.</p>\n         <p>For type Number, value comparisons are numeric.</p>\n         <p>String value comparisons for greater than, equals, or less than are based on ASCII\n            character code values. For example, <code>a</code> is greater than <code>A</code>, and\n                <code>a</code> is greater than <code>B</code>. For a list of code values, see <a href=\"http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters\">http://en.wikipedia.org/wiki/ASCII#ASCII_printable_characters</a>.</p>\n         <p>For Binary, DynamoDB treats each byte of the binary data as unsigned when it\n            compares binary values.</p>\n         <p>For information on specifying data types in JSON, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataFormat.html\">JSON Data Format</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents a condition to be compared with an attribute value. This condition can be\n            used with <code>DeleteItem</code>, <code>PutItem</code>, or <code>UpdateItem</code>\n            operations; if the comparison evaluates to true, the operation succeeds; if not, the\n            operation fails. You can use <code>ExpectedAttributeValue</code> in one of two different\n            ways:</p>\n        <ul>\n            <li>\n                <p>Use <code>AttributeValueList</code> to specify one or more values to compare\n                    against an attribute. Use <code>ComparisonOperator</code> to specify how you\n                    want to perform the comparison. If the comparison evaluates to true, then the\n                    conditional operation succeeds.</p>\n            </li>\n            <li>\n                <p>Use <code>Value</code> to specify a value that DynamoDB will compare against\n                    an attribute. If the values match, then <code>ExpectedAttributeValue</code>\n                    evaluates to true and the conditional operation succeeds. Optionally, you can\n                    also set <code>Exists</code> to false, indicating that you <i>do\n                        not</i> expect to find the attribute value in the table. In this\n                    case, the conditional operation succeeds only if the comparison evaluates to\n                    false.</p>\n            </li>\n         </ul>\n        <p>\n            <code>Value</code> and <code>Exists</code> are incompatible with\n                <code>AttributeValueList</code> and <code>ComparisonOperator</code>. Note that if\n            you use both sets of parameters at once, DynamoDB will return a\n                <code>ValidationException</code> exception.</p>"
+                "smithy.api#documentation": "<p>Represents a condition to be compared with an attribute value. This condition can be\n            used with <code>DeleteItem</code>, <code>PutItem</code>, or <code>UpdateItem</code>\n            operations; if the comparison evaluates to true, the operation succeeds; if not, the\n            operation fails. You can use <code>ExpectedAttributeValue</code> in one of two different\n            ways:</p>\n         <ul>\n            <li>\n               <p>Use <code>AttributeValueList</code> to specify one or more values to compare\n                    against an attribute. Use <code>ComparisonOperator</code> to specify how you\n                    want to perform the comparison. If the comparison evaluates to true, then the\n                    conditional operation succeeds.</p>\n            </li>\n            <li>\n               <p>Use <code>Value</code> to specify a value that DynamoDB will compare against\n                    an attribute. If the values match, then <code>ExpectedAttributeValue</code>\n                    evaluates to true and the conditional operation succeeds. Optionally, you can\n                    also set <code>Exists</code> to false, indicating that you <i>do\n                        not</i> expect to find the attribute value in the table. In this\n                    case, the conditional operation succeeds only if the comparison evaluates to\n                    false.</p>\n            </li>\n         </ul>\n         <p>\n            <code>Value</code> and <code>Exists</code> are incompatible with\n                <code>AttributeValueList</code> and <code>ComparisonOperator</code>. Note that if\n            you use both sets of parameters at once, DynamoDB will return a\n                <code>ValidationException</code> exception.</p>"
             }
         },
         "com.amazonaws.dynamodb#ExportArn": {
@@ -4825,7 +4989,7 @@
                 "S3SseAlgorithm": {
                     "target": "com.amazonaws.dynamodb#S3SseAlgorithm",
                     "traits": {
-                        "smithy.api#documentation": "<p>Type of encryption used on the bucket where export data is stored. Valid values for\n                <code>S3SseAlgorithm</code> are:</p>\n        <ul>\n            <li>\n                <p>\n                  <code>AES256</code> - server-side encryption with Amazon S3 managed\n                    keys</p>\n            </li>\n            <li>\n                <p>\n                  <code>KMS</code> - server-side encryption with KMS managed\n                    keys</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Type of encryption used on the bucket where export data is stored. Valid values for\n                <code>S3SseAlgorithm</code> are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AES256</code> - server-side encryption with Amazon S3 managed\n                    keys</p>\n            </li>\n            <li>\n               <p>\n                  <code>KMS</code> - server-side encryption with KMS managed\n                    keys</p>\n            </li>\n         </ul>"
                     }
                 },
                 "S3SseKmsKeyId": {
@@ -5010,7 +5174,7 @@
                 "ClientToken": {
                     "target": "com.amazonaws.dynamodb#ClientToken",
                     "traits": {
-                        "smithy.api#documentation": "<p>Providing a <code>ClientToken</code> makes the call to\n                <code>ExportTableToPointInTimeInput</code> idempotent, meaning that multiple\n            identical calls have the same effect as one single call.</p>\n        <p>A client token is valid for 8 hours after the first request that uses it is completed.\n            After 8 hours, any request with the same client token is treated as a new request. Do\n            not resubmit the same request with the same client token for more than 8 hours, or the\n            result might not be idempotent.</p>\n        <p>If you submit a request with the same client token but a change in other parameters\n            within the 8-hour idempotency window, DynamoDB returns an\n                <code>ImportConflictException</code>.</p>",
+                        "smithy.api#documentation": "<p>Providing a <code>ClientToken</code> makes the call to\n                <code>ExportTableToPointInTimeInput</code> idempotent, meaning that multiple\n            identical calls have the same effect as one single call.</p>\n         <p>A client token is valid for 8 hours after the first request that uses it is completed.\n            After 8 hours, any request with the same client token is treated as a new request. Do\n            not resubmit the same request with the same client token for more than 8 hours, or the\n            result might not be idempotent.</p>\n         <p>If you submit a request with the same client token but a change in other parameters\n            within the 8-hour idempotency window, DynamoDB returns an\n                <code>ImportConflictException</code>.</p>",
                         "smithy.api#idempotencyToken": {}
                     }
                 },
@@ -5036,7 +5200,7 @@
                 "S3SseAlgorithm": {
                     "target": "com.amazonaws.dynamodb#S3SseAlgorithm",
                     "traits": {
-                        "smithy.api#documentation": "<p>Type of encryption used on the bucket where export data will be stored. Valid values\n            for <code>S3SseAlgorithm</code> are:</p>\n        <ul>\n            <li>\n                <p>\n                  <code>AES256</code> - server-side encryption with Amazon S3 managed\n                    keys</p>\n            </li>\n            <li>\n                <p>\n                  <code>KMS</code> - server-side encryption with KMS managed\n                    keys</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Type of encryption used on the bucket where export data will be stored. Valid values\n            for <code>S3SseAlgorithm</code> are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AES256</code> - server-side encryption with Amazon S3 managed\n                    keys</p>\n            </li>\n            <li>\n               <p>\n                  <code>KMS</code> - server-side encryption with KMS managed\n                    keys</p>\n            </li>\n         </ul>"
                     }
                 },
                 "S3SseKmsKeyId": {
@@ -5051,6 +5215,9 @@
                         "smithy.api#documentation": "<p>The format for the exported data. Valid values for <code>ExportFormat</code> are\n                <code>DYNAMODB_JSON</code> or <code>ION</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ExportTableToPointInTimeOutput": {
@@ -5062,6 +5229,9 @@
                         "smithy.api#documentation": "<p>Contains a description of the table export.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ExportTime": {
@@ -5189,7 +5359,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>GetItem</code> operation returns a set of attributes for the item with the\n            given primary key. If there is no matching item, <code>GetItem</code> does not return\n            any data and there will be no <code>Item</code> element in the response.</p>\n        <p>\n            <code>GetItem</code> provides an eventually consistent read by default. If your\n            application requires a strongly consistent read, set <code>ConsistentRead</code> to\n                <code>true</code>. Although a strongly consistent read might take more time than an\n            eventually consistent read, it always returns the last updated value.</p>"
+                "smithy.api#documentation": "<p>The <code>GetItem</code> operation returns a set of attributes for the item with the\n            given primary key. If there is no matching item, <code>GetItem</code> does not return\n            any data and there will be no <code>Item</code> element in the response.</p>\n         <p>\n            <code>GetItem</code> provides an eventually consistent read by default. If your\n            application requires a strongly consistent read, set <code>ConsistentRead</code> to\n                <code>true</code>. Although a strongly consistent read might take more time than an\n            eventually consistent read, it always returns the last updated value.</p>"
             }
         },
         "com.amazonaws.dynamodb#GetItemInput": {
@@ -5205,7 +5375,7 @@
                 "Key": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of attribute names to <code>AttributeValue</code> objects, representing the\n            primary key of the item to retrieve.</p>\n        <p>For the primary key, you must provide all of the attributes. For example, with a\n            simple primary key, you only need to provide a value for the partition key. For a\n            composite primary key, you must provide values for both the partition key and the sort\n            key.</p>",
+                        "smithy.api#documentation": "<p>A map of attribute names to <code>AttributeValue</code> objects, representing the\n            primary key of the item to retrieve.</p>\n         <p>For the primary key, you must provide all of the attributes. For example, with a\n            simple primary key, you only need to provide a value for the partition key. For a\n            composite primary key, you must provide values for both the partition key and the sort\n            key.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -5227,18 +5397,19 @@
                 "ProjectionExpression": {
                     "target": "com.amazonaws.dynamodb#ProjectionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the table. These\n            attributes can include scalars, sets, or elements of a JSON document. The attributes in\n            the expression must be separated by commas.</p>\n        <p>If no attribute names are specified, then all attributes are returned. If any of the\n            requested attributes are not found, they do not appear in the result.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the table. These\n            attributes can include scalars, sets, or elements of a JSON document. The attributes in\n            the expression must be separated by commas.</p>\n         <p>If no attribute names are specified, then all attributes are returned. If any of the\n            requested attributes are not found, they do not appear in the result.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>GetItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>GetItem</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#GetItemOutput": {
@@ -5253,12 +5424,13 @@
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacity",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>GetItem</code> operation. The data returned\n            includes the total provisioned throughput consumed, along with statistics for the table\n            and any indexes involved in the operation. <code>ConsumedCapacity</code> is only\n            returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more\n            information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Read/Write Capacity Mode</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>GetItem</code> operation. The data returned\n            includes the total provisioned throughput consumed, along with statistics for the table\n            and any indexes involved in the operation. <code>ConsumedCapacity</code> is only\n            returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more\n            information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html#ItemSizeCalculations.Reads\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>GetItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>GetItem</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#GlobalSecondaryIndex": {
@@ -5274,7 +5446,7 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>",
+                        "smithy.api#documentation": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>",
                         "smithy.api#required": {}
                     }
                 },
@@ -5288,7 +5460,7 @@
                 "ProvisionedThroughput": {
                     "target": "com.amazonaws.dynamodb#ProvisionedThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n        <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
@@ -5336,7 +5508,7 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>"
                     }
                 },
                 "Projection": {
@@ -5348,29 +5520,29 @@
                 "IndexStatus": {
                     "target": "com.amazonaws.dynamodb#IndexStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the global secondary index:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The index is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The index is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The index is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The index is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the global secondary index:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The index is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The index is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The index is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The index is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "Backfilling": {
                     "target": "com.amazonaws.dynamodb#Backfilling",
                     "traits": {
-                        "smithy.api#documentation": "<p>Indicates whether the index is currently backfilling. <i>Backfilling</i>\n            is the process of reading items from the table and determining whether they can be added\n            to the index. (Not all items will qualify: For example, a partition key cannot have any\n            duplicate values.) If an item can be added to the index, DynamoDB will do so. After all\n            items have been processed, the backfilling operation is complete and\n                <code>Backfilling</code> is false.</p>\n        <p>You can delete an index that is being created during the <code>Backfilling</code>\n            phase when <code>IndexStatus</code> is set to CREATING and <code>Backfilling</code> is\n            true. You can't delete the index that is being created when <code>IndexStatus</code> is\n            set to CREATING and <code>Backfilling</code> is false. </p>\n        <note>\n            <p>For indexes that were created during a <code>CreateTable</code> operation, the\n                    <code>Backfilling</code> attribute does not appear in the\n                    <code>DescribeTable</code> output.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>Indicates whether the index is currently backfilling. <i>Backfilling</i>\n            is the process of reading items from the table and determining whether they can be added\n            to the index. (Not all items will qualify: For example, a partition key cannot have any\n            duplicate values.) If an item can be added to the index, DynamoDB will do so. After all\n            items have been processed, the backfilling operation is complete and\n                <code>Backfilling</code> is false.</p>\n         <p>You can delete an index that is being created during the <code>Backfilling</code>\n            phase when <code>IndexStatus</code> is set to CREATING and <code>Backfilling</code> is\n            true. You can't delete the index that is being created when <code>IndexStatus</code> is\n            set to CREATING and <code>Backfilling</code> is false. </p>\n         <note>\n            <p>For indexes that were created during a <code>CreateTable</code> operation, the\n                    <code>Backfilling</code> attribute does not appear in the\n                    <code>DescribeTable</code> output.</p>\n         </note>"
                     }
                 },
                 "ProvisionedThroughput": {
                     "target": "com.amazonaws.dynamodb#ProvisionedThroughputDescription",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n        <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "IndexSizeBytes": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The total size of the specified index, in bytes. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>"
                     }
                 },
                 "ItemCount": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The number of items in the specified index. DynamoDB updates this value approximately\n            every six hours. Recent changes might not be reflected in this value.</p>"
                     }
@@ -5404,7 +5576,7 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The complete key schema for a global secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>"
                     }
                 },
                 "Projection": {
@@ -5442,7 +5614,7 @@
                 "Create": {
                     "target": "com.amazonaws.dynamodb#CreateGlobalSecondaryIndexAction",
                     "traits": {
-                        "smithy.api#documentation": "<p>The parameters required for creating a global secondary index on an existing\n            table:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>IndexName </code>\n                </p>\n            </li>\n            <li>\n                <p>\n                    <code>KeySchema </code>\n                </p>\n            </li>\n            <li>\n                <p>\n                    <code>AttributeDefinitions </code>\n                </p>\n            </li>\n            <li>\n                <p>\n                    <code>Projection </code>\n                </p>\n            </li>\n            <li>\n                <p>\n                    <code>ProvisionedThroughput </code>\n                </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The parameters required for creating a global secondary index on an existing\n            table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>AttributeDefinitions </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection </code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput </code>\n               </p>\n            </li>\n         </ul>"
                     }
                 },
                 "Delete": {
@@ -5453,7 +5625,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents one of the following:</p>\n        <ul>\n            <li>\n                <p>A new global secondary index to be added to an existing table.</p>\n            </li>\n            <li>\n                <p>New provisioned throughput parameters for an existing global secondary\n                    index.</p>\n            </li>\n            <li>\n                <p>An existing global secondary index to be removed from an existing\n                    table.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Represents one of the following:</p>\n         <ul>\n            <li>\n               <p>A new global secondary index to be added to an existing table.</p>\n            </li>\n            <li>\n               <p>New provisioned throughput parameters for an existing global secondary\n                    index.</p>\n            </li>\n            <li>\n               <p>An existing global secondary index to be removed from an existing\n                    table.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#GlobalSecondaryIndexUpdateList": {
@@ -5527,7 +5699,7 @@
                 "GlobalTableStatus": {
                     "target": "com.amazonaws.dynamodb#GlobalTableStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the global table:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The global table is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The global table is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The global table is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The global table is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the global table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The global table is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The global table is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The global table is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The global table is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "GlobalTableName": {
@@ -5897,7 +6069,7 @@
                     }
                 },
                 "ProcessedSizeBytes": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p> The total size of data processed from the source file, in Bytes. </p>"
                     }
@@ -5939,7 +6111,7 @@
                 "ClientToken": {
                     "target": "com.amazonaws.dynamodb#ClientToken",
                     "traits": {
-                        "smithy.api#documentation": "<p>Providing a <code>ClientToken</code> makes the call to <code>ImportTableInput</code>\n            idempotent, meaning that multiple identical calls have the same effect as one single\n            call.</p>\n        <p>A client token is valid for 8 hours after the first request that uses it is completed.\n            After 8 hours, any request with the same client token is treated as a new request. Do\n            not resubmit the same request with the same client token for more than 8 hours, or the\n            result might not be idempotent.</p>\n        <p>If you submit a request with the same client token but a change in other parameters\n            within the 8-hour idempotency window, DynamoDB returns an\n                <code>IdempotentParameterMismatch</code> exception.</p>",
+                        "smithy.api#documentation": "<p>Providing a <code>ClientToken</code> makes the call to <code>ImportTableInput</code>\n            idempotent, meaning that multiple identical calls have the same effect as one single\n            call.</p>\n         <p>A client token is valid for 8 hours after the first request that uses it is completed.\n            After 8 hours, any request with the same client token is treated as a new request. Do\n            not resubmit the same request with the same client token for more than 8 hours, or the\n            result might not be idempotent.</p>\n         <p>If you submit a request with the same client token but a change in other parameters\n            within the 8-hour idempotency window, DynamoDB returns an\n                <code>IdempotentParameterMismatch</code> exception.</p>",
                         "smithy.api#idempotencyToken": {}
                     }
                 },
@@ -5976,6 +6148,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ImportTableOutput": {
@@ -5988,6 +6163,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ImportedItemCount": {
@@ -6191,7 +6369,7 @@
                 "SizeEstimateRangeGB": {
                     "target": "com.amazonaws.dynamodb#ItemCollectionSizeEstimateRange",
                     "traits": {
-                        "smithy.api#documentation": "<p>An estimate of item collection size, in gigabytes. This value is a two-element array\n            containing a lower bound and an upper bound for the estimate. The estimate includes the\n            size of all the items in the table, plus the size of all attributes projected into all\n            of the local secondary indexes on that table. Use this estimate to measure whether a\n            local secondary index is approaching its size limit.</p>\n        <p>The estimate is subject to change over time; therefore, do not rely on the precision\n            or accuracy of the estimate.</p>"
+                        "smithy.api#documentation": "<p>An estimate of item collection size, in gigabytes. This value is a two-element array\n            containing a lower bound and an upper bound for the estimate. The estimate includes the\n            size of all the items in the table, plus the size of all attributes projected into all\n            of the local secondary indexes on that table. Use this estimate to measure whether a\n            local secondary index is approaching its size limit.</p>\n         <p>The estimate is subject to change over time; therefore, do not rely on the precision\n            or accuracy of the estimate.</p>"
                     }
                 }
             },
@@ -6351,13 +6529,13 @@
                 "KeyType": {
                     "target": "com.amazonaws.dynamodb#KeyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The role that this key attribute will assume:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>",
+                        "smithy.api#documentation": "<p>The role that this key attribute will assume:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of an internal hash function to evenly distribute data items across\n                partitions, based on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with\n                the same partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents <i>a single element</i> of a key schema. A key schema\n            specifies the attributes that make up the primary key of a table, or the key attributes\n            of an index.</p>\n        <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key.\n            For example, a simple primary key would be represented by one\n                <code>KeySchemaElement</code> (for the partition key). A composite primary key would\n            require one <code>KeySchemaElement</code> for the partition key, and another\n                <code>KeySchemaElement</code> for the sort key.</p>\n        <p>A <code>KeySchemaElement</code> must be a scalar, top-level attribute (not a nested\n            attribute). The data type must be one of String, Number, or Binary. The attribute cannot\n            be nested within a List or a Map.</p>"
+                "smithy.api#documentation": "<p>Represents <i>a single element</i> of a key schema. A key schema\n            specifies the attributes that make up the primary key of a table, or the key attributes\n            of an index.</p>\n         <p>A <code>KeySchemaElement</code> represents exactly one attribute of the primary key.\n            For example, a simple primary key would be represented by one\n                <code>KeySchemaElement</code> (for the partition key). A composite primary key would\n            require one <code>KeySchemaElement</code> for the partition key, and another\n                <code>KeySchemaElement</code> for the sort key.</p>\n         <p>A <code>KeySchemaElement</code> must be a scalar, top-level attribute (not a nested\n            attribute). The data type must be one of String, Number, or Binary. The attribute cannot\n            be nested within a List or a Map.</p>"
             }
         },
         "com.amazonaws.dynamodb#KeyType": {
@@ -6402,18 +6580,18 @@
                 "ProjectionExpression": {
                     "target": "com.amazonaws.dynamodb#ProjectionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the table. These\n            attributes can include scalars, sets, or elements of a JSON document. The attributes in\n            the <code>ProjectionExpression</code> must be separated by commas.</p>\n        <p>If no attribute names are specified, then all attributes will be returned. If any of\n            the requested attributes are not found, they will not appear in the result.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the table. These\n            attributes can include scalars, sets, or elements of a JSON document. The attributes in\n            the <code>ProjectionExpression</code> must be separated by commas.</p>\n         <p>If no attribute names are specified, then all attributes will be returned. If any of\n            the requested attributes are not found, they will not appear in the result.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents a set of primary keys and, for each key, the attributes to retrieve from\n            the table.</p>\n        <p>For each primary key, you must provide <i>all</i> of the key attributes.\n            For example, with a simple primary key, you only need to provide the partition key. For\n            a composite primary key, you must provide <i>both</i> the partition key\n            and the sort key.</p>"
+                "smithy.api#documentation": "<p>Represents a set of primary keys and, for each key, the attributes to retrieve from\n            the table.</p>\n         <p>For each primary key, you must provide <i>all</i> of the key attributes.\n            For example, with a simple primary key, you only need to provide the partition key. For\n            a composite primary key, you must provide <i>both</i> the partition key\n            and the sort key.</p>"
             }
         },
         "com.amazonaws.dynamodb#KinesisDataStreamDestination": {
@@ -6504,7 +6682,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>There is no limit to the number of daily on-demand backups that can be taken. </p>\n        <p>For most purposes, up to 500 simultaneous table operations are allowed per account. These operations\n            include <code>CreateTable</code>, <code>UpdateTable</code>,\n                <code>DeleteTable</code>,<code>UpdateTimeToLive</code>,\n                <code>RestoreTableFromBackup</code>, and <code>RestoreTableToPointInTime</code>. </p>\n        <p>When you are creating a table with one or more secondary\n            indexes, you can have up to 250 such requests running at a time. However, if the table or\n            index specifications are complex, then DynamoDB might temporarily reduce the number\n            of concurrent operations.</p>\n        <p>When importing into DynamoDB, up to 50 simultaneous import table operations are allowed per account.</p>\n        <p>There is a soft account quota of 2,500 tables.</p>",
+                "smithy.api#documentation": "<p>There is no limit to the number of daily on-demand backups that can be taken. </p>\n         <p>For most purposes, up to 500 simultaneous table operations are allowed per account. These operations\n            include <code>CreateTable</code>, <code>UpdateTable</code>,\n                <code>DeleteTable</code>,<code>UpdateTimeToLive</code>,\n                <code>RestoreTableFromBackup</code>, and <code>RestoreTableToPointInTime</code>. </p>\n         <p>When you are creating a table with one or more secondary\n            indexes, you can have up to 250 such requests running at a time. However, if the table or\n            index specifications are complex, then DynamoDB might temporarily reduce the number\n            of concurrent operations.</p>\n         <p>When importing into DynamoDB, up to 50 simultaneous import table operations are allowed per account.</p>\n         <p>There is a soft account quota of 2,500 tables.</p>",
                 "smithy.api#error": "client"
             }
         },
@@ -6534,7 +6712,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>List backups associated with an Amazon Web Services account. To list backups for a\n            given table, specify <code>TableName</code>. <code>ListBackups</code> returns a\n            paginated list of results with at most 1 MB worth of items in a page. You can also\n            specify a maximum number of entries to be returned in a page.</p>\n        <p>In the request, start time is inclusive, but end time is exclusive. Note that these\n            boundaries are for the time at which the original backup was requested.</p>\n        <p>You can call <code>ListBackups</code> a maximum of five times per second.</p>"
+                "smithy.api#documentation": "<p>List backups associated with an Amazon Web Services account. To list backups for a\n            given table, specify <code>TableName</code>. <code>ListBackups</code> returns a\n            paginated list of results with at most 1 MB worth of items in a page. You can also\n            specify a maximum number of entries to be returned in a page.</p>\n         <p>In the request, start time is inclusive, but end time is exclusive. Note that these\n            boundaries are for the time at which the original backup was requested.</p>\n         <p>You can call <code>ListBackups</code> a maximum of five times per second.</p>"
             }
         },
         "com.amazonaws.dynamodb#ListBackupsInput": {
@@ -6573,9 +6751,12 @@
                 "BackupType": {
                     "target": "com.amazonaws.dynamodb#BackupTypeFilter",
                     "traits": {
-                        "smithy.api#documentation": "<p>The backups from the table specified by <code>BackupType</code> are listed.</p>\n        <p>Where <code>BackupType</code> can be:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>USER</code> - On-demand backup created by you. (The default setting if no\n                    other backup types are specified.)</p>\n            </li>\n            <li>\n                <p>\n                    <code>SYSTEM</code> - On-demand backup automatically created by DynamoDB.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL</code> - All types of on-demand backups (USER and SYSTEM).</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The backups from the table specified by <code>BackupType</code> are listed.</p>\n         <p>Where <code>BackupType</code> can be:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>USER</code> - On-demand backup created by you. (The default setting if no\n                    other backup types are specified.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>SYSTEM</code> - On-demand backup automatically created by DynamoDB.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL</code> - All types of on-demand backups (USER and SYSTEM).</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListBackupsOutput": {
@@ -6590,9 +6771,12 @@
                 "LastEvaluatedBackupArn": {
                     "target": "com.amazonaws.dynamodb#BackupArn",
                     "traits": {
-                        "smithy.api#documentation": "<p> The ARN of the backup last evaluated when the current page of results was returned,\n            inclusive of the current page of results. This value may be specified as the\n                <code>ExclusiveStartBackupArn</code> of a new <code>ListBackups</code> operation in\n            order to fetch the next page of results. </p>\n        <p> If <code>LastEvaluatedBackupArn</code> is empty, then the last page of results has\n            been processed and there are no more results to be retrieved. </p>\n        <p> If <code>LastEvaluatedBackupArn</code> is not empty, this may or may not indicate\n            that there is more data to be returned. All results are guaranteed to have been returned\n            if and only if no value for <code>LastEvaluatedBackupArn</code> is returned. </p>"
+                        "smithy.api#documentation": "<p> The ARN of the backup last evaluated when the current page of results was returned,\n            inclusive of the current page of results. This value may be specified as the\n                <code>ExclusiveStartBackupArn</code> of a new <code>ListBackups</code> operation in\n            order to fetch the next page of results. </p>\n         <p> If <code>LastEvaluatedBackupArn</code> is empty, then the last page of results has\n            been processed and there are no more results to be retrieved. </p>\n         <p> If <code>LastEvaluatedBackupArn</code> is not empty, this may or may not indicate\n            that there is more data to be returned. All results are guaranteed to have been returned\n            if and only if no value for <code>LastEvaluatedBackupArn</code> is returned. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ListContributorInsights": {
@@ -6642,6 +6826,9 @@
                         "smithy.api#documentation": "<p>Maximum number of results to return per page.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListContributorInsightsLimit": {
@@ -6668,6 +6855,9 @@
                         "smithy.api#documentation": "<p>A token to go to the next page if there is one.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ListExports": {
@@ -6716,6 +6906,9 @@
                         "smithy.api#documentation": "<p>An optional string that, if supplied, must be copied from the output of a previous\n            call to <code>ListExports</code>. When provided in this manner, the API fetches the next\n            page of results.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListExportsMaxLimit": {
@@ -6742,6 +6935,9 @@
                         "smithy.api#documentation": "<p>If this value is returned, there are additional results to be displayed. To retrieve\n            them, call <code>ListExports</code> again, with <code>NextToken</code> set to this\n            value.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ListGlobalTables": {
@@ -6764,7 +6960,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Lists all global tables that have a replica in the specified Region.</p>\n        <note>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                    2017.11.29</a> of global tables.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Lists all global tables that have a replica in the specified Region.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                2017.11.29 (Legacy)</a> of global tables. We recommend using\n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                when creating new global tables, as it provides greater flexibility, higher efficiency and consumes less write capacity than \n                2017.11.29 (Legacy). To determine which version you are using, see \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.DetermineVersion.html\">Determining the version</a>. \n                To update existing global tables from version 2017.11.29 (Legacy) to version\n                2019.11.21 (Current), see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_upgrade.html\">\n                    Updating global tables</a>.\n            </p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#ListGlobalTablesInput": {
@@ -6779,7 +6975,7 @@
                 "Limit": {
                     "target": "com.amazonaws.dynamodb#PositiveIntegerObject",
                     "traits": {
-                        "smithy.api#documentation": "<p>The maximum number of table names to return, if the parameter is not specified\n            DynamoDB defaults to 100.</p>\n        <p>If the number of global tables DynamoDB finds reaches this limit, it stops the\n            operation and returns the table names collected up to that point, with a table name in\n            the <code>LastEvaluatedGlobalTableName</code> to apply in a subsequent operation to the\n                <code>ExclusiveStartGlobalTableName</code> parameter.</p>"
+                        "smithy.api#documentation": "<p>The maximum number of table names to return, if the parameter is not specified\n            DynamoDB defaults to 100.</p>\n         <p>If the number of global tables DynamoDB finds reaches this limit, it stops the\n            operation and returns the table names collected up to that point, with a table name in\n            the <code>LastEvaluatedGlobalTableName</code> to apply in a subsequent operation to the\n                <code>ExclusiveStartGlobalTableName</code> parameter.</p>"
                     }
                 },
                 "RegionName": {
@@ -6788,6 +6984,9 @@
                         "smithy.api#documentation": "<p>Lists the global tables in a specific Region.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListGlobalTablesOutput": {
@@ -6805,6 +7004,9 @@
                         "smithy.api#documentation": "<p>Last evaluated global table name.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ListImports": {
@@ -6850,6 +7052,9 @@
                         "smithy.api#documentation": "<p> An optional string that, if supplied, must be copied from the output of a previous\n            call to <code>ListImports</code>. When provided in this manner, the API fetches the next\n            page of results. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListImportsMaxLimit": {
@@ -6876,6 +7081,9 @@
                         "smithy.api#documentation": "<p> If this value is returned, there are additional results to be displayed. To retrieve\n            them, call <code>ListImports</code> again, with <code>NextToken</code> set to this\n            value. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ListTables": {
@@ -6924,7 +7132,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>ListTables</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>ListTables</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListTablesInputLimit": {
@@ -6942,18 +7151,19 @@
                 "TableNames": {
                     "target": "com.amazonaws.dynamodb#TableNameList",
                     "traits": {
-                        "smithy.api#documentation": "<p>The names of the tables associated with the current account at the current endpoint.\n            The maximum size of this array is 100.</p>\n        <p>If <code>LastEvaluatedTableName</code> also appears in the output, you can use this\n            value as the <code>ExclusiveStartTableName</code> parameter in a subsequent\n                <code>ListTables</code> request and obtain the next page of results.</p>"
+                        "smithy.api#documentation": "<p>The names of the tables associated with the current account at the current endpoint.\n            The maximum size of this array is 100.</p>\n         <p>If <code>LastEvaluatedTableName</code> also appears in the output, you can use this\n            value as the <code>ExclusiveStartTableName</code> parameter in a subsequent\n                <code>ListTables</code> request and obtain the next page of results.</p>"
                     }
                 },
                 "LastEvaluatedTableName": {
                     "target": "com.amazonaws.dynamodb#TableName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the last table in the current page of results. Use this value as the\n                <code>ExclusiveStartTableName</code> in a new request to obtain the next page of\n            results, until all the table names are returned.</p>\n        <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response,\n            this means that there are no more table names to be retrieved.</p>"
+                        "smithy.api#documentation": "<p>The name of the last table in the current page of results. Use this value as the\n                <code>ExclusiveStartTableName</code> in a new request to obtain the next page of\n            results, until all the table names are returned.</p>\n         <p>If you do not receive a <code>LastEvaluatedTableName</code> value in the response,\n            this means that there are no more table names to be retrieved.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>ListTables</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>ListTables</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ListTagsOfResource": {
@@ -6979,7 +7189,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>List all tags on an Amazon DynamoDB resource. You can call ListTagsOfResource up to 10\n            times per second, per account.</p>\n        <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>List all tags on an Amazon DynamoDB resource. You can call ListTagsOfResource up to 10\n            times per second, per account.</p>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#ListTagsOfResourceInput": {
@@ -6998,6 +7208,9 @@
                         "smithy.api#documentation": "<p>An optional string that, if supplied, must be copied from the output of a previous\n            call to ListTagOfResource. When provided in this manner, this API fetches the next page\n            of results.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ListTagsOfResourceOutput": {
@@ -7015,6 +7228,9 @@
                         "smithy.api#documentation": "<p>If this value is returned, there are additional results to be displayed. To retrieve\n            them, call ListTagsOfResource again, with NextToken set to this value.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#LocalSecondaryIndex": {
@@ -7030,7 +7246,7 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The complete key schema for the local secondary index, consisting of one or more pairs\n            of attribute names and key types:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>",
+                        "smithy.api#documentation": "<p>The complete key schema for the local secondary index, consisting of one or more pairs\n            of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7058,7 +7274,7 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The complete key schema for the local secondary index, consisting of one or more pairs\n            of attribute names and key types:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The complete key schema for the local secondary index, consisting of one or more pairs\n            of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>"
                     }
                 },
                 "Projection": {
@@ -7068,13 +7284,13 @@
                     }
                 },
                 "IndexSizeBytes": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The total size of the specified index, in bytes. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>"
                     }
                 },
                 "ItemCount": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The number of items in the specified index. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>"
                     }
@@ -7108,7 +7324,7 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The complete key schema for a local secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n                <p>\n                    <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n        <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The complete key schema for a local secondary index, which consists of one or more\n            pairs of attribute names and key types:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>HASH</code> - partition key</p>\n            </li>\n            <li>\n               <p>\n                  <code>RANGE</code> - sort key</p>\n            </li>\n         </ul>\n         <note>\n            <p>The partition key of an item is also known as its <i>hash\n                    attribute</i>. The term \"hash attribute\" derives from DynamoDB's usage of\n                an internal hash function to evenly distribute data items across partitions, based\n                on their partition key values.</p>\n            <p>The sort key of an item is also known as its <i>range attribute</i>.\n                The term \"range attribute\" derives from the way DynamoDB stores items with the same\n                partition key physically close together, in sorted order by the sort key\n                value.</p>\n         </note>"
                     }
                 },
                 "Projection": {
@@ -7135,6 +7351,12 @@
             }
         },
         "com.amazonaws.dynamodb#Long": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.dynamodb#LongObject": {
             "type": "long"
         },
         "com.amazonaws.dynamodb#MapAttributeValue": {
@@ -7265,7 +7487,7 @@
                 "PointInTimeRecoveryStatus": {
                     "target": "com.amazonaws.dynamodb#PointInTimeRecoveryStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of point in time recovery:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ENABLED</code> - Point in time recovery is enabled.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DISABLED</code> - Point in time recovery is disabled.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of point in time recovery:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> - Point in time recovery is enabled.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DISABLED</code> - Point in time recovery is disabled.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "EarliestRestorableDateTime": {
@@ -7371,13 +7593,13 @@
                 "ProjectionType": {
                     "target": "com.amazonaws.dynamodb#ProjectionType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The set of attributes that are projected into the index:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>KEYS_ONLY</code> - Only the index and primary keys are projected into the\n                    index.</p>\n            </li>\n            <li>\n                <p>\n                    <code>INCLUDE</code> - In addition to the attributes described in\n                        <code>KEYS_ONLY</code>, the secondary index will include other non-key\n                    attributes that you specify.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL</code> - All of the table attributes are projected into the\n                    index.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The set of attributes that are projected into the index:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KEYS_ONLY</code> - Only the index and primary keys are projected into the\n                    index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INCLUDE</code> - In addition to the attributes described in\n                        <code>KEYS_ONLY</code>, the secondary index will include other non-key\n                    attributes that you specify.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL</code> - All of the table attributes are projected into the\n                    index.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "NonKeyAttributes": {
                     "target": "com.amazonaws.dynamodb#NonKeyAttributeNameList",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the non-key attribute names which will be projected into the index.</p>\n        <p>For local secondary indexes, the total count of <code>NonKeyAttributes</code> summed\n            across all of the local secondary indexes, must not exceed 100. If you project the same\n            attribute into two different indexes, this counts as two distinct attributes when\n            determining the total.</p>"
+                        "smithy.api#documentation": "<p>Represents the non-key attribute names which will be projected into the index.</p>\n         <p>For local secondary indexes, the total count of <code>NonKeyAttributes</code> summed\n            across all of the local secondary indexes, must not exceed 100. If you project the same\n            attribute into two different indexes, this counts as two distinct attributes when\n            determining the total.</p>"
                     }
                 }
             },
@@ -7417,20 +7639,20 @@
                 "ReadCapacityUnits": {
                     "target": "com.amazonaws.dynamodb#PositiveLongObject",
                     "traits": {
-                        "smithy.api#documentation": "<p>The maximum number of strongly consistent reads consumed per second before DynamoDB\n            returns a <code>ThrottlingException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput\">Specifying Read and Write Requirements</a> in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>\n        <p>If read/write capacity mode is <code>PAY_PER_REQUEST</code> the value is set to\n            0.</p>",
+                        "smithy.api#documentation": "<p>The maximum number of strongly consistent reads consumed per second before DynamoDB\n            returns a <code>ThrottlingException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput\">Specifying Read and Write Requirements</a> in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>\n         <p>If read/write capacity mode is <code>PAY_PER_REQUEST</code> the value is set to\n            0.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "WriteCapacityUnits": {
                     "target": "com.amazonaws.dynamodb#PositiveLongObject",
                     "traits": {
-                        "smithy.api#documentation": "<p>The maximum number of writes consumed per second before DynamoDB returns a\n                <code>ThrottlingException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput\">Specifying Read and Write Requirements</a> in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>\n        <p>If read/write capacity mode is <code>PAY_PER_REQUEST</code> the value is set to\n            0.</p>",
+                        "smithy.api#documentation": "<p>The maximum number of writes consumed per second before DynamoDB returns a\n                <code>ThrottlingException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithTables.html#ProvisionedThroughput\">Specifying Read and Write Requirements</a> in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>\n         <p>If read/write capacity mode is <code>PAY_PER_REQUEST</code> the value is set to\n            0.</p>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the provisioned throughput settings for a specified table or index. The\n            settings can be modified using the <code>UpdateTable</code> operation.</p>\n        <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Represents the provisioned throughput settings for a specified table or index. The\n            settings can be modified using the <code>UpdateTable</code> operation.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#ProvisionedThroughputDescription": {
@@ -7584,7 +7806,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Creates a new item, or replaces an old item with a new item. If an item that has the\n            same primary key as the new item already exists in the specified table, the new item\n            completely replaces the existing item. You can perform a conditional put operation (add\n            a new item if one with the specified primary key doesn't exist), or replace an existing\n            item if it has certain attribute values. You can return the item's attribute values in\n            the same operation, using the <code>ReturnValues</code> parameter.</p>\n\n        <p>When you add an item, the primary key attributes are the only required attributes.\n            </p>\n        <p>Empty String and Binary attribute values are allowed. Attribute values of type String\n            and Binary must have a length greater than zero if the attribute is used as a key\n            attribute for a table or index. Set type attributes cannot be empty. </p>\n        <p>Invalid Requests with empty values will be rejected with a\n                <code>ValidationException</code> exception.</p>\n        <note>\n            <p>To prevent a new item from replacing an existing item, use a conditional\n                expression that contains the <code>attribute_not_exists</code> function with the\n                name of the attribute being used as the partition key for the table. Since every\n                record must contain that attribute, the <code>attribute_not_exists</code> function\n                will only succeed if no matching item exists.</p>\n        </note>\n        <p>For more information about <code>PutItem</code>, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html\">Working with\n                Items</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates a new item, or replaces an old item with a new item. If an item that has the\n            same primary key as the new item already exists in the specified table, the new item\n            completely replaces the existing item. You can perform a conditional put operation (add\n            a new item if one with the specified primary key doesn't exist), or replace an existing\n            item if it has certain attribute values. You can return the item's attribute values in\n            the same operation, using the <code>ReturnValues</code> parameter.</p>\n         <p>When you add an item, the primary key attributes are the only required attributes.\n            </p>\n         <p>Empty String and Binary attribute values are allowed. Attribute values of type String\n            and Binary must have a length greater than zero if the attribute is used as a key\n            attribute for a table or index. Set type attributes cannot be empty. </p>\n         <p>Invalid Requests with empty values will be rejected with a\n                <code>ValidationException</code> exception.</p>\n         <note>\n            <p>To prevent a new item from replacing an existing item, use a conditional\n                expression that contains the <code>attribute_not_exists</code> function with the\n                name of the attribute being used as the partition key for the table. Since every\n                record must contain that attribute, the <code>attribute_not_exists</code> function\n                will only succeed if no matching item exists.</p>\n         </note>\n         <p>For more information about <code>PutItem</code>, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html\">Working with\n                Items</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#PutItemInput": {
@@ -7600,7 +7822,7 @@
                 "Item": {
                     "target": "com.amazonaws.dynamodb#PutItemInputAttributeMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of attribute name/value pairs, one for each attribute. Only the primary key\n            attributes are required; you can optionally provide other attribute name-value pairs for\n            the item.</p>\n        <p>You must provide all of the attributes for the primary key. For example, with a simple\n            primary key, you only need to provide a value for the partition key. For a composite\n            primary key, you must provide both values for both the partition key and the sort\n            key.</p>\n        <p>If you specify any attributes that are part of an index key, then the data types for\n            those attributes must match those of the schema in the table's attribute\n            definition.</p>\n        <p>Empty String and Binary attribute values are allowed. Attribute values of type String\n            and Binary must have a length greater than zero if the attribute is used as a key\n            attribute for a table or index.</p>\n\n        <p>For more information about primary keys, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey\">Primary Key</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n        <p>Each element in the <code>Item</code> map is an <code>AttributeValue</code>\n            object.</p>",
+                        "smithy.api#documentation": "<p>A map of attribute name/value pairs, one for each attribute. Only the primary key\n            attributes are required; you can optionally provide other attribute name-value pairs for\n            the item.</p>\n         <p>You must provide all of the attributes for the primary key. For example, with a simple\n            primary key, you only need to provide a value for the partition key. For a composite\n            primary key, you must provide both values for both the partition key and the sort\n            key.</p>\n         <p>If you specify any attributes that are part of an index key, then the data types for\n            those attributes must match those of the schema in the table's attribute\n            definition.</p>\n         <p>Empty String and Binary attribute values are allowed. Attribute values of type String\n            and Binary must have a length greater than zero if the attribute is used as a key\n            attribute for a table or index.</p>\n         <p>For more information about primary keys, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.CoreComponents.html#HowItWorks.CoreComponents.PrimaryKey\">Primary Key</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n         <p>Each element in the <code>Item</code> map is an <code>AttributeValue</code>\n            object.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7613,7 +7835,7 @@
                 "ReturnValues": {
                     "target": "com.amazonaws.dynamodb#ReturnValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>Use <code>ReturnValues</code> if you want to get the item attributes as they appeared\n            before they were updated with the <code>PutItem</code> request. For\n            <code>PutItem</code>, the valid values are:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>NONE</code> - If <code>ReturnValues</code> is not specified, or if its\n                    value is <code>NONE</code>, then nothing is returned. (This setting is the\n                    default for <code>ReturnValues</code>.)</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL_OLD</code> - If <code>PutItem</code> overwrote an attribute name-value\n                    pair, then the content of the old item is returned.</p>\n            </li>\n         </ul>\n        <p>The values returned are strongly consistent.</p>\n        <p>There is no additional cost associated with requesting a return value aside from the\n            small network and processing overhead of receiving a larger response. No read capacity\n            units are consumed.</p>\n        <note>\n            <p>The <code>ReturnValues</code> parameter is used by several DynamoDB operations;\n                however, <code>PutItem</code> does not recognize any values other than\n                    <code>NONE</code> or <code>ALL_OLD</code>.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>Use <code>ReturnValues</code> if you want to get the item attributes as they appeared\n            before they were updated with the <code>PutItem</code> request. For\n            <code>PutItem</code>, the valid values are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NONE</code> - If <code>ReturnValues</code> is not specified, or if its\n                    value is <code>NONE</code>, then nothing is returned. (This setting is the\n                    default for <code>ReturnValues</code>.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL_OLD</code> - If <code>PutItem</code> overwrote an attribute name-value\n                    pair, then the content of the old item is returned.</p>\n            </li>\n         </ul>\n         <p>The values returned are strongly consistent.</p>\n         <p>There is no additional cost associated with requesting a return value aside from the\n            small network and processing overhead of receiving a larger response. No read capacity\n            units are consumed.</p>\n         <note>\n            <p>The <code>ReturnValues</code> parameter is used by several DynamoDB operations;\n                however, <code>PutItem</code> does not recognize any values other than\n                    <code>NONE</code> or <code>ALL_OLD</code>.</p>\n         </note>"
                     }
                 },
                 "ReturnConsumedCapacity": {
@@ -7634,24 +7856,25 @@
                 "ConditionExpression": {
                     "target": "com.amazonaws.dynamodb#ConditionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional <code>PutItem</code>\n            operation to succeed.</p>\n        <p>An expression can contain any of the following:</p>\n        <ul>\n            <li>\n                <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type |\n                        contains | begins_with | size</code>\n                </p>\n                <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n                <p>Comparison operators: <code>= | <> |\n            < | > | <= | >= |\n            BETWEEN | IN </code>\n                </p>\n            </li>\n            <li>\n                <p> Logical operators: <code>AND | OR | NOT</code>\n                </p>\n            </li>\n         </ul>\n        <p>For more information on condition expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional <code>PutItem</code>\n            operation to succeed.</p>\n         <p>An expression can contain any of the following:</p>\n         <ul>\n            <li>\n               <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type |\n                        contains | begins_with | size</code>\n               </p>\n               <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Comparison operators: <code>= | <> |\n            < | > | <= | >= |\n            BETWEEN | IN </code>\n               </p>\n            </li>\n            <li>\n               <p> Logical operators: <code>AND | OR | NOT</code>\n               </p>\n            </li>\n         </ul>\n         <p>For more information on condition expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeValues": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeValueMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n        <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <i>ProductStatus</i> attribute was one of the following: </p>\n        <p>\n            <code>Available | Backordered | Discontinued</code>\n        </p>\n        <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n        <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n        </p>\n        <p>You could then use these values in an expression, such as this:</p>\n        <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n        </p>\n        <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n         <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <i>ProductStatus</i> attribute was one of the following: </p>\n         <p>\n            <code>Available | Backordered | Discontinued</code>\n         </p>\n         <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n         <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n         </p>\n         <p>You could then use these values in an expression, such as this:</p>\n         <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n         </p>\n         <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>PutItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>PutItem</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#PutItemInputAttributeMap": {
@@ -7675,18 +7898,19 @@
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacity",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>PutItem</code> operation. The data returned\n            includes the total provisioned throughput consumed, along with statistics for the table\n            and any indexes involved in the operation. <code>ConsumedCapacity</code> is only\n            returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more\n            information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Read/Write Capacity Mode</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>PutItem</code> operation. The data returned\n            includes the total provisioned throughput consumed, along with statistics for the table\n            and any indexes involved in the operation. <code>ConsumedCapacity</code> is only\n            returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more\n            information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ItemCollectionMetrics": {
                     "target": "com.amazonaws.dynamodb#ItemCollectionMetrics",
                     "traits": {
-                        "smithy.api#documentation": "<p>Information about item collections, if any, that were affected by the\n                <code>PutItem</code> operation. <code>ItemCollectionMetrics</code> is only returned\n            if the <code>ReturnItemCollectionMetrics</code> parameter was specified. If the table\n            does not have any local secondary indexes, this information is not returned in the\n            response.</p>\n        <p>Each <code>ItemCollectionMetrics</code> element consists of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item itself.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SizeEstimateRangeGB</code> - An estimate of item collection size, in\n                    gigabytes. This value is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on that table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n                <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Information about item collections, if any, that were affected by the\n                <code>PutItem</code> operation. <code>ItemCollectionMetrics</code> is only returned\n            if the <code>ReturnItemCollectionMetrics</code> parameter was specified. If the table\n            does not have any local secondary indexes, this information is not returned in the\n            response.</p>\n         <p>Each <code>ItemCollectionMetrics</code> element consists of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item itself.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SizeEstimateRangeGB</code> - An estimate of item collection size, in\n                    gigabytes. This value is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on that table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n               <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>PutItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>PutItem</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#PutRequest": {
@@ -7733,7 +7957,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>You must provide the name of the partition key attribute and a single value for that\n            attribute. <code>Query</code> returns all items with that partition key value.\n            Optionally, you can provide a sort key attribute and use a comparison operator to refine\n            the search results.</p>\n\n        <p>Use the <code>KeyConditionExpression</code> parameter to provide a specific value for\n            the partition key. The <code>Query</code> operation will return all of the items from\n            the table or index with that partition key value. You can optionally narrow the scope of\n            the <code>Query</code> operation by specifying a sort key value and a comparison\n            operator in <code>KeyConditionExpression</code>. To further refine the\n                <code>Query</code> results, you can optionally provide a\n                <code>FilterExpression</code>. A <code>FilterExpression</code> determines which\n            items within the results should be returned to you. All of the other results are\n            discarded. </p>\n        <p> A <code>Query</code> operation always returns a result set. If no matching items are\n            found, the result set will be empty. Queries that do not return results consume the\n            minimum number of read capacity units for that type of read operation. </p>\n        <note>\n            <p> DynamoDB calculates the number of read capacity units consumed based on item\n                size, not on the amount of data that is returned to an application. The number of\n                capacity units consumed will be the same whether you request all of the attributes\n                (the default behavior) or just some of them (using a projection expression). The\n                number will also be the same whether or not you use a <code>FilterExpression</code>.\n            </p>\n        </note>\n        <p>\n            <code>Query</code> results are always sorted by the sort key value. If the data type of\n            the sort key is Number, the results are returned in numeric order; otherwise, the\n            results are returned in order of UTF-8 bytes. By default, the sort order is ascending.\n            To reverse the order, set the <code>ScanIndexForward</code> parameter to false. </p>\n        <p> A single <code>Query</code> operation will read up to the maximum number of items set\n            (if using the <code>Limit</code> parameter) or a maximum of 1 MB of data and then apply\n            any filtering to the results using <code>FilterExpression</code>. If\n                <code>LastEvaluatedKey</code> is present in the response, you will need to paginate\n            the result set. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Pagination\">Paginating\n                the Results</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p>\n        <p>\n            <code>FilterExpression</code> is applied after a <code>Query</code> finishes, but before\n            the results are returned. A <code>FilterExpression</code> cannot contain partition key\n            or sort key attributes. You need to specify those attributes in the\n                <code>KeyConditionExpression</code>. </p>\n        <note>\n            <p> A <code>Query</code> operation can return an empty result set and a\n                    <code>LastEvaluatedKey</code> if all the items read for the page of results are\n                filtered out. </p>\n        </note>\n        <p>You can query a table, a local secondary index, or a global secondary index. For a\n            query on a table or on a local secondary index, you can set the\n                <code>ConsistentRead</code> parameter to <code>true</code> and obtain a strongly\n            consistent result. Global secondary indexes support eventually consistent reads only, so\n            do not specify <code>ConsistentRead</code> when querying a global secondary\n            index.</p>",
+                "smithy.api#documentation": "<p>You must provide the name of the partition key attribute and a single value for that\n            attribute. <code>Query</code> returns all items with that partition key value.\n            Optionally, you can provide a sort key attribute and use a comparison operator to refine\n            the search results.</p>\n         <p>Use the <code>KeyConditionExpression</code> parameter to provide a specific value for\n            the partition key. The <code>Query</code> operation will return all of the items from\n            the table or index with that partition key value. You can optionally narrow the scope of\n            the <code>Query</code> operation by specifying a sort key value and a comparison\n            operator in <code>KeyConditionExpression</code>. To further refine the\n                <code>Query</code> results, you can optionally provide a\n                <code>FilterExpression</code>. A <code>FilterExpression</code> determines which\n            items within the results should be returned to you. All of the other results are\n            discarded. </p>\n         <p> A <code>Query</code> operation always returns a result set. If no matching items are\n            found, the result set will be empty. Queries that do not return results consume the\n            minimum number of read capacity units for that type of read operation. </p>\n         <note>\n            <p> DynamoDB calculates the number of read capacity units consumed based on item\n                size, not on the amount of data that is returned to an application. The number of\n                capacity units consumed will be the same whether you request all of the attributes\n                (the default behavior) or just some of them (using a projection expression). The\n                number will also be the same whether or not you use a <code>FilterExpression</code>.\n            </p>\n         </note>\n         <p>\n            <code>Query</code> results are always sorted by the sort key value. If the data type of\n            the sort key is Number, the results are returned in numeric order; otherwise, the\n            results are returned in order of UTF-8 bytes. By default, the sort order is ascending.\n            To reverse the order, set the <code>ScanIndexForward</code> parameter to false. </p>\n         <p> A single <code>Query</code> operation will read up to the maximum number of items set\n            (if using the <code>Limit</code> parameter) or a maximum of 1 MB of data and then apply\n            any filtering to the results using <code>FilterExpression</code>. If\n                <code>LastEvaluatedKey</code> is present in the response, you will need to paginate\n            the result set. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Pagination\">Paginating\n                the Results</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p>\n         <p>\n            <code>FilterExpression</code> is applied after a <code>Query</code> finishes, but before\n            the results are returned. A <code>FilterExpression</code> cannot contain partition key\n            or sort key attributes. You need to specify those attributes in the\n                <code>KeyConditionExpression</code>. </p>\n         <note>\n            <p> A <code>Query</code> operation can return an empty result set and a\n                    <code>LastEvaluatedKey</code> if all the items read for the page of results are\n                filtered out. </p>\n         </note>\n         <p>You can query a table, a local secondary index, or a global secondary index. For a\n            query on a table or on a local secondary index, you can set the\n                <code>ConsistentRead</code> parameter to <code>true</code> and obtain a strongly\n            consistent result. Global secondary indexes support eventually consistent reads only, so\n            do not specify <code>ConsistentRead</code> when querying a global secondary\n            index.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "ExclusiveStartKey",
                     "outputToken": "LastEvaluatedKey",
@@ -7758,13 +7982,13 @@
                 "IndexName": {
                     "target": "com.amazonaws.dynamodb#IndexName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of an index to query. This index can be any local secondary index or global\n            secondary index on the table. Note that if you use the <code>IndexName</code> parameter,\n            you must also provide <code>TableName.</code>\n        </p>"
+                        "smithy.api#documentation": "<p>The name of an index to query. This index can be any local secondary index or global\n            secondary index on the table. Note that if you use the <code>IndexName</code> parameter,\n            you must also provide <code>TableName.</code>\n         </p>"
                     }
                 },
                 "Select": {
                     "target": "com.amazonaws.dynamodb#Select",
                     "traits": {
-                        "smithy.api#documentation": "<p>The attributes to be returned in the result. You can retrieve all item attributes,\n            specific item attributes, the count of matching items, or in the case of an index, some\n            or all of the attributes projected into the index.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ALL_ATTRIBUTES</code> - Returns all of the item attributes from the\n                    specified table or index. If you query a local secondary index, then for each\n                    matching item in the index, DynamoDB fetches the entire item from the parent\n                    table. If the index is configured to project all item attributes, then all of\n                    the data can be obtained from the local secondary index, and no fetching is\n                    required.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL_PROJECTED_ATTRIBUTES</code> - Allowed only when querying an index.\n                    Retrieves all attributes that have been projected into the index. If the index\n                    is configured to project all attributes, this return value is equivalent to\n                    specifying <code>ALL_ATTRIBUTES</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>COUNT</code> - Returns the number of matching items, rather than the\n                    matching items themselves.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SPECIFIC_ATTRIBUTES</code> - Returns only the attributes listed in\n                        <code>ProjectionExpression</code>. This return value is equivalent to\n                    specifying <code>ProjectionExpression</code> without specifying any value for\n                        <code>Select</code>.</p>\n                <p>If you query or scan a local secondary index and request only attributes that\n                    are projected into that index, the operation will read only the index and not\n                    the table. If any of the requested attributes are not projected into the local\n                    secondary index, DynamoDB fetches each of these attributes from the parent\n                    table. This extra fetching incurs additional throughput cost and latency.</p>\n                <p>If you query or scan a global secondary index, you can only request attributes\n                    that are projected into the index. Global secondary index queries cannot fetch\n                    attributes from the parent table.</p>\n            </li>\n         </ul>\n        <p>If neither <code>Select</code> nor <code>ProjectionExpression</code> are specified,\n            DynamoDB defaults to <code>ALL_ATTRIBUTES</code> when accessing a table, and\n                <code>ALL_PROJECTED_ATTRIBUTES</code> when accessing an index. You cannot use both\n                <code>Select</code> and <code>ProjectionExpression</code> together in a single\n            request, unless the value for <code>Select</code> is <code>SPECIFIC_ATTRIBUTES</code>.\n            (This usage is equivalent to specifying <code>ProjectionExpression</code> without any\n            value for <code>Select</code>.)</p>\n        <note>\n            <p>If you use the <code>ProjectionExpression</code> parameter, then the value for\n                    <code>Select</code> can only be <code>SPECIFIC_ATTRIBUTES</code>. Any other\n                value for <code>Select</code> will return an error.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The attributes to be returned in the result. You can retrieve all item attributes,\n            specific item attributes, the count of matching items, or in the case of an index, some\n            or all of the attributes projected into the index.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_ATTRIBUTES</code> - Returns all of the item attributes from the\n                    specified table or index. If you query a local secondary index, then for each\n                    matching item in the index, DynamoDB fetches the entire item from the parent\n                    table. If the index is configured to project all item attributes, then all of\n                    the data can be obtained from the local secondary index, and no fetching is\n                    required.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL_PROJECTED_ATTRIBUTES</code> - Allowed only when querying an index.\n                    Retrieves all attributes that have been projected into the index. If the index\n                    is configured to project all attributes, this return value is equivalent to\n                    specifying <code>ALL_ATTRIBUTES</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COUNT</code> - Returns the number of matching items, rather than the\n                    matching items themselves. Note that this uses the same quantity of read capacity units \n                    as getting the items, and is subject to the same item size calculations.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SPECIFIC_ATTRIBUTES</code> - Returns only the attributes listed in\n                        <code>ProjectionExpression</code>. This return value is equivalent to\n                    specifying <code>ProjectionExpression</code> without specifying any value for\n                        <code>Select</code>.</p>\n               <p>If you query or scan a local secondary index and request only attributes that\n                    are projected into that index, the operation will read only the index and not\n                    the table. If any of the requested attributes are not projected into the local\n                    secondary index, DynamoDB fetches each of these attributes from the parent\n                    table. This extra fetching incurs additional throughput cost and latency.</p>\n               <p>If you query or scan a global secondary index, you can only request attributes\n                    that are projected into the index. Global secondary index queries cannot fetch\n                    attributes from the parent table.</p>\n            </li>\n         </ul>\n         <p>If neither <code>Select</code> nor <code>ProjectionExpression</code> are specified,\n            DynamoDB defaults to <code>ALL_ATTRIBUTES</code> when accessing a table, and\n                <code>ALL_PROJECTED_ATTRIBUTES</code> when accessing an index. You cannot use both\n                <code>Select</code> and <code>ProjectionExpression</code> together in a single\n            request, unless the value for <code>Select</code> is <code>SPECIFIC_ATTRIBUTES</code>.\n            (This usage is equivalent to specifying <code>ProjectionExpression</code> without any\n            value for <code>Select</code>.)</p>\n         <note>\n            <p>If you use the <code>ProjectionExpression</code> parameter, then the value for\n                    <code>Select</code> can only be <code>SPECIFIC_ATTRIBUTES</code>. Any other\n                value for <code>Select</code> will return an error.</p>\n         </note>"
                     }
                 },
                 "AttributesToGet": {
@@ -7782,7 +8006,7 @@
                 "ConsistentRead": {
                     "target": "com.amazonaws.dynamodb#ConsistentRead",
                     "traits": {
-                        "smithy.api#documentation": "<p>Determines the read consistency model: If set to <code>true</code>, then the operation\n            uses strongly consistent reads; otherwise, the operation uses eventually consistent\n            reads.</p>\n        <p>Strongly consistent reads are not supported on global secondary indexes. If you query\n            a global secondary index with <code>ConsistentRead</code> set to <code>true</code>, you\n            will receive a <code>ValidationException</code>.</p>"
+                        "smithy.api#documentation": "<p>Determines the read consistency model: If set to <code>true</code>, then the operation\n            uses strongly consistent reads; otherwise, the operation uses eventually consistent\n            reads.</p>\n         <p>Strongly consistent reads are not supported on global secondary indexes. If you query\n            a global secondary index with <code>ConsistentRead</code> set to <code>true</code>, you\n            will receive a <code>ValidationException</code>.</p>"
                     }
                 },
                 "KeyConditions": {
@@ -7806,13 +8030,13 @@
                 "ScanIndexForward": {
                     "target": "com.amazonaws.dynamodb#BooleanObject",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the order for index traversal: If <code>true</code> (default), the traversal\n            is performed in ascending order; if <code>false</code>, the traversal is performed in\n            descending order. </p>\n        <p>Items with the same partition key value are stored in sorted order by sort key. If the\n            sort key data type is Number, the results are stored in numeric order. For type String,\n            the results are stored in order of UTF-8 bytes. For type Binary, DynamoDB treats each\n            byte of the binary data as unsigned.</p>\n        <p>If <code>ScanIndexForward</code> is <code>true</code>, DynamoDB returns the results in\n            the order in which they are stored (by sort key value). This is the default behavior. If\n                <code>ScanIndexForward</code> is <code>false</code>, DynamoDB reads the results in\n            reverse order by sort key value, and then returns the results to the client.</p>"
+                        "smithy.api#documentation": "<p>Specifies the order for index traversal: If <code>true</code> (default), the traversal\n            is performed in ascending order; if <code>false</code>, the traversal is performed in\n            descending order. </p>\n         <p>Items with the same partition key value are stored in sorted order by sort key. If the\n            sort key data type is Number, the results are stored in numeric order. For type String,\n            the results are stored in order of UTF-8 bytes. For type Binary, DynamoDB treats each\n            byte of the binary data as unsigned.</p>\n         <p>If <code>ScanIndexForward</code> is <code>true</code>, DynamoDB returns the results in\n            the order in which they are stored (by sort key value). This is the default behavior. If\n                <code>ScanIndexForward</code> is <code>false</code>, DynamoDB reads the results in\n            reverse order by sort key value, and then returns the results to the client.</p>"
                     }
                 },
                 "ExclusiveStartKey": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>The primary key of the first item that this operation will evaluate. Use the value\n            that was returned for <code>LastEvaluatedKey</code> in the previous operation.</p>\n        <p>The data type for <code>ExclusiveStartKey</code> must be String, Number, or Binary. No\n            set data types are allowed.</p>"
+                        "smithy.api#documentation": "<p>The primary key of the first item that this operation will evaluate. Use the value\n            that was returned for <code>LastEvaluatedKey</code> in the previous operation.</p>\n         <p>The data type for <code>ExclusiveStartKey</code> must be String, Number, or Binary. No\n            set data types are allowed.</p>"
                     }
                 },
                 "ReturnConsumedCapacity": {
@@ -7821,36 +8045,37 @@
                 "ProjectionExpression": {
                     "target": "com.amazonaws.dynamodb#ProjectionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the table. These\n            attributes can include scalars, sets, or elements of a JSON document. The attributes in\n            the expression must be separated by commas.</p>\n        <p>If no attribute names are specified, then all attributes will be returned. If any of\n            the requested attributes are not found, they will not appear in the result.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the table. These\n            attributes can include scalars, sets, or elements of a JSON document. The attributes in\n            the expression must be separated by commas.</p>\n         <p>If no attribute names are specified, then all attributes will be returned. If any of\n            the requested attributes are not found, they will not appear in the result.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Accessing Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "FilterExpression": {
                     "target": "com.amazonaws.dynamodb#ConditionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string that contains conditions that DynamoDB applies after the <code>Query</code>\n            operation, but before the data is returned to you. Items that do not satisfy the\n                <code>FilterExpression</code> criteria are not returned.</p>\n        <p>A <code>FilterExpression</code> does not allow key attributes. You cannot define a\n            filter expression based on a partition key or a sort key.</p>\n        <note>\n            <p>A <code>FilterExpression</code> is applied after the items have already been read;\n                the process of filtering does not consume any additional read capacity units.</p>\n        </note>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Query.FilterExpression\">Filter Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A string that contains conditions that DynamoDB applies after the <code>Query</code>\n            operation, but before the data is returned to you. Items that do not satisfy the\n                <code>FilterExpression</code> criteria are not returned.</p>\n         <p>A <code>FilterExpression</code> does not allow key attributes. You cannot define a\n            filter expression based on a partition key or a sort key.</p>\n         <note>\n            <p>A <code>FilterExpression</code> is applied after the items have already been read;\n                the process of filtering does not consume any additional read capacity units.</p>\n         </note>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Query.FilterExpression\">Filter Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "KeyConditionExpression": {
                     "target": "com.amazonaws.dynamodb#KeyExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>The condition that specifies the key values for items to be retrieved by the\n                <code>Query</code> action.</p>\n\n        <p>The condition must perform an equality test on a single partition key value.</p>\n        <p>The condition can optionally perform one of several comparison tests on a single sort\n            key value. This allows <code>Query</code> to retrieve one item with a given partition\n            key value and sort key value, or several items that have the same partition key value\n            but different sort key values.</p>\n\n        <p>The partition key equality test is required, and must be specified in the following\n            format:</p>\n\n        <p>\n            <code>partitionKeyName</code>\n            <i>=</i>\n            <code>:partitionkeyval</code>\n        </p>\n\n        <p>If you also want to provide a condition for the sort key, it must be combined using\n                <code>AND</code> with the condition for the sort key. Following is an example, using\n            the <b>=</b> comparison operator for the sort key:</p>\n\n        <p>\n            <code>partitionKeyName</code>\n            <code>=</code>\n            <code>:partitionkeyval</code>\n            <code>AND</code>\n            <code>sortKeyName</code>\n            <code>=</code>\n            <code>:sortkeyval</code>\n        </p>\n        <p>Valid comparisons for the sort key condition are as follows:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>sortKeyName</code>\n                    <code>=</code>\n                    <code>:sortkeyval</code> - true if the sort key value is equal to\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>sortKeyName</code>\n                    <code><</code>\n                    <code>:sortkeyval</code> - true if the sort key value is less than\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>sortKeyName</code>\n                    <code><=</code>\n                    <code>:sortkeyval</code> - true if the sort key value is less than or equal to\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>sortKeyName</code>\n                    <code>></code>\n                    <code>:sortkeyval</code> - true if the sort key value is greater than\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>sortKeyName</code>\n                    <code>>= </code>\n                    <code>:sortkeyval</code> - true if the sort key value is greater than or equal\n                    to <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>sortKeyName</code>\n                    <code>BETWEEN</code>\n                    <code>:sortkeyval1</code>\n                    <code>AND</code>\n                    <code>:sortkeyval2</code> - true if the sort key value is greater than or equal\n                    to <code>:sortkeyval1</code>, and less than or equal to\n                        <code>:sortkeyval2</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>begins_with (</code>\n                    <code>sortKeyName</code>, <code>:sortkeyval</code>\n                    <code>)</code> - true if the sort key value begins with a particular operand.\n                    (You cannot use this function with a sort key that is of type Number.) Note that\n                    the function name <code>begins_with</code> is case-sensitive.</p>\n\n            </li>\n         </ul>\n\n        <p>Use the <code>ExpressionAttributeValues</code> parameter to replace tokens such as\n                <code>:partitionval</code> and <code>:sortval</code> with actual values at\n            runtime.</p>\n\n        <p>You can optionally use the <code>ExpressionAttributeNames</code> parameter to replace\n            the names of the partition key and sort key with placeholder tokens. This option might\n            be necessary if an attribute name conflicts with a DynamoDB reserved word. For example,\n            the following <code>KeyConditionExpression</code> parameter causes an error because\n                <i>Size</i> is a reserved word:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Size = :myval</code>\n                </p>\n            </li>\n         </ul>\n        <p>To work around this, define a placeholder (such a <code>#S</code>) to represent the\n            attribute name <i>Size</i>. <code>KeyConditionExpression</code> then is as\n            follows:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#S = :myval</code>\n                </p>\n            </li>\n         </ul>\n        <p>For a list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>\n\n        <p>For more information on <code>ExpressionAttributeNames</code> and\n                <code>ExpressionAttributeValues</code>, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html\">Using\n                Placeholders for Attribute Names and Values</a> in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The condition that specifies the key values for items to be retrieved by the\n                <code>Query</code> action.</p>\n         <p>The condition must perform an equality test on a single partition key value.</p>\n         <p>The condition can optionally perform one of several comparison tests on a single sort\n            key value. This allows <code>Query</code> to retrieve one item with a given partition\n            key value and sort key value, or several items that have the same partition key value\n            but different sort key values.</p>\n         <p>The partition key equality test is required, and must be specified in the following\n            format:</p>\n         <p>\n            <code>partitionKeyName</code>\n            <i>=</i>\n            <code>:partitionkeyval</code>\n         </p>\n         <p>If you also want to provide a condition for the sort key, it must be combined using\n                <code>AND</code> with the condition for the sort key. Following is an example, using\n            the <b>=</b> comparison operator for the sort key:</p>\n         <p>\n            <code>partitionKeyName</code>\n            <code>=</code>\n            <code>:partitionkeyval</code>\n            <code>AND</code>\n            <code>sortKeyName</code>\n            <code>=</code>\n            <code>:sortkeyval</code>\n         </p>\n         <p>Valid comparisons for the sort key condition are as follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>sortKeyName</code>\n                  <code>=</code>\n                  <code>:sortkeyval</code> - true if the sort key value is equal to\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>sortKeyName</code>\n                  <code><</code>\n                  <code>:sortkeyval</code> - true if the sort key value is less than\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>sortKeyName</code>\n                  <code><=</code>\n                  <code>:sortkeyval</code> - true if the sort key value is less than or equal to\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>sortKeyName</code>\n                  <code>></code>\n                  <code>:sortkeyval</code> - true if the sort key value is greater than\n                        <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>sortKeyName</code>\n                  <code>>= </code>\n                  <code>:sortkeyval</code> - true if the sort key value is greater than or equal\n                    to <code>:sortkeyval</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>sortKeyName</code>\n                  <code>BETWEEN</code>\n                  <code>:sortkeyval1</code>\n                  <code>AND</code>\n                  <code>:sortkeyval2</code> - true if the sort key value is greater than or equal\n                    to <code>:sortkeyval1</code>, and less than or equal to\n                        <code>:sortkeyval2</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>begins_with (</code>\n                  <code>sortKeyName</code>, <code>:sortkeyval</code>\n                  <code>)</code> - true if the sort key value begins with a particular operand.\n                    (You cannot use this function with a sort key that is of type Number.) Note that\n                    the function name <code>begins_with</code> is case-sensitive.</p>\n            </li>\n         </ul>\n         <p>Use the <code>ExpressionAttributeValues</code> parameter to replace tokens such as\n                <code>:partitionval</code> and <code>:sortval</code> with actual values at\n            runtime.</p>\n         <p>You can optionally use the <code>ExpressionAttributeNames</code> parameter to replace\n            the names of the partition key and sort key with placeholder tokens. This option might\n            be necessary if an attribute name conflicts with a DynamoDB reserved word. For example,\n            the following <code>KeyConditionExpression</code> parameter causes an error because\n                <i>Size</i> is a reserved word:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Size = :myval</code>\n               </p>\n            </li>\n         </ul>\n         <p>To work around this, define a placeholder (such a <code>#S</code>) to represent the\n            attribute name <i>Size</i>. <code>KeyConditionExpression</code> then is as\n            follows:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#S = :myval</code>\n               </p>\n            </li>\n         </ul>\n         <p>For a list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>\n         <p>For more information on <code>ExpressionAttributeNames</code> and\n                <code>ExpressionAttributeValues</code>, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ExpressionPlaceholders.html\">Using\n                Placeholders for Attribute Names and Values</a> in the <i>Amazon DynamoDB\n                Developer Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeValues": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeValueMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n        <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <i>ProductStatus</i> attribute was one of the following: </p>\n        <p>\n            <code>Available | Backordered | Discontinued</code>\n        </p>\n        <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n        <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n        </p>\n        <p>You could then use these values in an expression, such as this:</p>\n        <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n        </p>\n        <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n         <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <i>ProductStatus</i> attribute was one of the following: </p>\n         <p>\n            <code>Available | Backordered | Discontinued</code>\n         </p>\n         <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n         <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n         </p>\n         <p>You could then use these values in an expression, such as this:</p>\n         <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n         </p>\n         <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>Query</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>Query</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#QueryOutput": {
@@ -7866,20 +8091,20 @@
                     "target": "com.amazonaws.dynamodb#Integer",
                     "traits": {
                         "smithy.api#default": 0,
-                        "smithy.api#documentation": "<p>The number of items in the response.</p>\n        <p>If you used a <code>QueryFilter</code> in the request, then <code>Count</code> is the\n            number of items returned after the filter was applied, and <code>ScannedCount</code> is\n            the number of matching items before the filter was applied.</p>\n        <p>If you did not use a filter in the request, then <code>Count</code> and\n                <code>ScannedCount</code> are the same.</p>"
+                        "smithy.api#documentation": "<p>The number of items in the response.</p>\n         <p>If you used a <code>QueryFilter</code> in the request, then <code>Count</code> is the\n            number of items returned after the filter was applied, and <code>ScannedCount</code> is\n            the number of matching items before the filter was applied.</p>\n         <p>If you did not use a filter in the request, then <code>Count</code> and\n                <code>ScannedCount</code> are the same.</p>"
                     }
                 },
                 "ScannedCount": {
                     "target": "com.amazonaws.dynamodb#Integer",
                     "traits": {
                         "smithy.api#default": 0,
-                        "smithy.api#documentation": "<p>The number of items evaluated, before any <code>QueryFilter</code> is applied. A high\n                <code>ScannedCount</code> value with few, or no, <code>Count</code> results\n            indicates an inefficient <code>Query</code> operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count\">Count and\n                ScannedCount</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n        <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same\n            as <code>Count</code>.</p>"
+                        "smithy.api#documentation": "<p>The number of items evaluated, before any <code>QueryFilter</code> is applied. A high\n                <code>ScannedCount</code> value with few, or no, <code>Count</code> results\n            indicates an inefficient <code>Query</code> operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count\">Count and\n                ScannedCount</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n         <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same\n            as <code>Count</code>.</p>"
                     }
                 },
                 "LastEvaluatedKey": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>The primary key of the item where the operation stopped, inclusive of the previous\n            result set. Use this value to start a new operation, excluding this value in the new\n            request.</p>\n        <p>If <code>LastEvaluatedKey</code> is empty, then the \"last page\" of results has been\n            processed and there is no more data to be retrieved.</p>\n        <p>If <code>LastEvaluatedKey</code> is not empty, it does not necessarily mean that there\n            is more data in the result set. The only way to know when you have reached the end of\n            the result set is when <code>LastEvaluatedKey</code> is empty.</p>"
+                        "smithy.api#documentation": "<p>The primary key of the item where the operation stopped, inclusive of the previous\n            result set. Use this value to start a new operation, excluding this value in the new\n            request.</p>\n         <p>If <code>LastEvaluatedKey</code> is empty, then the \"last page\" of results has been\n            processed and there is no more data to be retrieved.</p>\n         <p>If <code>LastEvaluatedKey</code> is not empty, it does not necessarily mean that there\n            is more data in the result set. The only way to know when you have reached the end of\n            the result set is when <code>LastEvaluatedKey</code> is empty.</p>"
                     }
                 },
                 "ConsumedCapacity": {
@@ -7890,7 +8115,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>Query</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>Query</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#RegionName": {
@@ -7946,7 +8172,7 @@
                 "ReplicaStatus": {
                     "target": "com.amazonaws.dynamodb#ReplicaStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the replica:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The replica is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The replica is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The replica is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The replica is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the replica:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The replica is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The replica is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The replica is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The replica is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
@@ -8007,7 +8233,7 @@
                 "ReplicaStatus": {
                     "target": "com.amazonaws.dynamodb#ReplicaStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the replica:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The replica is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The replica is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The replica is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The replica is ready for use.</p>\n            </li>\n            <li>\n                <p>\n                    <code>REGION_DISABLED</code> - The replica is inaccessible because the Amazon Web Services Region has been disabled.</p>\n                <note>\n                    <p>If the Amazon Web Services Region remains inaccessible for more than 20\n                        hours, DynamoDB will remove this replica from the replication\n                        group. The replica will not be deleted and replication will stop from and to\n                        this region.</p>\n                </note>\n            </li>\n            <li>\n                <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS </code> - The KMS key\n                    used to encrypt the table is inaccessible.</p>\n                <note>\n                    <p>If the KMS key remains inaccessible for more than 20 hours,\n                            DynamoDB will remove this replica from the replication group.\n                        The replica will not be deleted and replication will stop from and to this\n                        region.</p>\n                </note>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the replica:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The replica is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The replica is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The replica is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The replica is ready for use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REGION_DISABLED</code> - The replica is inaccessible because the Amazon Web Services Region has been disabled.</p>\n               <note>\n                  <p>If the Amazon Web Services Region remains inaccessible for more than 20\n                        hours, DynamoDB will remove this replica from the replication\n                        group. The replica will not be deleted and replication will stop from and to\n                        this region.</p>\n               </note>\n            </li>\n            <li>\n               <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS </code> - The KMS key\n                    used to encrypt the table is inaccessible.</p>\n               <note>\n                  <p>If the KMS key remains inaccessible for more than 20 hours,\n                            DynamoDB will remove this replica from the replication group.\n                        The replica will not be deleted and replication will stop from and to this\n                        region.</p>\n               </note>\n            </li>\n         </ul>"
                     }
                 },
                 "ReplicaStatusDescription": {
@@ -8093,7 +8319,7 @@
                 "IndexStatus": {
                     "target": "com.amazonaws.dynamodb#IndexStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the replica global secondary index:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The index is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The table/index configuration is being updated. The\n                    table/index remains available for data operations when\n                    <code>UPDATING</code>\n               </p>\n\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The index is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The index is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the replica global secondary index:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The index is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The table/index configuration is being updated. The\n                    table/index remains available for data operations when\n                    <code>UPDATING</code>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The index is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The index is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ProvisionedReadCapacityAutoScalingSettings": {
@@ -8186,7 +8412,7 @@
                 "IndexStatus": {
                     "target": "com.amazonaws.dynamodb#IndexStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p> The current status of the global secondary index:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The global secondary index is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The global secondary index is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The global secondary index is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The global secondary index is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p> The current status of the global secondary index:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The global secondary index is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The global secondary index is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The global secondary index is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The global secondary index is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ProvisionedReadCapacityUnits": {
@@ -8294,7 +8520,7 @@
                 "ReplicaStatus": {
                     "target": "com.amazonaws.dynamodb#ReplicaStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the Region:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The Region is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The Region is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The Region is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The Region is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the Region:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The Region is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The Region is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The Region is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The Region is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ReplicaBillingModeSummary": {
@@ -8468,7 +8694,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents one of the following:</p>\n        <ul>\n            <li>\n                <p>A new replica to be added to an existing global table.</p>\n            </li>\n            <li>\n                <p>New parameters for an existing replica.</p>\n            </li>\n            <li>\n                <p>An existing replica to be removed from an existing global table.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Represents one of the following:</p>\n         <ul>\n            <li>\n               <p>A new replica to be added to an existing global table.</p>\n            </li>\n            <li>\n               <p>New parameters for an existing replica.</p>\n            </li>\n            <li>\n               <p>An existing replica to be removed from an existing global table.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#ReplicaUpdateList": {
@@ -8500,7 +8726,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents one of the following:</p>\n        <ul>\n            <li>\n                <p>A new replica to be added to an existing regional table or global table. This\n                    request invokes the <code>CreateTableReplica</code> action in the destination\n                    Region.</p>\n            </li>\n            <li>\n                <p>New parameters for an existing replica. This request invokes the\n                        <code>UpdateTable</code> action in the destination Region.</p>\n            </li>\n            <li>\n                <p>An existing replica to be deleted. The request invokes the\n                        <code>DeleteTableReplica</code> action in the destination Region, deleting\n                    the replica and all if its items in the destination Region.</p>\n            </li>\n         </ul>\n        <note>\n            <p>When you manually remove a table or global table replica, you do not automatically\n                remove any associated scalable targets, scaling policies, or CloudWatch\n                alarms.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Represents one of the following:</p>\n         <ul>\n            <li>\n               <p>A new replica to be added to an existing regional table or global table. This\n                    request invokes the <code>CreateTableReplica</code> action in the destination\n                    Region.</p>\n            </li>\n            <li>\n               <p>New parameters for an existing replica. This request invokes the\n                        <code>UpdateTable</code> action in the destination Region.</p>\n            </li>\n            <li>\n               <p>An existing replica to be deleted. The request invokes the\n                        <code>DeleteTableReplica</code> action in the destination Region, deleting\n                    the replica and all if its items in the destination Region.</p>\n            </li>\n         </ul>\n         <note>\n            <p>When you manually remove a table or global table replica, you do not automatically\n                remove any associated scalable targets, scaling policies, or CloudWatch\n                alarms.</p>\n         </note>"
             }
         },
         "com.amazonaws.dynamodb#ReplicationGroupUpdateList": {
@@ -8637,7 +8863,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Creates a new table from an existing backup. Any number of users can execute up to 4\n            concurrent restores (any type of restore) in a given account. </p>\n        <p>You can call <code>RestoreTableFromBackup</code> at a maximum rate of 10 times per\n            second.</p>\n        <p>You must manually set up the following on the restored table:</p>\n        <ul>\n            <li>\n                <p>Auto scaling policies</p>\n            </li>\n            <li>\n                <p>IAM policies</p>\n            </li>\n            <li>\n                <p>Amazon CloudWatch metrics and alarms</p>\n            </li>\n            <li>\n                <p>Tags</p>\n            </li>\n            <li>\n                <p>Stream settings</p>\n            </li>\n            <li>\n                <p>Time to Live (TTL) settings</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Creates a new table from an existing backup. Any number of users can execute up to 4\n            concurrent restores (any type of restore) in a given account. </p>\n         <p>You can call <code>RestoreTableFromBackup</code> at a maximum rate of 10 times per\n            second.</p>\n         <p>You must manually set up the following on the restored table:</p>\n         <ul>\n            <li>\n               <p>Auto scaling policies</p>\n            </li>\n            <li>\n               <p>IAM policies</p>\n            </li>\n            <li>\n               <p>Amazon CloudWatch metrics and alarms</p>\n            </li>\n            <li>\n               <p>Tags</p>\n            </li>\n            <li>\n               <p>Stream settings</p>\n            </li>\n            <li>\n               <p>Time to Live (TTL) settings</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#RestoreTableFromBackupInput": {
@@ -8687,6 +8913,9 @@
                         "smithy.api#documentation": "<p>The new server-side encryption settings for the restored table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#RestoreTableFromBackupOutput": {
@@ -8698,6 +8927,9 @@
                         "smithy.api#documentation": "<p>The description of the table created from an existing backup.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#RestoreTableToPointInTime": {
@@ -8738,7 +8970,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Restores the specified table to the specified point in time within\n                <code>EarliestRestorableDateTime</code> and <code>LatestRestorableDateTime</code>.\n            You can restore your table to any point in time during the last 35 days. Any number of\n            users can execute up to 4 concurrent restores (any type of restore) in a given account. </p>\n        <p> When you restore using point in time recovery, DynamoDB restores your table data to\n            the state based on the selected date and time (day:hour:minute:second) to a new table. </p>\n        <p> Along with data, the following are also included on the new restored table using\n            point in time recovery: </p>\n        <ul>\n            <li>\n                <p>Global secondary indexes (GSIs)</p>\n            </li>\n            <li>\n                <p>Local secondary indexes (LSIs)</p>\n            </li>\n            <li>\n                <p>Provisioned read and write capacity</p>\n            </li>\n            <li>\n                <p>Encryption settings</p>\n                <important>\n                    <p> All these settings come from the current settings of the source table at\n                        the time of restore. </p>\n                </important>\n            </li>\n         </ul>\n\n        <p>You must manually set up the following on the restored table:</p>\n        <ul>\n            <li>\n                <p>Auto scaling policies</p>\n            </li>\n            <li>\n                <p>IAM policies</p>\n            </li>\n            <li>\n                <p>Amazon CloudWatch metrics and alarms</p>\n            </li>\n            <li>\n                <p>Tags</p>\n            </li>\n            <li>\n                <p>Stream settings</p>\n            </li>\n            <li>\n                <p>Time to Live (TTL) settings</p>\n            </li>\n            <li>\n                <p>Point in time recovery settings</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Restores the specified table to the specified point in time within\n                <code>EarliestRestorableDateTime</code> and <code>LatestRestorableDateTime</code>.\n            You can restore your table to any point in time during the last 35 days. Any number of\n            users can execute up to 4 concurrent restores (any type of restore) in a given account. </p>\n         <p> When you restore using point in time recovery, DynamoDB restores your table data to\n            the state based on the selected date and time (day:hour:minute:second) to a new table. </p>\n         <p> Along with data, the following are also included on the new restored table using\n            point in time recovery: </p>\n         <ul>\n            <li>\n               <p>Global secondary indexes (GSIs)</p>\n            </li>\n            <li>\n               <p>Local secondary indexes (LSIs)</p>\n            </li>\n            <li>\n               <p>Provisioned read and write capacity</p>\n            </li>\n            <li>\n               <p>Encryption settings</p>\n               <important>\n                  <p> All these settings come from the current settings of the source table at\n                        the time of restore. </p>\n               </important>\n            </li>\n         </ul>\n         <p>You must manually set up the following on the restored table:</p>\n         <ul>\n            <li>\n               <p>Auto scaling policies</p>\n            </li>\n            <li>\n               <p>IAM policies</p>\n            </li>\n            <li>\n               <p>Amazon CloudWatch metrics and alarms</p>\n            </li>\n            <li>\n               <p>Tags</p>\n            </li>\n            <li>\n               <p>Stream settings</p>\n            </li>\n            <li>\n               <p>Time to Live (TTL) settings</p>\n            </li>\n            <li>\n               <p>Point in time recovery settings</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#RestoreTableToPointInTimeInput": {
@@ -8805,6 +9037,9 @@
                         "smithy.api#documentation": "<p>The new server-side encryption settings for the restored table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#RestoreTableToPointInTimeOutput": {
@@ -8816,6 +9051,9 @@
                         "smithy.api#documentation": "<p>Represents the properties of a table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ReturnConsumedCapacity": {
@@ -8841,7 +9079,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Determines the level of detail about either provisioned or on-demand throughput\n            consumption that is returned in the response:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>INDEXES</code> - The response includes the aggregate\n                        <code>ConsumedCapacity</code> for the operation, together with\n                        <code>ConsumedCapacity</code> for each table and secondary index that was\n                    accessed.</p>\n                <p>Note that some operations, such as <code>GetItem</code> and\n                        <code>BatchGetItem</code>, do not access any indexes at all. In these cases,\n                    specifying <code>INDEXES</code> will only return <code>ConsumedCapacity</code>\n                    information for table(s).</p>\n            </li>\n            <li>\n                <p>\n                    <code>TOTAL</code> - The response includes only the aggregate\n                        <code>ConsumedCapacity</code> for the operation.</p>\n            </li>\n            <li>\n                <p>\n                    <code>NONE</code> - No <code>ConsumedCapacity</code> details are included in the\n                    response.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Determines the level of detail about either provisioned or on-demand throughput\n            consumption that is returned in the response:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>INDEXES</code> - The response includes the aggregate\n                        <code>ConsumedCapacity</code> for the operation, together with\n                        <code>ConsumedCapacity</code> for each table and secondary index that was\n                    accessed.</p>\n               <p>Note that some operations, such as <code>GetItem</code> and\n                        <code>BatchGetItem</code>, do not access any indexes at all. In these cases,\n                    specifying <code>INDEXES</code> will only return <code>ConsumedCapacity</code>\n                    information for table(s).</p>\n            </li>\n            <li>\n               <p>\n                  <code>TOTAL</code> - The response includes only the aggregate\n                        <code>ConsumedCapacity</code> for the operation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NONE</code> - No <code>ConsumedCapacity</code> details are included in the\n                    response.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#ReturnItemCollectionMetrics": {
@@ -8997,13 +9235,13 @@
                 "Status": {
                     "target": "com.amazonaws.dynamodb#SSEStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the current state of server-side encryption. The only supported values\n            are:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ENABLED</code> - Server-side encryption is enabled.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - Server-side encryption is being updated.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Represents the current state of server-side encryption. The only supported values\n            are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ENABLED</code> - Server-side encryption is enabled.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - Server-side encryption is being updated.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "SSEType": {
                     "target": "com.amazonaws.dynamodb#SSEType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Server-side encryption type. The only supported value is:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>KMS</code> - Server-side encryption that uses Key Management Service. The\n                    key is stored in your account and is managed by KMS (KMS charges apply).</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Server-side encryption type. The only supported value is:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KMS</code> - Server-side encryption that uses Key Management Service. The\n                    key is stored in your account and is managed by KMS (KMS charges apply).</p>\n            </li>\n         </ul>"
                     }
                 },
                 "KMSMasterKeyArn": {
@@ -9038,7 +9276,7 @@
                 "SSEType": {
                     "target": "com.amazonaws.dynamodb#SSEType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Server-side encryption type. The only supported value is:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>KMS</code> - Server-side encryption that uses Key Management Service. The\n                    key is stored in your account and is managed by KMS (KMS charges apply).</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Server-side encryption type. The only supported value is:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KMS</code> - Server-side encryption that uses Key Management Service. The\n                    key is stored in your account and is managed by KMS (KMS charges apply).</p>\n            </li>\n         </ul>"
                     }
                 },
                 "KMSMasterKeyId": {
@@ -9156,7 +9394,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>Scan</code> operation returns one or more items and item attributes by\n            accessing every item in a table or a secondary index. To have DynamoDB return fewer\n            items, you can provide a <code>FilterExpression</code> operation.</p>\n        <p>If the total number of scanned items exceeds the maximum dataset size limit of 1 MB,\n            the scan stops and results are returned to the user as a <code>LastEvaluatedKey</code>\n            value to continue the scan in a subsequent operation. The results also include the\n            number of items exceeding the limit. A scan can result in no table data meeting the\n            filter criteria. </p>\n        <p>A single <code>Scan</code> operation reads up to the maximum number of items set (if\n            using the <code>Limit</code> parameter) or a maximum of 1 MB of data and then apply any\n            filtering to the results using <code>FilterExpression</code>. If\n                <code>LastEvaluatedKey</code> is present in the response, you need to paginate the\n            result set. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination\">Paginating the\n                Results</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p>\n        <p>\n            <code>Scan</code> operations proceed sequentially; however, for faster performance on\n            a large table or secondary index, applications can request a parallel <code>Scan</code>\n            operation by providing the <code>Segment</code> and <code>TotalSegments</code>\n            parameters. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan\">Parallel\n                Scan</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>\n        <p>\n            <code>Scan</code> uses eventually consistent reads when accessing the data in a table;\n            therefore, the result set might not include the changes to data in the table immediately\n            before the operation began. If you need a consistent copy of the data, as of the time\n            that the <code>Scan</code> begins, you can set the <code>ConsistentRead</code> parameter\n            to <code>true</code>.</p>",
+                "smithy.api#documentation": "<p>The <code>Scan</code> operation returns one or more items and item attributes by\n            accessing every item in a table or a secondary index. To have DynamoDB return fewer\n            items, you can provide a <code>FilterExpression</code> operation.</p>\n         <p>If the total number of scanned items exceeds the maximum dataset size limit of 1 MB,\n            the scan stops and results are returned to the user as a <code>LastEvaluatedKey</code>\n            value to continue the scan in a subsequent operation. The results also include the\n            number of items exceeding the limit. A scan can result in no table data meeting the\n            filter criteria. </p>\n         <p>A single <code>Scan</code> operation reads up to the maximum number of items set (if\n            using the <code>Limit</code> parameter) or a maximum of 1 MB of data and then apply any\n            filtering to the results using <code>FilterExpression</code>. If\n                <code>LastEvaluatedKey</code> is present in the response, you need to paginate the\n            result set. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.Pagination\">Paginating the\n                Results</a> in the <i>Amazon DynamoDB Developer Guide</i>. </p>\n         <p>\n            <code>Scan</code> operations proceed sequentially; however, for faster performance on\n            a large table or secondary index, applications can request a parallel <code>Scan</code>\n            operation by providing the <code>Segment</code> and <code>TotalSegments</code>\n            parameters. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Scan.html#Scan.ParallelScan\">Parallel\n                Scan</a> in the <i>Amazon DynamoDB Developer Guide</i>.</p>\n         <p>\n            <code>Scan</code> uses eventually consistent reads when accessing the data in a table;\n            therefore, the result set might not include the changes to data in the table immediately\n            before the operation began. If you need a consistent copy of the data, as of the time\n            that the <code>Scan</code> begins, you can set the <code>ConsistentRead</code> parameter\n            to <code>true</code>.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "ExclusiveStartKey",
                     "outputToken": "LastEvaluatedKey",
@@ -9199,7 +9437,7 @@
                 "Select": {
                     "target": "com.amazonaws.dynamodb#Select",
                     "traits": {
-                        "smithy.api#documentation": "<p>The attributes to be returned in the result. You can retrieve all item attributes,\n            specific item attributes, the count of matching items, or in the case of an index, some\n            or all of the attributes projected into the index.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ALL_ATTRIBUTES</code> - Returns all of the item attributes from the\n                    specified table or index. If you query a local secondary index, then for each\n                    matching item in the index, DynamoDB fetches the entire item from the parent\n                    table. If the index is configured to project all item attributes, then all of\n                    the data can be obtained from the local secondary index, and no fetching is\n                    required.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL_PROJECTED_ATTRIBUTES</code> - Allowed only when querying an index.\n                    Retrieves all attributes that have been projected into the index. If the index\n                    is configured to project all attributes, this return value is equivalent to\n                    specifying <code>ALL_ATTRIBUTES</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>COUNT</code> - Returns the number of matching items, rather than the\n                    matching items themselves.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SPECIFIC_ATTRIBUTES</code> - Returns only the attributes listed in\n                        <code>ProjectionExpression</code>. This return value is equivalent to\n                    specifying <code>ProjectionExpression</code> without specifying any value for\n                        <code>Select</code>.</p>\n                <p>If you query or scan a local secondary index and request only attributes that\n                    are projected into that index, the operation reads only the index and not the\n                    table. If any of the requested attributes are not projected into the local\n                    secondary index, DynamoDB fetches each of these attributes from the parent\n                    table. This extra fetching incurs additional throughput cost and latency.</p>\n                <p>If you query or scan a global secondary index, you can only request attributes\n                    that are projected into the index. Global secondary index queries cannot fetch\n                    attributes from the parent table.</p>\n            </li>\n         </ul>\n        <p>If neither <code>Select</code> nor <code>ProjectionExpression</code> are specified,\n            DynamoDB defaults to <code>ALL_ATTRIBUTES</code> when accessing a table, and\n                <code>ALL_PROJECTED_ATTRIBUTES</code> when accessing an index. You cannot use both\n                <code>Select</code> and <code>ProjectionExpression</code> together in a single\n            request, unless the value for <code>Select</code> is <code>SPECIFIC_ATTRIBUTES</code>.\n            (This usage is equivalent to specifying <code>ProjectionExpression</code> without any\n            value for <code>Select</code>.)</p>\n        <note>\n            <p>If you use the <code>ProjectionExpression</code> parameter, then the value for\n                    <code>Select</code> can only be <code>SPECIFIC_ATTRIBUTES</code>. Any other\n                value for <code>Select</code> will return an error.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The attributes to be returned in the result. You can retrieve all item attributes,\n            specific item attributes, the count of matching items, or in the case of an index, some\n            or all of the attributes projected into the index.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ALL_ATTRIBUTES</code> - Returns all of the item attributes from the\n                    specified table or index. If you query a local secondary index, then for each\n                    matching item in the index, DynamoDB fetches the entire item from the parent\n                    table. If the index is configured to project all item attributes, then all of\n                    the data can be obtained from the local secondary index, and no fetching is\n                    required.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL_PROJECTED_ATTRIBUTES</code> - Allowed only when querying an index.\n                    Retrieves all attributes that have been projected into the index. If the index\n                    is configured to project all attributes, this return value is equivalent to\n                    specifying <code>ALL_ATTRIBUTES</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>COUNT</code> - Returns the number of matching items, rather than the\n                    matching items themselves. Note that this uses the same quantity of read capacity units \n                    as getting the items, and is subject to the same item size calculations.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SPECIFIC_ATTRIBUTES</code> - Returns only the attributes listed in\n                        <code>ProjectionExpression</code>. This return value is equivalent to\n                    specifying <code>ProjectionExpression</code> without specifying any value for\n                        <code>Select</code>.</p>\n               <p>If you query or scan a local secondary index and request only attributes that\n                    are projected into that index, the operation reads only the index and not the\n                    table. If any of the requested attributes are not projected into the local\n                    secondary index, DynamoDB fetches each of these attributes from the parent\n                    table. This extra fetching incurs additional throughput cost and latency.</p>\n               <p>If you query or scan a global secondary index, you can only request attributes\n                    that are projected into the index. Global secondary index queries cannot fetch\n                    attributes from the parent table.</p>\n            </li>\n         </ul>\n         <p>If neither <code>Select</code> nor <code>ProjectionExpression</code> are specified,\n            DynamoDB defaults to <code>ALL_ATTRIBUTES</code> when accessing a table, and\n                <code>ALL_PROJECTED_ATTRIBUTES</code> when accessing an index. You cannot use both\n                <code>Select</code> and <code>ProjectionExpression</code> together in a single\n            request, unless the value for <code>Select</code> is <code>SPECIFIC_ATTRIBUTES</code>.\n            (This usage is equivalent to specifying <code>ProjectionExpression</code> without any\n            value for <code>Select</code>.)</p>\n         <note>\n            <p>If you use the <code>ProjectionExpression</code> parameter, then the value for\n                    <code>Select</code> can only be <code>SPECIFIC_ATTRIBUTES</code>. Any other\n                value for <code>Select</code> will return an error.</p>\n         </note>"
                     }
                 },
                 "ScanFilter": {
@@ -9217,7 +9455,7 @@
                 "ExclusiveStartKey": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>The primary key of the first item that this operation will evaluate. Use the value\n            that was returned for <code>LastEvaluatedKey</code> in the previous operation.</p>\n        <p>The data type for <code>ExclusiveStartKey</code> must be String, Number or Binary. No\n            set data types are allowed.</p>\n        <p>In a parallel scan, a <code>Scan</code> request that includes\n                <code>ExclusiveStartKey</code> must specify the same segment whose previous\n                <code>Scan</code> returned the corresponding value of\n            <code>LastEvaluatedKey</code>.</p>"
+                        "smithy.api#documentation": "<p>The primary key of the first item that this operation will evaluate. Use the value\n            that was returned for <code>LastEvaluatedKey</code> in the previous operation.</p>\n         <p>The data type for <code>ExclusiveStartKey</code> must be String, Number or Binary. No\n            set data types are allowed.</p>\n         <p>In a parallel scan, a <code>Scan</code> request that includes\n                <code>ExclusiveStartKey</code> must specify the same segment whose previous\n                <code>Scan</code> returned the corresponding value of\n            <code>LastEvaluatedKey</code>.</p>"
                     }
                 },
                 "ReturnConsumedCapacity": {
@@ -9226,48 +9464,49 @@
                 "TotalSegments": {
                     "target": "com.amazonaws.dynamodb#ScanTotalSegments",
                     "traits": {
-                        "smithy.api#documentation": "<p>For a parallel <code>Scan</code> request, <code>TotalSegments</code> represents the\n            total number of segments into which the <code>Scan</code> operation will be divided. The\n            value of <code>TotalSegments</code> corresponds to the number of application workers\n            that will perform the parallel scan. For example, if you want to use four application\n            threads to scan a table or an index, specify a <code>TotalSegments</code> value of\n            4.</p>\n        <p>The value for <code>TotalSegments</code> must be greater than or equal to 1, and less\n            than or equal to 1000000. If you specify a <code>TotalSegments</code> value of 1, the\n                <code>Scan</code> operation will be sequential rather than parallel.</p>\n        <p>If you specify <code>TotalSegments</code>, you must also specify\n            <code>Segment</code>.</p>"
+                        "smithy.api#documentation": "<p>For a parallel <code>Scan</code> request, <code>TotalSegments</code> represents the\n            total number of segments into which the <code>Scan</code> operation will be divided. The\n            value of <code>TotalSegments</code> corresponds to the number of application workers\n            that will perform the parallel scan. For example, if you want to use four application\n            threads to scan a table or an index, specify a <code>TotalSegments</code> value of\n            4.</p>\n         <p>The value for <code>TotalSegments</code> must be greater than or equal to 1, and less\n            than or equal to 1000000. If you specify a <code>TotalSegments</code> value of 1, the\n                <code>Scan</code> operation will be sequential rather than parallel.</p>\n         <p>If you specify <code>TotalSegments</code>, you must also specify\n            <code>Segment</code>.</p>"
                     }
                 },
                 "Segment": {
                     "target": "com.amazonaws.dynamodb#ScanSegment",
                     "traits": {
-                        "smithy.api#documentation": "<p>For a parallel <code>Scan</code> request, <code>Segment</code> identifies an\n            individual segment to be scanned by an application worker.</p>\n        <p>Segment IDs are zero-based, so the first segment is always 0. For example, if you want\n            to use four application threads to scan a table or an index, then the first thread\n            specifies a <code>Segment</code> value of 0, the second thread specifies 1, and so\n            on.</p>\n        <p>The value of <code>LastEvaluatedKey</code> returned from a parallel <code>Scan</code>\n            request must be used as <code>ExclusiveStartKey</code> with the same segment ID in a\n            subsequent <code>Scan</code> operation.</p>\n        <p>The value for <code>Segment</code> must be greater than or equal to 0, and less than\n            the value provided for <code>TotalSegments</code>.</p>\n        <p>If you provide <code>Segment</code>, you must also provide\n            <code>TotalSegments</code>.</p>"
+                        "smithy.api#documentation": "<p>For a parallel <code>Scan</code> request, <code>Segment</code> identifies an\n            individual segment to be scanned by an application worker.</p>\n         <p>Segment IDs are zero-based, so the first segment is always 0. For example, if you want\n            to use four application threads to scan a table or an index, then the first thread\n            specifies a <code>Segment</code> value of 0, the second thread specifies 1, and so\n            on.</p>\n         <p>The value of <code>LastEvaluatedKey</code> returned from a parallel <code>Scan</code>\n            request must be used as <code>ExclusiveStartKey</code> with the same segment ID in a\n            subsequent <code>Scan</code> operation.</p>\n         <p>The value for <code>Segment</code> must be greater than or equal to 0, and less than\n            the value provided for <code>TotalSegments</code>.</p>\n         <p>If you provide <code>Segment</code>, you must also provide\n            <code>TotalSegments</code>.</p>"
                     }
                 },
                 "ProjectionExpression": {
                     "target": "com.amazonaws.dynamodb#ProjectionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the specified table\n            or index. These attributes can include scalars, sets, or elements of a JSON document.\n            The attributes in the expression must be separated by commas.</p>\n        <p>If no attribute names are specified, then all attributes will be returned. If any of\n            the requested attributes are not found, they will not appear in the result.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A string that identifies one or more attributes to retrieve from the specified table\n            or index. These attributes can include scalars, sets, or elements of a JSON document.\n            The attributes in the expression must be separated by commas.</p>\n         <p>If no attribute names are specified, then all attributes will be returned. If any of\n            the requested attributes are not found, they will not appear in the result.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "FilterExpression": {
                     "target": "com.amazonaws.dynamodb#ConditionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string that contains conditions that DynamoDB applies after the <code>Scan</code>\n            operation, but before the data is returned to you. Items that do not satisfy the\n                <code>FilterExpression</code> criteria are not returned.</p>\n        <note>\n            <p>A <code>FilterExpression</code> is applied after the items have already been read;\n                the process of filtering does not consume any additional read capacity units.</p>\n        </note>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Query.FilterExpression\">Filter Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A string that contains conditions that DynamoDB applies after the <code>Scan</code>\n            operation, but before the data is returned to you. Items that do not satisfy the\n                <code>FilterExpression</code> criteria are not returned.</p>\n         <note>\n            <p>A <code>FilterExpression</code> is applied after the items have already been read;\n                the process of filtering does not consume any additional read capacity units.</p>\n         </note>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Query.FilterExpression\">Filter Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>). To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information on expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeValues": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeValueMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n        <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <code>ProductStatus</code> attribute was one of the following: </p>\n        <p>\n            <code>Available | Backordered | Discontinued</code>\n        </p>\n        <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n        <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n        </p>\n        <p>You could then use these values in an expression, such as this:</p>\n        <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n        </p>\n        <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n         <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <code>ProductStatus</code> attribute was one of the following: </p>\n         <p>\n            <code>Available | Backordered | Discontinued</code>\n         </p>\n         <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n         <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n         </p>\n         <p>You could then use these values in an expression, such as this:</p>\n         <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n         </p>\n         <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ConsistentRead": {
                     "target": "com.amazonaws.dynamodb#ConsistentRead",
                     "traits": {
-                        "smithy.api#documentation": "<p>A Boolean value that determines the read consistency model during the scan:</p>\n        <ul>\n            <li>\n                <p>If <code>ConsistentRead</code> is <code>false</code>, then the data returned\n                    from <code>Scan</code> might not contain the results from other recently\n                    completed write operations (<code>PutItem</code>, <code>UpdateItem</code>, or\n                        <code>DeleteItem</code>).</p>\n            </li>\n            <li>\n                <p>If <code>ConsistentRead</code> is <code>true</code>, then all of the write\n                    operations that completed before the <code>Scan</code> began are guaranteed to\n                    be contained in the <code>Scan</code> response.</p>\n            </li>\n         </ul>\n        <p>The default setting for <code>ConsistentRead</code> is <code>false</code>.</p>\n        <p>The <code>ConsistentRead</code> parameter is not supported on global secondary\n            indexes. If you scan a global secondary index with <code>ConsistentRead</code> set to\n            true, you will receive a <code>ValidationException</code>.</p>"
+                        "smithy.api#documentation": "<p>A Boolean value that determines the read consistency model during the scan:</p>\n         <ul>\n            <li>\n               <p>If <code>ConsistentRead</code> is <code>false</code>, then the data returned\n                    from <code>Scan</code> might not contain the results from other recently\n                    completed write operations (<code>PutItem</code>, <code>UpdateItem</code>, or\n                        <code>DeleteItem</code>).</p>\n            </li>\n            <li>\n               <p>If <code>ConsistentRead</code> is <code>true</code>, then all of the write\n                    operations that completed before the <code>Scan</code> began are guaranteed to\n                    be contained in the <code>Scan</code> response.</p>\n            </li>\n         </ul>\n         <p>The default setting for <code>ConsistentRead</code> is <code>false</code>.</p>\n         <p>The <code>ConsistentRead</code> parameter is not supported on global secondary\n            indexes. If you scan a global secondary index with <code>ConsistentRead</code> set to\n            true, you will receive a <code>ValidationException</code>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of a <code>Scan</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of a <code>Scan</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#ScanOutput": {
@@ -9283,31 +9522,32 @@
                     "target": "com.amazonaws.dynamodb#Integer",
                     "traits": {
                         "smithy.api#default": 0,
-                        "smithy.api#documentation": "<p>The number of items in the response.</p>\n        <p>If you set <code>ScanFilter</code> in the request, then <code>Count</code> is the\n            number of items returned after the filter was applied, and <code>ScannedCount</code> is\n            the number of matching items before the filter was applied.</p>\n        <p>If you did not use a filter in the request, then <code>Count</code> is the same as\n                <code>ScannedCount</code>.</p>"
+                        "smithy.api#documentation": "<p>The number of items in the response.</p>\n         <p>If you set <code>ScanFilter</code> in the request, then <code>Count</code> is the\n            number of items returned after the filter was applied, and <code>ScannedCount</code> is\n            the number of matching items before the filter was applied.</p>\n         <p>If you did not use a filter in the request, then <code>Count</code> is the same as\n                <code>ScannedCount</code>.</p>"
                     }
                 },
                 "ScannedCount": {
                     "target": "com.amazonaws.dynamodb#Integer",
                     "traits": {
                         "smithy.api#default": 0,
-                        "smithy.api#documentation": "<p>The number of items evaluated, before any <code>ScanFilter</code> is applied. A high\n                <code>ScannedCount</code> value with few, or no, <code>Count</code> results\n            indicates an inefficient <code>Scan</code> operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count\">Count and\n                ScannedCount</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n        <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same\n            as <code>Count</code>.</p>"
+                        "smithy.api#documentation": "<p>The number of items evaluated, before any <code>ScanFilter</code> is applied. A high\n                <code>ScannedCount</code> value with few, or no, <code>Count</code> results\n            indicates an inefficient <code>Scan</code> operation. For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count\">Count and\n                ScannedCount</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>\n         <p>If you did not use a filter in the request, then <code>ScannedCount</code> is the same\n            as <code>Count</code>.</p>"
                     }
                 },
                 "LastEvaluatedKey": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>The primary key of the item where the operation stopped, inclusive of the previous\n            result set. Use this value to start a new operation, excluding this value in the new\n            request.</p>\n        <p>If <code>LastEvaluatedKey</code> is empty, then the \"last page\" of results has been\n            processed and there is no more data to be retrieved.</p>\n        <p>If <code>LastEvaluatedKey</code> is not empty, it does not necessarily mean that there\n            is more data in the result set. The only way to know when you have reached the end of\n            the result set is when <code>LastEvaluatedKey</code> is empty.</p>"
+                        "smithy.api#documentation": "<p>The primary key of the item where the operation stopped, inclusive of the previous\n            result set. Use this value to start a new operation, excluding this value in the new\n            request.</p>\n         <p>If <code>LastEvaluatedKey</code> is empty, then the \"last page\" of results has been\n            processed and there is no more data to be retrieved.</p>\n         <p>If <code>LastEvaluatedKey</code> is not empty, it does not necessarily mean that there\n            is more data in the result set. The only way to know when you have reached the end of\n            the result set is when <code>LastEvaluatedKey</code> is empty.</p>"
                     }
                 },
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacity",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>Scan</code> operation. The data returned\n            includes the total provisioned throughput consumed, along with statistics for the table\n            and any indexes involved in the operation. <code>ConsumedCapacity</code> is only\n            returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more\n            information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>Scan</code> operation. The data returned\n            includes the total provisioned throughput consumed, along with statistics for the table\n            and any indexes involved in the operation. <code>ConsumedCapacity</code> is only\n            returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For more\n            information, see \n            <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html#ItemSizeCalculations.Reads\">Provisioned Throughput</a> \n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of a <code>Scan</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of a <code>Scan</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#ScanSegment": {
@@ -9390,7 +9630,7 @@
                     }
                 },
                 "TableSizeBytes": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>Size of the table in bytes. Note that this is an approximate value.</p>"
                     }
@@ -9425,7 +9665,7 @@
                 "BillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>PROVISIONED</code> - Sets the read/write capacity mode to\n                        <code>PROVISIONED</code>. We recommend using <code>PROVISIONED</code> for\n                    predictable workloads.</p>\n            </li>\n            <li>\n                <p>\n                    <code>PAY_PER_REQUEST</code> - Sets the read/write capacity mode to\n                        <code>PAY_PER_REQUEST</code>. We recommend using\n                        <code>PAY_PER_REQUEST</code> for unpredictable workloads. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. This setting can be changed later.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - Sets the read/write capacity mode to\n                        <code>PROVISIONED</code>. We recommend using <code>PROVISIONED</code> for\n                    predictable workloads.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - Sets the read/write capacity mode to\n                        <code>PAY_PER_REQUEST</code>. We recommend using\n                        <code>PAY_PER_REQUEST</code> for unpredictable workloads. </p>\n            </li>\n         </ul>"
                     }
                 }
             },
@@ -9496,7 +9736,7 @@
                 "StreamViewType": {
                     "target": "com.amazonaws.dynamodb#StreamViewType",
                     "traits": {
-                        "smithy.api#documentation": "<p> When an item in the table is modified, <code>StreamViewType</code> determines what\n            information is written to the stream for this table. Valid values for\n                <code>StreamViewType</code> are:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>KEYS_ONLY</code> - Only the key attributes of the modified item are\n                    written to the stream.</p>\n            </li>\n            <li>\n                <p>\n                    <code>NEW_IMAGE</code> - The entire item, as it appears after it was modified,\n                    is written to the stream.</p>\n            </li>\n            <li>\n                <p>\n                    <code>OLD_IMAGE</code> - The entire item, as it appeared before it was modified,\n                    is written to the stream.</p>\n            </li>\n            <li>\n                <p>\n                    <code>NEW_AND_OLD_IMAGES</code> - Both the new and the old item images of the\n                    item are written to the stream.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p> When an item in the table is modified, <code>StreamViewType</code> determines what\n            information is written to the stream for this table. Valid values for\n                <code>StreamViewType</code> are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>KEYS_ONLY</code> - Only the key attributes of the modified item are\n                    written to the stream.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NEW_IMAGE</code> - The entire item, as it appears after it was modified,\n                    is written to the stream.</p>\n            </li>\n            <li>\n               <p>\n                  <code>OLD_IMAGE</code> - The entire item, as it appeared before it was modified,\n                    is written to the stream.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NEW_AND_OLD_IMAGES</code> - Both the new and the old item images of the\n                    item are written to the stream.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
@@ -9572,7 +9812,7 @@
                 "TableStatus": {
                     "target": "com.amazonaws.dynamodb#TableStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the table:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The table is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The table is being updated.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The table is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The table is being updated.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "Replicas": {
@@ -9679,7 +9919,7 @@
                 "AttributeDefinitions": {
                     "target": "com.amazonaws.dynamodb#AttributeDefinitions",
                     "traits": {
-                        "smithy.api#documentation": "<p>An array of <code>AttributeDefinition</code> objects. Each of these objects describes\n            one attribute in the table and index key schema.</p>\n        <p>Each <code>AttributeDefinition</code> object in this array is composed of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>AttributeName</code> - The name of the attribute.</p>\n            </li>\n            <li>\n                <p>\n                    <code>AttributeType</code> - The data type for the attribute.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>An array of <code>AttributeDefinition</code> objects. Each of these objects describes\n            one attribute in the table and index key schema.</p>\n         <p>Each <code>AttributeDefinition</code> object in this array is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AttributeName</code> - The name of the attribute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>AttributeType</code> - The data type for the attribute.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "TableName": {
@@ -9691,13 +9931,13 @@
                 "KeySchema": {
                     "target": "com.amazonaws.dynamodb#KeySchema",
                     "traits": {
-                        "smithy.api#documentation": "<p>The primary key structure for the table. Each <code>KeySchemaElement</code> consists\n            of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>AttributeName</code> - The name of the attribute.</p>\n            </li>\n            <li>\n                <p>\n                    <code>KeyType</code> - The role of the attribute:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>HASH</code> - partition key</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>RANGE</code> - sort key</p>\n                    </li>\n               </ul>\n                <note>\n                    <p>The partition key of an item is also known as its <i>hash\n                            attribute</i>. The term \"hash attribute\" derives from DynamoDB's\n                        usage of an internal hash function to evenly distribute data items across\n                        partitions, based on their partition key values.</p>\n                    <p>The sort key of an item is also known as its <i>range\n                            attribute</i>. The term \"range attribute\" derives from the way\n                        DynamoDB stores items with the same partition key physically close together,\n                        in sorted order by the sort key value.</p>\n                </note>\n\n            </li>\n         </ul>\n        <p>For more information about primary keys, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModelPrimaryKey\">Primary Key</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The primary key structure for the table. Each <code>KeySchemaElement</code> consists\n            of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>AttributeName</code> - The name of the attribute.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeyType</code> - The role of the attribute:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>HASH</code> - partition key</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RANGE</code> - sort key</p>\n                  </li>\n               </ul>\n               <note>\n                  <p>The partition key of an item is also known as its <i>hash\n                            attribute</i>. The term \"hash attribute\" derives from DynamoDB's\n                        usage of an internal hash function to evenly distribute data items across\n                        partitions, based on their partition key values.</p>\n                  <p>The sort key of an item is also known as its <i>range\n                            attribute</i>. The term \"range attribute\" derives from the way\n                        DynamoDB stores items with the same partition key physically close together,\n                        in sorted order by the sort key value.</p>\n               </note>\n            </li>\n         </ul>\n         <p>For more information about primary keys, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataModel.html#DataModelPrimaryKey\">Primary Key</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.</p>"
                     }
                 },
                 "TableStatus": {
                     "target": "com.amazonaws.dynamodb#TableStatus",
                     "traits": {
-                        "smithy.api#documentation": "<p>The current state of the table:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>CREATING</code> - The table is being created.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATING</code> - The table/index configuration is being updated. The\n                    table/index remains available for data operations when\n                    <code>UPDATING</code>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n            <li>\n                <p>\n                    <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS</code> - The KMS key\n                    used to encrypt the table in inaccessible. Table operations may fail due to\n                    failure to use the KMS key. DynamoDB will initiate the\n                    table archival process when a table's KMS key remains\n                    inaccessible for more than seven days. </p>\n            </li>\n            <li>\n                <p>\n                    <code>ARCHIVING</code> - The table is being archived. Operations are not allowed\n                    until archival is complete. </p>\n            </li>\n            <li>\n                <p>\n                    <code>ARCHIVED</code> - The table has been archived. See the ArchivalReason for\n                    more information. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The current state of the table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>CREATING</code> - The table is being created.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATING</code> - The table/index configuration is being updated. The\n                    table/index remains available for data operations when\n                    <code>UPDATING</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INACCESSIBLE_ENCRYPTION_CREDENTIALS</code> - The KMS key\n                    used to encrypt the table in inaccessible. Table operations may fail due to\n                    failure to use the KMS key. DynamoDB will initiate the\n                    table archival process when a table's KMS key remains\n                    inaccessible for more than seven days. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ARCHIVING</code> - The table is being archived. Operations are not allowed\n                    until archival is complete. </p>\n            </li>\n            <li>\n               <p>\n                  <code>ARCHIVED</code> - The table has been archived. See the ArchivalReason for\n                    more information. </p>\n            </li>\n         </ul>"
                     }
                 },
                 "CreationDateTime": {
@@ -9713,13 +9953,13 @@
                     }
                 },
                 "TableSizeBytes": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The total size of the specified table, in bytes. DynamoDB updates this value\n            approximately every six hours. Recent changes might not be reflected in this\n            value.</p>"
                     }
                 },
                 "ItemCount": {
-                    "target": "com.amazonaws.dynamodb#Long",
+                    "target": "com.amazonaws.dynamodb#LongObject",
                     "traits": {
                         "smithy.api#documentation": "<p>The number of items in the specified table. DynamoDB updates this value approximately\n            every six hours. Recent changes might not be reflected in this value.</p>"
                     }
@@ -9745,13 +9985,13 @@
                 "LocalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#LocalSecondaryIndexDescriptionList",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents one or more local secondary indexes on the table. Each index is scoped to a\n            given partition key value. Tables with one or more local secondary indexes are subject\n            to an item collection size limit, where the amount of data within a given item\n            collection cannot exceed 10 GB. Each element is composed of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>IndexName</code> - The name of the local secondary index.</p>\n            </li>\n            <li>\n                <p>\n                    <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>ProjectionType</code> - One of the following:</p>\n                        <ul>\n                        <li>\n                                <p>\n                                    <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                            </li>\n                     </ul>\n                    </li>\n                  <li>\n                        <p>\n                            <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>\n                    <code>IndexSizeBytes</code> - Represents the total size of the index, in bytes.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ItemCount</code> - Represents the number of items in the index. DynamoDB\n                    updates this value approximately every six hours. Recent changes might not be\n                    reflected in this value.</p>\n            </li>\n         </ul>\n        <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
+                        "smithy.api#documentation": "<p>Represents one or more local secondary indexes on the table. Each index is scoped to a\n            given partition key value. Tables with one or more local secondary indexes are subject\n            to an item collection size limit, where the amount of data within a given item\n            collection cannot exceed 10 GB. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the local secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - Only the specified table attributes are\n                                    projected into the index. The list of projected attributes is in\n                                        <code>NonKeyAttributes</code>.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - Represents the total size of the index, in bytes.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - Represents the number of items in the index. DynamoDB\n                    updates this value approximately every six hours. Recent changes might not be\n                    reflected in this value.</p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
                     }
                 },
                 "GlobalSecondaryIndexes": {
                     "target": "com.amazonaws.dynamodb#GlobalSecondaryIndexDescriptionList",
                     "traits": {
-                        "smithy.api#documentation": "<p>The global secondary indexes, if any, on the table. Each index is scoped to a given\n            partition key value. Each element is composed of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Backfilling</code> - If true, then the index is currently in the\n                    backfilling phase. Backfilling occurs only when a new global secondary index is\n                    added to the table. It is the process by which DynamoDB populates the new index\n                    with data from the table. (This attribute does not appear for indexes that were\n                    created during a <code>CreateTable</code> operation.) </p>\n                <p> You can delete an index that is being created during the\n                        <code>Backfilling</code> phase when <code>IndexStatus</code> is set to\n                    CREATING and <code>Backfilling</code> is true. You can't delete the index that\n                    is being created when <code>IndexStatus</code> is set to CREATING and\n                        <code>Backfilling</code> is false. (This attribute does not appear for\n                    indexes that were created during a <code>CreateTable</code> operation.)</p>\n            </li>\n            <li>\n                <p>\n                    <code>IndexName</code> - The name of the global secondary index.</p>\n            </li>\n            <li>\n                <p>\n                    <code>IndexSizeBytes</code> - The total size of the global secondary index, in\n                    bytes. DynamoDB updates this value approximately every six hours. Recent changes\n                    might not be reflected in this value. </p>\n            </li>\n            <li>\n                <p>\n                    <code>IndexStatus</code> - The current status of the global secondary\n                    index:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>CREATING</code> - The index is being created.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>UPDATING</code> - The index is being updated.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>DELETING</code> - The index is being deleted.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>ACTIVE</code> - The index is ready for use.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>\n                    <code>ItemCount</code> - The number of items in the global secondary index.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value. </p>\n            </li>\n            <li>\n                <p>\n                    <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>ProjectionType</code> - One of the following:</p>\n                        <ul>\n                        <li>\n                                <p>\n                                    <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>INCLUDE</code> - In addition to the attributes described\n                                    in <code>KEYS_ONLY</code>, the secondary index will include\n                                    other non-key attributes that you specify.</p>\n                            </li>\n                        <li>\n                                <p>\n                                    <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                            </li>\n                     </ul>\n                    </li>\n                  <li>\n                        <p>\n                            <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>\n                    <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units, along with\n                    data about increases and decreases. </p>\n            </li>\n         </ul>\n        <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
+                        "smithy.api#documentation": "<p>The global secondary indexes, if any, on the table. Each index is scoped to a given\n            partition key value. Each element is composed of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Backfilling</code> - If true, then the index is currently in the\n                    backfilling phase. Backfilling occurs only when a new global secondary index is\n                    added to the table. It is the process by which DynamoDB populates the new index\n                    with data from the table. (This attribute does not appear for indexes that were\n                    created during a <code>CreateTable</code> operation.) </p>\n               <p> You can delete an index that is being created during the\n                        <code>Backfilling</code> phase when <code>IndexStatus</code> is set to\n                    CREATING and <code>Backfilling</code> is true. You can't delete the index that\n                    is being created when <code>IndexStatus</code> is set to CREATING and\n                        <code>Backfilling</code> is false. (This attribute does not appear for\n                    indexes that were created during a <code>CreateTable</code> operation.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexName</code> - The name of the global secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexSizeBytes</code> - The total size of the global secondary index, in\n                    bytes. DynamoDB updates this value approximately every six hours. Recent changes\n                    might not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>IndexStatus</code> - The current status of the global secondary\n                    index:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>CREATING</code> - The index is being created.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>UPDATING</code> - The index is being updated.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>DELETING</code> - The index is being deleted.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ACTIVE</code> - The index is ready for use.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ItemCount</code> - The number of items in the global secondary index.\n                    DynamoDB updates this value approximately every six hours. Recent changes might\n                    not be reflected in this value. </p>\n            </li>\n            <li>\n               <p>\n                  <code>KeySchema</code> - Specifies the complete index key schema. The attribute\n                    names in the key schema must be between 1 and 255 characters (inclusive). The\n                    key schema must begin with the same partition key as the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Projection</code> - Specifies attributes that are copied (projected) from\n                    the table into the index. These are in addition to the primary key attributes\n                    and index key attributes, which are automatically projected. Each attribute\n                    specification is composed of:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ProjectionType</code> - One of the following:</p>\n                     <ul>\n                        <li>\n                           <p>\n                              <code>KEYS_ONLY</code> - Only the index and primary keys are\n                                    projected into the index.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>INCLUDE</code> - In addition to the attributes described\n                                    in <code>KEYS_ONLY</code>, the secondary index will include\n                                    other non-key attributes that you specify.</p>\n                        </li>\n                        <li>\n                           <p>\n                              <code>ALL</code> - All of the table attributes are projected\n                                    into the index.</p>\n                        </li>\n                     </ul>\n                  </li>\n                  <li>\n                     <p>\n                        <code>NonKeyAttributes</code> - A list of one or more non-key attribute\n                            names that are projected into the secondary index. The total count of\n                            attributes provided in <code>NonKeyAttributes</code>, summed across all\n                            of the secondary indexes, must not exceed 100. If you project the same\n                            attribute into two different indexes, this counts as two distinct\n                            attributes when determining the total.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>ProvisionedThroughput</code> - The provisioned throughput settings for the\n                    global secondary index, consisting of read and write capacity units, along with\n                    data about increases and decreases. </p>\n            </li>\n         </ul>\n         <p>If the table is in the <code>DELETING</code> state, no information about indexes will\n            be returned.</p>"
                     }
                 },
                 "StreamSpecification": {
@@ -9763,7 +10003,7 @@
                 "LatestStreamLabel": {
                     "target": "com.amazonaws.dynamodb#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>A timestamp, in ISO 8601 format, for this stream.</p>\n\n        <p>Note that <code>LatestStreamLabel</code> is not a unique identifier for the stream,\n            because it is possible that a stream from another table might have the same timestamp.\n            However, the combination of the following three elements is guaranteed to be\n            unique:</p>\n        <ul>\n            <li>\n                <p>Amazon Web Services customer ID</p>\n            </li>\n            <li>\n                <p>Table name</p>\n            </li>\n            <li>\n                <p>\n                  <code>StreamLabel</code>\n               </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>A timestamp, in ISO 8601 format, for this stream.</p>\n         <p>Note that <code>LatestStreamLabel</code> is not a unique identifier for the stream,\n            because it is possible that a stream from another table might have the same timestamp.\n            However, the combination of the following three elements is guaranteed to be\n            unique:</p>\n         <ul>\n            <li>\n               <p>Amazon Web Services customer ID</p>\n            </li>\n            <li>\n               <p>Table name</p>\n            </li>\n            <li>\n               <p>\n                  <code>StreamLabel</code>\n               </p>\n            </li>\n         </ul>"
                     }
                 },
                 "LatestStreamArn": {
@@ -9806,6 +10046,12 @@
                     "target": "com.amazonaws.dynamodb#TableClassSummary",
                     "traits": {
                         "smithy.api#documentation": "<p>Contains details of the table class.</p>"
+                    }
+                },
+                "DeletionProtectionEnabled": {
+                    "target": "com.amazonaws.dynamodb#DeletionProtectionEnabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether deletion protection is enabled (true) or disabled (false) on the table.</p>"
                     }
                 }
             },
@@ -9925,7 +10171,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Describes a tag. A tag is a key-value pair. You can add up to 50 tags to a single\n            DynamoDB table. </p>\n        <p>Amazon Web Services-assigned tag names and values are automatically assigned the\n                <code>aws:</code> prefix, which the user cannot assign. Amazon Web Services-assigned\n            tag names do not count towards the tag limit of 50. User-assigned tag names have the\n            prefix <code>user:</code> in the Cost Allocation Report. You cannot backdate the\n            application of a tag.</p>\n        <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging\n                for DynamoDB</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Describes a tag. A tag is a key-value pair. You can add up to 50 tags to a single\n            DynamoDB table. </p>\n         <p>Amazon Web Services-assigned tag names and values are automatically assigned the\n                <code>aws:</code> prefix, which the user cannot assign. Amazon Web Services-assigned\n            tag names do not count towards the tag limit of 50. User-assigned tag names have the\n            prefix <code>user:</code> in the Cost Allocation Report. You cannot backdate the\n            application of a tag.</p>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging\n                for DynamoDB</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#TagKeyList": {
@@ -9978,7 +10224,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Associate a set of tags with an Amazon DynamoDB resource. You can then activate these\n            user-defined tags so that they appear on the Billing and Cost Management console for\n            cost allocation tracking. You can call TagResource up to five times per second, per\n            account. </p>\n        <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Associate a set of tags with an Amazon DynamoDB resource. You can then activate these\n            user-defined tags so that they appear on the Billing and Cost Management console for\n            cost allocation tracking. You can call TagResource up to five times per second, per\n            account. </p>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#TagResourceInput": {
@@ -9998,6 +10244,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#TagValueString": {
@@ -10157,7 +10406,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>\n            <code>TransactGetItems</code> is a synchronous operation that atomically retrieves\n            multiple items from one or more tables (but not from indexes) in a single account and\n            Region. A <code>TransactGetItems</code> call can contain up to 100\n                <code>TransactGetItem</code> objects, each of which contains a <code>Get</code>\n            structure that specifies an item to retrieve from a table in the account and Region. A\n            call to <code>TransactGetItems</code> cannot retrieve items from tables in more than one\n                Amazon Web Services account or Region. The aggregate size of the items in the\n            transaction cannot exceed 4 MB.</p>\n        <p>DynamoDB rejects the entire <code>TransactGetItems</code> request if any of\n            the following is true:</p>\n        <ul>\n            <li>\n                <p>A conflicting operation is in the process of updating an item to be\n                    read.</p>\n            </li>\n            <li>\n                <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n                <p>There is a user error, such as an invalid data format.</p>\n            </li>\n            <li>\n                <p>The aggregate size of the items in the transaction cannot exceed 4 MB.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>\n            <code>TransactGetItems</code> is a synchronous operation that atomically retrieves\n            multiple items from one or more tables (but not from indexes) in a single account and\n            Region. A <code>TransactGetItems</code> call can contain up to 100\n                <code>TransactGetItem</code> objects, each of which contains a <code>Get</code>\n            structure that specifies an item to retrieve from a table in the account and Region. A\n            call to <code>TransactGetItems</code> cannot retrieve items from tables in more than one\n                Amazon Web Services account or Region. The aggregate size of the items in the\n            transaction cannot exceed 4 MB.</p>\n         <p>DynamoDB rejects the entire <code>TransactGetItems</code> request if any of\n            the following is true:</p>\n         <ul>\n            <li>\n               <p>A conflicting operation is in the process of updating an item to be\n                    read.</p>\n            </li>\n            <li>\n               <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n               <p>There is a user error, such as an invalid data format.</p>\n            </li>\n            <li>\n               <p>The aggregate size of the items in the transaction exceeded 4 MB.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#TransactGetItemsInput": {
@@ -10176,6 +10425,9 @@
                         "smithy.api#documentation": "<p>A value of <code>TOTAL</code> causes consumed capacity information to be returned, and\n            a value of <code>NONE</code> prevents that information from being returned. No other\n            value is valid.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#TransactGetItemsOutput": {
@@ -10190,9 +10442,12 @@
                 "Responses": {
                     "target": "com.amazonaws.dynamodb#ItemResponseList",
                     "traits": {
-                        "smithy.api#documentation": "<p>An ordered array of up to 100 <code>ItemResponse</code> objects, each of which\n            corresponds to the <code>TransactGetItem</code> object in the same position in the\n                <i>TransactItems</i> array. Each <code>ItemResponse</code> object\n            contains a Map of the name-value pairs that are the projected attributes of the\n            requested item.</p>\n        <p>If a requested item could not be retrieved, the corresponding\n                <code>ItemResponse</code> object is Null, or if the requested item has no projected\n            attributes, the corresponding <code>ItemResponse</code> object is an empty Map. </p>"
+                        "smithy.api#documentation": "<p>An ordered array of up to 100 <code>ItemResponse</code> objects, each of which\n            corresponds to the <code>TransactGetItem</code> object in the same position in the\n                <i>TransactItems</i> array. Each <code>ItemResponse</code> object\n            contains a Map of the name-value pairs that are the projected attributes of the\n            requested item.</p>\n         <p>If a requested item could not be retrieved, the corresponding\n                <code>ItemResponse</code> object is Null, or if the requested item has no projected\n            attributes, the corresponding <code>ItemResponse</code> object is an empty Map. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#TransactWriteItem": {
@@ -10277,7 +10532,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>\n            <code>TransactWriteItems</code> is a synchronous write operation that groups up to 100\n            action requests. These actions can target items in different tables, but not in\n            different Amazon Web Services accounts or Regions, and no two actions can target the same\n            item. For example, you cannot both <code>ConditionCheck</code> and <code>Update</code>\n            the same item. The aggregate size of the items in the transaction cannot exceed 4\n            MB.</p>\n\n        <p>The actions are completed atomically so that either all of them succeed, or all of\n            them fail. They are defined by the following objects:</p>\n\n        <ul>\n            <li>\n                <p>\n                  <code>Put</code>  —   Initiates a <code>PutItem</code>\n                    operation to write a new item. This structure specifies the primary key of the\n                    item to be written, the name of the table to write it in, an optional condition\n                    expression that must be satisfied for the write to succeed, a list of the item's\n                    attributes, and a field indicating whether to retrieve the item's attributes if\n                    the condition is not met.</p>\n            </li>\n            <li>\n                <p>\n                  <code>Update</code>  —   Initiates an <code>UpdateItem</code>\n                    operation to update an existing item. This structure specifies the primary key\n                    of the item to be updated, the name of the table where it resides, an optional\n                    condition expression that must be satisfied for the update to succeed, an\n                    expression that defines one or more attributes to be updated, and a field\n                    indicating whether to retrieve the item's attributes if the condition is not\n                    met.</p>\n            </li>\n            <li>\n                <p>\n                  <code>Delete</code>  —   Initiates a <code>DeleteItem</code>\n                    operation to delete an existing item. This structure specifies the primary key\n                    of the item to be deleted, the name of the table where it resides, an optional\n                    condition expression that must be satisfied for the deletion to succeed, and a\n                    field indicating whether to retrieve the item's attributes if the condition is\n                    not met.</p>\n            </li>\n            <li>\n                <p>\n                  <code>ConditionCheck</code>  —   Applies a condition to an item\n                    that is not being modified by the transaction. This structure specifies the\n                    primary key of the item to be checked, the name of the table where it resides, a\n                    condition expression that must be satisfied for the transaction to succeed, and\n                    a field indicating whether to retrieve the item's attributes if the condition is\n                    not met.</p>\n            </li>\n         </ul>\n\n        <p>DynamoDB rejects the entire <code>TransactWriteItems</code> request if any of the\n            following is true:</p>\n        <ul>\n            <li>\n                <p>A condition in one of the condition expressions is not met.</p>\n            </li>\n            <li>\n                <p>An ongoing operation is in the process of updating the same item.</p>\n            </li>\n            <li>\n                <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n                <p>An item size becomes too large (bigger than 400 KB), a local secondary index\n                    (LSI) becomes too large, or a similar validation error occurs because of changes\n                    made by the transaction.</p>\n            </li>\n            <li>\n                <p>The aggregate size of the items in the transaction exceeds 4 MB.</p>\n            </li>\n            <li>\n                <p>There is a user error, such as an invalid data format.</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>\n            <code>TransactWriteItems</code> is a synchronous write operation that groups up to 100\n            action requests. These actions can target items in different tables, but not in\n            different Amazon Web Services accounts or Regions, and no two actions can target the same\n            item. For example, you cannot both <code>ConditionCheck</code> and <code>Update</code>\n            the same item. The aggregate size of the items in the transaction cannot exceed 4\n            MB.</p>\n         <p>The actions are completed atomically so that either all of them succeed, or all of\n            them fail. They are defined by the following objects:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Put</code>  —   Initiates a <code>PutItem</code>\n                    operation to write a new item. This structure specifies the primary key of the\n                    item to be written, the name of the table to write it in, an optional condition\n                    expression that must be satisfied for the write to succeed, a list of the item's\n                    attributes, and a field indicating whether to retrieve the item's attributes if\n                    the condition is not met.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Update</code>  —   Initiates an <code>UpdateItem</code>\n                    operation to update an existing item. This structure specifies the primary key\n                    of the item to be updated, the name of the table where it resides, an optional\n                    condition expression that must be satisfied for the update to succeed, an\n                    expression that defines one or more attributes to be updated, and a field\n                    indicating whether to retrieve the item's attributes if the condition is not\n                    met.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Delete</code>  —   Initiates a <code>DeleteItem</code>\n                    operation to delete an existing item. This structure specifies the primary key\n                    of the item to be deleted, the name of the table where it resides, an optional\n                    condition expression that must be satisfied for the deletion to succeed, and a\n                    field indicating whether to retrieve the item's attributes if the condition is\n                    not met.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ConditionCheck</code>  —   Applies a condition to an item\n                    that is not being modified by the transaction. This structure specifies the\n                    primary key of the item to be checked, the name of the table where it resides, a\n                    condition expression that must be satisfied for the transaction to succeed, and\n                    a field indicating whether to retrieve the item's attributes if the condition is\n                    not met.</p>\n            </li>\n         </ul>\n         <p>DynamoDB rejects the entire <code>TransactWriteItems</code> request if any of the\n            following is true:</p>\n         <ul>\n            <li>\n               <p>A condition in one of the condition expressions is not met.</p>\n            </li>\n            <li>\n               <p>An ongoing operation is in the process of updating the same item.</p>\n            </li>\n            <li>\n               <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n               <p>An item size becomes too large (bigger than 400 KB), a local secondary index\n                    (LSI) becomes too large, or a similar validation error occurs because of changes\n                    made by the transaction.</p>\n            </li>\n            <li>\n               <p>The aggregate size of the items in the transaction exceeds 4 MB.</p>\n            </li>\n            <li>\n               <p>There is a user error, such as an invalid data format.</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#TransactWriteItemsInput": {
@@ -10302,10 +10557,13 @@
                 "ClientRequestToken": {
                     "target": "com.amazonaws.dynamodb#ClientRequestToken",
                     "traits": {
-                        "smithy.api#documentation": "<p>Providing a <code>ClientRequestToken</code> makes the call to\n                <code>TransactWriteItems</code> idempotent, meaning that multiple identical calls\n            have the same effect as one single call.</p>\n        <p>Although multiple identical calls using the same client request token produce the same\n            result on the server (no side effects), the responses to the calls might not be the\n            same. If the <code>ReturnConsumedCapacity></code> parameter is set, then the initial\n                <code>TransactWriteItems</code> call returns the amount of write capacity units\n            consumed in making the changes. Subsequent <code>TransactWriteItems</code> calls with\n            the same client token return the number of read capacity units consumed in reading the\n            item.</p>\n        <p>A client request token is valid for 10 minutes after the first request that uses it is\n            completed. After 10 minutes, any request with the same client token is treated as a new\n            request. Do not resubmit the same request with the same client token for more than 10\n            minutes, or the result might not be idempotent.</p>\n        <p>If you submit a request with the same client token but a change in other parameters\n            within the 10-minute idempotency window, DynamoDB returns an\n                <code>IdempotentParameterMismatch</code> exception.</p>",
+                        "smithy.api#documentation": "<p>Providing a <code>ClientRequestToken</code> makes the call to\n                <code>TransactWriteItems</code> idempotent, meaning that multiple identical calls\n            have the same effect as one single call.</p>\n         <p>Although multiple identical calls using the same client request token produce the same\n            result on the server (no side effects), the responses to the calls might not be the\n            same. If the <code>ReturnConsumedCapacity</code> parameter is set, then the initial\n                <code>TransactWriteItems</code> call returns the amount of write capacity units\n            consumed in making the changes. Subsequent <code>TransactWriteItems</code> calls with\n            the same client token return the number of read capacity units consumed in reading the\n            item.</p>\n         <p>A client request token is valid for 10 minutes after the first request that uses it is\n            completed. After 10 minutes, any request with the same client token is treated as a new\n            request. Do not resubmit the same request with the same client token for more than 10\n            minutes, or the result might not be idempotent.</p>\n         <p>If you submit a request with the same client token but a change in other parameters\n            within the 10-minute idempotency window, DynamoDB returns an\n                <code>IdempotentParameterMismatch</code> exception.</p>",
                         "smithy.api#idempotencyToken": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#TransactWriteItemsOutput": {
@@ -10323,6 +10581,9 @@
                         "smithy.api#documentation": "<p>A list of tables that were processed by <code>TransactWriteItems</code> and, for each\n            table, information about any item collections that were affected by individual\n                <code>UpdateItem</code>, <code>PutItem</code>, or <code>DeleteItem</code>\n            operations. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#TransactionCanceledException": {
@@ -10339,7 +10600,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The entire transaction request was canceled.</p>\n        <p>DynamoDB cancels a <code>TransactWriteItems</code> request under the following\n            circumstances:</p>\n        <ul>\n            <li>\n                <p>A condition in one of the condition expressions is not met.</p>\n            </li>\n            <li>\n                <p>A table in the <code>TransactWriteItems</code> request is in a different\n                    account or region.</p>\n            </li>\n            <li>\n                <p>More than one action in the <code>TransactWriteItems</code> operation\n                    targets the same item.</p>\n            </li>\n            <li>\n                <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n                <p>An item size becomes too large (larger than 400 KB), or a local secondary\n                    index (LSI) becomes too large, or a similar validation error occurs because of\n                    changes made by the transaction.</p>\n            </li>\n            <li>\n                <p>There is a user error, such as an invalid data format.</p>\n            </li>\n         </ul>\n\n        <p>DynamoDB cancels a <code>TransactGetItems</code> request under the\n            following circumstances:</p>\n        <ul>\n            <li>\n                <p>There is an ongoing <code>TransactGetItems</code> operation that conflicts\n                    with a concurrent <code>PutItem</code>, <code>UpdateItem</code>,\n                        <code>DeleteItem</code> or <code>TransactWriteItems</code> request. In this\n                    case the <code>TransactGetItems</code> operation fails with a\n                        <code>TransactionCanceledException</code>.</p>\n            </li>\n            <li>\n                <p>A table in the <code>TransactGetItems</code> request is in a different\n                    account or region.</p>\n            </li>\n            <li>\n                <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n                <p>There is a user error, such as an invalid data format.</p>\n            </li>\n         </ul>\n\n        <note>\n            <p>If using Java, DynamoDB lists the cancellation reasons on the\n                    <code>CancellationReasons</code> property. This property is not set for other\n                languages. Transaction cancellation reasons are ordered in the order of requested\n                items, if an item has no error it will have <code>None</code> code and\n                    <code>Null</code> message.</p>\n        </note>\n        <p>Cancellation reason codes and possible error messages:</p>\n        <ul>\n            <li>\n                <p>No Errors:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>None</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Message: <code>null</code>\n                        </p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Conditional Check Failed:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>ConditionalCheckFailed</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Message: The conditional request failed. </p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Item Collection Size Limit Exceeded:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>ItemCollectionSizeLimitExceeded</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Message: Collection size exceeded.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Transaction Conflict:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>TransactionConflict</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Message: Transaction is ongoing for the item.</p>\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Provisioned Throughput Exceeded:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>ProvisionedThroughputExceeded</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Messages:</p>\n                        <ul>\n                        <li>\n                                <p>The level of configured provisioned throughput for the\n                                    table was exceeded. Consider increasing your provisioning level\n                                    with the UpdateTable API.</p>\n                                <note>\n                                    <p>This Message is received when provisioned throughput is\n                                        exceeded is on a provisioned DynamoDB\n                                        table.</p>\n                                </note>\n                            </li>\n                        <li>\n                                <p>The level of configured provisioned throughput for one or\n                                    more global secondary indexes of the table was exceeded.\n                                    Consider increasing your provisioning level for the\n                                    under-provisioned global secondary indexes with the UpdateTable\n                                    API.</p>\n                                <note>\n                                    <p>This message is returned when provisioned throughput is\n                                        exceeded is on a provisioned GSI.</p>\n                                </note>\n                            </li>\n                     </ul>\n\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Throttling Error:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>ThrottlingError</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Messages: </p>\n                        <ul>\n                        <li>\n                                <p>Throughput exceeds the current capacity of your table or\n                                    index. DynamoDB is automatically scaling your table or\n                                    index so please try again shortly. If exceptions persist, check\n                                    if you have a hot key:\n                                    https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-design.html.</p>\n                                <note>\n                                    <p>This message is returned when writes get throttled on an\n                                        On-Demand table as DynamoDB is automatically\n                                        scaling the table.</p>\n                                </note>\n                            </li>\n                        <li>\n                                <p>Throughput exceeds the current capacity for one or more\n                                    global secondary indexes. DynamoDB is automatically\n                                    scaling your index so please try again shortly.</p>\n                                <note>\n                                    <p>This message is returned when when writes get throttled on\n                                        an On-Demand GSI as DynamoDB is automatically\n                                        scaling the GSI.</p>\n                                </note>\n                            </li>\n                     </ul>\n\n                    </li>\n               </ul>\n            </li>\n            <li>\n                <p>Validation Error:</p>\n                <ul>\n                  <li>\n                        <p>Code: <code>ValidationError</code>\n                        </p>\n                    </li>\n                  <li>\n                        <p>Messages: </p>\n                        <ul>\n                        <li>\n                                <p>One or more parameter values were invalid.</p>\n                            </li>\n                        <li>\n                                <p>The update expression attempted to update the secondary\n                                    index key beyond allowed size limits.</p>\n                            </li>\n                        <li>\n                                <p>The update expression attempted to update the secondary\n                                    index key to unsupported type.</p>\n                            </li>\n                        <li>\n                                <p>An operand in the update expression has an incorrect data\n                                    type.</p>\n                            </li>\n                        <li>\n                                <p>Item size to update has exceeded the maximum allowed\n                                    size.</p>\n                            </li>\n                        <li>\n                                <p>Number overflow. Attempting to store a number with\n                                    magnitude larger than supported range.</p>\n                            </li>\n                        <li>\n                                <p>Type mismatch for attribute to update.</p>\n                            </li>\n                        <li>\n                                <p>Nesting Levels have exceeded supported limits.</p>\n                            </li>\n                        <li>\n                                <p>The document path provided in the update expression is\n                                    invalid for update.</p>\n                            </li>\n                        <li>\n                                <p>The provided expression refers to an attribute that does\n                                    not exist in the item.</p>\n                            </li>\n                     </ul>\n\n                    </li>\n               </ul>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>The entire transaction request was canceled.</p>\n         <p>DynamoDB cancels a <code>TransactWriteItems</code> request under the following\n            circumstances:</p>\n         <ul>\n            <li>\n               <p>A condition in one of the condition expressions is not met.</p>\n            </li>\n            <li>\n               <p>A table in the <code>TransactWriteItems</code> request is in a different\n                    account or region.</p>\n            </li>\n            <li>\n               <p>More than one action in the <code>TransactWriteItems</code> operation\n                    targets the same item.</p>\n            </li>\n            <li>\n               <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n               <p>An item size becomes too large (larger than 400 KB), or a local secondary\n                    index (LSI) becomes too large, or a similar validation error occurs because of\n                    changes made by the transaction.</p>\n            </li>\n            <li>\n               <p>There is a user error, such as an invalid data format.</p>\n            </li>\n         </ul>\n         <p>DynamoDB cancels a <code>TransactGetItems</code> request under the\n            following circumstances:</p>\n         <ul>\n            <li>\n               <p>There is an ongoing <code>TransactGetItems</code> operation that conflicts\n                    with a concurrent <code>PutItem</code>, <code>UpdateItem</code>,\n                        <code>DeleteItem</code> or <code>TransactWriteItems</code> request. In this\n                    case the <code>TransactGetItems</code> operation fails with a\n                        <code>TransactionCanceledException</code>.</p>\n            </li>\n            <li>\n               <p>A table in the <code>TransactGetItems</code> request is in a different\n                    account or region.</p>\n            </li>\n            <li>\n               <p>There is insufficient provisioned capacity for the transaction to be\n                    completed.</p>\n            </li>\n            <li>\n               <p>There is a user error, such as an invalid data format.</p>\n            </li>\n         </ul>\n         <note>\n            <p>If using Java, DynamoDB lists the cancellation reasons on the\n                    <code>CancellationReasons</code> property. This property is not set for other\n                languages. Transaction cancellation reasons are ordered in the order of requested\n                items, if an item has no error it will have <code>None</code> code and\n                    <code>Null</code> message.</p>\n         </note>\n         <p>Cancellation reason codes and possible error messages:</p>\n         <ul>\n            <li>\n               <p>No Errors:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>None</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Message: <code>null</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Conditional Check Failed:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>ConditionalCheckFailed</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Message: The conditional request failed. </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Item Collection Size Limit Exceeded:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>ItemCollectionSizeLimitExceeded</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Message: Collection size exceeded.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Transaction Conflict:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>TransactionConflict</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Message: Transaction is ongoing for the item.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Provisioned Throughput Exceeded:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>ProvisionedThroughputExceeded</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Messages:</p>\n                     <ul>\n                        <li>\n                           <p>The level of configured provisioned throughput for the\n                                    table was exceeded. Consider increasing your provisioning level\n                                    with the UpdateTable API.</p>\n                           <note>\n                              <p>This Message is received when provisioned throughput is\n                                        exceeded is on a provisioned DynamoDB\n                                        table.</p>\n                           </note>\n                        </li>\n                        <li>\n                           <p>The level of configured provisioned throughput for one or\n                                    more global secondary indexes of the table was exceeded.\n                                    Consider increasing your provisioning level for the\n                                    under-provisioned global secondary indexes with the UpdateTable\n                                    API.</p>\n                           <note>\n                              <p>This message is returned when provisioned throughput is\n                                        exceeded is on a provisioned GSI.</p>\n                           </note>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Throttling Error:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>ThrottlingError</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Messages: </p>\n                     <ul>\n                        <li>\n                           <p>Throughput exceeds the current capacity of your table or\n                                    index. DynamoDB is automatically scaling your table or\n                                    index so please try again shortly. If exceptions persist, check\n                                    if you have a hot key:\n                                    https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-design.html.</p>\n                           <note>\n                              <p>This message is returned when writes get throttled on an\n                                        On-Demand table as DynamoDB is automatically\n                                        scaling the table.</p>\n                           </note>\n                        </li>\n                        <li>\n                           <p>Throughput exceeds the current capacity for one or more\n                                    global secondary indexes. DynamoDB is automatically\n                                    scaling your index so please try again shortly.</p>\n                           <note>\n                              <p>This message is returned when writes get throttled on\n                                        an On-Demand GSI as DynamoDB is automatically\n                                        scaling the GSI.</p>\n                           </note>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Validation Error:</p>\n               <ul>\n                  <li>\n                     <p>Code: <code>ValidationError</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>Messages: </p>\n                     <ul>\n                        <li>\n                           <p>One or more parameter values were invalid.</p>\n                        </li>\n                        <li>\n                           <p>The update expression attempted to update the secondary\n                                    index key beyond allowed size limits.</p>\n                        </li>\n                        <li>\n                           <p>The update expression attempted to update the secondary\n                                    index key to unsupported type.</p>\n                        </li>\n                        <li>\n                           <p>An operand in the update expression has an incorrect data\n                                    type.</p>\n                        </li>\n                        <li>\n                           <p>Item size to update has exceeded the maximum allowed\n                                    size.</p>\n                        </li>\n                        <li>\n                           <p>Number overflow. Attempting to store a number with\n                                    magnitude larger than supported range.</p>\n                        </li>\n                        <li>\n                           <p>Type mismatch for attribute to update.</p>\n                        </li>\n                        <li>\n                           <p>Nesting Levels have exceeded supported limits.</p>\n                        </li>\n                        <li>\n                           <p>The document path provided in the update expression is\n                                    invalid for update.</p>\n                        </li>\n                        <li>\n                           <p>The provided expression refers to an attribute that does\n                                    not exist in the item.</p>\n                        </li>\n                     </ul>\n                  </li>\n               </ul>\n            </li>\n         </ul>",
                 "smithy.api#error": "client"
             }
         },
@@ -10363,7 +10624,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The transaction with the given request token is already in progress.</p>",
+                "smithy.api#documentation": "<p>The transaction with the given request token is already in progress.</p>\n         <p>\n            Recommended Settings            \n        </p>\n         <note>\n            <p>\n                This is a general recommendation for handling the <code>TransactionInProgressException</code>. These settings help \n                ensure that the client retries will trigger completion of the ongoing <code>TransactWriteItems</code> request.\n            </p>\n         </note>\n         <ul>\n            <li>\n               <p>\n                    Set <code>clientExecutionTimeout</code> to a value that allows at least one retry to be processed after 5 \n                    seconds have elapsed since the first attempt for the <code>TransactWriteItems</code> operation.\n                </p>\n            </li>\n            <li>\n               <p>\n                    Set <code>socketTimeout</code> to a value a little lower than the <code>requestTimeout</code> setting.\n                </p>\n            </li>\n            <li>\n               <p>\n                  <code>requestTimeout</code> should be set based on the time taken for the individual retries of a single \n                    HTTP request for your use case, but setting it to 1 second or higher should work well to reduce chances of \n                    retries and <code>TransactionInProgressException</code> errors.\n                </p>\n            </li>\n            <li>\n               <p>\n                    Use exponential backoff when retrying and tune backoff if needed.\n                </p>\n            </li>\n         </ul>\n         <p>\n            Assuming <a href=\"https://github.com/aws/aws-sdk-java/blob/fd409dee8ae23fb8953e0bb4dbde65536a7e0514/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedRetryPolicies.java#L97\">default retry policy</a>, \n            example timeout settings based on the guidelines above are as follows:            \n        </p>\n         <p>Example timeline:</p>\n         <ul>\n            <li>\n               <p>0-1000 first attempt</p>\n            </li>\n            <li>\n               <p>1000-1500 first sleep/delay (default retry policy uses 500 ms as base delay for 4xx errors)</p>\n            </li>\n            <li>\n               <p>1500-2500 second attempt</p>\n            </li>\n            <li>\n               <p>2500-3500 second sleep/delay (500 * 2, exponential backoff)</p>\n            </li>\n            <li>\n               <p>3500-4500 third attempt</p>\n            </li>\n            <li>\n               <p>4500-6500 third sleep/delay (500 * 2^2)</p>\n            </li>\n            <li>\n               <p>6500-7500 fourth attempt (this can trigger inline recovery since 5 seconds have elapsed since the first attempt reached TC)</p>\n            </li>\n         </ul>",
                 "smithy.api#error": "client"
             }
         },
@@ -10396,7 +10657,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Removes the association of tags from an Amazon DynamoDB resource. You can call\n                <code>UntagResource</code> up to five times per second, per account. </p>\n        <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Removes the association of tags from an Amazon DynamoDB resource. You can call\n                <code>UntagResource</code> up to five times per second, per account. </p>\n         <p>For an overview on tagging DynamoDB resources, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Tagging.html\">Tagging for DynamoDB</a>\n            in the <i>Amazon DynamoDB Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.dynamodb#UntagResourceInput": {
@@ -10416,6 +10677,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#Update": {
@@ -10497,7 +10761,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>\n            <code>UpdateContinuousBackups</code> enables or disables point in time recovery for\n            the specified table. A successful <code>UpdateContinuousBackups</code> call returns the\n            current <code>ContinuousBackupsDescription</code>. Continuous backups are\n                <code>ENABLED</code> on all tables at table creation. If point in time recovery is\n            enabled, <code>PointInTimeRecoveryStatus</code> will be set to ENABLED.</p>\n        <p> Once continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n        <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time during the last 35 days. </p>"
+                "smithy.api#documentation": "<p>\n            <code>UpdateContinuousBackups</code> enables or disables point in time recovery for\n            the specified table. A successful <code>UpdateContinuousBackups</code> call returns the\n            current <code>ContinuousBackupsDescription</code>. Continuous backups are\n                <code>ENABLED</code> on all tables at table creation. If point in time recovery is\n            enabled, <code>PointInTimeRecoveryStatus</code> will be set to ENABLED.</p>\n         <p> Once continuous backups and point in time recovery are enabled, you can restore to\n            any point in time within <code>EarliestRestorableDateTime</code> and\n                <code>LatestRestorableDateTime</code>. </p>\n         <p>\n            <code>LatestRestorableDateTime</code> is typically 5 minutes before the current time.\n            You can restore your table to any point in time during the last 35 days. </p>"
             }
         },
         "com.amazonaws.dynamodb#UpdateContinuousBackupsInput": {
@@ -10517,6 +10781,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateContinuousBackupsOutput": {
@@ -10528,6 +10795,9 @@
                         "smithy.api#documentation": "<p>Represents the continuous backups and point in time recovery settings on the\n            table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateContributorInsights": {
@@ -10573,6 +10843,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateContributorInsightsOutput": {
@@ -10596,6 +10869,9 @@
                         "smithy.api#documentation": "<p>The status of contributor insights</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateExpression": {
@@ -10614,7 +10890,7 @@
                 "ProvisionedThroughput": {
                     "target": "com.amazonaws.dynamodb#ProvisionedThroughput",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n        <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>Represents the provisioned throughput settings for the specified global secondary\n            index.</p>\n         <p>For current minimum and maximum provisioned throughput values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Limits.html\">Service,\n                Account, and Table Quotas</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
@@ -10655,7 +10931,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Adds or removes replicas in the specified global table. The global table must already\n            exist to be able to use this operation. Any replica to be added must be empty, have the\n            same name as the global table, have the same key schema, have DynamoDB Streams enabled,\n            and have the same provisioned and maximum write capacity units.</p>\n        <note>\n            <p>Although you can use <code>UpdateGlobalTable</code> to add replicas and remove\n                replicas in a single request, for simplicity we recommend that you issue separate\n                requests for adding or removing replicas.</p>\n        </note>\n        <p> If global secondary indexes are specified, then the following conditions must also be\n            met: </p>\n        <ul>\n            <li>\n                <p> The global secondary indexes must have the same name. </p>\n            </li>\n            <li>\n                <p> The global secondary indexes must have the same hash key and sort key (if\n                    present). </p>\n            </li>\n            <li>\n                <p> The global secondary indexes must have the same provisioned and maximum write\n                    capacity units. </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Adds or removes replicas in the specified global table. The global table must already\n            exist to be able to use this operation. Any replica to be added must be empty, have the\n            same name as the global table, have the same key schema, have DynamoDB Streams enabled,\n            and have the same provisioned and maximum write capacity units.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                2017.11.29 (Legacy)</a> of global tables. We recommend using\n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                when creating new global tables, as it provides greater flexibility, higher efficiency and consumes less write capacity than \n                2017.11.29 (Legacy). To determine which version you are using, see \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.DetermineVersion.html\">Determining the version</a>. \n                To update existing global tables from version 2017.11.29 (Legacy) to version\n                2019.11.21 (Current), see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_upgrade.html\">\n                    Updating global tables</a>.\n            </p>\n         </important>\n         <note>\n            <p>\n                This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                    2017.11.29</a> of global tables. If you are using global tables <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version\n                        2019.11.21</a> you can use <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeTable.html\">DescribeTable</a> instead.\n            </p>\n            <p>\n                Although you can use <code>UpdateGlobalTable</code> to add replicas and remove\n                replicas in a single request, for simplicity we recommend that you issue separate\n                requests for adding or removing replicas.\n            </p>\n         </note>\n         <p> If global secondary indexes are specified, then the following conditions must also be\n            met: </p>\n         <ul>\n            <li>\n               <p> The global secondary indexes must have the same name. </p>\n            </li>\n            <li>\n               <p> The global secondary indexes must have the same hash key and sort key (if\n                    present). </p>\n            </li>\n            <li>\n               <p> The global secondary indexes must have the same provisioned and maximum write\n                    capacity units. </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.dynamodb#UpdateGlobalTableInput": {
@@ -10675,6 +10951,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateGlobalTableOutput": {
@@ -10686,6 +10965,9 @@
                         "smithy.api#documentation": "<p>Contains the details of the global table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateGlobalTableSettings": {
@@ -10723,7 +11005,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Updates settings for a global table.</p>"
+                "smithy.api#documentation": "<p>Updates settings for a global table.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V1.html\">Version\n                2017.11.29 (Legacy)</a> of global tables. We recommend using\n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                when creating new global tables, as it provides greater flexibility, higher efficiency and consumes less write capacity than \n                2017.11.29 (Legacy). To determine which version you are using, see \n                <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.DetermineVersion.html\">Determining the version</a>. \n                To update existing global tables from version 2017.11.29 (Legacy) to version\n                2019.11.21 (Current), see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_upgrade.html\">\n                    Updating global tables</a>.\n            </p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#UpdateGlobalTableSettingsInput": {
@@ -10739,7 +11021,7 @@
                 "GlobalTableBillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>The billing mode of the global table. If <code>GlobalTableBillingMode</code> is not\n            specified, the global table defaults to <code>PROVISIONED</code> capacity billing\n            mode.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual\">Provisioned Mode</a>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand\">On-Demand Mode</a>. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The billing mode of the global table. If <code>GlobalTableBillingMode</code> is not\n            specified, the global table defaults to <code>PROVISIONED</code> capacity billing\n            mode.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual\">Provisioned Mode</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand\">On-Demand Mode</a>. </p>\n            </li>\n         </ul>"
                     }
                 },
                 "GlobalTableProvisionedWriteCapacityUnits": {
@@ -10766,6 +11048,9 @@
                         "smithy.api#documentation": "<p>Represents the settings for a global table in a Region that will be modified.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateGlobalTableSettingsOutput": {
@@ -10783,6 +11068,9 @@
                         "smithy.api#documentation": "<p>The Region-specific settings for the global table.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateItem": {
@@ -10823,7 +11111,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Edits an existing item's attributes, or adds a new item to the table if it does not\n            already exist. You can put, delete, or add attribute values. You can also perform a\n            conditional update on an existing item (insert a new attribute name-value pair if it\n            doesn't exist, or replace an existing name-value pair if it has certain expected\n            attribute values).</p>\n        <p>You can also return the item's attribute values in the same <code>UpdateItem</code>\n            operation using the <code>ReturnValues</code> parameter.</p>"
+                "smithy.api#documentation": "<p>Edits an existing item's attributes, or adds a new item to the table if it does not\n            already exist. You can put, delete, or add attribute values. You can also perform a\n            conditional update on an existing item (insert a new attribute name-value pair if it\n            doesn't exist, or replace an existing name-value pair if it has certain expected\n            attribute values).</p>\n         <p>You can also return the item's attribute values in the same <code>UpdateItem</code>\n            operation using the <code>ReturnValues</code> parameter.</p>"
             }
         },
         "com.amazonaws.dynamodb#UpdateItemInput": {
@@ -10839,7 +11127,7 @@
                 "Key": {
                     "target": "com.amazonaws.dynamodb#Key",
                     "traits": {
-                        "smithy.api#documentation": "<p>The primary key of the item to be updated. Each element consists of an attribute name\n            and a value for that attribute.</p>\n        <p>For the primary key, you must provide all of the attributes. For example, with a\n            simple primary key, you only need to provide a value for the partition key. For a\n            composite primary key, you must provide values for both the partition key and the sort\n            key.</p>",
+                        "smithy.api#documentation": "<p>The primary key of the item to be updated. Each element consists of an attribute name\n            and a value for that attribute.</p>\n         <p>For the primary key, you must provide all of the attributes. For example, with a\n            simple primary key, you only need to provide a value for the partition key. For a\n            composite primary key, you must provide values for both the partition key and the sort\n            key.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -10864,7 +11152,7 @@
                 "ReturnValues": {
                     "target": "com.amazonaws.dynamodb#ReturnValue",
                     "traits": {
-                        "smithy.api#documentation": "<p>Use <code>ReturnValues</code> if you want to get the item attributes as they appear\n            before or after they are updated. For <code>UpdateItem</code>, the valid values\n            are:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>NONE</code> - If <code>ReturnValues</code> is not specified, or if its\n                    value is <code>NONE</code>, then nothing is returned. (This setting is the\n                    default for <code>ReturnValues</code>.)</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL_OLD</code> - Returns all of the attributes of the item, as they\n                    appeared before the UpdateItem operation.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATED_OLD</code> - Returns only the updated attributes, as they appeared\n                    before the UpdateItem operation.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ALL_NEW</code> - Returns all of the attributes of the item, as they appear\n                    after the UpdateItem operation.</p>\n            </li>\n            <li>\n                <p>\n                    <code>UPDATED_NEW</code> - Returns only the updated attributes, as they appear\n                    after the UpdateItem operation.</p>\n            </li>\n         </ul>\n        <p>There is no additional cost associated with requesting a return value aside from the\n            small network and processing overhead of receiving a larger response. No read capacity\n            units are consumed.</p>\n        <p>The values returned are strongly consistent.</p>"
+                        "smithy.api#documentation": "<p>Use <code>ReturnValues</code> if you want to get the item attributes as they appear\n            before or after they are successfully updated. For <code>UpdateItem</code>, the valid values\n            are:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>NONE</code> - If <code>ReturnValues</code> is not specified, or if its\n                    value is <code>NONE</code>, then nothing is returned. (This setting is the\n                    default for <code>ReturnValues</code>.)</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL_OLD</code> - Returns all of the attributes of the item, as they\n                    appeared before the UpdateItem operation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATED_OLD</code> - Returns only the updated attributes, as they appeared\n                    before the UpdateItem operation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ALL_NEW</code> - Returns all of the attributes of the item, as they appear\n                    after the UpdateItem operation.</p>\n            </li>\n            <li>\n               <p>\n                  <code>UPDATED_NEW</code> - Returns only the updated attributes, as they appear\n                    after the UpdateItem operation.</p>\n            </li>\n         </ul>\n         <p>There is no additional cost associated with requesting a return value aside from the\n            small network and processing overhead of receiving a larger response. No read capacity\n            units are consumed.</p>\n         <p>The values returned are strongly consistent.</p>"
                     }
                 },
                 "ReturnConsumedCapacity": {
@@ -10879,30 +11167,31 @@
                 "UpdateExpression": {
                     "target": "com.amazonaws.dynamodb#UpdateExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>An expression that defines one or more attributes to be updated, the action to be\n            performed on them, and new values for them.</p>\n        <p>The following action values are available for <code>UpdateExpression</code>.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>SET</code> - Adds one or more attributes and values to an item. If any of\n                    these attributes already exist, they are replaced by the new values. You can\n                    also use <code>SET</code> to add or subtract from an attribute that is of type\n                    Number. For example: <code>SET myNum = myNum + :val</code>\n                </p>\n                <p>\n                    <code>SET</code> supports the following functions:</p>\n                <ul>\n                  <li>\n                        <p>\n                            <code>if_not_exists (path, operand)</code> - if the item does not\n                            contain an attribute at the specified path, then\n                                <code>if_not_exists</code> evaluates to operand; otherwise, it\n                            evaluates to path. You can use this function to avoid overwriting an\n                            attribute that may already be present in the item.</p>\n                    </li>\n                  <li>\n                        <p>\n                            <code>list_append (operand, operand)</code> - evaluates to a list with a\n                            new element added to it. You can append the new element to the start or\n                            the end of the list by reversing the order of the operands.</p>\n                    </li>\n               </ul>\n                <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n                <p>\n                    <code>REMOVE</code> - Removes one or more attributes from an item.</p>\n            </li>\n            <li>\n                <p>\n                    <code>ADD</code> - Adds the specified value to the item, if the attribute does\n                    not already exist. If the attribute does exist, then the behavior of\n                        <code>ADD</code> depends on the data type of the attribute:</p>\n                <ul>\n                  <li>\n                        <p>If the existing attribute is a number, and if <code>Value</code> is\n                            also a number, then <code>Value</code> is mathematically added to the\n                            existing attribute. If <code>Value</code> is a negative number, then it\n                            is subtracted from the existing attribute.</p>\n                        <note>\n                            <p>If you use <code>ADD</code> to increment or decrement a number\n                                value for an item that doesn't exist before the update, DynamoDB\n                                uses <code>0</code> as the initial value.</p>\n                            <p>Similarly, if you use <code>ADD</code> for an existing item to\n                                increment or decrement an attribute value that doesn't exist before\n                                the update, DynamoDB uses <code>0</code> as the initial value. For\n                                example, suppose that the item you want to update doesn't have an\n                                attribute named <code>itemcount</code>, but you decide to\n                                    <code>ADD</code> the number <code>3</code> to this attribute\n                                anyway. DynamoDB will create the <code>itemcount</code> attribute,\n                                set its initial value to <code>0</code>, and finally add\n                                    <code>3</code> to it. The result will be a new\n                                    <code>itemcount</code> attribute in the item, with a value of\n                                    <code>3</code>.</p>\n                        </note>\n                    </li>\n                  <li>\n                        <p>If the existing data type is a set and if <code>Value</code> is also a\n                            set, then <code>Value</code> is added to the existing set. For example,\n                            if the attribute value is the set <code>[1,2]</code>, and the\n                                <code>ADD</code> action specified <code>[3]</code>, then the final\n                            attribute value is <code>[1,2,3]</code>. An error occurs if an\n                                <code>ADD</code> action is specified for a set attribute and the\n                            attribute type specified does not match the existing set type. </p>\n                        <p>Both sets must have the same primitive data type. For example, if the\n                            existing data type is a set of strings, the <code>Value</code> must also\n                            be a set of strings.</p>\n                    </li>\n               </ul>\n                <important>\n                    <p>The <code>ADD</code> action only supports Number and set data types. In\n                        addition, <code>ADD</code> can only be used on top-level attributes, not\n                        nested attributes.</p>\n                </important>\n            </li>\n            <li>\n                <p>\n                    <code>DELETE</code> - Deletes an element from a set.</p>\n                <p>If a set of values is specified, then those values are subtracted from the old\n                    set. For example, if the attribute value was the set <code>[a,b,c]</code> and\n                    the <code>DELETE</code> action specifies <code>[a,c]</code>, then the final\n                    attribute value is <code>[b]</code>. Specifying an empty set is an error.</p>\n                <important>\n                    <p>The <code>DELETE</code> action only supports set data types. In addition,\n                            <code>DELETE</code> can only be used on top-level attributes, not nested\n                        attributes.</p>\n                </important>\n\n            </li>\n         </ul>\n        <p>You can have many actions in a single expression, such as the following: <code>SET\n                a=:value1, b=:value2 DELETE :value3, :value4, :value5</code>\n        </p>\n        <p>For more information on update expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Modifying.html\">Modifying\n                Items and Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>An expression that defines one or more attributes to be updated, the action to be\n            performed on them, and new values for them.</p>\n         <p>The following action values are available for <code>UpdateExpression</code>.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>SET</code> - Adds one or more attributes and values to an item. If any of\n                    these attributes already exist, they are replaced by the new values. You can\n                    also use <code>SET</code> to add or subtract from an attribute that is of type\n                    Number. For example: <code>SET myNum = myNum + :val</code>\n               </p>\n               <p>\n                  <code>SET</code> supports the following functions:</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>if_not_exists (path, operand)</code> - if the item does not\n                            contain an attribute at the specified path, then\n                                <code>if_not_exists</code> evaluates to operand; otherwise, it\n                            evaluates to path. You can use this function to avoid overwriting an\n                            attribute that may already be present in the item.</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>list_append (operand, operand)</code> - evaluates to a list with a\n                            new element added to it. You can append the new element to the start or\n                            the end of the list by reversing the order of the operands.</p>\n                  </li>\n               </ul>\n               <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n               <p>\n                  <code>REMOVE</code> - Removes one or more attributes from an item.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ADD</code> - Adds the specified value to the item, if the attribute does\n                    not already exist. If the attribute does exist, then the behavior of\n                        <code>ADD</code> depends on the data type of the attribute:</p>\n               <ul>\n                  <li>\n                     <p>If the existing attribute is a number, and if <code>Value</code> is\n                            also a number, then <code>Value</code> is mathematically added to the\n                            existing attribute. If <code>Value</code> is a negative number, then it\n                            is subtracted from the existing attribute.</p>\n                     <note>\n                        <p>If you use <code>ADD</code> to increment or decrement a number\n                                value for an item that doesn't exist before the update, DynamoDB\n                                uses <code>0</code> as the initial value.</p>\n                        <p>Similarly, if you use <code>ADD</code> for an existing item to\n                                increment or decrement an attribute value that doesn't exist before\n                                the update, DynamoDB uses <code>0</code> as the initial value. For\n                                example, suppose that the item you want to update doesn't have an\n                                attribute named <code>itemcount</code>, but you decide to\n                                    <code>ADD</code> the number <code>3</code> to this attribute\n                                anyway. DynamoDB will create the <code>itemcount</code> attribute,\n                                set its initial value to <code>0</code>, and finally add\n                                    <code>3</code> to it. The result will be a new\n                                    <code>itemcount</code> attribute in the item, with a value of\n                                    <code>3</code>.</p>\n                     </note>\n                  </li>\n                  <li>\n                     <p>If the existing data type is a set and if <code>Value</code> is also a\n                            set, then <code>Value</code> is added to the existing set. For example,\n                            if the attribute value is the set <code>[1,2]</code>, and the\n                                <code>ADD</code> action specified <code>[3]</code>, then the final\n                            attribute value is <code>[1,2,3]</code>. An error occurs if an\n                                <code>ADD</code> action is specified for a set attribute and the\n                            attribute type specified does not match the existing set type. </p>\n                     <p>Both sets must have the same primitive data type. For example, if the\n                            existing data type is a set of strings, the <code>Value</code> must also\n                            be a set of strings.</p>\n                  </li>\n               </ul>\n               <important>\n                  <p>The <code>ADD</code> action only supports Number and set data types. In\n                        addition, <code>ADD</code> can only be used on top-level attributes, not\n                        nested attributes.</p>\n               </important>\n            </li>\n            <li>\n               <p>\n                  <code>DELETE</code> - Deletes an element from a set.</p>\n               <p>If a set of values is specified, then those values are subtracted from the old\n                    set. For example, if the attribute value was the set <code>[a,b,c]</code> and\n                    the <code>DELETE</code> action specifies <code>[a,c]</code>, then the final\n                    attribute value is <code>[b]</code>. Specifying an empty set is an error.</p>\n               <important>\n                  <p>The <code>DELETE</code> action only supports set data types. In addition,\n                            <code>DELETE</code> can only be used on top-level attributes, not nested\n                        attributes.</p>\n               </important>\n            </li>\n         </ul>\n         <p>You can have many actions in a single expression, such as the following: <code>SET\n                a=:value1, b=:value2 DELETE :value3, :value4, :value5</code>\n         </p>\n         <p>For more information on update expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Modifying.html\">Modifying\n                Items and Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ConditionExpression": {
                     "target": "com.amazonaws.dynamodb#ConditionExpression",
                     "traits": {
-                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional update to\n            succeed.</p>\n        <p>An expression can contain any of the following:</p>\n        <ul>\n            <li>\n                <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type |\n                        contains | begins_with | size</code>\n                </p>\n                <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n                <p>Comparison operators: <code>= | <> |\n            < | > | <= | >= |\n            BETWEEN | IN </code>\n                </p>\n            </li>\n            <li>\n                <p> Logical operators: <code>AND | OR | NOT</code>\n                </p>\n            </li>\n         </ul>\n        <p>For more information about condition expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A condition that must be satisfied in order for a conditional update to\n            succeed.</p>\n         <p>An expression can contain any of the following:</p>\n         <ul>\n            <li>\n               <p>Functions: <code>attribute_exists | attribute_not_exists | attribute_type |\n                        contains | begins_with | size</code>\n               </p>\n               <p>These function names are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Comparison operators: <code>= | <> |\n            < | > | <= | >= |\n            BETWEEN | IN </code>\n               </p>\n            </li>\n            <li>\n               <p> Logical operators: <code>AND | OR | NOT</code>\n               </p>\n            </li>\n         </ul>\n         <p>For more information about condition expressions, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Specifying Conditions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeNames": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeNameMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n                <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n                <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n        <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Percentile</code>\n                </p>\n            </li>\n         </ul>\n        <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.) To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>{\"#P\":\"Percentile\"}</code>\n                </p>\n            </li>\n         </ul>\n        <p>You could then use this substitution in an expression, as in this example:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>#P = :val</code>\n                </p>\n            </li>\n         </ul>\n        <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n        </note>\n        <p>For more information about expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more substitution tokens for attribute names in an expression. The following\n            are some use cases for using <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>To access an attribute whose name conflicts with a DynamoDB reserved\n                    word.</p>\n            </li>\n            <li>\n               <p>To create a placeholder for repeating occurrences of an attribute name in an\n                    expression.</p>\n            </li>\n            <li>\n               <p>To prevent special characters in an attribute name from being misinterpreted\n                    in an expression.</p>\n            </li>\n         </ul>\n         <p>Use the <b>#</b> character in an expression to dereference\n            an attribute name. For example, consider the following attribute name:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Percentile</code>\n               </p>\n            </li>\n         </ul>\n         <p>The name of this attribute conflicts with a reserved word, so it cannot be used\n            directly in an expression. (For the complete list of reserved words, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ReservedWords.html\">Reserved Words</a> in the <i>Amazon DynamoDB Developer\n            Guide</i>.) To work around this, you could specify the following for\n                <code>ExpressionAttributeNames</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>{\"#P\":\"Percentile\"}</code>\n               </p>\n            </li>\n         </ul>\n         <p>You could then use this substitution in an expression, as in this example:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>#P = :val</code>\n               </p>\n            </li>\n         </ul>\n         <note>\n            <p>Tokens that begin with the <b>:</b> character are\n                    <i>expression attribute values</i>, which are placeholders for the\n                actual value at runtime.</p>\n         </note>\n         <p>For more information about expression attribute names, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html\">Specifying Item Attributes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ExpressionAttributeValues": {
                     "target": "com.amazonaws.dynamodb#ExpressionAttributeValueMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n        <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <code>ProductStatus</code> attribute was one of the following: </p>\n        <p>\n            <code>Available | Backordered | Discontinued</code>\n        </p>\n        <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n        <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n        </p>\n        <p>You could then use these values in an expression, such as this:</p>\n        <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n        </p>\n        <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>One or more values that can be substituted in an expression.</p>\n         <p>Use the <b>:</b> (colon) character in an expression to\n            dereference an attribute value. For example, suppose that you wanted to check whether\n            the value of the <code>ProductStatus</code> attribute was one of the following: </p>\n         <p>\n            <code>Available | Backordered | Discontinued</code>\n         </p>\n         <p>You would first need to specify <code>ExpressionAttributeValues</code> as\n            follows:</p>\n         <p>\n            <code>{ \":avail\":{\"S\":\"Available\"}, \":back\":{\"S\":\"Backordered\"},\n                \":disc\":{\"S\":\"Discontinued\"} }</code>\n         </p>\n         <p>You could then use these values in an expression, such as this:</p>\n         <p>\n            <code>ProductStatus IN (:avail, :back, :disc)</code>\n         </p>\n         <p>For more information on expression attribute values, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html\">Condition Expressions</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of an <code>UpdateItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of an <code>UpdateItem</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateItemOutput": {
@@ -10911,24 +11200,25 @@
                 "Attributes": {
                     "target": "com.amazonaws.dynamodb#AttributeMap",
                     "traits": {
-                        "smithy.api#documentation": "<p>A map of attribute values as they appear before or after the <code>UpdateItem</code>\n            operation, as determined by the <code>ReturnValues</code> parameter.</p>\n        <p>The <code>Attributes</code> map is only present if <code>ReturnValues</code> was\n            specified as something other than <code>NONE</code> in the request. Each element\n            represents one attribute.</p>"
+                        "smithy.api#documentation": "<p>A map of attribute values as they appear before or after the <code>UpdateItem</code>\n            operation, as determined by the <code>ReturnValues</code> parameter.</p>\n         <p>The <code>Attributes</code> map is only present if the update was successful and <code>ReturnValues</code> was\n            specified as something other than <code>NONE</code> in the request. Each element\n            represents one attribute.</p>"
                     }
                 },
                 "ConsumedCapacity": {
                     "target": "com.amazonaws.dynamodb#ConsumedCapacity",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>UpdateItem</code> operation. The data\n            returned includes the total provisioned throughput consumed, along with statistics for\n            the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is\n            only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For\n            more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The capacity units consumed by the <code>UpdateItem</code> operation. The data\n            returned includes the total provisioned throughput consumed, along with statistics for\n            the table and any indexes involved in the operation. <code>ConsumedCapacity</code> is\n            only returned if the <code>ReturnConsumedCapacity</code> parameter was specified. For\n            more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughput.html#ItemSizeCalculations.Reads\">Provisioned Throughput</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>.</p>"
                     }
                 },
                 "ItemCollectionMetrics": {
                     "target": "com.amazonaws.dynamodb#ItemCollectionMetrics",
                     "traits": {
-                        "smithy.api#documentation": "<p>Information about item collections, if any, that were affected by the\n                <code>UpdateItem</code> operation. <code>ItemCollectionMetrics</code> is only\n            returned if the <code>ReturnItemCollectionMetrics</code> parameter was specified. If the\n            table does not have any local secondary indexes, this information is not returned in the\n            response.</p>\n        <p>Each <code>ItemCollectionMetrics</code> element consists of:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item itself.</p>\n            </li>\n            <li>\n                <p>\n                    <code>SizeEstimateRangeGB</code> - An estimate of item collection size, in\n                    gigabytes. This value is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on that table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n                <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Information about item collections, if any, that were affected by the\n                <code>UpdateItem</code> operation. <code>ItemCollectionMetrics</code> is only\n            returned if the <code>ReturnItemCollectionMetrics</code> parameter was specified. If the\n            table does not have any local secondary indexes, this information is not returned in the\n            response.</p>\n         <p>Each <code>ItemCollectionMetrics</code> element consists of:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>ItemCollectionKey</code> - The partition key value of the item collection.\n                    This is the same as the partition key value of the item itself.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SizeEstimateRangeGB</code> - An estimate of item collection size, in\n                    gigabytes. This value is a two-element array containing a lower bound and an\n                    upper bound for the estimate. The estimate includes the size of all the items in\n                    the table, plus the size of all attributes projected into all of the local\n                    secondary indexes on that table. Use this estimate to measure whether a local\n                    secondary index is approaching its size limit.</p>\n               <p>The estimate is subject to change over time; therefore, do not rely on the\n                    precision or accuracy of the estimate.</p>\n            </li>\n         </ul>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of an <code>UpdateItem</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of an <code>UpdateItem</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateReplicationGroupMemberAction": {
@@ -10999,7 +11289,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>Modifies the provisioned throughput settings, global secondary indexes, or DynamoDB\n            Streams settings for a given table.</p>\n        <p>You can only perform one of the following operations at once:</p>\n        <ul>\n            <li>\n                <p>Modify the provisioned throughput settings of the table.</p>\n            </li>\n            <li>\n                <p>Remove a global secondary index from the table.</p>\n            </li>\n            <li>\n                <p>Create a new global secondary index on the table. After the index begins\n                    backfilling, you can use <code>UpdateTable</code> to perform other\n                    operations.</p>\n            </li>\n         </ul>\n        <p>\n            <code>UpdateTable</code> is an asynchronous operation; while it is executing, the table\n            status changes from <code>ACTIVE</code> to <code>UPDATING</code>. While it is\n                <code>UPDATING</code>, you cannot issue another <code>UpdateTable</code> request.\n            When the table returns to the <code>ACTIVE</code> state, the <code>UpdateTable</code>\n            operation is complete.</p>"
+                "smithy.api#documentation": "<p>Modifies the provisioned throughput settings, global secondary indexes, or DynamoDB\n            Streams settings for a given table.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a> \n                of global tables.\n            </p>\n         </important>\n         <p>You can only perform one of the following operations at once:</p>\n         <ul>\n            <li>\n               <p>Modify the provisioned throughput settings of the table.</p>\n            </li>\n            <li>\n               <p>Remove a global secondary index from the table.</p>\n            </li>\n            <li>\n               <p>Create a new global secondary index on the table. After the index begins\n                    backfilling, you can use <code>UpdateTable</code> to perform other\n                    operations.</p>\n            </li>\n         </ul>\n         <p>\n            <code>UpdateTable</code> is an asynchronous operation; while it is executing, the table\n            status changes from <code>ACTIVE</code> to <code>UPDATING</code>. While it is\n                <code>UPDATING</code>, you cannot issue another <code>UpdateTable</code> request.\n            When the table returns to the <code>ACTIVE</code> state, the <code>UpdateTable</code>\n            operation is complete.</p>"
             }
         },
         "com.amazonaws.dynamodb#UpdateTableInput": {
@@ -11021,7 +11311,7 @@
                 "BillingMode": {
                     "target": "com.amazonaws.dynamodb#BillingMode",
                     "traits": {
-                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. When switching from pay-per-request to provisioned capacity, initial\n            provisioned capacity values must be set. The initial provisioned capacity values are\n            estimated based on the consumed read and write capacity of your table and global\n            secondary indexes over the past 30 minutes.</p>\n        <ul>\n            <li>\n                <p>\n                    <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual\">Provisioned Mode</a>.</p>\n            </li>\n            <li>\n                <p>\n                    <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand\">On-Demand Mode</a>. </p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Controls how you are charged for read and write throughput and how you manage\n            capacity. When switching from pay-per-request to provisioned capacity, initial\n            provisioned capacity values must be set. The initial provisioned capacity values are\n            estimated based on the consumed read and write capacity of your table and global\n            secondary indexes over the past 30 minutes.</p>\n         <ul>\n            <li>\n               <p>\n                  <code>PROVISIONED</code> - We recommend using <code>PROVISIONED</code> for\n                    predictable workloads. <code>PROVISIONED</code> sets the billing mode to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual\">Provisioned Mode</a>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>PAY_PER_REQUEST</code> - We recommend using <code>PAY_PER_REQUEST</code>\n                    for unpredictable workloads. <code>PAY_PER_REQUEST</code> sets the billing mode\n                    to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand\">On-Demand Mode</a>. </p>\n            </li>\n         </ul>"
                     }
                 },
                 "ProvisionedThroughput": {
@@ -11033,13 +11323,13 @@
                 "GlobalSecondaryIndexUpdates": {
                     "target": "com.amazonaws.dynamodb#GlobalSecondaryIndexUpdateList",
                     "traits": {
-                        "smithy.api#documentation": "<p>An array of one or more global secondary indexes for the table. For each index in the\n            array, you can request one action:</p>\n        <ul>\n            <li>\n                <p>\n                    <code>Create</code> - add a new global secondary index to the table.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Update</code> - modify the provisioned throughput settings of an existing\n                    global secondary index.</p>\n            </li>\n            <li>\n                <p>\n                    <code>Delete</code> - remove a global secondary index from the table.</p>\n            </li>\n         </ul>\n        <p>You can create or delete only one global secondary index per <code>UpdateTable</code>\n            operation.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.OnlineOps.html\">Managing Global\n                Secondary Indexes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>. </p>"
+                        "smithy.api#documentation": "<p>An array of one or more global secondary indexes for the table. For each index in the\n            array, you can request one action:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>Create</code> - add a new global secondary index to the table.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Update</code> - modify the provisioned throughput settings of an existing\n                    global secondary index.</p>\n            </li>\n            <li>\n               <p>\n                  <code>Delete</code> - remove a global secondary index from the table.</p>\n            </li>\n         </ul>\n         <p>You can create or delete only one global secondary index per <code>UpdateTable</code>\n            operation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GSI.OnlineOps.html\">Managing Global\n                Secondary Indexes</a> in the <i>Amazon DynamoDB Developer\n                Guide</i>. </p>"
                     }
                 },
                 "StreamSpecification": {
                     "target": "com.amazonaws.dynamodb#StreamSpecification",
                     "traits": {
-                        "smithy.api#documentation": "<p>Represents the DynamoDB Streams configuration for the table.</p>\n        <note>\n            <p>You receive a <code>ResourceInUseException</code> if you try to enable a stream on\n                a table that already has a stream, or if you try to disable a stream on a table that\n                doesn't have a stream.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>Represents the DynamoDB Streams configuration for the table.</p>\n         <note>\n            <p>You receive a <code>ResourceInUseException</code> if you try to enable a stream on\n                a table that already has a stream, or if you try to disable a stream on a table that\n                doesn't have a stream.</p>\n         </note>"
                     }
                 },
                 "SSESpecification": {
@@ -11051,7 +11341,7 @@
                 "ReplicaUpdates": {
                     "target": "com.amazonaws.dynamodb#ReplicationGroupUpdateList",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of replica update actions (create, delete, or update) for the table.</p>\n        <note>\n            <p>This property only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version\n                    2019.11.21</a> of global tables.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>A list of replica update actions (create, delete, or update) for the table.</p>\n         <note>\n            <p>This property only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a>\n                of global tables.\n            </p>\n         </note>"
                     }
                 },
                 "TableClass": {
@@ -11059,10 +11349,17 @@
                     "traits": {
                         "smithy.api#documentation": "<p>The table class of the table to be updated. Valid values are <code>STANDARD</code> and\n                <code>STANDARD_INFREQUENT_ACCESS</code>.</p>"
                     }
+                },
+                "DeletionProtectionEnabled": {
+                    "target": "com.amazonaws.dynamodb#DeletionProtectionEnabled",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether deletion protection is to be enabled (true) or disabled (false) on the table.</p>"
+                    }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of an <code>UpdateTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of an <code>UpdateTable</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateTableOutput": {
@@ -11076,7 +11373,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the output of an <code>UpdateTable</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the output of an <code>UpdateTable</code> operation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateTableReplicaAutoScaling": {
@@ -11102,7 +11400,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates auto scaling settings on your global tables at once.</p>\n        <note>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version\n                    2019.11.21</a> of global tables.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Updates auto scaling settings on your global tables at once.</p>\n         <important>\n            <p>This operation only applies to <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/globaltables.V2.html\">Version 2019.11.21 (Current)</a> \n                of global tables.\n            </p>\n         </important>"
             }
         },
         "com.amazonaws.dynamodb#UpdateTableReplicaAutoScalingInput": {
@@ -11130,6 +11428,9 @@
                         "smithy.api#documentation": "<p>Represents the auto scaling settings of replicas of the table that will be\n            modified.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateTableReplicaAutoScalingOutput": {
@@ -11141,6 +11442,9 @@
                         "smithy.api#documentation": "<p>Returns information about the auto scaling settings of a table with replicas.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateTimeToLive": {
@@ -11172,7 +11476,7 @@
                 "aws.api#clientDiscoveredEndpoint": {
                     "required": false
                 },
-                "smithy.api#documentation": "<p>The <code>UpdateTimeToLive</code> method enables or disables Time to Live (TTL) for\n            the specified table. A successful <code>UpdateTimeToLive</code> call returns the current\n                <code>TimeToLiveSpecification</code>. It can take up to one hour for the change to\n            fully process. Any additional <code>UpdateTimeToLive</code> calls for the same table\n            during this one hour duration result in a <code>ValidationException</code>. </p>\n        <p>TTL compares the current time in epoch time format to the time stored in the TTL\n            attribute of an item. If the epoch time value stored in the attribute is less than the\n            current time, the item is marked as expired and subsequently deleted.</p>\n        <note>\n            <p> The epoch time format is the number of seconds elapsed since 12:00:00 AM January\n                1, 1970 UTC. </p>\n        </note>\n        <p>DynamoDB deletes expired items on a best-effort basis to ensure availability of\n            throughput for other data operations. </p>\n        <important>\n            <p>DynamoDB typically deletes expired items within two days of expiration. The exact\n                duration within which an item gets deleted after expiration is specific to the\n                nature of the workload. Items that have expired and not been deleted will still show\n                up in reads, queries, and scans.</p>\n        </important>\n        <p>As items are deleted, they are removed from any local secondary index and global\n            secondary index immediately in the same eventually consistent way as a standard delete\n            operation.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html\">Time To Live</a> in the\n            Amazon DynamoDB Developer Guide. </p>"
+                "smithy.api#documentation": "<p>The <code>UpdateTimeToLive</code> method enables or disables Time to Live (TTL) for\n            the specified table. A successful <code>UpdateTimeToLive</code> call returns the current\n                <code>TimeToLiveSpecification</code>. It can take up to one hour for the change to\n            fully process. Any additional <code>UpdateTimeToLive</code> calls for the same table\n            during this one hour duration result in a <code>ValidationException</code>. </p>\n         <p>TTL compares the current time in epoch time format to the time stored in the TTL\n            attribute of an item. If the epoch time value stored in the attribute is less than the\n            current time, the item is marked as expired and subsequently deleted.</p>\n         <note>\n            <p> The epoch time format is the number of seconds elapsed since 12:00:00 AM January\n                1, 1970 UTC. </p>\n         </note>\n         <p>DynamoDB deletes expired items on a best-effort basis to ensure availability of\n            throughput for other data operations. </p>\n         <important>\n            <p>DynamoDB typically deletes expired items within two days of expiration. The exact\n                duration within which an item gets deleted after expiration is specific to the\n                nature of the workload. Items that have expired and not been deleted will still show\n                up in reads, queries, and scans.</p>\n         </important>\n         <p>As items are deleted, they are removed from any local secondary index and global\n            secondary index immediately in the same eventually consistent way as a standard delete\n            operation.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html\">Time To Live</a> in the\n            Amazon DynamoDB Developer Guide. </p>"
             }
         },
         "com.amazonaws.dynamodb#UpdateTimeToLiveInput": {
@@ -11194,7 +11498,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Represents the input of an <code>UpdateTimeToLive</code> operation.</p>"
+                "smithy.api#documentation": "<p>Represents the input of an <code>UpdateTimeToLive</code> operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.dynamodb#UpdateTimeToLiveOutput": {
@@ -11206,6 +11511,9 @@
                         "smithy.api#documentation": "<p>Represents the output of an <code>UpdateTimeToLive</code> operation.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.dynamodb#WriteRequest": {

--- a/aws/sdk/aws-models/ecs.json
+++ b/aws/sdk/aws-models/ecs.json
@@ -114,6 +114,9 @@
                     "target": "com.amazonaws.ecs#DeleteService"
                 },
                 {
+                    "target": "com.amazonaws.ecs#DeleteTaskDefinitions"
+                },
+                {
                     "target": "com.amazonaws.ecs#DeleteTaskSet"
                 },
                 {
@@ -274,7 +277,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -303,15 +306,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -320,7 +375,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -330,22 +385,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://ecs-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://ecs-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -358,82 +548,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://ecs.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -441,7 +601,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://ecs-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "url": "https://ecs.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -450,144 +610,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://ecs-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://ecs.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://ecs.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -596,16 +625,16 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://ecs.sa-east-1.amazonaws.com"
+                                    "url": "https://ecs.af-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
-                                "Region": "sa-east-1"
+                                "UseFIPS": false,
+                                "Region": "af-south-1"
                             }
                         },
                         {
@@ -616,165 +645,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.af-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-south-1"
                             }
                         },
                         {
@@ -785,8 +658,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-northeast-1"
                             }
                         },
@@ -798,8 +671,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-northeast-2"
                             }
                         },
@@ -811,35 +684,113 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-northeast-3"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://ecs.us-east-1.amazonaws.com"
+                                    "url": "https://ecs.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false,
+                                "Region": "ap-south-1"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://ecs-fips.us-east-1.amazonaws.com"
+                                    "url": "https://ecs.ap-southeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false,
+                                "Region": "ap-southeast-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "ap-southeast-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.ap-southeast-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "ap-southeast-3"
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "ca-central-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-central-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-south-1"
                             }
                         },
                         {
@@ -850,8 +801,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "eu-west-1"
                             }
                         },
@@ -863,8 +814,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "eu-west-2"
                             }
                         },
@@ -876,8 +827,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "eu-west-3"
                             }
                         },
@@ -889,22 +840,48 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "me-south-1"
                             }
                         },
                         {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://ecs.eu-north-1.amazonaws.com"
+                                    "url": "https://ecs.sa-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
-                                "Region": "eu-north-1"
+                                "UseFIPS": false,
+                                "Region": "sa-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-east-1"
                             }
                         },
                         {
@@ -915,8 +892,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-2"
                             }
                         },
@@ -928,9 +905,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-east-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-west-2"
                             }
                         },
                         {
@@ -941,8 +970,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": true,
+                                "UseFIPS": true,
                                 "Region": "us-east-1"
                             }
                         },
@@ -954,126 +983,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs-fips.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs-fips.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://ecs.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "cn-northwest-1"
                             }
                         },
                         {
@@ -1084,9 +996,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "cn-northwest-1"
                             }
                         },
                         {
@@ -1097,8 +1022,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": true,
+                                "UseFIPS": true,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -1110,8 +1035,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -1123,22 +1048,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "cn-north-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://ecs.us-iso-west-1.c2s.ic.gov"
+                                    "url": "https://ecs.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
-                                "Region": "us-iso-west-1"
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-gov-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
@@ -1149,9 +1139,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-iso-west-1"
                             }
                         },
                         {
@@ -1162,22 +1165,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ecs-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1187,8 +1229,8 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
@@ -1199,8 +1241,8 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
@@ -1392,7 +1434,7 @@
                 "managedTerminationProtection": {
                     "target": "com.amazonaws.ecs#ManagedTerminationProtection",
                     "traits": {
-                        "smithy.api#documentation": "<p>The managed termination protection setting to use for the Auto Scaling group capacity\n\t\t\tprovider. This determines whether the Auto Scaling group has managed termination\n\t\t\tprotection. The default is disabled.</p>\n         <important>\n            <p>When using managed termination protection, managed scaling must also be used\n\t\t\t\totherwise managed termination protection doesn't work.</p>\n         </important>\n         <p>When managed termination protection is enabled, Amazon ECS prevents the Amazon EC2 instances in\n\t\t\tan Auto Scaling group that contain tasks from being terminated during a scale-in action.\n\t\t\tThe Auto Scaling group and each instance in the Auto Scaling group must have instance\n\t\t\tprotection from scale-in actions enabled as well. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection\">Instance Protection</a> in the <i>Auto Scaling User Guide</i>.</p>\n         <p>When managed termination protection is disabled, your Amazon EC2 instances aren't protected\n\t\t\tfrom termination when the Auto Scaling group scales in.</p>"
+                        "smithy.api#documentation": "<p>The managed termination protection setting to use for the Auto Scaling group capacity\n\t\t\tprovider. This determines whether the Auto Scaling group has managed termination\n\t\t\tprotection. The default is off.</p>\n         <important>\n            <p>When using managed termination protection, managed scaling must also be used\n\t\t\t\totherwise managed termination protection doesn't work.</p>\n         </important>\n         <p>When managed termination protection is on, Amazon ECS prevents the Amazon EC2 instances in an Auto\n\t\t\tScaling group that contain tasks from being terminated during a scale-in action. The\n\t\t\tAuto Scaling group and each instance in the Auto Scaling group must have instance\n\t\t\tprotection from scale-in actions enabled as well. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection\">Instance Protection</a> in the <i>Auto Scaling User Guide</i>.</p>\n         <p>When managed termination protection is off, your Amazon EC2 instances aren't protected from\n\t\t\ttermination when the Auto Scaling group scales in.</p>"
                     }
                 }
             },
@@ -1412,7 +1454,7 @@
                 "managedTerminationProtection": {
                     "target": "com.amazonaws.ecs#ManagedTerminationProtection",
                     "traits": {
-                        "smithy.api#documentation": "<p>The managed termination protection setting to use for the Auto Scaling group capacity\n\t\t\tprovider. This determines whether the Auto Scaling group has managed termination\n\t\t\tprotection.</p>\n         <important>\n            <p>When using managed termination protection, managed scaling must also be used\n\t\t\t\totherwise managed termination protection doesn't work.</p>\n         </important>\n         <p>When managed termination protection is enabled, Amazon ECS prevents the Amazon EC2 instances in\n\t\t\tan Auto Scaling group that contain tasks from being terminated during a scale-in action.\n\t\t\tThe Auto Scaling group and each instance in the Auto Scaling group must have instance\n\t\t\tprotection from scale-in actions enabled. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection\">Instance Protection</a> in the <i>Auto Scaling User Guide</i>.</p>\n         <p>When managed termination protection is disabled, your Amazon EC2 instances aren't protected\n\t\t\tfrom termination when the Auto Scaling group scales in.</p>"
+                        "smithy.api#documentation": "<p>The managed termination protection setting to use for the Auto Scaling group capacity\n\t\t\tprovider. This determines whether the Auto Scaling group has managed termination\n\t\t\tprotection.</p>\n         <important>\n            <p>When using managed termination protection, managed scaling must also be used\n\t\t\t\totherwise managed termination protection doesn't work.</p>\n         </important>\n         <p>When managed termination protection is on, Amazon ECS prevents the Amazon EC2 instances in an Auto\n\t\t\tScaling group that contain tasks from being terminated during a scale-in action. The\n\t\t\tAuto Scaling group and each instance in the Auto Scaling group must have instance\n\t\t\tprotection from scale-in actions on. For more information, see <a href=\"https://docs.aws.amazon.com/autoscaling/ec2/userguide/as-instance-termination.html#instance-protection\">Instance Protection</a> in the <i>Auto Scaling User Guide</i>.</p>\n         <p>When managed termination protection is off, your Amazon EC2 instances aren't protected from\n\t\t\ttermination when the Auto Scaling group scales in.</p>"
                     }
                 }
             },
@@ -1756,7 +1798,7 @@
                 "settings": {
                     "target": "com.amazonaws.ecs#ClusterSettings",
                     "traits": {
-                        "smithy.api#documentation": "<p>The settings for the cluster. This parameter indicates whether CloudWatch Container Insights\n\t\t\tis enabled or disabled for a cluster.</p>"
+                        "smithy.api#documentation": "<p>The settings for the cluster. This parameter indicates whether CloudWatch Container Insights is on\n\t\t\tor off for a cluster.</p>"
                     }
                 },
                 "capacityProviders": {
@@ -1938,7 +1980,7 @@
                 "value": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The value to set for the cluster setting. The supported values are\n\t\t\t\t<code>enabled</code> and <code>disabled</code>. If <code>enabled</code> is\n\t\t\tspecified, CloudWatch Container Insights will be enabled for the cluster, otherwise it will be\n\t\t\tdisabled unless the <code>containerInsights</code> account setting is enabled. If a\n\t\t\tcluster value is specified, it will override the <code>containerInsights</code> value\n\t\t\tset with <a>PutAccountSetting</a> or <a>PutAccountSettingDefault</a>.</p>"
+                        "smithy.api#documentation": "<p>The value to set for the cluster setting. The supported values are <code>enabled</code> and\n\t\t\t\t<code>disabled</code>. If <code>enabled</code> is specified, CloudWatch Container Insights\n\t\t\twill be enabled for the cluster, otherwise it will be off unless the\n\t\t\t\t<code>containerInsights</code> account setting is turned on. If a cluster value is\n\t\t\tspecified, it will override the <code>containerInsights</code> value set with <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutAccountSetting.html\">PutAccountSetting</a> or <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutAccountSettingDefault.html\">PutAccountSettingDefault</a>.</p>"
                     }
                 }
             },
@@ -2299,7 +2341,7 @@
                 "disableNetworking": {
                     "target": "com.amazonaws.ecs#BoxedBoolean",
                     "traits": {
-                        "smithy.api#documentation": "<p>When this parameter is true, networking is disabled within the container. This\n\t\t\tparameter maps to <code>NetworkDisabled</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a container</a>\n\t\t\tsection of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker Remote API</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+                        "smithy.api#documentation": "<p>When this parameter is true, networking is off within the container. This parameter maps to\n\t\t\t\t<code>NetworkDisabled</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a container</a> section of\n\t\t\tthe <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker Remote API</a>.</p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
                     }
                 },
                 "privileged": {
@@ -2359,7 +2401,7 @@
                 "ulimits": {
                     "target": "com.amazonaws.ecs#UlimitList",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of <code>ulimits</code> to set in the container. If a <code>ulimit</code> value\n\t\t\tis specified in a task definition, it overrides the default values set by Docker. This\n\t\t\tparameter maps to <code>Ulimits</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a container</a> section\n\t\t\tof the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker Remote API</a> and the <code>--ulimit</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker run</a>. Valid naming values are displayed\n\t\t\tin the <a>Ulimit</a> data type.</p>\n         <p>Amazon ECS tasks hosted on Fargate use the default\n\t\t\t\t\t\t\tresource limit values set by the operating system with the exception of\n\t\t\t\t\t\t\tthe <code>nofile</code> resource limit parameter which Fargate\n\t\t\t\t\t\t\toverrides. The <code>nofile</code> resource limit sets a restriction on\n\t\t\t\t\t\t\tthe number of open files that a container can use. The default\n\t\t\t\t\t\t\t\t<code>nofile</code> soft limit is <code>1024</code> and hard limit\n\t\t\t\t\t\t\tis <code>4096</code>.</p>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container instance. To check the Docker Remote API version on your container instance, log in to your container instance and run the following command: <code>sudo docker version --format '{{.Server.APIVersion}}'</code>\n         </p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
+                        "smithy.api#documentation": "<p>A list of <code>ulimits</code> to set in the container. If a <code>ulimit</code> value\n\t\t\tis specified in a task definition, it overrides the default values set by Docker. This\n\t\t\tparameter maps to <code>Ulimits</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a container</a> section\n\t\t\tof the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker Remote API</a> and the <code>--ulimit</code> option to <a href=\"https://docs.docker.com/engine/reference/run/#security-configuration\">docker run</a>. Valid naming values are displayed\n\t\t\tin the <a>Ulimit</a> data type.</p>\n         <p>Amazon ECS tasks hosted on Fargate use the default\n\t\t\t\t\t\t\tresource limit values set by the operating system with the exception of\n\t\t\t\t\t\t\tthe <code>nofile</code> resource limit parameter which Fargate\n\t\t\t\t\t\t\toverrides. The <code>nofile</code> resource limit sets a restriction on\n\t\t\t\t\t\t\tthe number of open files that a container can use. The default\n\t\t\t\t\t\t\t\t<code>nofile</code> soft limit is <code>1024</code> and the default hard limit\n\t\t\t\t\t\t\tis <code>4096</code>.</p>\n         <p>This parameter requires version 1.18 of the Docker Remote API or greater on your container instance. To check the Docker Remote API version on your container instance, log in to your container instance and run the following command: <code>sudo docker version --format '{{.Server.APIVersion}}'</code>\n         </p>\n         <note>\n            <p>This parameter is not supported for Windows containers.</p>\n         </note>"
                     }
                 },
                 "logConfiguration": {
@@ -2811,6 +2853,9 @@
                         "smithy.api#documentation": "<p>The metadata that you apply to the capacity provider to categorize and organize them\n\t\t\tmore conveniently. Each tag consists of a key and an optional value. You define both of\n\t\t\tthem.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : / @.</p>\n            </li>\n            <li>\n               <p>Tag keys and values are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Do not use <code>aws:</code>, <code>AWS:</code>, or any upper or lowercase\n                    combination of such as a prefix for either keys or values as it is reserved for\n                    Amazon Web Services use. You cannot edit or delete tag keys or values with this prefix. Tags with\n                    this prefix do not count against your tags per resource limit.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#CreateCapacityProviderResponse": {
@@ -2822,6 +2867,9 @@
                         "smithy.api#documentation": "<p>The full description of the new capacity provider.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#CreateCluster": {
@@ -2844,7 +2892,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a new Amazon ECS cluster. By default, your account receives a <code>default</code>\n\t\t\tcluster when you launch your first container instance. However, you can create your own\n\t\t\tcluster with a unique name with the <code>CreateCluster</code> action.</p>\n         <note>\n            <p>When you call the <a>CreateCluster</a> API operation, Amazon ECS attempts to\n\t\t\t\tcreate the Amazon ECS service-linked role for your account. This is so that it can manage\n\t\t\t\trequired resources in other Amazon Web Services services on your behalf. However, if the IAM user\n\t\t\t\tthat makes the call doesn't have permissions to create the service-linked role, it\n\t\t\t\tisn't created. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html\">Using\n\t\t\t\t\tservice-linked roles for Amazon ECS</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
+                "smithy.api#documentation": "<p>Creates a new Amazon ECS cluster. By default, your account receives a <code>default</code>\n\t\t\tcluster when you launch your first container instance. However, you can create your own\n\t\t\tcluster with a unique name with the <code>CreateCluster</code> action.</p>\n         <note>\n            <p>When you call the <a>CreateCluster</a> API operation, Amazon ECS attempts to\n\t\t\t\tcreate the Amazon ECS service-linked role for your account. This is so that it can manage\n\t\t\t\trequired resources in other Amazon Web Services services on your behalf. However, if the user\n\t\t\t\tthat makes the call doesn't have permissions to create the service-linked role, it\n\t\t\t\tisn't created. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html\">Using\n\t\t\t\t\tservice-linked roles for Amazon ECS</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.ecs#CreateClusterRequest": {
@@ -2877,13 +2925,13 @@
                 "capacityProviders": {
                     "target": "com.amazonaws.ecs#StringList",
                     "traits": {
-                        "smithy.api#documentation": "<p>The short name of one or more capacity providers to associate with the cluster. A\n\t\t\tcapacity provider must be associated with a cluster before it can be included as part of\n\t\t\tthe default capacity provider strategy of the cluster or used in a capacity provider\n\t\t\tstrategy when calling the <a>CreateService</a> or <a>RunTask</a>\n\t\t\tactions.</p>\n         <p>If specifying a capacity provider that uses an Auto Scaling group, the capacity\n\t\t\tprovider must be created but not associated with another cluster. New Auto Scaling group\n\t\t\tcapacity providers can be created with the <a>CreateCapacityProvider</a> API\n\t\t\toperation.</p>\n         <p>To use a Fargate capacity provider, specify either the <code>FARGATE</code> or\n\t\t\t\t<code>FARGATE_SPOT</code> capacity providers. The Fargate capacity providers are\n\t\t\tavailable to all accounts and only need to be associated with a cluster to be\n\t\t\tused.</p>\n         <p>The <a>PutClusterCapacityProviders</a> API operation is used to update the\n\t\t\tlist of available capacity providers for a cluster after the cluster is created.</p>"
+                        "smithy.api#documentation": "<p>The short name of one or more capacity providers to associate with the cluster. A\n\t\t\tcapacity provider must be associated with a cluster before it can be included as part of\n\t\t\tthe default capacity provider strategy of the cluster or used in a capacity provider\n\t\t\tstrategy when calling the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html\">CreateService</a> or <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html\">RunTask</a>\n\t\t\tactions.</p>\n         <p>If specifying a capacity provider that uses an Auto Scaling group, the capacity\n\t\t\tprovider must be created but not associated with another cluster. New Auto Scaling group\n\t\t\tcapacity providers can be created with the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateCapacityProvider.html\">CreateCapacityProvider</a> API\n\t\t\toperation.</p>\n         <p>To use a Fargate capacity provider, specify either the <code>FARGATE</code> or\n\t\t\t\t<code>FARGATE_SPOT</code> capacity providers. The Fargate capacity providers are\n\t\t\tavailable to all accounts and only need to be associated with a cluster to be\n\t\t\tused.</p>\n         <p>The <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PutCapacityProvider.html\">PutCapacityProvider</a> API operation is used to update the\n\t\t\tlist of available capacity providers for a cluster after the cluster is created.</p>"
                     }
                 },
                 "defaultCapacityProviderStrategy": {
                     "target": "com.amazonaws.ecs#CapacityProviderStrategy",
                     "traits": {
-                        "smithy.api#documentation": "<p>The capacity provider strategy to set as the default for the cluster. After a default\n\t\t\tcapacity provider strategy is set for a cluster, when you call the <a>RunTask</a> or <a>CreateService</a> APIs with no capacity\n\t\t\tprovider strategy or launch type specified, the default capacity provider strategy for\n\t\t\tthe cluster is used.</p>\n         <p>If a default capacity provider strategy isn't defined for a cluster when it was\n\t\t\tcreated, it can be defined later with the <a>PutClusterCapacityProviders</a>\n\t\t\tAPI operation.</p>"
+                        "smithy.api#documentation": "<p>The capacity provider strategy to set as the default for the cluster. After a default\n\t\t\tcapacity provider strategy is set for a cluster, when you call the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_CreateService.html\">CreateService</a> or <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html\">RunTask</a> APIs with no capacity\n\t\t\tprovider strategy or launch type specified, the default capacity provider strategy for\n\t\t\tthe cluster is used.</p>\n         <p>If a default capacity provider strategy isn't defined for a cluster when it was\n\t\t\tcreated, it can be defined later with the <a>PutClusterCapacityProviders</a>\n\t\t\tAPI operation.</p>"
                     }
                 },
                 "serviceConnectDefaults": {
@@ -2892,6 +2940,9 @@
                         "smithy.api#documentation": "<p>Use this parameter to set a default Service Connect namespace. After you set a default \n\tService Connect namespace, any new services with Service Connect turned on that are created in the cluster are added as\n\tclient services in the namespace. This setting only applies to new services that set the <code>enabled</code> parameter to\n\t<code>true</code> in the <code>ServiceConnectConfiguration</code>.\n\tYou can set the namespace of each service individually in the <code>ServiceConnectConfiguration</code> to override this default\n\tparameter.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#CreateClusterResponse": {
@@ -2903,6 +2954,9 @@
                         "smithy.api#documentation": "<p>The full description of your new cluster.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#CreateService": {
@@ -3090,6 +3144,9 @@
                         "smithy.api#documentation": "<p>The configuration for this service to discover and connect to\n\tservices, and be discovered by, and connected from, other services within a namespace.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#CreateServiceResponse": {
@@ -3101,6 +3158,9 @@
                         "smithy.api#documentation": "<p>The full description of your service following the create call.</p>\n         <p>A service will return either a <code>capacityProviderStrategy</code> or\n\t\t\t\t<code>launchType</code> parameter, but not both, depending where one was specified\n\t\t\twhen it was created.</p>\n         <p>If a service is using the <code>ECS</code> deployment controller, the\n\t\t\t\t<code>deploymentController</code> and <code>taskSets</code> parameters will not be\n\t\t\treturned.</p>\n         <p>if the service uses the <code>CODE_DEPLOY</code> deployment controller, the\n\t\t\t\t<code>deploymentController</code>, <code>taskSets</code> and\n\t\t\t\t<code>deployments</code> parameters will be returned, however the\n\t\t\t\t<code>deployments</code> parameter will be an empty list.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#CreateTaskSet": {
@@ -3234,6 +3294,9 @@
                         "smithy.api#documentation": "<p>The metadata that you apply to the task set to help you categorize and organize them.\n\t\t\tEach tag consists of a key and an optional value. You define both. When a service is\n\t\t\tdeleted, the tags are deleted.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : / @.</p>\n            </li>\n            <li>\n               <p>Tag keys and values are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Do not use <code>aws:</code>, <code>AWS:</code>, or any upper or lowercase\n                    combination of such as a prefix for either keys or values as it is reserved for\n                    Amazon Web Services use. You cannot edit or delete tag keys or values with this prefix. Tags with\n                    this prefix do not count against your tags per resource limit.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#CreateTaskSetResponse": {
@@ -3245,6 +3308,9 @@
                         "smithy.api#documentation": "<p>Information about a set of Amazon ECS tasks in either an CodeDeploy or an\n\t\t\t\t<code>EXTERNAL</code> deployment. A task set includes details such as the desired\n\t\t\tnumber of tasks, how many tasks are running, and whether the task set serves production\n\t\t\ttraffic.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeleteAccountSetting": {
@@ -3267,7 +3333,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Disables an account setting for a specified IAM user, IAM role, or the root user for\n\t\t\tan account.</p>"
+                "smithy.api#documentation": "<p>Disables an account setting for a specified  user, role, or the root user for\n\t\t\tan account.</p>"
             }
         },
         "com.amazonaws.ecs#DeleteAccountSettingRequest": {
@@ -3283,9 +3349,12 @@
                 "principalArn": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the principal. It can be an IAM user, IAM role, or\n\t\t\tthe root user. If you specify the root user, it disables the account setting for all IAM\n\t\t\tusers, IAM roles, and the root user of the account unless an IAM user or role explicitly\n\t\t\toverrides these settings. If this field is omitted, the setting is changed only for the\n\t\t\tauthenticated user.</p>"
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the principal. It can be an user, role, or\n\t\t\tthe root user. If you specify the root user, it disables the account setting for all users, roles, and the root user of the account unless a user or role explicitly\n\t\t\toverrides these settings. If this field is omitted, the setting is changed only for the\n\t\t\tauthenticated user.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeleteAccountSettingResponse": {
@@ -3297,6 +3366,9 @@
                         "smithy.api#documentation": "<p>The account setting for the specified principal ARN.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeleteAttributes": {
@@ -3338,6 +3410,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeleteAttributesResponse": {
@@ -3349,6 +3424,9 @@
                         "smithy.api#documentation": "<p>A list of attribute objects that were successfully deleted from your resource.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeleteCapacityProvider": {
@@ -3384,6 +3462,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeleteCapacityProviderResponse": {
@@ -3395,6 +3476,9 @@
                         "smithy.api#documentation": "<p>The details of the capacity provider.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeleteCluster": {
@@ -3445,6 +3529,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeleteClusterResponse": {
@@ -3456,6 +3543,9 @@
                         "smithy.api#documentation": "<p>The full description of the deleted cluster.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeleteService": {
@@ -3509,6 +3599,9 @@
                         "smithy.api#documentation": "<p>If <code>true</code>, allows you to delete a service even if it wasn't scaled down to\n\t\t\tzero tasks. It's only necessary to use this if the service uses the <code>REPLICA</code>\n\t\t\tscheduling strategy.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeleteServiceResponse": {
@@ -3520,6 +3613,70 @@
                         "smithy.api#documentation": "<p>The full description of the deleted service.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.ecs#DeleteTaskDefinitions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.ecs#DeleteTaskDefinitionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.ecs#DeleteTaskDefinitionsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.ecs#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.ecs#ClientException"
+                },
+                {
+                    "target": "com.amazonaws.ecs#InvalidParameterException"
+                },
+                {
+                    "target": "com.amazonaws.ecs#ServerException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes one or more task definitions.</p>\n         <p>You must deregister a task definition revision before you delete it. For more information,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeregisterTaskDefinition.html\">DeregisterTaskDefinition</a>.</p>\n         <p>When you delete a task definition revision, it is immediately transitions from the\n\t\t<code>INACTIVE</code> to <code>DELETE_IN_PROGRESS</code>. Existing tasks and services\n\t\tthat reference a <code>DELETE_IN_PROGRESS</code> task definition revision continue to run\n\t\twithout disruption. Existing services that reference a <code>DELETE_IN_PROGRESS</code> task\n\t\tdefinition revision can still scale up or down by modifying the service's desired\n\t\tcount.</p>\n         <p>You can't use a <code>DELETE_IN_PROGRESS</code> task definition revision to run new tasks\n\t\t\tor create new services. You also can't update an existing service to reference a\n\t\t\t<code>DELETE_IN_PROGRESS</code> task definition revision.</p>\n         <p> A task definition revision will stay in <code>DELETE_IN_PROGRESS</code> status until\n\t\t\tall the associated tasks and services have been terminated.</p>"
+            }
+        },
+        "com.amazonaws.ecs#DeleteTaskDefinitionsRequest": {
+            "type": "structure",
+            "members": {
+                "taskDefinitions": {
+                    "target": "com.amazonaws.ecs#StringList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or\n\t\t\tfull Amazon Resource Name (ARN) of the task definition to delete. You must specify a\n\t\t\t\t<code>revision</code>.</p>\n         <p>You can specify up to 10 task definitions as a comma separated list.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.ecs#DeleteTaskDefinitionsResponse": {
+            "type": "structure",
+            "members": {
+                "taskDefinitions": {
+                    "target": "com.amazonaws.ecs#TaskDefinitionList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of deleted task definitions.</p>"
+                    }
+                },
+                "failures": {
+                    "target": "com.amazonaws.ecs#Failures",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeleteTaskSet": {
@@ -3593,6 +3750,9 @@
                         "smithy.api#documentation": "<p>If <code>true</code>, you can delete a task set even if it hasn't been scaled down to\n\t\t\tzero.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeleteTaskSetResponse": {
@@ -3604,6 +3764,9 @@
                         "smithy.api#documentation": "<p>Details about the task set.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#Deployment": {
@@ -3778,7 +3941,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<note>\n            <p>The deployment circuit breaker can only be used for services using the rolling\n\t\t\t\tupdate (<code>ECS</code>) deployment type that aren't behind a Classic Load Balancer.</p>\n         </note>\n         <p>The <b>deployment circuit breaker</b> determines whether a\n\t\t\tservice deployment will fail if the service can't reach a steady state. If enabled, a\n\t\t\tservice deployment will transition to a failed state and stop launching new tasks. You\n\t\t\tcan also configure Amazon ECS to roll back your service to the last completed deployment\n\t\t\tafter a failure. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html\">Rolling\n\t\t\t\tupdate</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<note>\n            <p>The deployment circuit breaker can only be used for services using the rolling\n\t\t\t\tupdate (<code>ECS</code>) deployment type.</p>\n         </note>\n         <p>The <b>deployment circuit breaker</b> determines whether a\n\t\t\tservice deployment will fail if the service can't reach a steady state. If enabled, a\n\t\t\tservice deployment will transition to a failed state and stop launching new tasks. You\n\t\t\tcan also configure Amazon ECS to roll back your service to the last completed deployment\n\t\t\tafter a failure. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html\">Rolling\n\t\t\t\tupdate</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.ecs#DeploymentConfiguration": {
@@ -3787,7 +3950,7 @@
                 "deploymentCircuitBreaker": {
                     "target": "com.amazonaws.ecs#DeploymentCircuitBreaker",
                     "traits": {
-                        "smithy.api#documentation": "<note>\n            <p>The deployment circuit breaker can only be used for services using the rolling\n\t\t\t\tupdate (<code>ECS</code>) deployment type.</p>\n         </note>\n         <p>The <b>deployment circuit breaker</b> determines whether a\n\t\t\tservice deployment will fail if the service can't reach a steady state. If deployment\n\t\t\tcircuit breaker is enabled, a service deployment will transition to a failed state and\n\t\t\tstop launching new tasks. If rollback is enabled, when a service deployment fails, the\n\t\t\tservice is rolled back to the last deployment that completed successfully.</p>"
+                        "smithy.api#documentation": "<note>\n            <p>The deployment circuit breaker can only be used for services using the rolling\n\t\t\t\tupdate (<code>ECS</code>) deployment type.</p>\n         </note>\n         <p>The <b>deployment circuit breaker</b> determines whether a\n\t\t\tservice deployment will fail if the service can't reach a steady state. If you use the deployment\n\t\t\tcircuit breaker, a service deployment will transition to a failed state and\n\t\t\tstop launching new tasks. If  you use the rollback option, when a service deployment fails, the\n\t\t\tservice is rolled back to the last deployment that completed successfully. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/deployment-type-ecs.html\">Rolling\n\t\t\t\tupdate</a> in the <i>Amazon Elastic Container Service Developer\n\t\t\t\t\tGuide</i>\n         </p>"
                     }
                 },
                 "maximumPercent": {
@@ -3928,6 +4091,9 @@
                         "smithy.api#documentation": "<p>Forces the container instance to be deregistered. If you have tasks running on the\n\t\t\tcontainer instance when you deregister it with the <code>force</code> option, these\n\t\t\ttasks remain running until you terminate the instance or the tasks stop through some\n\t\t\tother means, but they're orphaned (no longer monitored or accounted for by Amazon ECS). If an\n\t\t\torphaned task on your container instance is part of an Amazon ECS service, then the service\n\t\t\tscheduler starts another copy of that task, on a different container instance if\n\t\t\tpossible. </p>\n         <p>Any containers in orphaned service tasks that are registered with a Classic Load Balancer or an Application Load Balancer\n\t\t\ttarget group are deregistered. They begin connection draining according to the settings\n\t\t\ton the load balancer or target group.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeregisterContainerInstanceResponse": {
@@ -3939,6 +4105,9 @@
                         "smithy.api#documentation": "<p>The container instance that was deregistered.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DeregisterTaskDefinition": {
@@ -3961,7 +4130,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deregisters the specified task definition by family and revision. Upon deregistration,\n\t\t\tthe task definition is marked as <code>INACTIVE</code>. Existing tasks and services that\n\t\t\treference an <code>INACTIVE</code> task definition continue to run without disruption.\n\t\t\tExisting services that reference an <code>INACTIVE</code> task definition can still\n\t\t\tscale up or down by modifying the service's desired count.</p>\n         <p>You can't use an <code>INACTIVE</code> task definition to run new tasks or create new\n\t\t\tservices, and you can't update an existing service to reference an <code>INACTIVE</code>\n\t\t\ttask definition. However, there may be up to a 10-minute window following deregistration\n\t\t\twhere these restrictions have not yet taken effect.</p>\n         <note>\n            <p>At this time, <code>INACTIVE</code> task definitions remain discoverable in your\n\t\t\t\taccount indefinitely. However, this behavior is subject to change in the future. We\n\t\t\t\tdon't recommend that you rely on <code>INACTIVE</code> task definitions persisting\n\t\t\t\tbeyond the lifecycle of any associated tasks and services.</p>\n         </note>"
+                "smithy.api#documentation": "<p>Deregisters the specified task definition by family and revision. Upon deregistration, the\n\t\t\ttask definition is marked as <code>INACTIVE</code>. Existing tasks and services that\n\t\t\treference an <code>INACTIVE</code> task definition continue to run without disruption.\n\t\t\tExisting services that reference an <code>INACTIVE</code> task definition can still\n\t\t\tscale up or down by modifying the service's desired count. If you want to delete a  task\n\t\t\tdefinition revision, you must first deregister the  task definition revision.</p>\n         <p>You can't use an <code>INACTIVE</code> task definition to run new tasks or create new\n\t\t\tservices, and you can't update an existing service to reference an <code>INACTIVE</code>\n\t\t\ttask definition. However, there may be up to a 10-minute window following deregistration\n\t\t\twhere these restrictions have not yet taken effect.</p>\n         <note>\n            <p>At this time, <code>INACTIVE</code> task definitions remain discoverable in your\n\t\t\t\taccount indefinitely. However, this behavior is subject to change in the future. We\n\t\t\t\tdon't recommend that you rely on <code>INACTIVE</code> task definitions persisting\n\t\t\t\tbeyond the lifecycle of any associated tasks and services.</p>\n         </note>\n         <p>You must deregister a task definition revision before you delete it. For more information,\n\t\t\tsee <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DeleteTaskDefinitions.html\">DeleteTaskDefinitions</a>.</p>"
             }
         },
         "com.amazonaws.ecs#DeregisterTaskDefinitionRequest": {
@@ -3974,6 +4143,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DeregisterTaskDefinitionResponse": {
@@ -3985,6 +4157,9 @@
                         "smithy.api#documentation": "<p>The full description of the deregistered task.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeCapacityProviders": {
@@ -4037,6 +4212,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n\t\t\t\t<code>DescribeCapacityProviders</code> request where <code>maxResults</code> was\n\t\t\tused and the results exceeded the value of that parameter. Pagination continues from the\n\t\t\tend of the previous results that returned the <code>nextToken</code> value.</p>\n         <note>\n            <p>This token should be treated as an opaque identifier that is only used to\n                retrieve the next items in a list and not for other programmatic purposes.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeCapacityProvidersResponse": {
@@ -4060,6 +4238,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n\t\t\t\t<code>DescribeCapacityProviders</code> request. When the results of a\n\t\t\t\t<code>DescribeCapacityProviders</code> request exceed <code>maxResults</code>, this\n\t\t\tvalue can be used to retrieve the next page of results. This value is <code>null</code>\n\t\t\twhen there are no more results to return.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeClusters": {
@@ -4100,6 +4281,9 @@
                         "smithy.api#documentation": "<p>Determines whether to include additional information about the clusters in the\n\t\t\tresponse. If this field is omitted, this information isn't included.</p>\n         <p>If <code>ATTACHMENTS</code> is specified, the attachments for the container instances\n\t\t\tor tasks within the cluster are included, for example the capacity providers.</p>\n         <p>If <code>SETTINGS</code> is specified, the settings for the cluster are\n\t\t\tincluded.</p>\n         <p>If <code>CONFIGURATIONS</code> is specified, the configuration for the cluster is\n\t\t\tincluded.</p>\n         <p>If <code>STATISTICS</code> is specified, the task and service count is included,\n\t\t\tseparated by launch type.</p>\n         <p>If <code>TAGS</code> is specified, the metadata tags associated with the cluster are\n\t\t\tincluded.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeClustersResponse": {
@@ -4117,6 +4301,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeContainerInstances": {
@@ -4167,6 +4354,9 @@
                         "smithy.api#documentation": "<p>Specifies whether you want to see the resource tags for the container instance. If\n\t\t\t\t<code>TAGS</code> is specified, the tags are included in the response. If\n\t\t\t\t<code>CONTAINER_INSTANCE_HEALTH</code> is specified, the container instance health\n\t\t\tis included in the response. If this field is omitted, tags and container instance\n\t\t\thealth status aren't included in the response.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeContainerInstancesResponse": {
@@ -4184,6 +4374,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeServices": {
@@ -4306,6 +4499,9 @@
                         "smithy.api#documentation": "<p>Determines whether you want to see the resource tags for the service. If\n\t\t\t\t<code>TAGS</code> is specified, the tags are included in the response. If this field\n\t\t\tis omitted, tags aren't included in the response.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeServicesResponse": {
@@ -4323,6 +4519,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeTaskDefinition": {
@@ -4364,6 +4563,9 @@
                         "smithy.api#documentation": "<p>Determines whether to see the resource tags for the task definition. If\n\t\t\t\t<code>TAGS</code> is specified, the tags are included in the response. If this field\n\t\t\tis omitted, tags aren't included in the response.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeTaskDefinitionResponse": {
@@ -4381,6 +4583,9 @@
                         "smithy.api#documentation": "<p>The metadata that's applied to the task definition to help you categorize and organize\n\t\t\tthem. Each tag consists of a key and an optional value. You define both.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : / @.</p>\n            </li>\n            <li>\n               <p>Tag keys and values are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Do not use <code>aws:</code>, <code>AWS:</code>, or any upper or lowercase\n                    combination of such as a prefix for either keys or values as it is reserved for\n                    Amazon Web Services use. You cannot edit or delete tag keys or values with this prefix. Tags with\n                    this prefix do not count against your tags per resource limit.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeTaskSets": {
@@ -4450,6 +4655,9 @@
                         "smithy.api#documentation": "<p>Specifies whether to see the resource tags for the task set. If <code>TAGS</code> is\n\t\t\tspecified, the tags are included in the response. If this field is omitted, tags aren't\n\t\t\tincluded in the response.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeTaskSetsResponse": {
@@ -4467,6 +4675,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DescribeTasks": {
@@ -4569,6 +4780,9 @@
                         "smithy.api#documentation": "<p>Specifies whether you want to see the resource tags for the task. If <code>TAGS</code>\n\t\t\tis specified, the tags are included in the response. If this field is omitted, tags\n\t\t\taren't included in the response.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DescribeTasksResponse": {
@@ -4586,6 +4800,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DesiredStatus": {
@@ -4708,6 +4925,9 @@
                         "smithy.api#documentation": "<p>The short name or full Amazon Resource Name (ARN) of the cluster that the container instance belongs\n\t\t\tto.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#DiscoverPollEndpointResponse": {
@@ -4731,6 +4951,9 @@
                         "smithy.api#documentation": "<p>The endpoint for the Amazon ECS agent to poll for Service Connect configuration.\n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#DockerLabelsMap": {
@@ -4798,7 +5021,7 @@
                 "iam": {
                     "target": "com.amazonaws.ecs#EFSAuthorizationConfigIAM",
                     "traits": {
-                        "smithy.api#documentation": "<p>Determines whether to use the Amazon ECS task IAM role defined in a task definition when\n\t\t\tmounting the Amazon EFS file system. If enabled, transit encryption must be enabled in the\n\t\t\t\t<code>EFSVolumeConfiguration</code>. If this parameter is omitted, the default value\n\t\t\tof <code>DISABLED</code> is used. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/efs-volumes.html#efs-volume-accesspoints\">Using\n\t\t\t\tAmazon EFS access points</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Determines whether to use the Amazon ECS task role defined in a task definition when\n\t\t\tmounting the Amazon EFS file system. If enabled, transit encryption must be enabled in the\n\t\t\t\t<code>EFSVolumeConfiguration</code>. If this parameter is omitted, the default value\n\t\t\tof <code>DISABLED</code> is used. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/efs-volumes.html#efs-volume-accesspoints\">Using\n\t\t\t\tAmazon EFS access points</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 }
             },
@@ -5011,7 +5234,7 @@
                     "target": "com.amazonaws.ecs#Boolean",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>Determines whether to use encryption on the CloudWatch logs. If not specified,\n\t\t\tencryption will be disabled.</p>"
+                        "smithy.api#documentation": "<p>Determines whether to use encryption on the CloudWatch logs. If not specified, encryption\n\t\t\twill be off.</p>"
                     }
                 },
                 "s3BucketName": {
@@ -5098,6 +5321,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ExecuteCommandResponse": {
@@ -5140,6 +5366,9 @@
                         "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the task.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#FSxWindowsFileServerAuthorizationConfig": {
@@ -5323,6 +5552,9 @@
                         "smithy.api#documentation": "<p>A list of up to 100 task IDs or full ARN entries.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#GetTaskProtectionResponse": {
@@ -5340,6 +5572,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#GpuIds": {
@@ -5354,7 +5589,7 @@
                 "command": {
                     "target": "com.amazonaws.ecs#StringList",
                     "traits": {
-                        "smithy.api#documentation": "<p>A string array representing the command that the container runs to determine if it is\n\t\t\thealthy. The string array must start with <code>CMD</code> to run the command arguments\n\t\t\tdirectly, or <code>CMD-SHELL</code> to run the command with the container's default\n\t\t\tshell. </p>\n         <p> When you use the Amazon Web Services Management Console JSON panel, the Command Line Interface, or the APIs, enclose the list\n\t\t\tof commands in brackets.</p>\n         <p>\n            <code>[ \"CMD-SHELL\", \"curl -f http://localhost/ || exit 1\" ]</code>\n         </p>\n         <p>You don't need to include the brackets when you use the Amazon Web Services Management Console.</p>\n         <p>\n            <code> \"CMD-SHELL\", \"curl -f http://localhost/ || exit 1\" </code>\n         </p>\n         <p>An exit code of 0 indicates success, and non-zero exit code indicates failure. For\n\t\t\tmore information, see <code>HealthCheck</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a container</a>\n\t\t\tsection of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker Remote API</a>.</p>",
+                        "smithy.api#documentation": "<p>A string array representing the command that the container runs to determine if it is\n\t\t\thealthy. The string array must start with <code>CMD</code> to run the command arguments\n\t\t\tdirectly, or <code>CMD-SHELL</code> to run the command with the container's default\n\t\t\tshell. </p>\n         <p> When you use the Amazon Web Services Management Console JSON panel, the Command Line Interface, or the APIs, enclose the list of\n\t\t\tcommands in double quotes and brackets.</p>\n         <p>\n            <code>[ \"CMD-SHELL\", \"curl -f http://localhost/ || exit 1\" ]</code>\n         </p>\n         <p>You don't include the double quotes and brackets when you use the Amazon Web Services Management Console.</p>\n         <p>\n            <code> CMD-SHELL, curl -f http://localhost/ || exit 1</code>\n         </p>\n         <p>An exit code of 0 indicates success, and non-zero exit code indicates failure. For\n\t\t\tmore information, see <code>HealthCheck</code> in the <a href=\"https://docs.docker.com/engine/api/v1.35/#operation/ContainerCreate\">Create a container</a>\n\t\t\tsection of the <a href=\"https://docs.docker.com/engine/api/v1.35/\">Docker Remote API</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -5379,7 +5614,7 @@
                 "startPeriod": {
                     "target": "com.amazonaws.ecs#BoxedInteger",
                     "traits": {
-                        "smithy.api#documentation": "<p>The optional grace period to provide containers time to bootstrap before failed health\n\t\t\tchecks count towards the maximum number of retries. You can specify between 0 and 300\n\t\t\tseconds. By default, the <code>startPeriod</code> is disabled.</p>\n         <note>\n            <p>If a health check succeeds within the <code>startPeriod</code>, then the container\n\t\t\t\tis considered healthy and any subsequent failures count toward the maximum number of\n\t\t\t\tretries.</p>\n         </note>"
+                        "smithy.api#documentation": "<p>The optional grace period to provide containers time to bootstrap before failed health\n\t\t\tchecks count towards the maximum number of retries. You can specify between 0 and 300\n\t\t\tseconds. By default, the <code>startPeriod</code> is off.</p>\n         <note>\n            <p>If a health check succeeds within the <code>startPeriod</code>, then the container\n\t\t\t\tis considered healthy and any subsequent failures count toward the maximum number of\n\t\t\t\tretries.</p>\n         </note>"
                     }
                 }
             },
@@ -5797,7 +6032,7 @@
                 "principalArn": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the principal, which can be an IAM user, IAM role, or the root user. If\n\t\t\tthis field is omitted, the account settings are listed only for the authenticated\n\t\t\tuser.</p>\n         <note>\n            <p>Federated users assume the account setting of the root user and can't have\n\t\t\t\texplicit account settings set for them.</p>\n         </note>"
+                        "smithy.api#documentation": "<p>The ARN of the principal, which can be a user, role, or the root user. If\n\t\t\tthis field is omitted, the account settings are listed only for the authenticated\n\t\t\tuser.</p>\n         <note>\n            <p>Federated users assume the account setting of the root user and can't have\n\t\t\t\texplicit account settings set for them.</p>\n         </note>"
                     }
                 },
                 "effectiveSettings": {
@@ -5820,6 +6055,9 @@
                         "smithy.api#documentation": "<p>The maximum number of account setting results returned by\n\t\t\t\t<code>ListAccountSettings</code> in paginated output. When this parameter is used,\n\t\t\t\t<code>ListAccountSettings</code> only returns <code>maxResults</code> results in a\n\t\t\tsingle page along with a <code>nextToken</code> response element. The remaining results\n\t\t\tof the initial request can be seen by sending another <code>ListAccountSettings</code>\n\t\t\trequest with the returned <code>nextToken</code> value. This value can be between\n\t\t\t1 and 10. If this\n\t\t\tparameter isn't used, then <code>ListAccountSettings</code> returns up to\n\t\t\t10 results and a <code>nextToken</code> value\n\t\t\tif applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListAccountSettingsResponse": {
@@ -5837,6 +6075,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n\t\t\t\t<code>ListAccountSettings</code> request. When the results of a\n\t\t\t\t<code>ListAccountSettings</code> request exceed <code>maxResults</code>, this value\n\t\t\tcan be used to retrieve the next page of results. This value is <code>null</code> when\n\t\t\tthere are no more results to return.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListAttributes": {
@@ -5905,6 +6146,9 @@
                         "smithy.api#documentation": "<p>The maximum number of cluster results that <code>ListAttributes</code> returned in\n\t\t\tpaginated output. When this parameter is used, <code>ListAttributes</code> only returns\n\t\t\t\t<code>maxResults</code> results in a single page along with a <code>nextToken</code>\n\t\t\tresponse element. The remaining results of the initial request can be seen by sending\n\t\t\tanother <code>ListAttributes</code> request with the returned <code>nextToken</code>\n\t\t\tvalue. This value can be between 1 and 100. If this\n\t\t\tparameter isn't used, then <code>ListAttributes</code> returns up to\n\t\t\t100 results and a <code>nextToken</code> value if applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListAttributesResponse": {
@@ -5922,6 +6166,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListAttributes</code>\n\t\t\trequest. When the results of a <code>ListAttributes</code> request exceed\n\t\t\t\t<code>maxResults</code>, this value can be used to retrieve the next page of\n\t\t\tresults. This value is <code>null</code> when there are no more results to\n\t\t\treturn.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListClusters": {
@@ -5968,6 +6215,9 @@
                         "smithy.api#documentation": "<p>The maximum number of cluster results that <code>ListClusters</code> returned in\n\t\t\tpaginated output. When this parameter is used, <code>ListClusters</code> only returns\n\t\t\t\t<code>maxResults</code> results in a single page along with a <code>nextToken</code>\n\t\t\tresponse element. The remaining results of the initial request can be seen by sending\n\t\t\tanother <code>ListClusters</code> request with the returned <code>nextToken</code>\n\t\t\tvalue. This value can be between 1 and 100. If this\n\t\t\tparameter isn't used, then <code>ListClusters</code> returns up to 100\n\t\t\tresults and a <code>nextToken</code> value if applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListClustersResponse": {
@@ -5985,6 +6235,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListClusters</code>\n\t\t\trequest. When the results of a <code>ListClusters</code> request exceed\n\t\t\t\t<code>maxResults</code>, this value can be used to retrieve the next page of\n\t\t\tresults. This value is <code>null</code> when there are no more results to\n\t\t\treturn.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListContainerInstances": {
@@ -6052,6 +6305,9 @@
                         "smithy.api#documentation": "<p>Filters the container instances by status. For example, if you specify the\n\t\t\t\t<code>DRAINING</code> status, the results include only container instances that have\n\t\t\tbeen set to <code>DRAINING</code> using <a>UpdateContainerInstancesState</a>.\n\t\t\tIf you don't specify this parameter, the default is to include container instances set\n\t\t\tto all states other than <code>INACTIVE</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListContainerInstancesResponse": {
@@ -6069,6 +6325,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n\t\t\t\t<code>ListContainerInstances</code> request. When the results of a\n\t\t\t\t<code>ListContainerInstances</code> request exceed <code>maxResults</code>, this\n\t\t\tvalue can be used to retrieve the next page of results. This value is <code>null</code>\n\t\t\twhen there are no more results to return.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListServices": {
@@ -6157,6 +6416,9 @@
                         "smithy.api#documentation": "<p>The maximum number of service results that <code>ListServicesByNamespace</code>\n\t\t\treturns in paginated output. When this parameter is used,\n\t\t\t\t<code>ListServicesByNamespace</code> only returns <code>maxResults</code> results in\n\t\t\ta single page along with a <code>nextToken</code> response element. The remaining\n\t\t\tresults of the initial request can be seen by sending another\n\t\t\t\t<code>ListServicesByNamespace</code> request with the returned\n\t\t\t\t<code>nextToken</code> value. This value can be between 1 and\n\t\t\t100. If this parameter isn't used, then\n\t\t\t\t<code>ListServicesByNamespace</code> returns up to\n\t\t\t10 results and a <code>nextToken</code>\n\t\t\tvalue if applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListServicesByNamespaceResponse": {
@@ -6174,6 +6436,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n\t\t\t\t<code>ListServicesByNamespace</code> request. When the results of a\n\t\t\t\t<code>ListServicesByNamespace</code> request exceed <code>maxResults</code>, this\n\t\t\tvalue can be used to retrieve the next page of results. When there are no more results\n\t\t\tto return, this value is <code>null</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListServicesRequest": {
@@ -6209,6 +6474,9 @@
                         "smithy.api#documentation": "<p>The scheduling strategy to use when filtering the <code>ListServices</code>\n\t\t\tresults.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListServicesResponse": {
@@ -6226,6 +6494,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListServices</code>\n\t\t\trequest. When the results of a <code>ListServices</code> request exceed\n\t\t\t\t<code>maxResults</code>, this value can be used to retrieve the next page of\n\t\t\tresults. This value is <code>null</code> when there are no more results to\n\t\t\treturn.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListTagsForResource": {
@@ -6264,6 +6535,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListTagsForResourceResponse": {
@@ -6275,6 +6549,9 @@
                         "smithy.api#documentation": "<p>The tags for the resource.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListTaskDefinitionFamilies": {
@@ -6333,6 +6610,9 @@
                         "smithy.api#documentation": "<p>The maximum number of task definition family results that\n\t\t\t\t<code>ListTaskDefinitionFamilies</code> returned in paginated output. When this\n\t\t\tparameter is used, <code>ListTaskDefinitions</code> only returns <code>maxResults</code>\n\t\t\tresults in a single page along with a <code>nextToken</code> response element. The\n\t\t\tremaining results of the initial request can be seen by sending another\n\t\t\t\t<code>ListTaskDefinitionFamilies</code> request with the returned\n\t\t\t\t<code>nextToken</code> value. This value can be between 1 and\n\t\t\t100. If this parameter isn't used, then\n\t\t\t\t<code>ListTaskDefinitionFamilies</code> returns up to 100 results\n\t\t\tand a <code>nextToken</code> value if applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListTaskDefinitionFamiliesResponse": {
@@ -6350,6 +6630,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n\t\t\t\t<code>ListTaskDefinitionFamilies</code> request. When the results of a\n\t\t\t\t<code>ListTaskDefinitionFamilies</code> request exceed <code>maxResults</code>, this\n\t\t\tvalue can be used to retrieve the next page of results. This value is <code>null</code>\n\t\t\twhen there are no more results to return.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListTaskDefinitions": {
@@ -6414,6 +6697,9 @@
                         "smithy.api#documentation": "<p>The maximum number of task definition results that <code>ListTaskDefinitions</code>\n\t\t\treturned in paginated output. When this parameter is used,\n\t\t\t\t<code>ListTaskDefinitions</code> only returns <code>maxResults</code> results in a\n\t\t\tsingle page along with a <code>nextToken</code> response element. The remaining results\n\t\t\tof the initial request can be seen by sending another <code>ListTaskDefinitions</code>\n\t\t\trequest with the returned <code>nextToken</code> value. This value can be between\n\t\t\t1 and 100. If this parameter isn't used, then\n\t\t\t\t<code>ListTaskDefinitions</code> returns up to 100 results and a\n\t\t\t\t<code>nextToken</code> value if applicable.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListTaskDefinitionsResponse": {
@@ -6431,6 +6717,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future\n\t\t\t\t<code>ListTaskDefinitions</code> request. When the results of a\n\t\t\t\t<code>ListTaskDefinitions</code> request exceed <code>maxResults</code>, this value\n\t\t\tcan be used to retrieve the next page of results. This value is <code>null</code> when\n\t\t\tthere are no more results to return.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#ListTasks": {
@@ -6525,6 +6814,9 @@
                         "smithy.api#documentation": "<p>The launch type to use when filtering the <code>ListTasks</code> results.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#ListTasksResponse": {
@@ -6542,6 +6834,9 @@
                         "smithy.api#documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListTasks</code>\n\t\t\trequest. When the results of a <code>ListTasks</code> request exceed\n\t\t\t\t<code>maxResults</code>, this value can be used to retrieve the next page of\n\t\t\tresults. This value is <code>null</code> when there are no more results to\n\t\t\treturn.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#LoadBalancer": {
@@ -6802,7 +7097,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The managed scaling settings for the Auto Scaling group capacity provider.</p>\n         <p>When managed scaling is enabled, Amazon ECS manages the scale-in and scale-out actions of\n\t\t\tthe Auto Scaling group. Amazon ECS manages a target tracking scaling policy using an Amazon ECS\n\t\t\tmanaged CloudWatch metric with the specified <code>targetCapacity</code> value as the target\n\t\t\tvalue for the metric. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html#asg-capacity-providers-managed-scaling\">Using managed scaling</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>If managed scaling is disabled, the user must manage the scaling of the Auto Scaling\n\t\t\tgroup.</p>"
+                "smithy.api#documentation": "<p>The managed scaling settings for the Auto Scaling group capacity provider.</p>\n         <p>When managed scaling is enabled, Amazon ECS manages the scale-in and scale-out actions of\n\t\t\tthe Auto Scaling group. Amazon ECS manages a target tracking scaling policy using an Amazon ECS\n\t\t\tmanaged CloudWatch metric with the specified <code>targetCapacity</code> value as the target\n\t\t\tvalue for the metric. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/asg-capacity-providers.html#asg-capacity-providers-managed-scaling\">Using managed scaling</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>If managed scaling is off, the user must manage the scaling of the Auto Scaling\n\t\t\tgroup.</p>"
             }
         },
         "com.amazonaws.ecs#ManagedScalingInstanceWarmupPeriod": {
@@ -6952,7 +7247,7 @@
                 "containerPortRange": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The port number range on the container that's bound to the dynamically mapped host port range.</p>\n         <p>The following rules apply when you specify a <code>containerPortRange</code>:</p>\n         <ul>\n            <li>\n               <p>You must use either the <code>bridge</code> network mode or the <code>awsvpc</code>\n\t\t\t\t\tnetwork mode.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the EC2 and Fargate launch types.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the Linux and Windows operating systems.</p>\n            </li>\n            <li>\n               <p>The container instance must have at least version 1.67.0 of the container agent\n\t\t\t\t\tand at least version 1.67.0-1 of the <code>ecs-init</code> package </p>\n            </li>\n            <li>\n               <p>You can specify a maximum of 100 port ranges per container.</p>\n            </li>\n            <li>\n               <p>You do not specify a <code>hostPortRange</code>. The value of the <code>hostPortRange</code> is set\n\t\t\t\t\tas follows:</p>\n               <ul>\n                  <li>\n                     <p>For containers in a task with the <code>awsvpc</code> network mode,\n\t\t\t\t\t\t\tthe <code>hostPort</code> is set to the same value as the\n\t\t\t\t\t\t\t\t<code>containerPort</code>. This is a static mapping\n\t\t\t\t\t\t\tstrategy.</p>\n                  </li>\n                  <li>\n                     <p>For containers in a task with the <code>bridge</code> network mode, the Amazon ECS agent finds open host ports from the default ephemeral range and passes it to docker to bind them to the container ports.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>The <code>containerPortRange</code> valid values are between 1 and\n\t\t\t\t\t65535.</p>\n            </li>\n            <li>\n               <p>A port can only be included in one port mapping per container.</p>\n            </li>\n            <li>\n               <p>You cannot specify overlapping port ranges.</p>\n            </li>\n            <li>\n               <p>The first port in the range must be less than last port in the range.</p>\n            </li>\n            <li>\n               <p>Docker recommends that you turn off the docker-proxy in the Docker daemon config file when you have a large number of ports.</p>\n               <p>For more information, see <a href=\"https://github.com/moby/moby/issues/11185\"> Issue #11185</a> on the Github website.</p>\n               <p>For information about how to  turn off the docker-proxy in the Docker daemon config file, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon\">Docker daemon</a> in the <i>Amazon ECS Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <p>You can call <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html\">\n               <code>DescribeTasks</code>\n            </a> to view the <code>hostPortRange</code> which\n\t\t\tare the host ports that are bound to the container ports.</p>"
+                        "smithy.api#documentation": "<p>The port number range on the container that's bound to the dynamically mapped host port\n\t\t\trange.</p>\n         <p>The following rules apply when you specify a <code>containerPortRange</code>:</p>\n         <ul>\n            <li>\n               <p>You must use either the <code>bridge</code> network mode or the <code>awsvpc</code>\n\t\t\t\t\tnetwork mode.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the EC2 and Fargate launch types.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the Linux and Windows operating systems.</p>\n            </li>\n            <li>\n               <p>The container instance must have at least version 1.67.0 of the container agent\n\t\t\t\t\tand at least version 1.67.0-1 of the <code>ecs-init</code> package </p>\n            </li>\n            <li>\n               <p>You can specify a maximum of 100 port ranges per container.</p>\n            </li>\n            <li>\n               <p>You do not specify a <code>hostPortRange</code>. The value of the <code>hostPortRange</code> is set\n\t\t\t\t\tas follows:</p>\n               <ul>\n                  <li>\n                     <p>For containers in a task with the <code>awsvpc</code> network mode,\n\t\t\t\t\t\t\tthe <code>hostPort</code> is set to the same value as the\n\t\t\t\t\t\t\t\t<code>containerPort</code>. This is a static mapping\n\t\t\t\t\t\t\tstrategy.</p>\n                  </li>\n                  <li>\n                     <p>For containers in a task with the <code>bridge</code> network mode, the Amazon ECS agent finds open host ports from the default ephemeral range and passes it to docker to bind them to the container ports.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>The <code>containerPortRange</code> valid values are between 1 and\n\t\t\t\t\t65535.</p>\n            </li>\n            <li>\n               <p>A port can only be included in one port mapping per container.</p>\n            </li>\n            <li>\n               <p>You cannot specify overlapping port ranges.</p>\n            </li>\n            <li>\n               <p>The first port in the range must be less than last port in the range.</p>\n            </li>\n            <li>\n               <p>Docker recommends that you turn off the docker-proxy in the Docker daemon config file when you have a large number of ports.</p>\n               <p>For more information, see <a href=\"https://github.com/moby/moby/issues/11185\"> Issue #11185</a> on the Github website.</p>\n               <p>For information about how to  turn off the docker-proxy in the Docker daemon config file, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon\">Docker daemon</a> in the <i>Amazon ECS Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <p>You can call <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html\">\n               <code>DescribeTasks</code>\n            </a> to view the <code>hostPortRange</code> which\n\t\t\tare the host ports that are bound to the container ports.</p>"
                     }
                 },
                 "hostPortRange": {
@@ -6983,7 +7278,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>An object representing the network configuration for a task or service.</p>"
+                "smithy.api#documentation": "<p>The network configuration for a task or service.</p>"
             }
         },
         "com.amazonaws.ecs#NetworkInterface": {
@@ -7320,7 +7615,7 @@
                 "containerPortRange": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The port number range on the container that's bound to the dynamically mapped host port range.</p>\n         <p>The following rules apply when you specify a <code>containerPortRange</code>:</p>\n         <ul>\n            <li>\n               <p>You must use either the <code>bridge</code> network mode or the <code>awsvpc</code>\n\t\t\t\t\tnetwork mode.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the EC2 and Fargate launch types.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the Linux and Windows operating systems.</p>\n            </li>\n            <li>\n               <p>The container instance must have at least version 1.67.0 of the container agent\n\t\t\t\t\tand at least version 1.67.0-1 of the <code>ecs-init</code> package </p>\n            </li>\n            <li>\n               <p>You can specify a maximum of 100 port ranges per container.</p>\n            </li>\n            <li>\n               <p>You do not specify a <code>hostPortRange</code>. The value of the <code>hostPortRange</code> is set\n\t\t\t\t\tas follows:</p>\n               <ul>\n                  <li>\n                     <p>For containers in a task with the <code>awsvpc</code> network mode,\n\t\t\t\t\t\t\tthe <code>hostPort</code> is set to the same value as the\n\t\t\t\t\t\t\t\t<code>containerPort</code>. This is a static mapping\n\t\t\t\t\t\t\tstrategy.</p>\n                  </li>\n                  <li>\n                     <p>For containers in a task with the <code>bridge</code> network mode, the Amazon ECS agent finds open host ports from the default ephemeral range and passes it to docker to bind them to the container ports.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>The <code>containerPortRange</code> valid values are between 1 and\n\t\t\t\t\t65535.</p>\n            </li>\n            <li>\n               <p>A port can only be included in one port mapping per container.</p>\n            </li>\n            <li>\n               <p>You cannot specify overlapping port ranges.</p>\n            </li>\n            <li>\n               <p>The first port in the range must be less than last port in the range.</p>\n            </li>\n            <li>\n               <p>Docker recommends that you turn off the docker-proxy in the Docker daemon config file when you have a large number of ports.</p>\n               <p>For more information, see <a href=\"https://github.com/moby/moby/issues/11185\"> Issue #11185</a> on the Github website.</p>\n               <p>For information about how to  turn off the docker-proxy in the Docker daemon config file, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon\">Docker daemon</a> in the <i>Amazon ECS Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <p>You can call <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html\">\n               <code>DescribeTasks</code>\n            </a> to view the <code>hostPortRange</code> which\n\t\t\tare the host ports that are bound to the container ports.</p>"
+                        "smithy.api#documentation": "<p>The port number range on the container that's bound to the dynamically mapped host port\n\t\t\trange. </p>\n         <p>The following rules apply when you specify a <code>containerPortRange</code>:</p>\n         <ul>\n            <li>\n               <p>You must use either the <code>bridge</code> network mode or the <code>awsvpc</code>\n\t\t\t\t\tnetwork mode.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the EC2 and Fargate launch types.</p>\n            </li>\n            <li>\n               <p>This parameter is available for both the Linux and Windows operating systems.</p>\n            </li>\n            <li>\n               <p>The container instance must have at least version 1.67.0 of the container agent\n\t\t\t\t\tand at least version 1.67.0-1 of the <code>ecs-init</code> package </p>\n            </li>\n            <li>\n               <p>You can specify a maximum of 100 port ranges per container.</p>\n            </li>\n            <li>\n               <p>You do not specify a <code>hostPortRange</code>. The value of the <code>hostPortRange</code> is set\n\t\t\t\t\tas follows:</p>\n               <ul>\n                  <li>\n                     <p>For containers in a task with the <code>awsvpc</code> network mode,\n\t\t\t\t\t\t\tthe <code>hostPort</code> is set to the same value as the\n\t\t\t\t\t\t\t\t<code>containerPort</code>. This is a static mapping\n\t\t\t\t\t\t\tstrategy.</p>\n                  </li>\n                  <li>\n                     <p>For containers in a task with the <code>bridge</code> network mode, the Amazon ECS agent finds open host ports from the default ephemeral range and passes it to docker to bind them to the container ports.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>The <code>containerPortRange</code> valid values are between 1 and\n\t\t\t\t\t65535.</p>\n            </li>\n            <li>\n               <p>A port can only be included in one port mapping per container.</p>\n            </li>\n            <li>\n               <p>You cannot specify overlapping port ranges.</p>\n            </li>\n            <li>\n               <p>The first port in the range must be less than last port in the range.</p>\n            </li>\n            <li>\n               <p>Docker recommends that you turn off the docker-proxy in the Docker daemon config file when you have a large number of ports.</p>\n               <p>For more information, see <a href=\"https://github.com/moby/moby/issues/11185\"> Issue #11185</a> on the Github website.</p>\n               <p>For information about how to  turn off the docker-proxy in the Docker daemon config file, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bootstrap_container_instance.html#bootstrap_docker_daemon\">Docker daemon</a> in the <i>Amazon ECS Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <p>You can call <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_DescribeTasks.html\">\n               <code>DescribeTasks</code>\n            </a> to view the <code>hostPortRange</code> which\n\t\t\tare the host ports that are bound to the container ports.</p>"
                     }
                 }
             },
@@ -7379,7 +7674,7 @@
                     "target": "com.amazonaws.ecs#Boolean",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>The protection status of the task. If scale-in protection is enabled for a task, the\n\t\t\tvalue is <code>true</code>. Otherwise, it is <code>false</code>.</p>"
+                        "smithy.api#documentation": "<p>The protection status of the task. If scale-in protection is on for a task, the\n\t\t\tvalue is <code>true</code>. Otherwise, it is <code>false</code>.</p>"
                     }
                 },
                 "expirationDate": {
@@ -7463,7 +7758,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Modifies an account setting. Account settings are set on a per-Region basis.</p>\n         <p>If you change the account setting for the root user, the default settings for all of\n\t\t\tthe IAM users and roles that no individual account setting was specified are reset for.\n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html\">Account\n\t\t\t\tSettings</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>When <code>serviceLongArnFormat</code>, <code>taskLongArnFormat</code>, or\n\t\t\t\t<code>containerInstanceLongArnFormat</code> are specified, the Amazon Resource Name\n\t\t\t(ARN) and resource ID format of the resource type for a specified IAM user, IAM role, or\n\t\t\tthe root user for an account is affected. The opt-in and opt-out account setting must be\n\t\t\tset for each Amazon ECS resource separately. The ARN and resource ID format of a resource\n\t\t\tis defined by the opt-in status of the IAM user or role that created the resource. You\n\t\t\tmust turn on this setting to use Amazon ECS features such as resource tagging.</p>\n         <p>When <code>awsvpcTrunking</code> is specified, the elastic network interface (ENI)\n\t\t\tlimit for any new container instances that support the feature is changed. If\n\t\t\t\t<code>awsvpcTrunking</code> is enabled, any new container instances that support the\n\t\t\tfeature are launched have the increased ENI limits available to them. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html\">Elastic Network\n\t\t\t\tInterface Trunking</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>When <code>containerInsights</code> is specified, the default setting indicating\n\t\t\twhether CloudWatch Container Insights is enabled for your clusters is changed. If\n\t\t\t\t<code>containerInsights</code> is enabled, any new clusters that are created will\n\t\t\thave Container Insights enabled unless you disable it during cluster creation. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html\">CloudWatch\n\t\t\t\tContainer Insights</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Modifies an account setting. Account settings are set on a per-Region basis.</p>\n         <p>If you change the account setting for the root user, the default settings for all of\n\t\t\tthe users and roles that no individual account setting was specified are reset for.\n\t\t\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html\">Account\n\t\t\t\tSettings</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>When <code>serviceLongArnFormat</code>, <code>taskLongArnFormat</code>, or\n\t\t\t\t<code>containerInstanceLongArnFormat</code> are specified, the Amazon Resource Name\n\t\t\t(ARN) and resource ID format of the resource type for a specified user, role, or\n\t\t\tthe root user for an account is affected. The opt-in and opt-out account setting must be\n\t\t\tset for each Amazon ECS resource separately. The ARN and resource ID format of a resource\n\t\t\tis defined by the opt-in status of the user or role that created the resource. You\n\t\t\tmust turn on this setting to use Amazon ECS features such as resource tagging.</p>\n         <p>When <code>awsvpcTrunking</code> is specified, the elastic network interface (ENI)\n\t\t\tlimit for any new container instances that support the feature is changed. If\n\t\t\t\t<code>awsvpcTrunking</code> is enabled, any new container instances that support the\n\t\t\tfeature are launched have the increased ENI limits available to them. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/container-instance-eni.html\">Elastic Network\n\t\t\t\tInterface Trunking</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>When <code>containerInsights</code> is specified, the default setting indicating\n\t\t\twhether CloudWatch Container Insights is enabled for your clusters is changed. If\n\t\t\t\t<code>containerInsights</code> is enabled, any new clusters that are created will\n\t\t\thave Container Insights enabled unless you disable it during cluster creation. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cloudwatch-container-insights.html\">CloudWatch\n\t\t\t\tContainer Insights</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.ecs#PutAccountSettingDefault": {
@@ -7486,7 +7781,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Modifies an account setting for all IAM users on an account for whom no individual\n\t\t\taccount setting has been specified. Account settings are set on a per-Region\n\t\t\tbasis.</p>"
+                "smithy.api#documentation": "<p>Modifies an account setting for all users on an account for whom no individual\n\t\t\taccount setting has been specified. Account settings are set on a per-Region\n\t\t\tbasis.</p>"
             }
         },
         "com.amazonaws.ecs#PutAccountSettingDefaultRequest": {
@@ -7506,6 +7801,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#PutAccountSettingDefaultResponse": {
@@ -7517,6 +7815,9 @@
                         "smithy.api#documentation": "<p>The current setting for a resource.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#PutAccountSettingRequest": {
@@ -7539,9 +7840,12 @@
                 "principalArn": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the principal, which can be an IAM user, IAM role, or the root user. If\n\t\t\tyou specify the root user, it modifies the account setting for all IAM users, IAM roles,\n\t\t\tand the root user of the account unless an IAM user or role explicitly overrides these\n\t\t\tsettings. If this field is omitted, the setting is changed only for the authenticated\n\t\t\tuser.</p>\n         <note>\n            <p>Federated users assume the account setting of the root user and can't have\n\t\t\t\texplicit account settings set for them.</p>\n         </note>"
+                        "smithy.api#documentation": "<p>The ARN of the principal, which can be a user, role, or the root user. If\n\t\t\tyou specify the root user, it modifies the account setting for all users, roles,\n\t\t\tand the root user of the account unless a user or role explicitly overrides these\n\t\t\tsettings. If this field is omitted, the setting is changed only for the authenticated\n\t\t\tuser.</p>\n         <note>\n            <p>Federated users assume the account setting of the root user and can't have\n\t\t\t\texplicit account settings set for them.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#PutAccountSettingResponse": {
@@ -7553,6 +7857,9 @@
                         "smithy.api#documentation": "<p>The current account setting for a resource.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#PutAttributes": {
@@ -7597,6 +7904,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#PutAttributesResponse": {
@@ -7608,6 +7918,9 @@
                         "smithy.api#documentation": "<p>The attributes applied to your resource.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#PutClusterCapacityProviders": {
@@ -7666,6 +7979,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#PutClusterCapacityProvidersResponse": {
@@ -7677,6 +7993,9 @@
                         "smithy.api#documentation": "<p>Details about the cluster.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#RegisterContainerInstance": {
@@ -7759,6 +8078,9 @@
                         "smithy.api#documentation": "<p>The metadata that you apply to the container instance to help you categorize and\n\t\t\torganize them. Each tag consists of a key and an optional value. You define both.</p>\n         <p>The following basic restrictions apply to tags:</p>\n         <ul>\n            <li>\n               <p>Maximum number of tags per resource - 50</p>\n            </li>\n            <li>\n               <p>For each resource, each tag key must be unique, and each tag key can have only\n                    one value.</p>\n            </li>\n            <li>\n               <p>Maximum key length - 128 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>Maximum value length - 256 Unicode characters in UTF-8</p>\n            </li>\n            <li>\n               <p>If your tagging schema is used across multiple services and resources,\n                    remember that other services may have restrictions on allowed characters.\n                    Generally allowed characters are: letters, numbers, and spaces representable in\n                    UTF-8, and the following characters: + - = . _ : / @.</p>\n            </li>\n            <li>\n               <p>Tag keys and values are case-sensitive.</p>\n            </li>\n            <li>\n               <p>Do not use <code>aws:</code>, <code>AWS:</code>, or any upper or lowercase\n                    combination of such as a prefix for either keys or values as it is reserved for\n                    Amazon Web Services use. You cannot edit or delete tag keys or values with this prefix. Tags with\n                    this prefix do not count against your tags per resource limit.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#RegisterContainerInstanceResponse": {
@@ -7770,6 +8092,9 @@
                         "smithy.api#documentation": "<p>The container instance that was registered.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#RegisterTaskDefinition": {
@@ -7792,7 +8117,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Registers a new task definition from the supplied <code>family</code> and\n\t\t\t\t<code>containerDefinitions</code>. Optionally, you can add data volumes to your\n\t\t\tcontainers with the <code>volumes</code> parameter. For more information about task\n\t\t\tdefinition parameters and defaults, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html\">Amazon ECS Task\n\t\t\t\tDefinitions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>You can specify an IAM role for your task with the <code>taskRoleArn</code> parameter.\n\t\t\tWhen you specify an IAM role for a task, its containers can then use the latest versions\n\t\t\tof the CLI or SDKs to make API requests to the Amazon Web Services services that are specified in\n\t\t\tthe IAM policy that's associated with the role. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM\n\t\t\t\tRoles for Tasks</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>You can specify a Docker networking mode for the containers in your task definition\n\t\t\twith the <code>networkMode</code> parameter. The available network modes correspond to\n\t\t\tthose described in <a href=\"https://docs.docker.com/engine/reference/run/#/network-settings\">Network\n\t\t\t\tsettings</a> in the Docker run reference. If you specify the <code>awsvpc</code>\n\t\t\tnetwork mode, the task is allocated an elastic network interface, and you must specify a\n\t\t\t\t<a>NetworkConfiguration</a> when you create a service or run a task with\n\t\t\tthe task definition. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html\">Task Networking</a>\n\t\t\tin the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Registers a new task definition from the supplied <code>family</code> and\n\t\t\t\t<code>containerDefinitions</code>. Optionally, you can add data volumes to your\n\t\t\tcontainers with the <code>volumes</code> parameter. For more information about task\n\t\t\tdefinition parameters and defaults, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html\">Amazon ECS Task\n\t\t\t\tDefinitions</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>You can specify a role for your task with the <code>taskRoleArn</code> parameter.\n\t\t\tWhen you specify a role for a task, its containers can then use the latest versions\n\t\t\tof the CLI or SDKs to make API requests to the Amazon Web Services services that are specified in\n\t\t\tthe policy that's associated with the role. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM\n\t\t\t\tRoles for Tasks</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n         <p>You can specify a Docker networking mode for the containers in your task definition\n\t\t\twith the <code>networkMode</code> parameter. The available network modes correspond to\n\t\t\tthose described in <a href=\"https://docs.docker.com/engine/reference/run/#/network-settings\">Network\n\t\t\t\tsettings</a> in the Docker run reference. If you specify the <code>awsvpc</code>\n\t\t\tnetwork mode, the task is allocated an elastic network interface, and you must specify a\n\t\t\t\t<a>NetworkConfiguration</a> when you create a service or run a task with\n\t\t\tthe task definition. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html\">Task Networking</a>\n\t\t\tin the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
             }
         },
         "com.amazonaws.ecs#RegisterTaskDefinitionRequest": {
@@ -7902,6 +8227,9 @@
                         "smithy.api#documentation": "<p>The operating system that your tasks definitions run on. A platform family is\n\t\t\tspecified only for tasks using the Fargate launch type. </p>\n         <p>When you specify a task definition in a service, this value must match the\n\t\t\t\t<code>runtimePlatform</code> value of the service.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#RegisterTaskDefinitionResponse": {
@@ -7919,6 +8247,9 @@
                         "smithy.api#documentation": "<p>The list of tags associated with the task definition.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#RepositoryCredentials": {
@@ -8209,10 +8540,13 @@
                 "taskDefinition": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or\n\t\t\tfull ARN of the task definition to run. If a <code>revision</code> isn't specified,\n\t\t\tthe latest <code>ACTIVE</code> revision is used.</p>\n         <p>When you create an IAM policy for run-task, you can set the resource to be the latest\n\t\t\ttask definition revision, or a specific revision.</p>\n         <p>The full ARN value must match the value that you specified as the\n\t\t\t\t<code>Resource</code> of the IAM principal's permissions policy.</p>\n         <p>When you specify the policy resource as the latest task definition version (by setting\n\t\t\tthe <code>Resource</code> in the policy to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName</code>),\n\t\t\tthen set this value to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName</code>.</p>\n         <p>When you specify the policy resource as a specific task definition version (by setting\n\t\t\tthe <code>Resource</code> in the policy to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName:1</code> or\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName:*</code>),\n\t\t\tthen set this value to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName:1</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security_iam_service-with-iam.html#security_iam_service-with-iam-id-based-policies-resources\">Policy Resources for Amazon ECS</a> in the Amazon Elastic Container Service developer Guide.</p>",
+                        "smithy.api#documentation": "<p>The <code>family</code> and <code>revision</code> (<code>family:revision</code>) or\n\t\t\tfull ARN of the task definition to run. If a <code>revision</code> isn't specified,\n\t\t\tthe latest <code>ACTIVE</code> revision is used.</p>\n         <p>When you create a policy for run-task, you can set the resource to be the latest\n\t\t\ttask definition revision, or a specific revision.</p>\n         <p>The full ARN value must match the value that you specified as the\n\t\t\t\t<code>Resource</code> of the principal's permissions policy.</p>\n         <p>When you specify the policy resource as the latest task definition version (by setting\n\t\t\tthe <code>Resource</code> in the policy to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName</code>),\n\t\t\tthen set this value to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName</code>.</p>\n         <p>When you specify the policy resource as a specific task definition version (by setting\n\t\t\tthe <code>Resource</code> in the policy to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName:1</code> or\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName:*</code>),\n\t\t\tthen set this value to\n\t\t\t\t<code>arn:aws:ecs:us-east-1:111122223333:task-definition/TaskFamilyName:1</code>.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/security_iam_service-with-iam.html#security_iam_service-with-iam-id-based-policies-resources\">Policy Resources for Amazon ECS</a> in the Amazon Elastic Container Service developer Guide.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#RunTaskResponse": {
@@ -8230,6 +8564,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#RuntimePlatform": {
@@ -8841,13 +9178,13 @@
                 "value": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>Determines whether the account setting is enabled or disabled for the specified\n\t\t\tresource.</p>"
+                        "smithy.api#documentation": "<p>Determines whether the account setting is on or off for the specified resource.</p>"
                     }
                 },
                 "principalArn": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the principal. It can be an IAM user, IAM role, or the root user. If this\n\t\t\tfield is omitted, the authenticated user is assumed.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the principal. It can be a user, role, or the root user. If this\n\t\t\tfield is omitted, the authenticated user is assumed.</p>"
                     }
                 }
             },
@@ -9035,6 +9372,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#StartTaskResponse": {
@@ -9052,6 +9392,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#Statistics": {
@@ -9098,7 +9441,7 @@
                 "task": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The task ID or full Amazon Resource Name (ARN) of the task to stop.</p>",
+                        "smithy.api#documentation": "<p>The task ID of the task to stop.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -9108,6 +9451,9 @@
                         "smithy.api#documentation": "<p>An optional message specified when a task is stopped. For example, if you're using a\n\t\t\tcustom scheduler, you can use this parameter to specify the reason for stopping the task\n\t\t\there, and the message appears in subsequent <a>DescribeTasks</a> API\n\t\t\toperations on this task. Up to 255 characters are allowed in this message.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#StopTaskResponse": {
@@ -9119,6 +9465,9 @@
                         "smithy.api#documentation": "<p>The task that was stopped.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#String": {
@@ -9181,6 +9530,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#SubmitAttachmentStateChangesResponse": {
@@ -9192,6 +9544,9 @@
                         "smithy.api#documentation": "<p>Acknowledgement of the state change.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#SubmitContainerStateChange": {
@@ -9268,6 +9623,9 @@
                         "smithy.api#documentation": "<p>The network bindings of the container.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#SubmitContainerStateChangeResponse": {
@@ -9279,6 +9637,9 @@
                         "smithy.api#documentation": "<p>Acknowledgement of the state change.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#SubmitTaskStateChange": {
@@ -9370,6 +9731,9 @@
                         "smithy.api#documentation": "<p>The Unix timestamp for the time when the task execution stopped.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#SubmitTaskStateChangeResponse": {
@@ -9381,6 +9745,9 @@
                         "smithy.api#documentation": "<p>Acknowledgement of the state change.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#SystemControl": {
@@ -9491,11 +9858,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#TagResourceResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.ecs#TagValue": {
             "type": "string",
@@ -9973,6 +10346,12 @@
                 "target": "com.amazonaws.ecs#TaskDefinitionField"
             }
         },
+        "com.amazonaws.ecs#TaskDefinitionList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.ecs#TaskDefinition"
+            }
+        },
         "com.amazonaws.ecs#TaskDefinitionPlacementConstraint": {
             "type": "structure",
             "members": {
@@ -10024,6 +10403,12 @@
                     "traits": {
                         "smithy.api#enumValue": "INACTIVE"
                     }
+                },
+                "DELETE_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+                    }
                 }
             }
         },
@@ -10068,7 +10453,7 @@
                 "executionRoleArn": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the task execution IAM role override for the task. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html\">Amazon ECS task\n\t\t\t\texecution IAM role</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the task execution role override for the task. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_execution_IAM_role.html\">Amazon ECS task\n\t\t\t\texecution IAM role</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 },
                 "memory": {
@@ -10080,7 +10465,7 @@
                 "taskRoleArn": {
                     "target": "com.amazonaws.ecs#String",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers\n\t\t\tin this task are granted the permissions that are specified in this role. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM Role for Tasks</a>\n\t\t\tin the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role that containers in this task can assume. All containers\n\t\t\tin this task are granted the permissions that are specified in this role. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html\">IAM Role for Tasks</a>\n\t\t\tin the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 },
                 "ephemeralStorage": {
@@ -10414,7 +10799,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The <code>ulimit</code> settings to pass to the container.</p>\n         <p>Amazon ECS tasks hosted on Fargate use the default\n\t\t\t\t\t\t\tresource limit values set by the operating system with the exception of\n\t\t\t\t\t\t\tthe <code>nofile</code> resource limit parameter which Fargate\n\t\t\t\t\t\t\toverrides. The <code>nofile</code> resource limit sets a restriction on\n\t\t\t\t\t\t\tthe number of open files that a container can use. The default\n\t\t\t\t\t\t\t\t<code>nofile</code> soft limit is <code>1024</code> and hard limit\n\t\t\t\t\t\t\tis <code>4096</code>.</p>"
+                "smithy.api#documentation": "<p>The <code>ulimit</code> settings to pass to the container.</p>\n         <p>Amazon ECS tasks hosted on Fargate use the default\n\t\t\t\t\t\t\tresource limit values set by the operating system with the exception of\n\t\t\t\t\t\t\tthe <code>nofile</code> resource limit parameter which Fargate\n\t\t\t\t\t\t\toverrides. The <code>nofile</code> resource limit sets a restriction on\n\t\t\t\t\t\t\tthe number of open files that a container can use. The default\n\t\t\t\t\t\t\t\t<code>nofile</code> soft limit is <code>1024</code> and the default hard limit\n\t\t\t\t\t\t\tis <code>4096</code>.</p>\n         <p>You can specify the <code>ulimit</code> settings for a container in a task\n\t\t\tdefinition.</p>"
             }
         },
         "com.amazonaws.ecs#UlimitList": {
@@ -10576,11 +10961,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UntagResourceResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.ecs#UpdateCapacityProvider": {
             "type": "operation",
@@ -10622,6 +11013,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateCapacityProviderResponse": {
@@ -10633,6 +11027,9 @@
                         "smithy.api#documentation": "<p>Details about the capacity provider.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateCluster": {
@@ -10689,6 +11086,9 @@
                         "smithy.api#documentation": "<p>Use this parameter to set a default Service Connect namespace. After you set a default \n\tService Connect namespace, any new services with Service Connect turned on that are created in the cluster are added as\n\tclient services in the namespace. This setting only applies to new services that set the <code>enabled</code> parameter to\n\t<code>true</code> in the <code>ServiceConnectConfiguration</code>.\n\tYou can set the namespace of each service individually in the <code>ServiceConnectConfiguration</code> to override this default\n\tparameter.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateClusterResponse": {
@@ -10700,6 +11100,9 @@
                         "smithy.api#documentation": "<p>Details about the cluster.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateClusterSettings": {
@@ -10745,6 +11148,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateClusterSettingsResponse": {
@@ -10756,6 +11162,9 @@
                         "smithy.api#documentation": "<p>Details about the cluster</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateContainerAgent": {
@@ -10809,6 +11218,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateContainerAgentResponse": {
@@ -10820,6 +11232,9 @@
                         "smithy.api#documentation": "<p>The container instance that the container agent was updated for.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateContainerInstancesState": {
@@ -10871,6 +11286,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateContainerInstancesStateResponse": {
@@ -10888,6 +11306,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateInProgressException": {
@@ -10943,7 +11364,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Modifies the parameters of a service.</p>\n         <p>For services using the rolling update (<code>ECS</code>) you can update the desired\n\t\t\tcount, deployment configuration, network configuration, load balancers, service\n\t\t\tregistries, enable ECS managed tags option, propagate tags option, task placement\n\t\t\tconstraints and strategies, and task definition. When you update any of these\n\t\t\tparameters, Amazon ECS starts new tasks with the new configuration. </p>\n         <p>For services using the blue/green (<code>CODE_DEPLOY</code>) deployment controller,\n\t\t\tonly the desired count, deployment configuration, health check grace period, task\n\t\t\tplacement constraints and strategies, enable ECS managed tags option, and propagate tags\n\t\t\tcan be updated using this API. If the network configuration, platform version, task\n\t\t\tdefinition, or load balancer need to be updated, create a new CodeDeploy deployment. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeployment.html\">CreateDeployment</a> in the <i>CodeDeploy API Reference</i>.</p>\n         <p>For services using an external deployment controller, you can update only the desired\n\t\t\tcount, task placement constraints and strategies, health check grace period, enable ECS\n\t\t\tmanaged tags option, and propagate tags option, using this API. If the launch type, load\n\t\t\tbalancer, network configuration, platform version, or task definition need to be\n\t\t\tupdated, create a new task set For more information, see <a>CreateTaskSet</a>.</p>\n         <p>You can add to or subtract from the number of instantiations of a task definition in a\n\t\t\tservice by specifying the cluster that the service is running in and a new\n\t\t\t\t<code>desiredCount</code> parameter.</p>\n         <p>If you have updated the Docker image of your application, you can create a new task\n\t\t\tdefinition with that image and deploy it to your service. The service scheduler uses the\n\t\t\tminimum healthy percent and maximum percent parameters (in the service's deployment\n\t\t\tconfiguration) to determine the deployment strategy.</p>\n         <note>\n            <p>If your updated Docker image uses the same tag as what is in the existing task\n\t\t\t\tdefinition for your service (for example, <code>my_image:latest</code>), you don't\n\t\t\t\tneed to create a new revision of your task definition. You can update the service\n\t\t\t\tusing the <code>forceNewDeployment</code> option. The new tasks launched by the\n\t\t\t\tdeployment pull the current image/tag combination from your repository when they\n\t\t\t\tstart.</p>\n         </note>\n         <p>You can also update the deployment configuration of a service. When a deployment is\n\t\t\ttriggered by updating the task definition of a service, the service scheduler uses the\n\t\t\tdeployment configuration parameters, <code>minimumHealthyPercent</code> and\n\t\t\t\t<code>maximumPercent</code>, to determine the deployment strategy.</p>\n         <ul>\n            <li>\n               <p>If <code>minimumHealthyPercent</code> is below 100%, the scheduler can ignore\n\t\t\t\t\t\t<code>desiredCount</code> temporarily during a deployment. For example, if\n\t\t\t\t\t\t<code>desiredCount</code> is four tasks, a minimum of 50% allows the\n\t\t\t\t\tscheduler to stop two existing tasks before starting two new tasks. Tasks for\n\t\t\t\t\tservices that don't use a load balancer are considered healthy if they're in the\n\t\t\t\t\t\t<code>RUNNING</code> state. Tasks for services that use a load balancer are\n\t\t\t\t\tconsidered healthy if they're in the <code>RUNNING</code> state and are reported\n\t\t\t\t\tas healthy by the load balancer.</p>\n            </li>\n            <li>\n               <p>The <code>maximumPercent</code> parameter represents an upper limit on the\n\t\t\t\t\tnumber of running tasks during a deployment. You can use it to define the\n\t\t\t\t\tdeployment batch size. For example, if <code>desiredCount</code> is four tasks,\n\t\t\t\t\ta maximum of 200% starts four new tasks before stopping the four older tasks\n\t\t\t\t\t(provided that the cluster resources required to do this are available).</p>\n            </li>\n         </ul>\n         <p>When <a>UpdateService</a> stops a task during a deployment, the equivalent\n\t\t\tof <code>docker stop</code> is issued to the containers running in the task. This\n\t\t\tresults in a <code>SIGTERM</code> and a 30-second timeout. After this,\n\t\t\t\t<code>SIGKILL</code> is sent and the containers are forcibly stopped. If the\n\t\t\tcontainer handles the <code>SIGTERM</code> gracefully and exits within 30 seconds from\n\t\t\treceiving it, no <code>SIGKILL</code> is sent.</p>\n         <p>When the service scheduler launches new tasks, it determines task placement in your\n\t\t\tcluster with the following logic.</p>\n         <ul>\n            <li>\n               <p>Determine which of the container instances in your cluster can support your\n\t\t\t\t\tservice's task definition. For example, they have the required CPU, memory,\n\t\t\t\t\tports, and container instance attributes.</p>\n            </li>\n            <li>\n               <p>By default, the service scheduler attempts to balance tasks across\n\t\t\t\t\tAvailability Zones in this manner even though you can choose a different\n\t\t\t\t\tplacement strategy.</p>\n               <ul>\n                  <li>\n                     <p>Sort the valid container instances by the fewest number of running\n\t\t\t\t\t\t\ttasks for this service in the same Availability Zone as the instance.\n\t\t\t\t\t\t\tFor example, if zone A has one running service task and zones B and C\n\t\t\t\t\t\t\teach have zero, valid container instances in either zone B or C are\n\t\t\t\t\t\t\tconsidered optimal for placement.</p>\n                  </li>\n                  <li>\n                     <p>Place the new service task on a valid container instance in an optimal\n\t\t\t\t\t\t\tAvailability Zone (based on the previous steps), favoring container\n\t\t\t\t\t\t\tinstances with the fewest number of running tasks for this\n\t\t\t\t\t\t\tservice.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>When the service scheduler stops running tasks, it attempts to maintain balance across\n\t\t\tthe Availability Zones in your cluster using the following logic: </p>\n         <ul>\n            <li>\n               <p>Sort the container instances by the largest number of running tasks for this\n\t\t\t\t\tservice in the same Availability Zone as the instance. For example, if zone A\n\t\t\t\t\thas one running service task and zones B and C each have two, container\n\t\t\t\t\tinstances in either zone B or C are considered optimal for termination.</p>\n            </li>\n            <li>\n               <p>Stop the task on a container instance in an optimal Availability Zone (based\n\t\t\t\t\ton the previous steps), favoring container instances with the largest number of\n\t\t\t\t\trunning tasks for this service.</p>\n            </li>\n         </ul>\n         <note>\n            <p>You must have a service-linked role when you update any of the following service\n\t\t\t\tproperties. If you specified a custom IAM role when you created the service, Amazon ECS\n\t\t\t\tautomatically replaces the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html#ECS-Type-Service-roleArn\">roleARN</a> associated with the service with the ARN of your\n\t\t\t\tservice-linked role. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html\">Service-linked roles</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>loadBalancers,</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>serviceRegistries</code>\n                  </p>\n               </li>\n            </ul>\n         </note>"
+                "smithy.api#documentation": "<p>Modifies the parameters of a service.</p>\n         <p>For services using the rolling update (<code>ECS</code>) you can update the desired\n\t\t\tcount, deployment configuration, network configuration, load balancers, service\n\t\t\tregistries, enable ECS managed tags option, propagate tags option, task placement\n\t\t\tconstraints and strategies, and task definition. When you update any of these\n\t\t\tparameters, Amazon ECS starts new tasks with the new configuration. </p>\n         <p>For services using the blue/green (<code>CODE_DEPLOY</code>) deployment controller,\n\t\t\tonly the desired count, deployment configuration, health check grace period, task\n\t\t\tplacement constraints and strategies, enable ECS managed tags option, and propagate tags\n\t\t\tcan be updated using this API. If the network configuration, platform version, task\n\t\t\tdefinition, or load balancer need to be updated, create a new CodeDeploy deployment. For more\n\t\t\tinformation, see <a href=\"https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_CreateDeployment.html\">CreateDeployment</a> in the <i>CodeDeploy API Reference</i>.</p>\n         <p>For services using an external deployment controller, you can update only the desired\n\t\t\tcount, task placement constraints and strategies, health check grace period, enable ECS\n\t\t\tmanaged tags option, and propagate tags option, using this API. If the launch type, load\n\t\t\tbalancer, network configuration, platform version, or task definition need to be\n\t\t\tupdated, create a new task set For more information, see <a>CreateTaskSet</a>.</p>\n         <p>You can add to or subtract from the number of instantiations of a task definition in a\n\t\t\tservice by specifying the cluster that the service is running in and a new\n\t\t\t\t<code>desiredCount</code> parameter.</p>\n         <p>If you have updated the Docker image of your application, you can create a new task\n\t\t\tdefinition with that image and deploy it to your service. The service scheduler uses the\n\t\t\tminimum healthy percent and maximum percent parameters (in the service's deployment\n\t\t\tconfiguration) to determine the deployment strategy.</p>\n         <note>\n            <p>If your updated Docker image uses the same tag as what is in the existing task\n\t\t\t\tdefinition for your service (for example, <code>my_image:latest</code>), you don't\n\t\t\t\tneed to create a new revision of your task definition. You can update the service\n\t\t\t\tusing the <code>forceNewDeployment</code> option. The new tasks launched by the\n\t\t\t\tdeployment pull the current image/tag combination from your repository when they\n\t\t\t\tstart.</p>\n         </note>\n         <p>You can also update the deployment configuration of a service. When a deployment is\n\t\t\ttriggered by updating the task definition of a service, the service scheduler uses the\n\t\t\tdeployment configuration parameters, <code>minimumHealthyPercent</code> and\n\t\t\t\t<code>maximumPercent</code>, to determine the deployment strategy.</p>\n         <ul>\n            <li>\n               <p>If <code>minimumHealthyPercent</code> is below 100%, the scheduler can ignore\n\t\t\t\t\t\t<code>desiredCount</code> temporarily during a deployment. For example, if\n\t\t\t\t\t\t<code>desiredCount</code> is four tasks, a minimum of 50% allows the\n\t\t\t\t\tscheduler to stop two existing tasks before starting two new tasks. Tasks for\n\t\t\t\t\tservices that don't use a load balancer are considered healthy if they're in the\n\t\t\t\t\t\t<code>RUNNING</code> state. Tasks for services that use a load balancer are\n\t\t\t\t\tconsidered healthy if they're in the <code>RUNNING</code> state and are reported\n\t\t\t\t\tas healthy by the load balancer.</p>\n            </li>\n            <li>\n               <p>The <code>maximumPercent</code> parameter represents an upper limit on the\n\t\t\t\t\tnumber of running tasks during a deployment. You can use it to define the\n\t\t\t\t\tdeployment batch size. For example, if <code>desiredCount</code> is four tasks,\n\t\t\t\t\ta maximum of 200% starts four new tasks before stopping the four older tasks\n\t\t\t\t\t(provided that the cluster resources required to do this are available).</p>\n            </li>\n         </ul>\n         <p>When <a>UpdateService</a> stops a task during a deployment, the equivalent\n\t\t\tof <code>docker stop</code> is issued to the containers running in the task. This\n\t\t\tresults in a <code>SIGTERM</code> and a 30-second timeout. After this,\n\t\t\t\t<code>SIGKILL</code> is sent and the containers are forcibly stopped. If the\n\t\t\tcontainer handles the <code>SIGTERM</code> gracefully and exits within 30 seconds from\n\t\t\treceiving it, no <code>SIGKILL</code> is sent.</p>\n         <p>When the service scheduler launches new tasks, it determines task placement in your\n\t\t\tcluster with the following logic.</p>\n         <ul>\n            <li>\n               <p>Determine which of the container instances in your cluster can support your\n\t\t\t\t\tservice's task definition. For example, they have the required CPU, memory,\n\t\t\t\t\tports, and container instance attributes.</p>\n            </li>\n            <li>\n               <p>By default, the service scheduler attempts to balance tasks across\n\t\t\t\t\tAvailability Zones in this manner even though you can choose a different\n\t\t\t\t\tplacement strategy.</p>\n               <ul>\n                  <li>\n                     <p>Sort the valid container instances by the fewest number of running\n\t\t\t\t\t\t\ttasks for this service in the same Availability Zone as the instance.\n\t\t\t\t\t\t\tFor example, if zone A has one running service task and zones B and C\n\t\t\t\t\t\t\teach have zero, valid container instances in either zone B or C are\n\t\t\t\t\t\t\tconsidered optimal for placement.</p>\n                  </li>\n                  <li>\n                     <p>Place the new service task on a valid container instance in an optimal\n\t\t\t\t\t\t\tAvailability Zone (based on the previous steps), favoring container\n\t\t\t\t\t\t\tinstances with the fewest number of running tasks for this\n\t\t\t\t\t\t\tservice.</p>\n                  </li>\n               </ul>\n            </li>\n         </ul>\n         <p>When the service scheduler stops running tasks, it attempts to maintain balance across\n\t\t\tthe Availability Zones in your cluster using the following logic: </p>\n         <ul>\n            <li>\n               <p>Sort the container instances by the largest number of running tasks for this\n\t\t\t\t\tservice in the same Availability Zone as the instance. For example, if zone A\n\t\t\t\t\thas one running service task and zones B and C each have two, container\n\t\t\t\t\tinstances in either zone B or C are considered optimal for termination.</p>\n            </li>\n            <li>\n               <p>Stop the task on a container instance in an optimal Availability Zone (based\n\t\t\t\t\ton the previous steps), favoring container instances with the largest number of\n\t\t\t\t\trunning tasks for this service.</p>\n            </li>\n         </ul>\n         <note>\n            <p>You must have a service-linked role when you update any of the following service\n\t\t\t\tproperties. If you specified a custom role when you created the service, Amazon ECS\n\t\t\t\tautomatically replaces the <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_Service.html#ECS-Type-Service-roleArn\">roleARN</a> associated with the service with the ARN of your\n\t\t\t\tservice-linked role. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using-service-linked-roles.html\">Service-linked roles</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>\n            <ul>\n               <li>\n                  <p>\n                     <code>loadBalancers,</code>\n                  </p>\n               </li>\n               <li>\n                  <p>\n                     <code>serviceRegistries</code>\n                  </p>\n               </li>\n            </ul>\n         </note>"
             }
         },
         "com.amazonaws.ecs#UpdateServicePrimaryTaskSet": {
@@ -11011,6 +11432,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateServicePrimaryTaskSetResponse": {
@@ -11022,6 +11446,9 @@
                         "smithy.api#documentation": "<p>The details about the task set.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateServiceRequest": {
@@ -11137,6 +11564,9 @@
                         "smithy.api#documentation": "<p>The configuration for this service to discover and connect to\n\tservices, and be discovered by, and connected from, other services within a namespace.</p>\n         <p>Tasks that run in a namespace can use short names to connect\n\tto services in the namespace. Tasks can connect to services across all of the clusters in the namespace.\n\tTasks connect through a managed proxy container\n\tthat collects logs and metrics for increased visibility.\n\tOnly the tasks that Amazon ECS services create are supported with Service Connect.\n\tFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-connect.html\">Service Connect</a> in the <i>Amazon Elastic Container Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateServiceResponse": {
@@ -11148,6 +11578,9 @@
                         "smithy.api#documentation": "<p>The full description of your service following the update call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateTaskProtection": {
@@ -11216,6 +11649,9 @@
                         "smithy.api#documentation": "<p>If you set <code>protectionEnabled</code> to <code>true</code>, you can specify the\n\t\t\tduration for task protection in minutes. You can specify a value from 1 minute to up to\n\t\t\t2,880 minutes (48 hours). During this time, your task will not be terminated by scale-in\n\t\t\tevents from Service Auto Scaling or deployments. After this time period lapses,\n\t\t\t\t<code>protectionEnabled</code> will be reset to <code>false</code>.</p>\n         <p>If you don’t specify the time, then the task is automatically protected for 120\n\t\t\tminutes (2 hours).</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateTaskProtectionResponse": {
@@ -11233,6 +11669,9 @@
                         "smithy.api#documentation": "<p>Any failures associated with the call.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#UpdateTaskSet": {
@@ -11307,6 +11746,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.ecs#UpdateTaskSetResponse": {
@@ -11318,6 +11760,9 @@
                         "smithy.api#documentation": "<p>Details about the task set.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.ecs#VersionInfo": {

--- a/aws/sdk/aws-models/glacier.json
+++ b/aws/sdk/aws-models/glacier.json
@@ -89,7 +89,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to abort a multipart upload identified by the upload ID.</p>\n\n         <p>For information about the underlying REST API, see <a href=\"https://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart\n            Upload</a>. For conceptual information, see <a href=\"https://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in\n            Amazon S3 Glacier</a>.</p>"
+                "smithy.api#documentation": "<p>Provides options to abort a multipart upload identified by the upload ID.</p>\n\n         <p>For information about the underlying REST API, see <a href=\"https://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html\">Abort Multipart\n            Upload</a>. For conceptual information, see <a href=\"https://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html\">Working with Archives in\n            Amazon S3 Glacier</a>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#AbortVaultLock": {
@@ -144,7 +145,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input values for <code>AbortVaultLock</code>.</p>"
+                "smithy.api#documentation": "<p>The input values for <code>AbortVaultLock</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#AccessControlPolicyList": {
@@ -154,22 +156,26 @@
             }
         },
         "com.amazonaws.glacier#ActionCode": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "ArchiveRetrieval",
-                        "name": "ArchiveRetrieval"
-                    },
-                    {
-                        "value": "InventoryRetrieval",
-                        "name": "InventoryRetrieval"
-                    },
-                    {
-                        "value": "Select",
-                        "name": "Select"
+            "type": "enum",
+            "members": {
+                "ArchiveRetrieval": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ArchiveRetrieval"
                     }
-                ]
+                },
+                "InventoryRetrieval": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "InventoryRetrieval"
+                    }
+                },
+                "Select": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Select"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#AddTagsToVault": {
@@ -233,7 +239,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input values for <code>AddTagsToVault</code>.</p>"
+                "smithy.api#documentation": "<p>The input values for <code>AddTagsToVault</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ArchiveCreationOutput": {
@@ -348,38 +355,50 @@
             }
         },
         "com.amazonaws.glacier#CannedACL": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "private",
-                        "name": "Private"
-                    },
-                    {
-                        "value": "public-read",
-                        "name": "PublicRead"
-                    },
-                    {
-                        "value": "public-read-write",
-                        "name": "PublicReadWrite"
-                    },
-                    {
-                        "value": "aws-exec-read",
-                        "name": "AwsExecRead"
-                    },
-                    {
-                        "value": "authenticated-read",
-                        "name": "AuthenticatedRead"
-                    },
-                    {
-                        "value": "bucket-owner-read",
-                        "name": "BucketOwnerRead"
-                    },
-                    {
-                        "value": "bucket-owner-full-control",
-                        "name": "BucketOwnerFullControl"
+            "type": "enum",
+            "members": {
+                "Private": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "private"
                     }
-                ]
+                },
+                "PublicRead": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "public-read"
+                    }
+                },
+                "PublicReadWrite": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "public-read-write"
+                    }
+                },
+                "AwsExecRead": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "aws-exec-read"
+                    }
+                },
+                "AuthenticatedRead": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "authenticated-read"
+                    }
+                },
+                "BucketOwnerRead": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "bucket-owner-read"
+                    }
+                },
+                "BucketOwnerFullControl": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "bucket-owner-full-control"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#CompleteMultipartUpload": {
@@ -456,7 +475,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to complete a multipart upload operation. This informs Amazon\n         Glacier that all the archive parts have been uploaded and Amazon S3 Glacier (Glacier) can now assemble\n         the archive from the uploaded parts. After assembling and saving the archive to the vault,\n         Glacier returns the URI path of the newly created archive resource.</p>"
+                "smithy.api#documentation": "<p>Provides options to complete a multipart upload operation. This informs Amazon\n         Glacier that all the archive parts have been uploaded and Amazon S3 Glacier (Glacier) can now assemble\n         the archive from the uploaded parts. After assembling and saving the archive to the vault,\n         Glacier returns the URI path of the newly created archive resource.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#CompleteVaultLock": {
@@ -519,7 +539,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input values for <code>CompleteVaultLock</code>.</p>"
+                "smithy.api#documentation": "<p>The input values for <code>CompleteVaultLock</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#CreateVault": {
@@ -574,7 +595,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to create a vault.</p>"
+                "smithy.api#documentation": "<p>Provides options to create a vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#CreateVaultOutput": {
@@ -589,7 +611,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#DataRetrievalPolicy": {
@@ -695,7 +718,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for deleting an archive from an Amazon S3 Glacier vault.</p>"
+                "smithy.api#documentation": "<p>Provides options for deleting an archive from an Amazon S3 Glacier vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#DeleteVault": {
@@ -781,7 +805,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>DeleteVaultAccessPolicy input.</p>"
+                "smithy.api#documentation": "<p>DeleteVaultAccessPolicy input.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#DeleteVaultInput": {
@@ -805,7 +830,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for deleting a vault from Amazon S3 Glacier.</p>"
+                "smithy.api#documentation": "<p>Provides options for deleting a vault from Amazon S3 Glacier.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#DeleteVaultNotifications": {
@@ -860,7 +886,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for deleting a vault notification configuration from an Amazon\n         Glacier vault.</p>"
+                "smithy.api#documentation": "<p>Provides options for deleting a vault notification configuration from an Amazon\n         Glacier vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#DescribeJob": {
@@ -923,7 +950,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for retrieving a job description.</p>"
+                "smithy.api#documentation": "<p>Provides options for retrieving a job description.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#DescribeVault": {
@@ -1014,7 +1042,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for retrieving metadata for a specific vault in Amazon\n         Glacier.</p>"
+                "smithy.api#documentation": "<p>Provides options for retrieving metadata for a specific vault in Amazon\n         Glacier.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#DescribeVaultOutput": {
@@ -1090,48 +1119,54 @@
             }
         },
         "com.amazonaws.glacier#EncryptionType": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "aws:kms",
-                        "name": "KMS"
-                    },
-                    {
-                        "value": "AES256",
-                        "name": "S3"
+            "type": "enum",
+            "members": {
+                "KMS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "aws:kms"
                     }
-                ]
+                },
+                "S3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AES256"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#ExpressionType": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "SQL",
-                        "name": "SQL"
+            "type": "enum",
+            "members": {
+                "SQL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SQL"
                     }
-                ]
+                }
             }
         },
         "com.amazonaws.glacier#FileHeaderInfo": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "USE",
-                        "name": "Use"
-                    },
-                    {
-                        "value": "IGNORE",
-                        "name": "Ignore"
-                    },
-                    {
-                        "value": "NONE",
-                        "name": "None"
+            "type": "enum",
+            "members": {
+                "Use": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "USE"
                     }
-                ]
+                },
+                "Ignore": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IGNORE"
+                    }
+                },
+                "None": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NONE"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#GetDataRetrievalPolicy": {
@@ -1175,7 +1210,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Input for GetDataRetrievalPolicy.</p>"
+                "smithy.api#documentation": "<p>Input for GetDataRetrievalPolicy.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#GetDataRetrievalPolicyOutput": {
@@ -1189,7 +1225,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to the <code>GetDataRetrievalPolicy</code>\n         request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to the <code>GetDataRetrievalPolicy</code>\n         request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#GetJobOutput": {
@@ -1259,7 +1296,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for downloading output of an Amazon S3 Glacier job.</p>"
+                "smithy.api#documentation": "<p>Provides options for downloading output of an Amazon S3 Glacier job.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#GetJobOutputOutput": {
@@ -1318,7 +1356,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#GetVaultAccessPolicy": {
@@ -1373,7 +1412,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Input for GetVaultAccessPolicy.</p>"
+                "smithy.api#documentation": "<p>Input for GetVaultAccessPolicy.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#GetVaultAccessPolicyOutput": {
@@ -1388,7 +1428,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Output for GetVaultAccessPolicy.</p>"
+                "smithy.api#documentation": "<p>Output for GetVaultAccessPolicy.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#GetVaultLock": {
@@ -1443,7 +1484,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input values for <code>GetVaultLock</code>.</p>"
+                "smithy.api#documentation": "<p>The input values for <code>GetVaultLock</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#GetVaultLockOutput": {
@@ -1475,7 +1517,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#GetVaultNotifications": {
@@ -1530,7 +1573,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for retrieving the notification configuration set on an Amazon\n         Glacier vault.</p>"
+                "smithy.api#documentation": "<p>Provides options for retrieving the notification configuration set on an Amazon\n         Glacier vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#GetVaultNotificationsOutput": {
@@ -1545,7 +1589,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#Glacier": {
@@ -1674,7 +1719,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -1703,15 +1748,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -1720,7 +1817,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -1730,22 +1827,182 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://glacier-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        "aws-us-gov",
+                                                                                        {
+                                                                                            "fn": "getAttr",
+                                                                                            "argv": [
+                                                                                                {
+                                                                                                    "ref": "PartitionResult"
+                                                                                                },
+                                                                                                "name"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://glacier.{Region}.amazonaws.com",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://glacier-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -1758,140 +2015,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
-                                                        },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
                                                     "type": "tree",
                                                     "rules": [
                                                         {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://glacier-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
+                                                            "conditions": [
                                                                 {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://glacier.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
                                                             ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
+                                                },
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -1901,21 +2070,34 @@
                                                                 {
                                                                     "fn": "stringEquals",
                                                                     "argv": [
-                                                                        "aws-us-gov",
                                                                         {
-                                                                            "fn": "getAttr",
-                                                                            "argv": [
-                                                                                {
-                                                                                    "ref": "PartitionResult"
-                                                                                },
-                                                                                "name"
-                                                                            ]
-                                                                        }
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-gov-east-1"
                                                                     ]
                                                                 }
                                                             ],
                                                             "endpoint": {
-                                                                "url": "https://glacier.{Region}.amazonaws.com",
+                                                                "url": "https://glacier.us-gov-east-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-gov-west-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://glacier.us-gov-west-1.amazonaws.com",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -1924,7 +2106,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://glacier-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://glacier.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -1933,124 +2115,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://glacier.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-gov-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://glacier.us-gov-east-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-gov-west-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://glacier.us-gov-west-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://glacier.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -2059,16 +2130,16 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.sa-east-1.amazonaws.com"
+                                    "url": "https://glacier.af-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "af-south-1",
                                 "UseDualStack": false,
-                                "Region": "sa-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2079,178 +2150,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-east-1",
                                 "UseDualStack": false,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier-fips.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.af-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-south-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2261,9 +2163,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2274,9 +2176,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-2",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2287,87 +2189,100 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-3",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-3"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.us-east-1.amazonaws.com"
+                                    "url": "https://glacier.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-south-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier-fips.us-east-1.amazonaws.com"
+                                    "url": "https://glacier.ap-southeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "ap-southeast-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.eu-west-1.amazonaws.com"
+                                    "url": "https://glacier.ap-southeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-southeast-2",
                                 "UseDualStack": false,
-                                "Region": "eu-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.eu-west-2.amazonaws.com"
+                                    "url": "https://glacier.ap-southeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-southeast-3",
                                 "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.eu-west-3.amazonaws.com"
+                                    "url": "https://glacier.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ca-central-1",
                                 "UseDualStack": false,
-                                "Region": "eu-west-3"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.me-south-1.amazonaws.com"
+                                    "url": "https://glacier-fips.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ca-central-1",
                                 "UseDualStack": false,
-                                "Region": "me-south-1"
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2378,9 +2293,113 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-north-1",
                                 "UseDualStack": false,
-                                "Region": "eu-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2391,9 +2410,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2404,9 +2423,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2417,9 +2488,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2430,126 +2501,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://glacier.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2560,9 +2514,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2573,9 +2540,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2586,9 +2553,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2599,22 +2566,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://glacier.us-iso-west-1.c2s.ic.gov"
+                                    "url": "https://glacier.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-gov-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-west-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2625,9 +2657,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2638,22 +2683,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://glacier-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2663,9 +2747,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2675,9 +2759,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
                                 "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         }
@@ -2945,7 +3029,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for initiating an Amazon S3 Glacier job.</p>"
+                "smithy.api#documentation": "<p>Provides options for initiating an Amazon S3 Glacier job.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#InitiateJobOutput": {
@@ -2974,7 +3059,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#InitiateMultipartUpload": {
@@ -3043,7 +3129,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for initiating a multipart upload to an Amazon S3 Glacier\n         vault.</p>"
+                "smithy.api#documentation": "<p>Provides options for initiating a multipart upload to an Amazon S3 Glacier\n         vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#InitiateMultipartUploadOutput": {
@@ -3065,7 +3152,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>The Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#InitiateVaultLock": {
@@ -3127,7 +3215,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input values for <code>InitiateVaultLock</code>.</p>"
+                "smithy.api#documentation": "<p>The input values for <code>InitiateVaultLock</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#InitiateVaultLockOutput": {
@@ -3142,7 +3231,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#InputSerialization": {
@@ -3464,7 +3554,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for retrieving a job list for an Amazon S3 Glacier vault.</p>"
+                "smithy.api#documentation": "<p>Provides options for retrieving a job list for an Amazon S3 Glacier vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ListJobsOutput": {
@@ -3484,7 +3575,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#ListMultipartUploads": {
@@ -3559,7 +3651,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for retrieving list of in-progress multipart uploads for an Amazon\n         Glacier vault.</p>"
+                "smithy.api#documentation": "<p>Provides options for retrieving list of in-progress multipart uploads for an Amazon\n         Glacier vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ListMultipartUploadsOutput": {
@@ -3579,7 +3672,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#ListParts": {
@@ -3662,7 +3756,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options for retrieving a list of parts of an archive that have been uploaded\n         in a specific multipart upload.</p>"
+                "smithy.api#documentation": "<p>Provides options for retrieving a list of parts of an archive that have been uploaded\n         in a specific multipart upload.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ListPartsOutput": {
@@ -3713,7 +3808,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#ListProvisionedCapacity": {
@@ -3755,6 +3851,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ListProvisionedCapacityOutput": {
@@ -3766,6 +3865,9 @@
                         "smithy.api#documentation": "<p>The response body contains the following JSON fields.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#ListTagsForVault": {
@@ -3820,7 +3922,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input value for <code>ListTagsForVaultInput</code>.</p>"
+                "smithy.api#documentation": "<p>The input value for <code>ListTagsForVaultInput</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ListTagsForVaultOutput": {
@@ -3834,7 +3937,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#ListVaults": {
@@ -3901,7 +4005,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to retrieve the vault list owned by the calling user's account. The\n         list provides metadata information for each vault.</p>"
+                "smithy.api#documentation": "<p>Provides options to retrieve the vault list owned by the calling user's account. The\n         list provides metadata information for each vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#ListVaultsOutput": {
@@ -3921,7 +4026,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#MissingParameterValueException": {
@@ -4016,30 +4122,38 @@
             }
         },
         "com.amazonaws.glacier#Permission": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "FULL_CONTROL",
-                        "name": "FULL_CONTROL"
-                    },
-                    {
-                        "value": "WRITE",
-                        "name": "WRITE"
-                    },
-                    {
-                        "value": "WRITE_ACP",
-                        "name": "WRITE_ACP"
-                    },
-                    {
-                        "value": "READ",
-                        "name": "READ"
-                    },
-                    {
-                        "value": "READ_ACP",
-                        "name": "READ_ACP"
+            "type": "enum",
+            "members": {
+                "FULL_CONTROL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FULL_CONTROL"
                     }
-                ]
+                },
+                "WRITE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "WRITE"
+                    }
+                },
+                "WRITE_ACP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "WRITE_ACP"
+                    }
+                },
+                "READ": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "READ"
+                    }
+                },
+                "READ_ACP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "READ_ACP"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#PolicyEnforcedException": {
@@ -4144,6 +4258,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#PurchaseProvisionedCapacityOutput": {
@@ -4156,21 +4273,26 @@
                         "smithy.api#httpHeader": "x-amz-capacity-id"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#QuoteFields": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "ALWAYS",
-                        "name": "Always"
-                    },
-                    {
-                        "value": "ASNEEDED",
-                        "name": "AsNeeded"
+            "type": "enum",
+            "members": {
+                "Always": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ALWAYS"
                     }
-                ]
+                },
+                "AsNeeded": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ASNEEDED"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#RemoveTagsFromVault": {
@@ -4231,7 +4353,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The input value for <code>RemoveTagsFromVaultInput</code>.</p>"
+                "smithy.api#documentation": "<p>The input value for <code>RemoveTagsFromVaultInput</code>.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#RequestTimeoutException": {
@@ -4453,7 +4576,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>SetDataRetrievalPolicy input.</p>"
+                "smithy.api#documentation": "<p>SetDataRetrievalPolicy input.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#SetVaultAccessPolicy": {
@@ -4515,7 +4639,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>SetVaultAccessPolicy input.</p>"
+                "smithy.api#documentation": "<p>SetVaultAccessPolicy input.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#SetVaultNotifications": {
@@ -4577,48 +4702,57 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to configure notifications that will be sent when specific events\n         happen to a vault.</p>"
+                "smithy.api#documentation": "<p>Provides options to configure notifications that will be sent when specific events\n         happen to a vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#Size": {
             "type": "long"
         },
         "com.amazonaws.glacier#StatusCode": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "InProgress",
-                        "name": "InProgress"
-                    },
-                    {
-                        "value": "Succeeded",
-                        "name": "Succeeded"
-                    },
-                    {
-                        "value": "Failed",
-                        "name": "Failed"
+            "type": "enum",
+            "members": {
+                "InProgress": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "InProgress"
                     }
-                ]
+                },
+                "Succeeded": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Succeeded"
+                    }
+                },
+                "Failed": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Failed"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#StorageClass": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "STANDARD",
-                        "name": "Standard"
-                    },
-                    {
-                        "value": "REDUCED_REDUNDANCY",
-                        "name": "ReducedRedundancy"
-                    },
-                    {
-                        "value": "STANDARD_IA",
-                        "name": "StandardInfrequentAccess"
+            "type": "enum",
+            "members": {
+                "Standard": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STANDARD"
                     }
-                ]
+                },
+                "ReducedRedundancy": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REDUCED_REDUNDANCY"
+                    }
+                },
+                "StandardInfrequentAccess": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STANDARD_IA"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#Stream": {
@@ -4649,22 +4783,26 @@
             "type": "string"
         },
         "com.amazonaws.glacier#Type": {
-            "type": "string",
-            "traits": {
-                "smithy.api#enum": [
-                    {
-                        "value": "AmazonCustomerByEmail",
-                        "name": "AmazonCustomerByEmail"
-                    },
-                    {
-                        "value": "CanonicalUser",
-                        "name": "CanonicalUser"
-                    },
-                    {
-                        "value": "Group",
-                        "name": "Group"
+            "type": "enum",
+            "members": {
+                "AmazonCustomerByEmail": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AmazonCustomerByEmail"
                     }
-                ]
+                },
+                "CanonicalUser": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CanonicalUser"
+                    }
+                },
+                "Group": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Group"
+                    }
+                }
             }
         },
         "com.amazonaws.glacier#UploadArchive": {
@@ -4744,7 +4882,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to add an archive to a vault.</p>"
+                "smithy.api#documentation": "<p>Provides options to add an archive to a vault.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#UploadListElement": {
@@ -4871,7 +5010,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Provides options to upload a part of an archive in a multipart upload\n         operation.</p>"
+                "smithy.api#documentation": "<p>Provides options to upload a part of an archive in a multipart upload\n         operation.</p>",
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.glacier#UploadMultipartPartOutput": {
@@ -4886,7 +5026,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>"
+                "smithy.api#documentation": "<p>Contains the Amazon S3 Glacier response to your request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.glacier#UploadsList": {

--- a/aws/sdk/aws-models/iam.json
+++ b/aws/sdk/aws-models/iam.json
@@ -530,7 +530,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -559,15 +559,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -576,7 +628,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -586,22 +638,1066 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "iam",
+                                                                                            "signingRegion": "us-east-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://iam.amazonaws.com",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-cn"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.api.amazonwebservices.com.cn",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.amazonaws.com.cn",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam.{Region}.api.amazonwebservices.com.cn",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://iam.cn-north-1.amazonaws.com.cn",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "cn-north-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-us-gov"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam.us-gov.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "iam",
+                                                                                            "signingRegion": "us-gov-west-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://iam.us-gov.amazonaws.com",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-gov-west-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-iso"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.c2s.ic.gov",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://iam.us-iso-east-1.c2s.ic.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-iso-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-iso-b"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.sc2s.sgov.gov",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://iam.us-isob-east-1.sc2s.sgov.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-isob-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Region"
+                                                                                        },
+                                                                                        "aws-global"
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "iam",
+                                                                                            "signingRegion": "us-east-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Region"
+                                                                                        },
+                                                                                        "aws-us-gov-global"
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam.us-gov.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "iam",
+                                                                                            "signingRegion": "us-gov-west-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -614,995 +1710,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
-                                                        },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
                                                     "type": "tree",
                                                     "rules": [
                                                         {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.api.aws",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
+                                                            "conditions": [
                                                                 {
-                                                                    "fn": "getAttr",
+                                                                    "fn": "booleanEquals",
                                                                     "argv": [
+                                                                        true,
                                                                         {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.amazonaws.com",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-east-1",
-                                                                            "signingName": "iam"
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
                                                                         }
                                                                     ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
                                                                 }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam.{Region}.api.aws",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "DualStack is enabled but this partition does not support DualStack",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://iam.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-cn"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
                                                                 {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
                                                                         {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.api.amazonwebservices.com.cn",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.amazonaws.com.cn",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam.{Region}.api.amazonwebservices.com.cn",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "DualStack is enabled but this partition does not support DualStack",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://iam.cn-north-1.amazonaws.com.cn",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "cn-north-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-us-gov"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.api.aws",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam.us-gov.amazonaws.com",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-gov-west-1",
-                                                                            "signingName": "iam"
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://iam.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
                                                                         }
                                                                     ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
                                                                 }
                                                             ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
+                                                        },
                                                         {
                                                             "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam.{Region}.api.aws",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "DualStack is enabled but this partition does not support DualStack",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://iam.us-gov.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-gov-west-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-iso"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.c2s.ic.gov",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://iam.us-iso-east-1.c2s.ic.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-iso-east-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-iso-b"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.sc2s.sgov.gov",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://iam.us-isob-east-1.sc2s.sgov.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-isob-east-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -1620,13 +1773,40 @@
                                                                 }
                                                             ],
                                                             "endpoint": {
-                                                                "url": "https://iam-fips.amazonaws.com",
+                                                                "url": "https://iam.amazonaws.com",
                                                                 "properties": {
                                                                     "authSchemes": [
                                                                         {
                                                                             "name": "sigv4",
-                                                                            "signingRegion": "us-east-1",
-                                                                            "signingName": "iam"
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-cn-global"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://iam.cn-north-1.amazonaws.com.cn",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "cn-north-1"
                                                                         }
                                                                     ]
                                                                 },
@@ -1652,8 +1832,62 @@
                                                                     "authSchemes": [
                                                                         {
                                                                             "name": "sigv4",
-                                                                            "signingRegion": "us-gov-west-1",
-                                                                            "signingName": "iam"
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-gov-west-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-iso-global"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://iam.us-iso-east-1.c2s.ic.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-iso-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-iso-b-global"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://iam.us-isob-east-1.sc2s.sgov.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "iam",
+                                                                            "signingRegion": "us-isob-east-1"
                                                                         }
                                                                     ]
                                                                 },
@@ -1664,7 +1898,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://iam-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://iam.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -1673,221 +1907,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://iam.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://iam.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-cn-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://iam.cn-north-1.amazonaws.com.cn",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "cn-north-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-us-gov-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://iam.us-gov.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-gov-west-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-iso-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://iam.us-iso-east-1.c2s.ic.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-iso-east-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-iso-b-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://iam.us-isob-east-1.sc2s.sgov.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-isob-east-1",
-                                                            "signingName": "iam"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://iam.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -1902,8 +1928,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "us-east-1"
                                             }
                                         ]
@@ -1912,8 +1938,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "aws-global"
                             }
                         },
@@ -1924,8 +1950,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "us-east-1"
                                             }
                                         ]
@@ -1934,8 +1960,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "aws-global"
                             }
                         },
@@ -1947,8 +1973,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": true,
+                                "UseFIPS": true,
                                 "Region": "us-east-1"
                             }
                         },
@@ -1959,8 +1985,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "us-east-1"
                                             }
                                         ]
@@ -1969,8 +1995,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-east-1"
                             }
                         },
@@ -1982,8 +2008,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "us-east-1"
                             }
                         },
@@ -1994,8 +2020,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "us-east-1"
                                             }
                                         ]
@@ -2004,180 +2030,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region aws-us-gov-global with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "iam",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-gov-west-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://iam.us-gov.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "aws-us-gov-global"
-                            }
-                        },
-                        {
-                            "documentation": "For region aws-us-gov-global with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "iam",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-gov-west-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://iam.us-gov.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "aws-us-gov-global"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://iam-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "iam",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-gov-west-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://iam.us-gov.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://iam.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "iam",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-gov-west-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://iam.us-gov.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region aws-iso-b-global with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "iam",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-isob-east-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://iam.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "aws-iso-b-global"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://iam-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingName": "iam",
-                                                "name": "sigv4",
-                                                "signingRegion": "us-isob-east-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://iam.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
                             }
                         },
                         {
@@ -2187,8 +2042,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "cn-north-1"
                                             }
                                         ]
@@ -2197,8 +2052,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "aws-cn-global"
                             }
                         },
@@ -2210,8 +2065,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": true,
+                                "UseFIPS": true,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -2223,8 +2078,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -2236,8 +2091,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -2248,8 +2103,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "cn-north-1"
                                             }
                                         ]
@@ -2258,9 +2113,123 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-us-gov-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "iam",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://iam.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "aws-us-gov-global"
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-us-gov-global with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "iam",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://iam.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "aws-us-gov-global"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://iam-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "iam",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://iam.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://iam.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "iam",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://iam.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
@@ -2270,8 +2239,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "us-iso-east-1"
                                             }
                                         ]
@@ -2280,8 +2249,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "aws-iso-global"
                             }
                         },
@@ -2293,8 +2262,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-iso-east-1"
                             }
                         },
@@ -2305,8 +2274,8 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingName": "iam",
                                                 "name": "sigv4",
+                                                "signingName": "iam",
                                                 "signingRegion": "us-iso-east-1"
                                             }
                                         ]
@@ -2315,22 +2284,92 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region aws-iso-b-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "iam",
+                                                "signingRegion": "us-isob-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://iam.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "aws-iso-b-global"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://iam-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "iam",
+                                                "signingRegion": "us-isob-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://iam.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2340,8 +2379,8 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
@@ -2352,8 +2391,8 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
@@ -2406,7 +2445,7 @@
                 "EntityPath": {
                     "target": "com.amazonaws.iam#organizationsEntityPathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path of the Organizations entity (root, organizational unit, or account) from which an\n         authenticated principal last attempted to access the service. Amazon Web Services does not report\n         unauthenticated requests.</p>\n         <p>This field is null if no principals (IAM users, IAM roles, or root users) in the\n         reported Organizations entity attempted to access the service within the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#service-last-accessed-reporting-period\">tracking period</a>.</p>"
+                        "smithy.api#documentation": "<p>The path of the Organizations entity (root, organizational unit, or account) from which an\n         authenticated principal last attempted to access the service. Amazon Web Services does not report\n         unauthenticated requests.</p>\n         <p>This field is null if no principals (IAM users, IAM roles, or root user) in the\n         reported Organizations entity attempted to access the service within the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#service-last-accessed-reporting-period\">tracking period</a>.</p>"
                     }
                 },
                 "LastAuthenticatedTime": {
@@ -2418,7 +2457,7 @@
                 "TotalAuthenticatedEntities": {
                     "target": "com.amazonaws.iam#integerType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The number of accounts with authenticated principals (root users, IAM users, and IAM\n         roles) that attempted to access the service in the tracking period.</p>"
+                        "smithy.api#documentation": "<p>The number of accounts with authenticated principals (root user, IAM users, and IAM\n         roles) that attempted to access the service in the tracking period.</p>"
                     }
                 }
             },
@@ -2573,7 +2612,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds a new client ID (also known as audience) to the list of client IDs already\n            registered for the specified IAM OpenID Connect (OIDC) provider resource.</p>\n        <p>This operation is idempotent; it does not fail or return an error if you add an\n            existing client ID to the provider.</p>"
+                "smithy.api#documentation": "<p>Adds a new client ID (also known as audience) to the list of client IDs already\n            registered for the specified IAM OpenID Connect (OIDC) provider resource.</p>\n         <p>This operation is idempotent; it does not fail or return an error if you add an\n            existing client ID to the provider.</p>"
             }
         },
         "com.amazonaws.iam#AddClientIDToOpenIDConnectProviderRequest": {
@@ -2593,6 +2632,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#AddRoleToInstanceProfile": {
@@ -2621,7 +2663,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds the specified IAM role to the specified instance profile. An instance profile\n            can contain only one role, and this quota cannot be increased. You can remove the\n            existing role and then add a different role to an instance profile. You must then wait\n            for the change to appear across all of Amazon Web Services because of <a href=\"https://en.wikipedia.org/wiki/Eventual_consistency\">eventual\n                consistency</a>. To force the change, you must <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisassociateIamInstanceProfile.html\">disassociate the instance profile</a> and then <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateIamInstanceProfile.html\">associate the\n                instance profile</a>, or you can stop your instance and then restart it.</p>\n        <note>\n            <p>The caller of this operation must be granted the <code>PassRole</code> permission\n                on the IAM role by a permissions policy.</p>\n        </note>\n        <p>For more information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>. For more\n            information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>"
+                "smithy.api#documentation": "<p>Adds the specified IAM role to the specified instance profile. An instance profile\n            can contain only one role, and this quota cannot be increased. You can remove the\n            existing role and then add a different role to an instance profile. You must then wait\n            for the change to appear across all of Amazon Web Services because of <a href=\"https://en.wikipedia.org/wiki/Eventual_consistency\">eventual\n                consistency</a>. To force the change, you must <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DisassociateIamInstanceProfile.html\">disassociate the instance profile</a> and then <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_AssociateIamInstanceProfile.html\">associate the\n                instance profile</a>, or you can stop your instance and then restart it.</p>\n         <note>\n            <p>The caller of this operation must be granted the <code>PassRole</code> permission\n                on the IAM role by a permissions policy.</p>\n         </note>\n         <p>For more information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>. For more\n            information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>"
             }
         },
         "com.amazonaws.iam#AddRoleToInstanceProfileRequest": {
@@ -2630,17 +2672,20 @@
                 "InstanceProfileName": {
                     "target": "com.amazonaws.iam#instanceProfileNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the instance profile to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the instance profile to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to add.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to add.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#AddUserToGroup": {
@@ -2672,17 +2717,20 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the group to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to add.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user to add.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ArnListType": {
@@ -2717,7 +2765,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Attaches the specified managed policy to the specified IAM group.</p>\n        <p>You use this operation to attach a managed policy to a group. To embed an inline\n            policy in a group, use <a>PutGroupPolicy</a>.</p>\n        <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>\n        <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Attaches the specified managed policy to the specified IAM group.</p>\n         <p>You use this operation to attach a managed policy to a group. To embed an inline\n            policy in a group, use <a>PutGroupPolicy</a>.</p>\n         <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>\n         <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#AttachGroupPolicyRequest": {
@@ -2726,17 +2774,20 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the group to attach the policy to.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the group to attach the policy to.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#AttachRolePolicy": {
@@ -2768,7 +2819,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Attaches the specified managed policy to the specified IAM role. When you attach a\n            managed policy to a role, the managed policy becomes part of the role's permission\n            (access) policy.</p>\n        <note>\n            <p>You cannot use a managed policy as the role's trust policy. The role's trust\n                policy is created at the same time as the role, using <a>CreateRole</a>.\n                You can update a role's trust policy using <a>UpdateAssumeRolePolicy</a>.</p>\n        </note>\n        <p>Use this operation to attach a <i>managed</i> policy to a role. To embed\n            an inline policy in a role, use <a>PutRolePolicy</a>. For more information\n            about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Attaches the specified managed policy to the specified IAM role. When you attach a\n            managed policy to a role, the managed policy becomes part of the role's permission\n            (access) policy.</p>\n         <note>\n            <p>You cannot use a managed policy as the role's trust policy. The role's trust\n                policy is created at the same time as the role, using <a>CreateRole</a>.\n                You can update a role's trust policy using <a>UpdateAssumeRolePolicy</a>.</p>\n         </note>\n         <p>Use this operation to attach a <i>managed</i> policy to a role. To embed\n            an inline policy in a role, use <a>PutRolePolicy</a>. For more information\n            about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#AttachRolePolicyRequest": {
@@ -2777,17 +2828,20 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the role to attach the policy to.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the role to attach the policy to.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#AttachUserPolicy": {
@@ -2816,7 +2870,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Attaches the specified managed policy to the specified user.</p>\n        <p>You use this operation to attach a <i>managed</i> policy to a user. To\n            embed an inline policy in a user, use <a>PutUserPolicy</a>.</p>\n        <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>\n        <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Attaches the specified managed policy to the specified user.</p>\n         <p>You use this operation to attach a <i>managed</i> policy to a user. To\n            embed an inline policy in a user, use <a>PutUserPolicy</a>.</p>\n         <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>\n         <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#AttachUserPolicyRequest": {
@@ -2825,17 +2879,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM user to attach the policy to.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM user to attach the policy to.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to attach.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#AttachedPermissionsBoundary": {
@@ -2910,7 +2967,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Changes the password of the IAM user who is calling this operation. This operation\n            can be performed using the CLI, the Amazon Web Services API, or the <b>My\n                Security Credentials</b> page in the Amazon Web Services Management Console. The Amazon Web Services account root user\n            password is not affected by this operation.</p>\n        <p>Use <a>UpdateLoginProfile</a> to use the CLI, the Amazon Web Services API, or the\n                <b>Users</b> page in the IAM console to change the\n            password for any IAM user. For more information about modifying passwords, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html\">Managing\n                passwords</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Changes the password of the IAM user who is calling this operation. This operation\n            can be performed using the CLI, the Amazon Web Services API, or the <b>My\n                Security Credentials</b> page in the Amazon Web Services Management Console. The Amazon Web Services account root user password is\n            not affected by this operation.</p>\n         <p>Use <a>UpdateLoginProfile</a> to use the CLI, the Amazon Web Services API, or the\n                <b>Users</b> page in the IAM console to change the\n            password for any IAM user. For more information about modifying passwords, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html\">Managing\n                passwords</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#ChangePasswordRequest": {
@@ -2926,10 +2983,13 @@
                 "NewPassword": {
                     "target": "com.amazonaws.iam#passwordType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The new password. The new password must conform to the Amazon Web Services account's password\n            policy, if one exists.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    that is used to validate this parameter is a string of characters. That string can include almost any printable \n    ASCII character from the space (<code>\\u0020</code>) through the end of the ASCII character range (<code>\\u00FF</code>). \n    You can also include the tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) \n    characters. Any of these characters are valid in a password. However, many tools, such \n    as the Amazon Web Services Management Console, might restrict the ability to type certain characters because they have \n    special meaning within that tool.</p>",
+                        "smithy.api#documentation": "<p>The new password. The new password must conform to the Amazon Web Services account's password\n            policy, if one exists.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    that is used to validate this parameter is a string of characters. That string can include almost any printable \n    ASCII character from the space (<code>\\u0020</code>) through the end of the ASCII character range (<code>\\u00FF</code>). \n    You can also include the tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) \n    characters. Any of these characters are valid in a password. However, many tools, such \n    as the Amazon Web Services Management Console, might restrict the ability to type certain characters because they have \n    special meaning within that tool.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ColumnNumber": {
@@ -3111,7 +3171,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p> Creates a new Amazon Web Services secret access key and corresponding Amazon Web Services access key ID for the\n            specified user. The default status for new keys is <code>Active</code>.</p>\n        <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID signing the request. This operation works for access keys under\n            the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root\n            user credentials. This is true even if the Amazon Web Services account has no associated users.</p>\n        <p> For information about quotas on the number of keys you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>\n        <important>\n            <p>To ensure the security of your Amazon Web Services account, the secret access key is accessible\n                only during key and user creation. You must save the key (for example, in a text\n                file) if you want to be able to access it again. If a secret key is lost, you can\n                delete the access keys for the associated user and then create new keys.</p>\n        </important>"
+                "smithy.api#documentation": "<p> Creates a new Amazon Web Services secret access key and corresponding Amazon Web Services access key ID for the\n            specified user. The default status for new keys is <code>Active</code>.</p>\n         <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID signing the request. This operation works for access keys under\n            the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root\n            user credentials. This is true even if the Amazon Web Services account has no associated users.</p>\n         <p> For information about quotas on the number of keys you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>\n         <important>\n            <p>To ensure the security of your Amazon Web Services account, the secret access key is accessible\n                only during key and user creation. You must save the key (for example, in a text\n                file) if you want to be able to access it again. If a secret key is lost, you can\n                delete the access keys for the associated user and then create new keys.</p>\n         </important>"
             }
         },
         "com.amazonaws.iam#CreateAccessKeyRequest": {
@@ -3120,9 +3180,12 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user that the new key will belong to.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user that the new key will belong to.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateAccessKeyResponse": {
@@ -3137,7 +3200,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateAccessKey</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateAccessKey</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateAccountAlias": {
@@ -3169,10 +3233,13 @@
                 "AccountAlias": {
                     "target": "com.amazonaws.iam#accountAliasType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The account alias to create.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of \n    lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have \n    two dashes in a row.</p>",
+                        "smithy.api#documentation": "<p>The account alias to create.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of \n    lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have \n    two dashes in a row.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateGroup": {
@@ -3198,7 +3265,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a new group.</p>\n        <p> For information about the number of groups you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates a new group.</p>\n         <p> For information about the number of groups you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreateGroupRequest": {
@@ -3207,16 +3274,19 @@
                 "Path": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path to the group. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path to the group. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group to create. Do not include the path in this value.</p>\n        <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
+                        "smithy.api#documentation": "<p>The name of the group to create. Do not include the path in this value.</p>\n         <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateGroupResponse": {
@@ -3231,7 +3301,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateGroup</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateGroup</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateInstanceProfile": {
@@ -3260,7 +3331,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p> Creates a new instance profile. For information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html\">Using\n                roles for applications on Amazon EC2</a> in the\n                <i>IAM User Guide</i>, and <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile\">Instance profiles</a> in the <i>Amazon EC2 User Guide</i>.</p>\n        <p> For information about the number of instance profiles you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM object\n                quotas</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p> Creates a new instance profile. For information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2.html\">Using\n                roles for applications on Amazon EC2</a> in the\n                <i>IAM User Guide</i>, and <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile\">Instance profiles</a> in the <i>Amazon EC2 User Guide</i>.</p>\n         <p> For information about the number of instance profiles you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM object\n                quotas</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreateInstanceProfileRequest": {
@@ -3269,14 +3340,14 @@
                 "InstanceProfileName": {
                     "target": "com.amazonaws.iam#instanceProfileNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the instance profile to create.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the instance profile to create.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Path": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path to the instance profile. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                Identifiers</a> in the <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path to the instance profile. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                Identifiers</a> in the <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Tags": {
@@ -3285,6 +3356,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the newly created IAM instance profile.\n      Each tag consists of a key name and an associated value. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateInstanceProfileResponse": {
@@ -3299,7 +3373,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateInstanceProfile</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateInstanceProfile</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateLoginProfile": {
@@ -3328,7 +3403,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a password for the specified IAM user. A password allows an IAM user to\n            access Amazon Web Services services through the Amazon Web Services Management Console.</p>\n        <p>You can use the CLI, the Amazon Web Services API, or the <b>Users</b>\n            page in the IAM console to create a password for any IAM user. Use <a>ChangePassword</a> to update your own existing password in the <b>My Security Credentials</b> page in the Amazon Web Services Management Console.</p>\n        <p>For more information about managing passwords, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html\">Managing passwords</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates a password for the specified IAM user. A password allows an IAM user to\n            access Amazon Web Services services through the Amazon Web Services Management Console.</p>\n         <p>You can use the CLI, the Amazon Web Services API, or the <b>Users</b>\n            page in the IAM console to create a password for any IAM user. Use <a>ChangePassword</a> to update your own existing password in the <b>My Security Credentials</b> page in the Amazon Web Services Management Console.</p>\n         <p>For more information about managing passwords, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html\">Managing passwords</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreateLoginProfileRequest": {
@@ -3337,14 +3412,14 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user to create a password for. The user must already\n            exist.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user to create a password for. The user must already\n            exist.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Password": {
                     "target": "com.amazonaws.iam#passwordType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The new password for the user.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    that is used to validate this parameter is a string of characters. That string can include almost any printable \n    ASCII character from the space (<code>\\u0020</code>) through the end of the ASCII character range (<code>\\u00FF</code>). \n    You can also include the tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) \n    characters. Any of these characters are valid in a password. However, many tools, such \n    as the Amazon Web Services Management Console, might restrict the ability to type certain characters because they have \n    special meaning within that tool.</p>",
+                        "smithy.api#documentation": "<p>The new password for the user.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    that is used to validate this parameter is a string of characters. That string can include almost any printable \n    ASCII character from the space (<code>\\u0020</code>) through the end of the ASCII character range (<code>\\u00FF</code>). \n    You can also include the tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) \n    characters. Any of these characters are valid in a password. However, many tools, such \n    as the Amazon Web Services Management Console, might restrict the ability to type certain characters because they have \n    special meaning within that tool.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3355,6 +3430,9 @@
                         "smithy.api#documentation": "<p>Specifies whether the user is required to set a new password on next sign-in.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateLoginProfileResponse": {
@@ -3369,7 +3447,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateLoginProfile</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateLoginProfile</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateOpenIDConnectProvider": {
@@ -3398,7 +3477,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates an IAM entity to describe an identity provider (IdP) that supports <a href=\"http://openid.net/connect/\">OpenID Connect (OIDC)</a>.</p>\n        <p>The OIDC provider that you create with this operation can be used as a principal in a\n            role's trust policy. Such a policy establishes a trust relationship between Amazon Web Services and\n            the OIDC provider.</p>\n        <p>If you are using an OIDC identity provider from Google, Facebook, or Amazon Cognito, you don't\n            need to create a separate IAM identity provider. These OIDC identity providers are\n            already built-in to Amazon Web Services and are available for your use. Instead, you can move directly\n            to creating new roles using your identity provider. To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html\">Creating\n                a role for web identity or OpenID connect federation</a> in the <i>IAM\n                User Guide</i>.</p>\n        <p>When you create the IAM OIDC provider, you specify the following:</p>\n        <ul>\n            <li>\n                <p>The URL of the OIDC identity provider (IdP) to trust</p>\n            </li>\n            <li>\n                <p>A list of client IDs (also known as audiences) that identify the application\n                    or applications allowed to authenticate using the OIDC provider</p>\n            </li>\n            <li>\n                <p>A list of thumbprints of one or more server certificates that the IdP\n                    uses</p>\n            </li>\n         </ul>\n        <p>You get all of this information from the OIDC IdP you want to use to access\n            Amazon Web Services.</p>\n        <note>\n            <p>Amazon Web Services secures communication with some OIDC identity providers (IdPs) through our\n            library of trusted certificate authorities (CAs) instead of using a certificate\n            thumbprint to verify your IdP server certificate. These OIDC IdPs include Google, and\n            those that use an Amazon S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these\n            cases, your legacy thumbprint remains in your configuration, but is no longer used for validation.</p> \n         </note>\n        <note>\n            <p>The trust for the OIDC provider is derived from the IAM provider that this\n                operation creates. Therefore, it is best to limit access to the <a>CreateOpenIDConnectProvider</a> operation to highly privileged\n                users.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Creates an IAM entity to describe an identity provider (IdP) that supports <a href=\"http://openid.net/connect/\">OpenID Connect (OIDC)</a>.</p>\n         <p>The OIDC provider that you create with this operation can be used as a principal in a\n            role's trust policy. Such a policy establishes a trust relationship between Amazon Web Services and\n            the OIDC provider.</p>\n         <p>If you are using an OIDC identity provider from Google, Facebook, or Amazon Cognito, you don't\n            need to create a separate IAM identity provider. These OIDC identity providers are\n            already built-in to Amazon Web Services and are available for your use. Instead, you can move directly\n            to creating new roles using your identity provider. To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-idp_oidc.html\">Creating\n                a role for web identity or OpenID connect federation</a> in the <i>IAM\n                User Guide</i>.</p>\n         <p>When you create the IAM OIDC provider, you specify the following:</p>\n         <ul>\n            <li>\n               <p>The URL of the OIDC identity provider (IdP) to trust</p>\n            </li>\n            <li>\n               <p>A list of client IDs (also known as audiences) that identify the application\n                    or applications allowed to authenticate using the OIDC provider</p>\n            </li>\n            <li>\n               <p>A list of tags that are attached to the specified IAM OIDC provider</p>\n            </li>\n            <li>\n               <p>A list of thumbprints of one or more server certificates that the IdP\n                    uses</p>\n            </li>\n         </ul>\n         <p>You get all of this information from the OIDC IdP you want to use to access\n            Amazon Web Services.</p>\n         <note>\n            <p>Amazon Web Services secures communication with some OIDC identity providers (IdPs) through our\n            library of trusted certificate authorities (CAs) instead of using a certificate\n            thumbprint to verify your IdP server certificate. These OIDC IdPs include Google, Auth0,\n            and those that use an Amazon S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these\n            cases, your legacy thumbprint remains in your configuration, but is no longer used for\n            validation.</p>\n         </note>\n         <note>\n            <p>The trust for the OIDC provider is derived from the IAM provider that this\n                operation creates. Therefore, it is best to limit access to the <a>CreateOpenIDConnectProvider</a> operation to highly privileged\n                users.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#CreateOpenIDConnectProviderRequest": {
@@ -3407,20 +3486,20 @@
                 "Url": {
                     "target": "com.amazonaws.iam#OpenIDConnectProviderUrlType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The URL of the identity provider. The URL must begin with <code>https://</code> and\n            should correspond to the <code>iss</code> claim in the provider's OpenID Connect ID\n            tokens. Per the OIDC standard, path components are allowed but query parameters are not.\n            Typically the URL consists of only a hostname, like\n                <code>https://server.example.org</code> or <code>https://example.com</code>. The URL\n            should not contain a port number. </p>\n        <p>You cannot register the same provider multiple times in a single Amazon Web Services account. If you\n            try to submit a URL that has already been used for an OpenID Connect provider in the\n            Amazon Web Services account, you will get an error.</p>",
+                        "smithy.api#documentation": "<p>The URL of the identity provider. The URL must begin with <code>https://</code> and\n            should correspond to the <code>iss</code> claim in the provider's OpenID Connect ID\n            tokens. Per the OIDC standard, path components are allowed but query parameters are not.\n            Typically the URL consists of only a hostname, like\n                <code>https://server.example.org</code> or <code>https://example.com</code>. The URL\n            should not contain a port number. </p>\n         <p>You cannot register the same provider multiple times in a single Amazon Web Services account. If you\n            try to submit a URL that has already been used for an OpenID Connect provider in the\n            Amazon Web Services account, you will get an error.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "ClientIDList": {
                     "target": "com.amazonaws.iam#clientIDListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Provides a list of client IDs, also known as audiences. When a mobile or web app\n            registers with an OpenID Connect provider, they establish a value that identifies the\n            application. This is the value that's sent as the <code>client_id</code> parameter on\n            OAuth requests.</p>\n        <p>You can register multiple client IDs with the same provider. For example, you might\n            have multiple applications that use the same OIDC provider. You cannot register more\n            than 100 client IDs with a single IAM OIDC provider.</p>\n        <p>There is no defined format for a client ID. The\n                <code>CreateOpenIDConnectProviderRequest</code> operation accepts client IDs up to\n            255 characters long.</p>"
+                        "smithy.api#documentation": "<p>Provides a list of client IDs, also known as audiences. When a mobile or web app\n            registers with an OpenID Connect provider, they establish a value that identifies the\n            application. This is the value that's sent as the <code>client_id</code> parameter on\n            OAuth requests.</p>\n         <p>You can register multiple client IDs with the same provider. For example, you might\n            have multiple applications that use the same OIDC provider. You cannot register more\n            than 100 client IDs with a single IAM OIDC provider.</p>\n         <p>There is no defined format for a client ID. The\n                <code>CreateOpenIDConnectProviderRequest</code> operation accepts client IDs up to\n            255 characters long.</p>"
                     }
                 },
                 "ThumbprintList": {
                     "target": "com.amazonaws.iam#thumbprintListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of server certificate thumbprints for the OpenID Connect (OIDC) identity\n            provider's server certificates. Typically this list includes only one entry. However,\n            IAM lets you have up to five thumbprints for an OIDC provider. This lets you maintain\n            multiple thumbprints if the identity provider is rotating certificates.</p>\n        <p>The server certificate thumbprint is the hex-encoded SHA-1 hash value of the X.509\n            certificate used by the domain where the OpenID Connect provider makes its keys\n            available. It is always a 40-character string.</p>\n        <p>You must provide at least one thumbprint when creating an IAM OIDC provider. For\n            example, assume that the OIDC provider is <code>server.example.com</code> and the\n            provider stores its keys at https://keys.server.example.com/openid-connect. In that\n            case, the thumbprint string would be the hex-encoded SHA-1 hash value of the certificate\n            used by <code>https://keys.server.example.com.</code>\n         </p>\n        <p>For more information about obtaining the OIDC provider thumbprint, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/identity-providers-oidc-obtain-thumbprint.html\">Obtaining the\n                thumbprint for an OpenID Connect provider</a> in the <i>IAM User\n                Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>A list of server certificate thumbprints for the OpenID Connect (OIDC) identity\n            provider's server certificates. Typically this list includes only one entry. However,\n            IAM lets you have up to five thumbprints for an OIDC provider. This lets you maintain\n            multiple thumbprints if the identity provider is rotating certificates.</p>\n         <p>The server certificate thumbprint is the hex-encoded SHA-1 hash value of the X.509\n            certificate used by the domain where the OpenID Connect provider makes its keys\n            available. It is always a 40-character string.</p>\n         <p>You must provide at least one thumbprint when creating an IAM OIDC provider. For\n            example, assume that the OIDC provider is <code>server.example.com</code> and the\n            provider stores its keys at https://keys.server.example.com/openid-connect. In that\n            case, the thumbprint string would be the hex-encoded SHA-1 hash value of the certificate\n            used by <code>https://keys.server.example.com.</code>\n         </p>\n         <p>For more information about obtaining the OIDC provider thumbprint, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/identity-providers-oidc-obtain-thumbprint.html\">Obtaining the\n                thumbprint for an OpenID Connect provider</a> in the <i>IAM user\n                Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3430,6 +3509,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new IAM OpenID Connect (OIDC) provider.\n      Each tag consists of a key name and an associated value. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateOpenIDConnectProviderResponse": {
@@ -3449,7 +3531,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateOpenIDConnectProvider</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateOpenIDConnectProvider</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreatePolicy": {
@@ -3481,7 +3564,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a new managed policy for your Amazon Web Services account.</p>\n        <p>This operation creates a policy version with a version identifier of <code>v1</code>\n            and sets v1 as the policy's default version. For more information about policy versions,\n            see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed policies</a> in the\n                <i>IAM User Guide</i>.</p>\n        <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>\n        <p>For more information about managed policies in general, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates a new managed policy for your Amazon Web Services account.</p>\n         <p>This operation creates a policy version with a version identifier of <code>v1</code>\n            and sets v1 as the policy's default version. For more information about policy versions,\n            see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed policies</a> in the\n                <i>IAM User Guide</i>.</p>\n         <p>As a best practice, you can validate your IAM policies. \n     To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_policy-validator.html\">Validating IAM policies</a> \n            in the <i>IAM User Guide</i>.</p>\n         <p>For more information about managed policies in general, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreatePolicyRequest": {
@@ -3490,27 +3573,27 @@
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The friendly name of the policy.</p>\n        <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
+                        "smithy.api#documentation": "<p>The friendly name of the policy.</p>\n         <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Path": {
                     "target": "com.amazonaws.iam#policyPathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path for the policy.</p>\n        <p>For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM identifiers</a> in the\n                <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>\n        <note>\n            <p>You cannot use an asterisk (*) in the path name.</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The path for the policy.</p>\n         <p>For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM identifiers</a> in the\n                <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>\n         <note>\n            <p>You cannot use an asterisk (*) in the path name.</p>\n         </note>"
                     }
                 },
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The JSON policy document that you want to use as the content for the new\n            policy.</p>\n        <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>To learn more about JSON policy grammar, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html\">Grammar of the IAM JSON\n                policy language</a> in the <i>IAM User Guide</i>. </p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The JSON policy document that you want to use as the content for the new\n            policy.</p>\n         <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>To learn more about JSON policy grammar, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_grammar.html\">Grammar of the IAM JSON\n                policy language</a> in the <i>IAM User Guide</i>. </p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
                 "Description": {
                     "target": "com.amazonaws.iam#policyDescriptionType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A friendly description of the policy.</p>\n        <p>Typically used to store information about the permissions defined in the policy. For\n            example, \"Grants access to production DynamoDB tables.\"</p>\n        <p>The policy description is immutable. After a value is assigned, it cannot be\n            changed.</p>"
+                        "smithy.api#documentation": "<p>A friendly description of the policy.</p>\n         <p>Typically used to store information about the permissions defined in the policy. For\n            example, \"Grants access to production DynamoDB tables.\"</p>\n         <p>The policy description is immutable. After a value is assigned, it cannot be\n            changed.</p>"
                     }
                 },
                 "Tags": {
@@ -3519,6 +3602,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new IAM customer managed policy.\n      Each tag consists of a key name and an associated value. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreatePolicyResponse": {
@@ -3532,7 +3618,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreatePolicy</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreatePolicy</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreatePolicyVersion": {
@@ -3561,7 +3648,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a new version of the specified managed policy. To update a managed policy, you\n            create a new policy version. A managed policy can have up to five versions. If the\n            policy has five versions, you must delete an existing version using <a>DeletePolicyVersion</a> before you create a new version.</p>\n        <p>Optionally, you can set the new version as the policy's default version. The default\n            version is the version that is in effect for the IAM users, groups, and roles to which\n            the policy is attached.</p>\n        <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates a new version of the specified managed policy. To update a managed policy, you\n            create a new policy version. A managed policy can have up to five versions. If the\n            policy has five versions, you must delete an existing version using <a>DeletePolicyVersion</a> before you create a new version.</p>\n         <p>Optionally, you can set the new version as the policy's default version. The default\n            version is the version that is in effect for the IAM users, groups, and roles to which\n            the policy is attached.</p>\n         <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreatePolicyVersionRequest": {
@@ -3570,14 +3657,14 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy to which you want to add a new\n            version.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy to which you want to add a new\n            version.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The JSON policy document that you want to use as the content for this new version of\n            the policy.</p>\n        <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The JSON policy document that you want to use as the content for this new version of\n            the policy.</p>\n         <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3585,9 +3672,12 @@
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>Specifies whether to set this version as the policy's default version.</p>\n        <p>When this parameter is <code>true</code>, the new policy version becomes the operative\n            version. That is, it becomes the version that is in effect for the IAM users, groups,\n            and roles that the policy is attached to.</p>\n        <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Specifies whether to set this version as the policy's default version.</p>\n         <p>When this parameter is <code>true</code>, the new policy version becomes the operative\n            version. That is, it becomes the version that is in effect for the IAM users, groups,\n            and roles that the policy is attached to.</p>\n         <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreatePolicyVersionResponse": {
@@ -3601,7 +3691,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreatePolicyVersion</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreatePolicyVersion</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateRole": {
@@ -3642,20 +3733,20 @@
                 "Path": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path to the role. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                Identifiers</a> in the <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path to the role. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                Identifiers</a> in the <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to create.</p>\n        <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
+                        "smithy.api#documentation": "<p>The name of the role to create.</p>\n         <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "AssumeRolePolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The trust relationship policy document that grants an entity permission to assume the\n            role.</p>\n        <p>In IAM, you must provide a JSON policy that has been converted to a string. However,\n            for CloudFormation templates formatted in YAML, you can provide the policy in JSON or YAML\n            format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>\n        <p> Upon success, the response includes the same trust policy in JSON format.</p>",
+                        "smithy.api#documentation": "<p>The trust relationship policy document that grants an entity permission to assume the\n            role.</p>\n         <p>In IAM, you must provide a JSON policy that has been converted to a string. However,\n            for CloudFormation templates formatted in YAML, you can provide the policy in JSON or YAML\n            format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>\n         <p> Upon success, the response includes the same trust policy in JSON format.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3668,13 +3759,13 @@
                 "MaxSessionDuration": {
                     "target": "com.amazonaws.iam#roleMaxSessionDurationType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The maximum session duration (in seconds) that you want to set for the specified role.\n            If you do not specify a value for this setting, the default value of one hour is\n            applied. This setting can have a value from 1 hour to 12 hours.</p>\n        <p>Anyone who assumes the role from the CLI or API can use the <code>DurationSeconds</code>\n            API parameter or the <code>duration-seconds</code> CLI parameter to request a longer\n            session. The <code>MaxSessionDuration</code> setting determines the maximum duration\n            that can be requested using the <code>DurationSeconds</code> parameter. If users don't\n            specify a value for the <code>DurationSeconds</code> parameter, their security\n            credentials are valid for one hour by default. This applies when you use the\n                <code>AssumeRole*</code> API operations or the <code>assume-role*</code> CLI\n            operations but does not apply when you use those operations to create a console URL. For\n            more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM roles</a> in the <i>IAM User Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The maximum session duration (in seconds) that you want to set for the specified role.\n            If you do not specify a value for this setting, the default value of one hour is\n            applied. This setting can have a value from 1 hour to 12 hours.</p>\n         <p>Anyone who assumes the role from the CLI or API can use the\n                <code>DurationSeconds</code> API parameter or the <code>duration-seconds</code>\n            CLI parameter to request a longer session. The <code>MaxSessionDuration</code> setting\n            determines the maximum duration that can be requested using the\n                <code>DurationSeconds</code> parameter. If users don't specify a value for the\n                <code>DurationSeconds</code> parameter, their security credentials are valid for one\n            hour by default. This applies when you use the <code>AssumeRole*</code> API operations\n            or the <code>assume-role*</code> CLI operations but does not apply when you use those\n            operations to create a console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM\n                roles</a> in the <i>IAM User Guide</i>.</p>"
                     }
                 },
                 "PermissionsBoundary": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the policy that is used to set the permissions boundary for the\n            role.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the managed policy that is used to set the permissions boundary for the\n            role.</p>\n         <p>A permissions boundary policy defines the maximum permissions that identity-based\n            policies can grant to an entity, but does not grant permissions. Permissions boundaries\n            do not define the maximum permissions that a resource-based policy can grant to an\n            entity. To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries\n                for IAM entities</a> in the <i>IAM User Guide</i>.</p>\n         <p>For more information about policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types\">Policy types\n            </a> in the <i>IAM User Guide</i>.</p>"
                     }
                 },
                 "Tags": {
@@ -3683,6 +3774,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new role. Each tag consists of a key name and an associated value.\n      For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateRoleResponse": {
@@ -3697,7 +3791,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateRole</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateRole</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateSAMLProvider": {
@@ -3726,7 +3821,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates an IAM resource that describes an identity provider (IdP) that supports SAML\n            2.0.</p>\n        <p>The SAML provider resource that you create with this operation can be used as a\n            principal in an IAM role's trust policy. Such a policy can enable federated users who\n            sign in using the SAML IdP to assume the role. You can create an IAM role that\n            supports Web-based single sign-on (SSO) to the Amazon Web Services Management Console or one that supports API access\n            to Amazon Web Services.</p>\n        <p>When you create the SAML provider resource, you upload a SAML metadata document that\n            you get from your IdP. That document includes the issuer's name, expiration information,\n            and keys that can be used to validate the SAML authentication response (assertions) that\n            the IdP sends. You must generate the metadata document using the identity management\n            software that is used as your organization's IdP.</p>\n        <note>\n            <p> This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n        </note>\n        <p> For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html\">Enabling SAML 2.0\n                federated users to access the Amazon Web Services Management Console</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About SAML 2.0-based\n                federation</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates an IAM resource that describes an identity provider (IdP) that supports SAML\n            2.0.</p>\n         <p>The SAML provider resource that you create with this operation can be used as a\n            principal in an IAM role's trust policy. Such a policy can enable federated users who\n            sign in using the SAML IdP to assume the role. You can create an IAM role that\n            supports Web-based single sign-on (SSO) to the Amazon Web Services Management Console or one that supports API access\n            to Amazon Web Services.</p>\n         <p>When you create the SAML provider resource, you upload a SAML metadata document that\n            you get from your IdP. That document includes the issuer's name, expiration information,\n            and keys that can be used to validate the SAML authentication response (assertions) that\n            the IdP sends. You must generate the metadata document using the identity management\n            software that is used as your organization's IdP.</p>\n         <note>\n            <p> This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         </note>\n         <p> For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-saml.html\">Enabling SAML 2.0\n                federated users to access the Amazon Web Services Management Console</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About SAML 2.0-based\n                federation</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreateSAMLProviderRequest": {
@@ -3735,14 +3830,14 @@
                 "SAMLMetadataDocument": {
                     "target": "com.amazonaws.iam#SAMLMetadataDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An XML document generated by an identity provider (IdP) that supports SAML 2.0. The\n            document includes the issuer's name, expiration information, and keys that can be used\n            to validate the SAML authentication response (assertions) that are received from the\n            IdP. You must generate the metadata document using the identity management software that\n            is used as your organization's IdP.</p>\n        <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About SAML 2.0-based\n                federation</a> in the <i>IAM User Guide</i>\n        </p>",
+                        "smithy.api#documentation": "<p>An XML document generated by an identity provider (IdP) that supports SAML 2.0. The\n            document includes the issuer's name, expiration information, and keys that can be used\n            to validate the SAML authentication response (assertions) that are received from the\n            IdP. You must generate the metadata document using the identity management software that\n            is used as your organization's IdP.</p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_saml.html\">About SAML 2.0-based\n                federation</a> in the <i>IAM User Guide</i>\n         </p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Name": {
                     "target": "com.amazonaws.iam#SAMLProviderNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the provider to create.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the provider to create.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3752,6 +3847,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new IAM SAML provider.\n      Each tag consists of a key name and an associated value. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateSAMLProviderResponse": {
@@ -3771,7 +3869,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateSAMLProvider</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateSAMLProvider</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateServiceLinkedRole": {
@@ -3797,7 +3896,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates an IAM role that is linked to a specific Amazon Web Services service. The service controls\n            the attached policies and when the role can be deleted. This helps ensure that the\n            service is not broken by an unexpectedly changed or deleted role, which could put your\n            Amazon Web Services resources into an unknown state. Allowing the service to control the role helps\n            improve service stability and proper cleanup when a service and its role are no longer\n            needed. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html\">Using service-linked\n                roles</a> in the <i>IAM User Guide</i>. </p>\n        <p>To attach a policy to this service-linked role, you must make the request using the\n            Amazon Web Services service that depends on this role.</p>"
+                "smithy.api#documentation": "<p>Creates an IAM role that is linked to a specific Amazon Web Services service. The service controls\n            the attached policies and when the role can be deleted. This helps ensure that the\n            service is not broken by an unexpectedly changed or deleted role, which could put your\n            Amazon Web Services resources into an unknown state. Allowing the service to control the role helps\n            improve service stability and proper cleanup when a service and its role are no longer\n            needed. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/using-service-linked-roles.html\">Using service-linked\n                roles</a> in the <i>IAM User Guide</i>. </p>\n         <p>To attach a policy to this service-linked role, you must make the request using the\n            Amazon Web Services service that depends on this role.</p>"
             }
         },
         "com.amazonaws.iam#CreateServiceLinkedRoleRequest": {
@@ -3806,7 +3905,7 @@
                 "AWSServiceName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The service principal for the Amazon Web Services service to which this role is attached. You use a\n            string similar to a URL but without the http:// in front. For example:\n                <code>elasticbeanstalk.amazonaws.com</code>. </p>\n        <p>Service principals are unique and case-sensitive. To find the exact service principal\n            for your service-linked role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html\">Amazon Web Services services\n                that work with IAM</a> in the <i>IAM User Guide</i>. Look for\n            the services that have <b>Yes </b>in the <b>Service-Linked Role</b> column. Choose the <b>Yes</b> link to view the service-linked role documentation for that\n            service.</p>",
+                        "smithy.api#documentation": "<p>The service principal for the Amazon Web Services service to which this role is attached. You use a\n            string similar to a URL but without the http:// in front. For example:\n                <code>elasticbeanstalk.amazonaws.com</code>. </p>\n         <p>Service principals are unique and case-sensitive. To find the exact service principal\n            for your service-linked role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html\">Amazon Web Services services\n                that work with IAM</a> in the <i>IAM User Guide</i>. Look for\n            the services that have <b>Yes </b>in the <b>Service-Linked Role</b> column. Choose the <b>Yes</b> link to view the service-linked role documentation for that\n            service.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3819,9 +3918,12 @@
                 "CustomSuffix": {
                     "target": "com.amazonaws.iam#customSuffixType",
                     "traits": {
-                        "smithy.api#documentation": "<p></p>\n        <p>A string that you provide, which is combined with the service-provided prefix to form\n            the complete role name. If you make multiple requests for the same service, then you\n            must supply a different <code>CustomSuffix</code> for each request. Otherwise the\n            request fails with a duplicate role name error. For example, you could add\n                <code>-1</code> or <code>-debug</code> to the suffix.</p>\n        <p>Some services do not support the <code>CustomSuffix</code> parameter. If you provide\n            an optional suffix and the operation fails, try the operation again without the\n            suffix.</p>"
+                        "smithy.api#documentation": "<p></p>\n         <p>A string that you provide, which is combined with the service-provided prefix to form\n            the complete role name. If you make multiple requests for the same service, then you\n            must supply a different <code>CustomSuffix</code> for each request. Otherwise the\n            request fails with a duplicate role name error. For example, you could add\n                <code>-1</code> or <code>-debug</code> to the suffix.</p>\n         <p>Some services do not support the <code>CustomSuffix</code> parameter. If you provide\n            an optional suffix and the operation fails, try the operation again without the\n            suffix.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateServiceLinkedRoleResponse": {
@@ -3833,6 +3935,9 @@
                         "smithy.api#documentation": "<p>A <a>Role</a> object that contains details about the newly created\n            role.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateServiceSpecificCredential": {
@@ -3855,7 +3960,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Generates a set of credentials consisting of a user name and password that can be used\n            to access the service specified in the request. These credentials are generated by\n            IAM, and can be used only for the specified service. </p>\n        <p>You can have a maximum of two sets of service-specific credentials for each supported\n            service per user.</p>\n        <p>You can create service-specific credentials for CodeCommit and Amazon Keyspaces (for Apache\n            Cassandra).</p>\n        <p>You can reset the password to a new service-generated value by calling <a>ResetServiceSpecificCredential</a>.</p>\n        <p>For more information about service-specific credentials, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html\">Using IAM\n                with CodeCommit: Git credentials, SSH keys, and Amazon Web Services access keys</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Generates a set of credentials consisting of a user name and password that can be used\n            to access the service specified in the request. These credentials are generated by\n            IAM, and can be used only for the specified service. </p>\n         <p>You can have a maximum of two sets of service-specific credentials for each supported\n            service per user.</p>\n         <p>You can create service-specific credentials for CodeCommit and Amazon Keyspaces (for Apache\n            Cassandra).</p>\n         <p>You can reset the password to a new service-generated value by calling <a>ResetServiceSpecificCredential</a>.</p>\n         <p>For more information about service-specific credentials, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_ssh-keys.html\">Using IAM\n                with CodeCommit: Git credentials, SSH keys, and Amazon Web Services access keys</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreateServiceSpecificCredentialRequest": {
@@ -3864,7 +3969,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user that is to be associated with the credentials. The new\n            service-specific credentials have the same permissions as the associated user except\n            that they can be used only to access the specified service.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user that is to be associated with the credentials. The new\n            service-specific credentials have the same permissions as the associated user except\n            that they can be used only to access the specified service.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3875,6 +3980,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateServiceSpecificCredentialResponse": {
@@ -3883,9 +3991,12 @@
                 "ServiceSpecificCredential": {
                     "target": "com.amazonaws.iam#ServiceSpecificCredential",
                     "traits": {
-                        "smithy.api#documentation": "<p>A structure that contains information about the newly created service-specific\n            credential.</p>\n        <important>\n            <p>This is the only time that the password for this credential set is available. It\n                cannot be recovered later. Instead, you must reset the password with <a>ResetServiceSpecificCredential</a>.</p>\n        </important>"
+                        "smithy.api#documentation": "<p>A structure that contains information about the newly created service-specific\n            credential.</p>\n         <important>\n            <p>This is the only time that the password for this credential set is available. It\n                cannot be recovered later. Instead, you must reset the password with <a>ResetServiceSpecificCredential</a>.</p>\n         </important>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateUser": {
@@ -3917,7 +4028,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a new IAM user for your Amazon Web Services account.</p>\n        <p> For information about quotas for the number of IAM users you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Creates a new IAM user for your Amazon Web Services account.</p>\n         <p> For information about quotas for the number of IAM users you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#CreateUserRequest": {
@@ -3926,20 +4037,20 @@
                 "Path": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path for the user name. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path for the user name. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to create.</p>\n        <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
+                        "smithy.api#documentation": "<p>The name of the user to create.</p>\n         <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PermissionsBoundary": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the policy that is used to set the permissions boundary for the\n            user.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the managed policy that is used to set the permissions boundary for the\n            user.</p>\n         <p>A permissions boundary policy defines the maximum permissions that identity-based\n            policies can grant to an entity, but does not grant permissions. Permissions boundaries\n            do not define the maximum permissions that a resource-based policy can grant to an\n            entity. To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries\n                for IAM entities</a> in the <i>IAM User Guide</i>.</p>\n         <p>For more information about policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types\">Policy types\n            </a> in the <i>IAM User Guide</i>.</p>"
                     }
                 },
                 "Tags": {
@@ -3948,6 +4059,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new user. Each tag consists of a key name and an associated value.\n      For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateUserResponse": {
@@ -3961,7 +4075,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateUser</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateUser</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CreateVirtualMFADevice": {
@@ -3990,7 +4105,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a new virtual MFA device for the Amazon Web Services account. After creating the virtual\n            MFA, use <a>EnableMFADevice</a> to attach the MFA device to an IAM user.\n            For more information about creating and working with virtual MFA devices, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html\">Using a virtual MFA\n                device</a> in the <i>IAM User Guide</i>.</p>\n        <p>For information about the maximum number of MFA devices you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>\n        <important>\n            <p>The seed information contained in the QR code and the Base32 string should be\n                treated like any other secret access information. In other words, protect the seed\n                information as you would your Amazon Web Services access keys or your passwords. After you\n                provision your virtual device, you should ensure that the information is destroyed\n                following secure procedures.</p>\n        </important>"
+                "smithy.api#documentation": "<p>Creates a new virtual MFA device for the Amazon Web Services account. After creating the virtual\n            MFA, use <a>EnableMFADevice</a> to attach the MFA device to an IAM user.\n            For more information about creating and working with virtual MFA devices, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html\">Using a virtual MFA\n                device</a> in the <i>IAM User Guide</i>.</p>\n         <p>For information about the maximum number of MFA devices you can create, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>\n         <important>\n            <p>The seed information contained in the QR code and the Base32 string should be\n                treated like any other secret access information. In other words, protect the seed\n                information as you would your Amazon Web Services access keys or your passwords. After you\n                provision your virtual device, you should ensure that the information is destroyed\n                following secure procedures.</p>\n         </important>"
             }
         },
         "com.amazonaws.iam#CreateVirtualMFADeviceRequest": {
@@ -3999,13 +4114,13 @@
                 "Path": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path for the virtual MFA device. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path for the virtual MFA device. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "VirtualMFADeviceName": {
                     "target": "com.amazonaws.iam#virtualMFADeviceName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the virtual MFA device. Use with path to uniquely identify a virtual MFA\n            device.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the virtual MFA device, which must be unique. Use with path to uniquely identify a virtual MFA\n            device.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4015,6 +4130,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new IAM virtual MFA device.\n      Each tag consists of a key name and an associated value. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#CreateVirtualMFADeviceResponse": {
@@ -4029,7 +4147,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateVirtualMFADevice</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>CreateVirtualMFADevice</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#CredentialReportExpiredException": {
@@ -4106,7 +4225,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deactivates the specified MFA device and removes it from association with the user\n            name for which it was originally enabled.</p>\n        <p>For more information about creating and working with virtual MFA devices, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html\">Enabling a virtual\n                multi-factor authentication (MFA) device</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deactivates the specified MFA device and removes it from association with the user\n            name for which it was originally enabled.</p>\n         <p>For more information about creating and working with virtual MFA devices, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html\">Enabling a virtual\n                multi-factor authentication (MFA) device</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeactivateMFADeviceRequest": {
@@ -4115,17 +4234,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose MFA device you want to deactivate.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user whose MFA device you want to deactivate.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SerialNumber": {
                     "target": "com.amazonaws.iam#serialNumberType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices,\n            the serial number is the device ARN.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of upper and lowercase alphanumeric characters with no spaces. You can also include any of the \n    following characters: =,.@:/-</p>",
+                        "smithy.api#documentation": "<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices,\n            the serial number is the device ARN.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of upper and lowercase alphanumeric characters with no spaces. You can also include any of the \n    following characters: =,.@:/-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteAccessKey": {
@@ -4148,7 +4270,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the access key pair associated with the specified IAM user.</p>\n        <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID signing the request. This operation works for access keys under\n            the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root\n            user credentials even if the Amazon Web Services account has no associated users.</p>"
+                "smithy.api#documentation": "<p>Deletes the access key pair associated with the specified IAM user.</p>\n         <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID signing the request. This operation works for access keys under\n            the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root\n            user credentials even if the Amazon Web Services account has no associated users.</p>"
             }
         },
         "com.amazonaws.iam#DeleteAccessKeyRequest": {
@@ -4157,16 +4279,19 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose access key pair you want to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user whose access key pair you want to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "AccessKeyId": {
                     "target": "com.amazonaws.iam#accessKeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The access key ID for the access key ID and secret access key you want to\n            delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The access key ID for the access key ID and secret access key you want to\n            delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteAccountAlias": {
@@ -4198,10 +4323,13 @@
                 "AccountAlias": {
                     "target": "com.amazonaws.iam#accountAliasType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the account alias to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of \n    lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have \n    two dashes in a row.</p>",
+                        "smithy.api#documentation": "<p>The name of the account alias to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of \n    lowercase letters, digits, and dashes. You cannot start or finish with a dash, nor can you have \n    two dashes in a row.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteAccountPasswordPolicy": {
@@ -4290,7 +4418,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified inline policy that is embedded in the specified IAM\n            group.</p>\n        <p>A group can also have managed policies attached to it. To detach a managed policy from\n            a group, use <a>DetachGroupPolicy</a>. For more information about policies,\n            refer to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified inline policy that is embedded in the specified IAM\n            group.</p>\n         <p>A group can also have managed policies attached to it. To detach a managed policy from\n            a group, use <a>DetachGroupPolicy</a>. For more information about policies,\n            refer to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeleteGroupPolicyRequest": {
@@ -4299,17 +4427,20 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) identifying the group that the policy is embedded\n            in.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) identifying the group that the policy is embedded\n            in.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name identifying the policy document to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name identifying the policy document to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteGroupRequest": {
@@ -4318,10 +4449,13 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM group to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM group to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteInstanceProfile": {
@@ -4347,7 +4481,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified instance profile. The instance profile must not have an\n            associated role.</p>\n        <important>\n            <p>Make sure that you do not have any Amazon EC2 instances running with the instance\n                profile you are about to delete. Deleting a role or instance profile that is\n                associated with a running instance will break any applications running on the\n                instance.</p>\n        </important>\n        <p>For more information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified instance profile. The instance profile must not have an\n            associated role.</p>\n         <important>\n            <p>Make sure that you do not have any Amazon EC2 instances running with the instance\n                profile you are about to delete. Deleting a role or instance profile that is\n                associated with a running instance will break any applications running on the\n                instance.</p>\n         </important>\n         <p>For more information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>"
             }
         },
         "com.amazonaws.iam#DeleteInstanceProfileRequest": {
@@ -4356,10 +4490,13 @@
                 "InstanceProfileName": {
                     "target": "com.amazonaws.iam#instanceProfileNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the instance profile to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the instance profile to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteLoginProfile": {
@@ -4385,7 +4522,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the password for the specified IAM user, For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html\">Managing\n                passwords for IAM users</a>.</p>\n        <p>You can use the CLI, the Amazon Web Services API, or the <b>Users</b>\n            page in the IAM console to delete a password for any IAM user. You can use <a>ChangePassword</a> to update, but not delete, your own password in the\n                <b>My Security Credentials</b> page in the\n            Amazon Web Services Management Console.</p>\n        <important>\n            <p>Deleting a user's password does not prevent a user from accessing Amazon Web Services through\n                the command line interface or the API. To prevent all user access, you must also\n                either make any access keys inactive or delete them. For more information about\n                making keys inactive or deleting them, see <a>UpdateAccessKey</a> and\n                    <a>DeleteAccessKey</a>.</p>\n        </important>"
+                "smithy.api#documentation": "<p>Deletes the password for the specified IAM user, For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_admin-change-user.html\">Managing\n                passwords for IAM users</a>.</p>\n         <p>You can use the CLI, the Amazon Web Services API, or the <b>Users</b>\n            page in the IAM console to delete a password for any IAM user. You can use <a>ChangePassword</a> to update, but not delete, your own password in the\n                <b>My Security Credentials</b> page in the\n            Amazon Web Services Management Console.</p>\n         <important>\n            <p>Deleting a user's password does not prevent a user from accessing Amazon Web Services through\n                the command line interface or the API. To prevent all user access, you must also\n                either make any access keys inactive or delete them. For more information about\n                making keys inactive or deleting them, see <a>UpdateAccessKey</a> and\n                    <a>DeleteAccessKey</a>.</p>\n         </important>"
             }
         },
         "com.amazonaws.iam#DeleteLoginProfileRequest": {
@@ -4394,10 +4531,13 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose password you want to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user whose password you want to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteOpenIDConnectProvider": {
@@ -4420,7 +4560,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes an OpenID Connect identity provider (IdP) resource object in IAM.</p>\n        <p>Deleting an IAM OIDC provider resource does not update any roles that reference the\n            provider as a principal in their trust policies. Any attempt to assume a role that\n            references a deleted provider fails.</p>\n        <p>This operation is idempotent; it does not fail or return an error if you call the\n            operation for a provider that does not exist.</p>"
+                "smithy.api#documentation": "<p>Deletes an OpenID Connect identity provider (IdP) resource object in IAM.</p>\n         <p>Deleting an IAM OIDC provider resource does not update any roles that reference the\n            provider as a principal in their trust policies. Any attempt to assume a role that\n            references a deleted provider fails.</p>\n         <p>This operation is idempotent; it does not fail or return an error if you call the\n            operation for a provider that does not exist.</p>"
             }
         },
         "com.amazonaws.iam#DeleteOpenIDConnectProviderRequest": {
@@ -4433,6 +4573,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeletePolicy": {
@@ -4461,7 +4604,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified managed policy.</p>\n        <p>Before you can delete a managed policy, you must first detach the policy from all\n            users, groups, and roles that it is attached to. In addition, you must delete all the\n            policy's versions. The following steps describe the process for deleting a managed\n            policy:</p>\n        <ul>\n            <li>\n                <p>Detach the policy from all users, groups, and roles that the policy is\n                    attached to, using <a>DetachUserPolicy</a>, <a>DetachGroupPolicy</a>, or <a>DetachRolePolicy</a>. To\n                    list all the users, groups, and roles that a policy is attached to, use <a>ListEntitiesForPolicy</a>.</p>\n            </li>\n            <li>\n                <p>Delete all versions of the policy using <a>DeletePolicyVersion</a>.\n                    To list the policy's versions, use <a>ListPolicyVersions</a>. You\n                    cannot use <a>DeletePolicyVersion</a> to delete the version that is\n                    marked as the default version. You delete the policy's default version in the\n                    next step of the process.</p>\n            </li>\n            <li>\n                <p>Delete the policy (this automatically deletes the policy's default version)\n                    using this operation.</p>\n            </li>\n         </ul>\n        <p>For information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified managed policy.</p>\n         <p>Before you can delete a managed policy, you must first detach the policy from all\n            users, groups, and roles that it is attached to. In addition, you must delete all the\n            policy's versions. The following steps describe the process for deleting a managed\n            policy:</p>\n         <ul>\n            <li>\n               <p>Detach the policy from all users, groups, and roles that the policy is\n                    attached to, using <a>DetachUserPolicy</a>, <a>DetachGroupPolicy</a>, or <a>DetachRolePolicy</a>. To\n                    list all the users, groups, and roles that a policy is attached to, use <a>ListEntitiesForPolicy</a>.</p>\n            </li>\n            <li>\n               <p>Delete all versions of the policy using <a>DeletePolicyVersion</a>.\n                    To list the policy's versions, use <a>ListPolicyVersions</a>. You\n                    cannot use <a>DeletePolicyVersion</a> to delete the version that is\n                    marked as the default version. You delete the policy's default version in the\n                    next step of the process.</p>\n            </li>\n            <li>\n               <p>Delete the policy (this automatically deletes the policy's default version)\n                    using this operation.</p>\n            </li>\n         </ul>\n         <p>For information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeletePolicyRequest": {
@@ -4470,10 +4613,13 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to delete.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to delete.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeletePolicyVersion": {
@@ -4502,7 +4648,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified version from the specified managed policy.</p>\n        <p>You cannot delete the default version from a policy using this operation. To delete\n            the default version from a policy, use <a>DeletePolicy</a>. To find out which\n            version of a policy is marked as the default version, use <a>ListPolicyVersions</a>.</p>\n        <p>For information about versions for managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified version from the specified managed policy.</p>\n         <p>You cannot delete the default version from a policy using this operation. To delete\n            the default version from a policy, use <a>DeletePolicy</a>. To find out which\n            version of a policy is marked as the default version, use <a>ListPolicyVersions</a>.</p>\n         <p>For information about versions for managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeletePolicyVersionRequest": {
@@ -4511,17 +4657,20 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy from which you want to delete a\n            version.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy from which you want to delete a\n            version.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "VersionId": {
                     "target": "com.amazonaws.iam#policyVersionIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy version to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that \n    consists of the lowercase letter 'v' followed by one or two digits, and optionally \n    followed by a period '.' and a string of letters and digits.</p>\n        <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>The policy version to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that \n    consists of the lowercase letter 'v' followed by one or two digits, and optionally \n    followed by a period '.' and a string of letters and digits.</p>\n         <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteRole": {
@@ -4553,7 +4702,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified role. The role must not have any policies attached. For more\n            information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>.</p>\n        <important>\n            <p>Make sure that you do not have any Amazon EC2 instances running with the role you\n                are about to delete. Deleting a role or instance profile that is associated with a\n                running instance will break any applications running on the instance.</p>\n        </important>"
+                "smithy.api#documentation": "<p>Deletes the specified role. Unlike the Amazon Web Services Management Console, when you delete a role\n            programmatically, you must delete the items attached to the role manually, or the\n            deletion fails. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_manage_delete.html#roles-managingrole-deleting-cli\">Deleting an IAM role</a>. Before attempting to delete a role, remove the\n            following attached items: </p>\n         <ul>\n            <li>\n               <p>Inline policies (<a>DeleteRolePolicy</a>)</p>\n            </li>\n            <li>\n               <p>Attached managed policies (<a>DetachRolePolicy</a>)</p>\n            </li>\n            <li>\n               <p>Instance profile (<a>RemoveRoleFromInstanceProfile</a>)</p>\n            </li>\n            <li>\n               <p>Optional – Delete instance profile after detaching from role for\n                    resource clean up (<a>DeleteInstanceProfile</a>)</p>\n            </li>\n         </ul>\n         <important>\n            <p>Make sure that you do not have any Amazon EC2 instances running with the role you\n                are about to delete. Deleting a role or instance profile that is associated with a\n                running instance will break any applications running on the instance.</p>\n         </important>"
             }
         },
         "com.amazonaws.iam#DeleteRolePermissionsBoundary": {
@@ -4576,7 +4725,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the permissions boundary for the specified IAM role. </p>\n        <important>\n            <p>Deleting the permissions boundary for a role might increase its permissions. For\n                example, it might allow anyone who assumes the role to perform all the actions\n                granted in its permissions policies. </p>\n        </important>"
+                "smithy.api#documentation": "<p>Deletes the permissions boundary for the specified IAM role. </p>\n         <important>\n            <p>Deleting the permissions boundary for a role might increase its permissions. For\n                example, it might allow anyone who assumes the role to perform all the actions\n                granted in its permissions policies. </p>\n         </important>"
             }
         },
         "com.amazonaws.iam#DeleteRolePermissionsBoundaryRequest": {
@@ -4589,6 +4738,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteRolePolicy": {
@@ -4614,7 +4766,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified inline policy that is embedded in the specified IAM\n            role.</p>\n        <p>A role can also have managed policies attached to it. To detach a managed policy from\n            a role, use <a>DetachRolePolicy</a>. For more information about policies,\n            refer to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified inline policy that is embedded in the specified IAM\n            role.</p>\n         <p>A role can also have managed policies attached to it. To detach a managed policy from\n            a role, use <a>DetachRolePolicy</a>. For more information about policies,\n            refer to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeleteRolePolicyRequest": {
@@ -4623,17 +4775,20 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) identifying the role that the policy is embedded\n            in.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) identifying the role that the policy is embedded\n            in.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the inline policy to delete from the specified IAM role.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the inline policy to delete from the specified IAM role.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteRoleRequest": {
@@ -4642,10 +4797,13 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteSAMLProvider": {
@@ -4671,7 +4829,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes a SAML provider resource in IAM.</p>\n        <p>Deleting the provider resource from IAM does not update any roles that reference the\n            SAML provider resource's ARN as a principal in their trust policies. Any attempt to\n            assume a role that references a non-existent provider resource ARN fails.</p>\n        <note>\n            <p> This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Deletes a SAML provider resource in IAM.</p>\n         <p>Deleting the provider resource from IAM does not update any roles that reference the\n            SAML provider resource's ARN as a principal in their trust policies. Any attempt to\n            assume a role that references a non-existent provider resource ARN fails.</p>\n         <note>\n            <p> This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#DeleteSAMLProviderRequest": {
@@ -4684,6 +4842,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteSSHPublicKey": {
@@ -4700,7 +4861,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified SSH public key.</p>\n        <p>The SSH public key deleted by this operation is used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified SSH public key.</p>\n         <p>The SSH public key deleted by this operation is used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeleteSSHPublicKeyRequest": {
@@ -4709,17 +4870,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user associated with the SSH public key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user associated with the SSH public key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SSHPublicKeyId": {
                     "target": "com.amazonaws.iam#publicKeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier for the SSH public key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier for the SSH public key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteServerCertificate": {
@@ -4745,7 +4909,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified server certificate.</p>\n        <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic also includes a list of Amazon Web Services services that can use the server certificates that\n            you manage with IAM.</p>\n        <important>\n            <p> If you are using a server certificate with Elastic Load Balancing, deleting the\n                certificate could have implications for your application. If Elastic Load Balancing\n                doesn't detect the deletion of bound certificates, it may continue to use the\n                certificates. This could cause Elastic Load Balancing to stop accepting traffic. We\n                recommend that you remove the reference to the certificate from Elastic Load\n                Balancing before using this command to delete the certificate. For more information,\n                see <a href=\"https://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DeleteLoadBalancerListeners.html\">DeleteLoadBalancerListeners</a> in the <i>Elastic Load Balancing API\n                    Reference</i>.</p>\n        </important>"
+                "smithy.api#documentation": "<p>Deletes the specified server certificate.</p>\n         <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic also includes a list of Amazon Web Services services that can use the server certificates that\n            you manage with IAM.</p>\n         <important>\n            <p> If you are using a server certificate with Elastic Load Balancing, deleting the\n                certificate could have implications for your application. If Elastic Load Balancing\n                doesn't detect the deletion of bound certificates, it may continue to use the\n                certificates. This could cause Elastic Load Balancing to stop accepting traffic. We\n                recommend that you remove the reference to the certificate from Elastic Load\n                Balancing before using this command to delete the certificate. For more information,\n                see <a href=\"https://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DeleteLoadBalancerListeners.html\">DeleteLoadBalancerListeners</a> in the <i>Elastic Load Balancing API\n                    Reference</i>.</p>\n         </important>"
             }
         },
         "com.amazonaws.iam#DeleteServerCertificateRequest": {
@@ -4754,10 +4918,13 @@
                 "ServerCertificateName": {
                     "target": "com.amazonaws.iam#serverCertificateNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the server certificate you want to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the server certificate you want to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteServiceLinkedRole": {
@@ -4780,7 +4947,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Submits a service-linked role deletion request and returns a\n                <code>DeletionTaskId</code>, which you can use to check the status of the deletion.\n            Before you call this operation, confirm that the role has no active sessions and that\n            any resources used by the role in the linked service are deleted. If you call this\n            operation more than once for the same service-linked role and an earlier deletion task\n            is not complete, then the <code>DeletionTaskId</code> of the earlier request is\n            returned.</p>\n        <p>If you submit a deletion request for a service-linked role whose linked service is\n            still accessing a resource, then the deletion task fails. If it fails, the <a>GetServiceLinkedRoleDeletionStatus</a> operation returns the reason for the\n            failure, usually including the resources that must be deleted. To delete the\n            service-linked role, you must first remove those resources from the linked service and\n            then submit the deletion request again. Resources are specific to the service that is\n            linked to the role. For more information about removing resources from a service, see\n            the <a href=\"http://docs.aws.amazon.com/\">Amazon Web Services documentation</a> for your\n            service.</p>\n        <p>For more information about service-linked roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-service-linked-role\">Roles terms and concepts: Amazon Web Services service-linked role</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Submits a service-linked role deletion request and returns a\n                <code>DeletionTaskId</code>, which you can use to check the status of the deletion.\n            Before you call this operation, confirm that the role has no active sessions and that\n            any resources used by the role in the linked service are deleted. If you call this\n            operation more than once for the same service-linked role and an earlier deletion task\n            is not complete, then the <code>DeletionTaskId</code> of the earlier request is\n            returned.</p>\n         <p>If you submit a deletion request for a service-linked role whose linked service is\n            still accessing a resource, then the deletion task fails. If it fails, the <a>GetServiceLinkedRoleDeletionStatus</a> operation returns the reason for the\n            failure, usually including the resources that must be deleted. To delete the\n            service-linked role, you must first remove those resources from the linked service and\n            then submit the deletion request again. Resources are specific to the service that is\n            linked to the role. For more information about removing resources from a service, see\n            the <a href=\"http://docs.aws.amazon.com/\">Amazon Web Services documentation</a> for your\n            service.</p>\n         <p>For more information about service-linked roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html#iam-term-service-linked-role\">Roles terms and concepts: Amazon Web Services service-linked role</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeleteServiceLinkedRoleRequest": {
@@ -4793,6 +4960,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteServiceLinkedRoleResponse": {
@@ -4805,6 +4975,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#DeleteServiceSpecificCredential": {
@@ -4830,16 +5003,19 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user associated with the service-specific credential. If this\n            value is not specified, then the operation assumes the user whose credentials are used\n            to call the operation.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user associated with the service-specific credential. If this\n            value is not specified, then the operation assumes the user whose credentials are used\n            to call the operation.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "ServiceSpecificCredentialId": {
                     "target": "com.amazonaws.iam#serviceSpecificCredentialId",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier of the service-specific credential. You can get this value by\n            calling <a>ListServiceSpecificCredentials</a>.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier of the service-specific credential. You can get this value by\n            calling <a>ListServiceSpecificCredentials</a>.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteSigningCertificate": {
@@ -4862,7 +5038,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes a signing certificate associated with the specified IAM user.</p>\n        <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID signing the request. This operation works for access keys under\n            the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root\n            user credentials even if the Amazon Web Services account has no associated IAM users.</p>"
+                "smithy.api#documentation": "<p>Deletes a signing certificate associated with the specified IAM user.</p>\n         <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID signing the request. This operation works for access keys under\n            the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root\n            user credentials even if the Amazon Web Services account has no associated IAM users.</p>"
             }
         },
         "com.amazonaws.iam#DeleteSigningCertificateRequest": {
@@ -4871,16 +5047,19 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user the signing certificate belongs to.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user the signing certificate belongs to.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "CertificateId": {
                     "target": "com.amazonaws.iam#certificateIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ID of the signing certificate to delete.</p>\n        <p>The format of this parameter, as described by its <a href=\"http://wikipedia.org/wiki/regex\">regex</a> pattern, is a string of\n            characters that can be upper- or lower-cased letters or digits.</p>",
+                        "smithy.api#documentation": "<p>The ID of the signing certificate to delete.</p>\n         <p>The format of this parameter, as described by its <a href=\"http://wikipedia.org/wiki/regex\">regex</a> pattern, is a string of\n            characters that can be upper- or lower-cased letters or digits.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteUser": {
@@ -4909,7 +5088,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified IAM user. Unlike the Amazon Web Services Management Console, when you delete a user\n            programmatically, you must delete the items attached to the user manually, or the\n            deletion fails. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_cli\">Deleting an IAM\n                user</a>. Before attempting to delete a user, remove the following items:</p>\n        <ul>\n            <li>\n                <p>Password (<a>DeleteLoginProfile</a>)</p>\n            </li>\n            <li>\n                <p>Access keys (<a>DeleteAccessKey</a>)</p>\n            </li>\n            <li>\n                <p>Signing certificate (<a>DeleteSigningCertificate</a>)</p>\n            </li>\n            <li>\n                <p>SSH public key (<a>DeleteSSHPublicKey</a>)</p>\n            </li>\n            <li>\n                <p>Git credentials (<a>DeleteServiceSpecificCredential</a>)</p>\n            </li>\n            <li>\n                <p>Multi-factor authentication (MFA) device (<a>DeactivateMFADevice</a>, <a>DeleteVirtualMFADevice</a>)</p>\n            </li>\n            <li>\n                <p>Inline policies (<a>DeleteUserPolicy</a>)</p>\n            </li>\n            <li>\n                <p>Attached managed policies (<a>DetachUserPolicy</a>)</p>\n            </li>\n            <li>\n                <p>Group memberships (<a>RemoveUserFromGroup</a>)</p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Deletes the specified IAM user. Unlike the Amazon Web Services Management Console, when you delete a user\n            programmatically, you must delete the items attached to the user manually, or the\n            deletion fails. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_deleting_cli\">Deleting an IAM\n                user</a>. Before attempting to delete a user, remove the following items:</p>\n         <ul>\n            <li>\n               <p>Password (<a>DeleteLoginProfile</a>)</p>\n            </li>\n            <li>\n               <p>Access keys (<a>DeleteAccessKey</a>)</p>\n            </li>\n            <li>\n               <p>Signing certificate (<a>DeleteSigningCertificate</a>)</p>\n            </li>\n            <li>\n               <p>SSH public key (<a>DeleteSSHPublicKey</a>)</p>\n            </li>\n            <li>\n               <p>Git credentials (<a>DeleteServiceSpecificCredential</a>)</p>\n            </li>\n            <li>\n               <p>Multi-factor authentication (MFA) device (<a>DeactivateMFADevice</a>, <a>DeleteVirtualMFADevice</a>)</p>\n            </li>\n            <li>\n               <p>Inline policies (<a>DeleteUserPolicy</a>)</p>\n            </li>\n            <li>\n               <p>Attached managed policies (<a>DetachUserPolicy</a>)</p>\n            </li>\n            <li>\n               <p>Group memberships (<a>RemoveUserFromGroup</a>)</p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.iam#DeleteUserPermissionsBoundary": {
@@ -4929,7 +5108,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the permissions boundary for the specified IAM user.</p>\n        <important>\n            <p>Deleting the permissions boundary for a user might increase its permissions by\n                allowing the user to perform all the actions granted in its permissions policies.\n            </p>\n        </important>"
+                "smithy.api#documentation": "<p>Deletes the permissions boundary for the specified IAM user.</p>\n         <important>\n            <p>Deleting the permissions boundary for a user might increase its permissions by\n                allowing the user to perform all the actions granted in its permissions policies.\n            </p>\n         </important>"
             }
         },
         "com.amazonaws.iam#DeleteUserPermissionsBoundaryRequest": {
@@ -4942,6 +5121,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteUserPolicy": {
@@ -4964,7 +5146,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes the specified inline policy that is embedded in the specified IAM\n            user.</p>\n        <p>A user can also have managed policies attached to it. To detach a managed policy from\n            a user, use <a>DetachUserPolicy</a>. For more information about policies,\n            refer to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Deletes the specified inline policy that is embedded in the specified IAM\n            user.</p>\n         <p>A user can also have managed policies attached to it. To detach a managed policy from\n            a user, use <a>DetachUserPolicy</a>. For more information about policies,\n            refer to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DeleteUserPolicyRequest": {
@@ -4973,17 +5155,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) identifying the user that the policy is embedded\n            in.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) identifying the user that the policy is embedded\n            in.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name identifying the policy document to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name identifying the policy document to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteUserRequest": {
@@ -4992,10 +5177,13 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to delete.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user to delete.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeleteVirtualMFADevice": {
@@ -5021,7 +5209,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes a virtual MFA device.</p>\n        <note>\n            <p> You must deactivate a user's virtual MFA device before you can delete it. For\n                information about deactivating MFA devices, see <a>DeactivateMFADevice</a>. </p>\n        </note>"
+                "smithy.api#documentation": "<p>Deletes a virtual MFA device.</p>\n         <note>\n            <p> You must deactivate a user's virtual MFA device before you can delete it. For\n                information about deactivating MFA devices, see <a>DeactivateMFADevice</a>. </p>\n         </note>"
             }
         },
         "com.amazonaws.iam#DeleteVirtualMFADeviceRequest": {
@@ -5030,10 +5218,13 @@
                 "SerialNumber": {
                     "target": "com.amazonaws.iam#serialNumberType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices,\n            the serial number is the same as the ARN.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of upper and lowercase alphanumeric characters with no spaces. You can also include any of the \n    following characters: =,.@:/-</p>",
+                        "smithy.api#documentation": "<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices,\n            the serial number is the same as the ARN.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of upper and lowercase alphanumeric characters with no spaces. You can also include any of the \n    following characters: =,.@:/-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DeletionTaskFailureReasonType": {
@@ -5117,7 +5308,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Removes the specified managed policy from the specified IAM group.</p>\n        <p>A group can also have inline policies embedded with it. To delete an inline policy,\n            use <a>DeleteGroupPolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Removes the specified managed policy from the specified IAM group.</p>\n         <p>A group can also have inline policies embedded with it. To delete an inline policy,\n            use <a>DeleteGroupPolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DetachGroupPolicyRequest": {
@@ -5126,17 +5317,20 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM group to detach the policy from.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM group to detach the policy from.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DetachRolePolicy": {
@@ -5165,7 +5359,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Removes the specified managed policy from the specified role.</p>\n        <p>A role can also have inline policies embedded with it. To delete an inline policy, use\n                <a>DeleteRolePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Removes the specified managed policy from the specified role.</p>\n         <p>A role can also have inline policies embedded with it. To delete an inline policy, use\n                <a>DeleteRolePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DetachRolePolicyRequest": {
@@ -5174,17 +5368,20 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM role to detach the policy from.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM role to detach the policy from.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DetachUserPolicy": {
@@ -5210,7 +5407,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Removes the specified managed policy from the specified user.</p>\n        <p>A user can also have inline policies embedded with it. To delete an inline policy, use\n                <a>DeleteUserPolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Removes the specified managed policy from the specified user.</p>\n         <p>A user can also have inline policies embedded with it. To delete an inline policy, use\n                <a>DeleteUserPolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#DetachUserPolicyRequest": {
@@ -5219,17 +5416,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM user to detach the policy from.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the IAM user to detach the policy from.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy you want to detach.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#DuplicateCertificateException": {
@@ -5304,31 +5504,34 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user for whom you want to enable the MFA device.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user for whom you want to enable the MFA device.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SerialNumber": {
                     "target": "com.amazonaws.iam#serialNumberType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices,\n            the serial number is the device ARN.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of upper and lowercase alphanumeric characters with no spaces. You can also include any of the \n    following characters: =,.@:/-</p>",
+                        "smithy.api#documentation": "<p>The serial number that uniquely identifies the MFA device. For virtual MFA devices,\n            the serial number is the device ARN.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of upper and lowercase alphanumeric characters with no spaces. You can also include any of the \n    following characters: =,.@:/-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "AuthenticationCode1": {
                     "target": "com.amazonaws.iam#authenticationCodeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An authentication code emitted by the device. </p>\n        <p>The format for this parameter is a string of six digits.</p>\n        <important>\n            <p>Submit your request immediately after generating the authentication codes. If you\n                generate the codes and then wait too long to submit the request, the MFA device\n                successfully associates with the user but the MFA device becomes out of sync. This\n                happens because time-based one-time passwords (TOTP) expire after a short period of\n                time. If this happens, you can <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html\">resync the\n                device</a>.</p>\n        </important>",
+                        "smithy.api#documentation": "<p>An authentication code emitted by the device. </p>\n         <p>The format for this parameter is a string of six digits.</p>\n         <important>\n            <p>Submit your request immediately after generating the authentication codes. If you\n                generate the codes and then wait too long to submit the request, the MFA device\n                successfully associates with the user but the MFA device becomes out of sync. This\n                happens because time-based one-time passwords (TOTP) expire after a short period of\n                time. If this happens, you can <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html\">resync the\n                device</a>.</p>\n         </important>",
                         "smithy.api#required": {}
                     }
                 },
                 "AuthenticationCode2": {
                     "target": "com.amazonaws.iam#authenticationCodeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A subsequent authentication code emitted by the device.</p>\n        <p>The format for this parameter is a string of six digits.</p>\n        <important>\n            <p>Submit your request immediately after generating the authentication codes. If you\n                generate the codes and then wait too long to submit the request, the MFA device\n                successfully associates with the user but the MFA device becomes out of sync. This\n                happens because time-based one-time passwords (TOTP) expire after a short period of\n                time. If this happens, you can <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html\">resync the\n                device</a>.</p>\n        </important>",
+                        "smithy.api#documentation": "<p>A subsequent authentication code emitted by the device.</p>\n         <p>The format for this parameter is a string of six digits.</p>\n         <important>\n            <p>Submit your request immediately after generating the authentication codes. If you\n                generate the codes and then wait too long to submit the request, the MFA device\n                successfully associates with the user but the MFA device becomes out of sync. This\n                happens because time-based one-time passwords (TOTP) expire after a short period of\n                time. If this happens, you can <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_sync.html\">resync the\n                device</a>.</p>\n         </important>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#EntityAlreadyExistsException": {
@@ -5609,7 +5812,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GenerateCredentialReport</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GenerateCredentialReport</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GenerateOrganizationsAccessReport": {
@@ -5626,7 +5830,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Generates a report for service last accessed data for Organizations. You can generate a\n            report for any entities (organization root, organizational unit, or account) or policies\n            in your organization.</p>\n        <p>To call this operation, you must be signed in using your Organizations management account\n            credentials. You can use your long-term IAM user or root user credentials, or\n            temporary credentials from assuming an IAM role. SCPs must be enabled for your\n            organization root. You must have the required IAM and Organizations permissions. For more\n            information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Refining permissions using\n                service last accessed data</a> in the\n            <i>IAM User Guide</i>.</p>\n        <p>You can generate a service last accessed data report for entities by specifying only\n            the entity's path. This data includes a list of services that are allowed by any service\n            control policies (SCPs) that apply to the entity.</p>\n        <p>You can generate a service last accessed data report for a policy by specifying an\n            entity's path and an optional Organizations policy ID. This data includes a list of services that\n            are allowed by the specified SCP.</p>\n        <p>For each service in both report types, the data includes the most recent account\n            activity that the policy allows to account principals in the entity or the entity's\n            children. For important information about the data, reporting period, permissions\n            required, troubleshooting, and supported Regions see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing permissions using\n                service last accessed data</a> in the\n            <i>IAM User Guide</i>.</p>\n        <important>\n            <p>The data includes all attempts to access Amazon Web Services, not just the successful ones. This\n                includes all attempts that were made using the Amazon Web Services Management Console, the Amazon Web Services API through any\n                of the SDKs, or any of the command line tools. An unexpected entry in the service\n                last accessed data does not mean that an account has been compromised, because the\n                request might have been denied. Refer to your CloudTrail logs as the authoritative\n                source for information about all API calls and whether they were successful or\n                denied access. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html\">Logging IAM events with\n                    CloudTrail</a> in the <i>IAM User Guide</i>.</p>\n        </important>\n        <p>This operation returns a <code>JobId</code>. Use this parameter in the <code>\n               <a>GetOrganizationsAccessReport</a>\n            </code> operation to check the status of\n            the report generation. To check the status of this request, use the <code>JobId</code>\n            parameter in the <code>\n               <a>GetOrganizationsAccessReport</a>\n            </code> operation\n            and test the <code>JobStatus</code> response parameter. When the job is complete, you\n            can retrieve the report.</p>\n        <p>To generate a service last accessed data report for entities, specify an entity path\n            without specifying the optional Organizations policy ID. The type of entity that you specify\n            determines the data returned in the report.</p>\n        <ul>\n            <li>\n                <p>\n                  <b>Root</b> – When you specify the\n                    organizations root as the entity, the resulting report lists all of the services\n                    allowed by SCPs that are attached to your root. For each service, the report\n                    includes data for all accounts in your organization except the\n                    management account, because the management account is not limited by SCPs.</p>\n            </li>\n            <li>\n                <p>\n                  <b>OU</b> – When you specify an\n                    organizational unit (OU) as the entity, the resulting report lists all of the\n                    services allowed by SCPs that are attached to the OU and its parents. For each\n                    service, the report includes data for all accounts in the OU or its children.\n                    This data excludes the management account, because the management account is not\n                    limited by SCPs.</p>\n            </li>\n            <li>\n                <p>\n                  <b>management account</b> – When you specify the\n                    management account, the resulting report lists all Amazon Web Services services, because the\n                    management account is not limited by SCPs. For each service, the report includes\n                    data for only the management account.</p>\n            </li>\n            <li>\n                <p>\n                  <b>Account</b> – When you specify another\n                    account as the entity, the resulting report lists all of the services allowed by\n                    SCPs that are attached to the account and its parents. For each service, the\n                    report includes data for only the specified account.</p>\n            </li>\n         </ul>\n        <p>To generate a service last accessed data report for policies, specify an entity path\n            and the optional Organizations policy ID. The type of entity that you specify determines the data\n            returned for each service.</p>\n        <ul>\n            <li>\n                <p>\n                  <b>Root</b> – When you specify the root\n                    entity and a policy ID, the resulting report lists all of the services that are\n                    allowed by the specified SCP. For each service, the report includes data for all\n                    accounts in your organization to which the SCP applies. This data excludes the\n                    management account, because the management account is not limited by SCPs. If the\n                    SCP is not attached to any entities in the organization, then the report will\n                    return a list of services with no data.</p>\n            </li>\n            <li>\n                <p>\n                  <b>OU</b> – When you specify an OU entity and\n                    a policy ID, the resulting report lists all of the services that are allowed by\n                    the specified SCP. For each service, the report includes data for all accounts\n                    in the OU or its children to which the SCP applies. This means that other\n                    accounts outside the OU that are affected by the SCP might not be included in\n                    the data. This data excludes the management account, because the\n                    management account is not limited by SCPs. If the SCP is not attached to the OU\n                    or one of its children, the report will return a list of services with no\n                    data.</p>\n            </li>\n            <li>\n                <p>\n                  <b>management account</b> – When you specify the\n                    management account, the resulting report lists all Amazon Web Services services, because the\n                    management account is not limited by SCPs. If you specify a policy ID in the CLI\n                    or API, the policy is ignored. For each service, the report includes data for\n                    only the management account.</p>\n            </li>\n            <li>\n                <p>\n                  <b>Account</b> – When you specify another\n                    account entity and a policy ID, the resulting report lists all of the services\n                    that are allowed by the specified SCP. For each service, the report includes\n                    data for only the specified account. This means that other accounts in the\n                    organization that are affected by the SCP might not be included in the data. If\n                    the SCP is not attached to the account, the report will return a list of\n                    services with no data.</p>\n            </li>\n         </ul>\n        <note>\n            <p>Service last accessed data does not use other policy types when determining\n                whether a principal could access a service. These other policy types include\n                identity-based policies, resource-based policies, access control lists, IAM\n                permissions boundaries, and STS assume role policies. It only applies SCP logic.\n                For more about the evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n        </note>\n        <p>For more information about service last accessed data, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing policy scope by\n                viewing user activity</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Generates a report for service last accessed data for Organizations. You can generate a\n            report for any entities (organization root, organizational unit, or account) or policies\n            in your organization.</p>\n         <p>To call this operation, you must be signed in using your Organizations management account\n            credentials. You can use your long-term IAM user or root user credentials, or temporary\n            credentials from assuming an IAM role. SCPs must be enabled for your organization\n            root. You must have the required IAM and Organizations permissions. For more information, see\n                <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Refining permissions using service last accessed data</a> in the\n                <i>IAM User Guide</i>.</p>\n         <p>You can generate a service last accessed data report for entities by specifying only\n            the entity's path. This data includes a list of services that are allowed by any service\n            control policies (SCPs) that apply to the entity.</p>\n         <p>You can generate a service last accessed data report for a policy by specifying an\n            entity's path and an optional Organizations policy ID. This data includes a list of services that\n            are allowed by the specified SCP.</p>\n         <p>For each service in both report types, the data includes the most recent account\n            activity that the policy allows to account principals in the entity or the entity's\n            children. For important information about the data, reporting period, permissions\n            required, troubleshooting, and supported Regions see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing permissions using\n                service last accessed data</a> in the\n            <i>IAM User Guide</i>.</p>\n         <important>\n            <p>The data includes all attempts to access Amazon Web Services, not just the successful ones. This\n                includes all attempts that were made using the Amazon Web Services Management Console, the Amazon Web Services API through any\n                of the SDKs, or any of the command line tools. An unexpected entry in the service\n                last accessed data does not mean that an account has been compromised, because the\n                request might have been denied. Refer to your CloudTrail logs as the authoritative\n                source for information about all API calls and whether they were successful or\n                denied access. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html\">Logging IAM events with\n                    CloudTrail</a> in the <i>IAM User Guide</i>.</p>\n         </important>\n         <p>This operation returns a <code>JobId</code>. Use this parameter in the <code>\n               <a>GetOrganizationsAccessReport</a>\n            </code> operation to check the status of\n            the report generation. To check the status of this request, use the <code>JobId</code>\n            parameter in the <code>\n               <a>GetOrganizationsAccessReport</a>\n            </code> operation\n            and test the <code>JobStatus</code> response parameter. When the job is complete, you\n            can retrieve the report.</p>\n         <p>To generate a service last accessed data report for entities, specify an entity path\n            without specifying the optional Organizations policy ID. The type of entity that you specify\n            determines the data returned in the report.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Root</b> – When you specify the\n                    organizations root as the entity, the resulting report lists all of the services\n                    allowed by SCPs that are attached to your root. For each service, the report\n                    includes data for all accounts in your organization except the\n                    management account, because the management account is not limited by SCPs.</p>\n            </li>\n            <li>\n               <p>\n                  <b>OU</b> – When you specify an\n                    organizational unit (OU) as the entity, the resulting report lists all of the\n                    services allowed by SCPs that are attached to the OU and its parents. For each\n                    service, the report includes data for all accounts in the OU or its children.\n                    This data excludes the management account, because the management account is not\n                    limited by SCPs.</p>\n            </li>\n            <li>\n               <p>\n                  <b>management account</b> – When you specify the\n                    management account, the resulting report lists all Amazon Web Services services, because the\n                    management account is not limited by SCPs. For each service, the report includes\n                    data for only the management account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Account</b> – When you specify another\n                    account as the entity, the resulting report lists all of the services allowed by\n                    SCPs that are attached to the account and its parents. For each service, the\n                    report includes data for only the specified account.</p>\n            </li>\n         </ul>\n         <p>To generate a service last accessed data report for policies, specify an entity path\n            and the optional Organizations policy ID. The type of entity that you specify determines the data\n            returned for each service.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Root</b> – When you specify the root\n                    entity and a policy ID, the resulting report lists all of the services that are\n                    allowed by the specified SCP. For each service, the report includes data for all\n                    accounts in your organization to which the SCP applies. This data excludes the\n                    management account, because the management account is not limited by SCPs. If the\n                    SCP is not attached to any entities in the organization, then the report will\n                    return a list of services with no data.</p>\n            </li>\n            <li>\n               <p>\n                  <b>OU</b> – When you specify an OU entity and\n                    a policy ID, the resulting report lists all of the services that are allowed by\n                    the specified SCP. For each service, the report includes data for all accounts\n                    in the OU or its children to which the SCP applies. This means that other\n                    accounts outside the OU that are affected by the SCP might not be included in\n                    the data. This data excludes the management account, because the\n                    management account is not limited by SCPs. If the SCP is not attached to the OU\n                    or one of its children, the report will return a list of services with no\n                    data.</p>\n            </li>\n            <li>\n               <p>\n                  <b>management account</b> – When you specify the\n                    management account, the resulting report lists all Amazon Web Services services, because the\n                    management account is not limited by SCPs. If you specify a policy ID in the CLI\n                    or API, the policy is ignored. For each service, the report includes data for\n                    only the management account.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Account</b> – When you specify another\n                    account entity and a policy ID, the resulting report lists all of the services\n                    that are allowed by the specified SCP. For each service, the report includes\n                    data for only the specified account. This means that other accounts in the\n                    organization that are affected by the SCP might not be included in the data. If\n                    the SCP is not attached to the account, the report will return a list of\n                    services with no data.</p>\n            </li>\n         </ul>\n         <note>\n            <p>Service last accessed data does not use other policy types when determining\n                whether a principal could access a service. These other policy types include\n                identity-based policies, resource-based policies, access control lists, IAM\n                permissions boundaries, and STS assume role policies. It only applies SCP logic.\n                For more about the evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n         </note>\n         <p>For more information about service last accessed data, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing policy scope by\n                viewing user activity</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GenerateOrganizationsAccessReportRequest": {
@@ -5642,9 +5846,12 @@
                 "OrganizationsPolicyId": {
                     "target": "com.amazonaws.iam#organizationsPolicyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier of the Organizations service control policy (SCP). This parameter is\n            optional.</p>\n        <p>This ID is used to generate information about when an account principal that is\n            limited by the SCP attempted to access an Amazon Web Services service.</p>"
+                        "smithy.api#documentation": "<p>The identifier of the Organizations service control policy (SCP). This parameter is\n            optional.</p>\n         <p>This ID is used to generate information about when an account principal that is\n            limited by the SCP attempted to access an Amazon Web Services service.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GenerateOrganizationsAccessReportResponse": {
@@ -5656,6 +5863,9 @@
                         "smithy.api#documentation": "<p>The job identifier that you can use in the <a>GetOrganizationsAccessReport</a> operation.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GenerateServiceLastAccessedDetails": {
@@ -5675,7 +5885,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Generates a report that includes details about when an IAM resource (user, group,\n            role, or policy) was last used in an attempt to access Amazon Web Services services. Recent activity\n            usually appears within four hours. IAM reports activity for at least the last 400\n            days, or less if your Region began supporting this feature within the last year. For\n            more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a>.</p>\n        <important>\n            <p>The service last accessed data includes all attempts to access an Amazon Web Services API, not\n                just the successful ones. This includes all attempts that were made using the\n                Amazon Web Services Management Console, the Amazon Web Services API through any of the SDKs, or any of the command line tools.\n                An unexpected entry in the service last accessed data does not mean that your\n                account has been compromised, because the request might have been denied. Refer to\n                your CloudTrail logs as the authoritative source for information about all API calls\n                and whether they were successful or denied access. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html\">Logging\n                    IAM events with CloudTrail</a> in the\n                    <i>IAM User Guide</i>.</p>\n        </important>\n        <p>The <code>GenerateServiceLastAccessedDetails</code> operation returns a\n                <code>JobId</code>. Use this parameter in the following operations to retrieve the\n            following details from your report: </p>\n        <ul>\n            <li>\n                <p>\n                  <a>GetServiceLastAccessedDetails</a> – Use this operation\n                    for users, groups, roles, or policies to list every Amazon Web Services service that the\n                    resource could access using permissions policies. For each service, the response\n                    includes information about the most recent access attempt.</p>\n                <p>The <code>JobId</code> returned by\n                        <code>GenerateServiceLastAccessedDetail</code> must be used by the same role\n                    within a session, or by the same user when used to call\n                        <code>GetServiceLastAccessedDetail</code>.</p>\n            </li>\n            <li>\n                <p>\n                  <a>GetServiceLastAccessedDetailsWithEntities</a> – Use this\n                    operation for groups and policies to list information about the associated\n                    entities (users or roles) that attempted to access a specific Amazon Web Services service.\n                </p>\n            </li>\n         </ul>\n        <p>To check the status of the <code>GenerateServiceLastAccessedDetails</code> request,\n            use the <code>JobId</code> parameter in the same operations and test the\n                <code>JobStatus</code> response parameter.</p>\n        <p>For additional information about the permissions policies that allow an identity\n            (user, group, or role) to access specific services, use the <a>ListPoliciesGrantingServiceAccess</a> operation.</p>\n        <note>\n            <p>Service last accessed data does not use other policy types when determining\n                whether a resource could access a service. These other policy types include\n                resource-based policies, access control lists, Organizations policies, IAM permissions\n                boundaries, and STS assume role policies. It only applies permissions policy\n                logic. For more about the evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n        </note>\n        <p>For more information about service and action last accessed data, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing permissions using service last accessed data</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Generates a report that includes details about when an IAM resource (user, group,\n            role, or policy) was last used in an attempt to access Amazon Web Services services. Recent activity\n            usually appears within four hours. IAM reports activity for at least the last 400\n            days, or less if your Region began supporting this feature within the last year. For\n            more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a>.</p>\n         <important>\n            <p>The service last accessed data includes all attempts to access an Amazon Web Services API, not\n                just the successful ones. This includes all attempts that were made using the\n                Amazon Web Services Management Console, the Amazon Web Services API through any of the SDKs, or any of the command line tools.\n                An unexpected entry in the service last accessed data does not mean that your\n                account has been compromised, because the request might have been denied. Refer to\n                your CloudTrail logs as the authoritative source for information about all API calls\n                and whether they were successful or denied access. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/cloudtrail-integration.html\">Logging\n                    IAM events with CloudTrail</a> in the\n                    <i>IAM User Guide</i>.</p>\n         </important>\n         <p>The <code>GenerateServiceLastAccessedDetails</code> operation returns a\n                <code>JobId</code>. Use this parameter in the following operations to retrieve the\n            following details from your report: </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetServiceLastAccessedDetails</a> – Use this operation\n                    for users, groups, roles, or policies to list every Amazon Web Services service that the\n                    resource could access using permissions policies. For each service, the response\n                    includes information about the most recent access attempt.</p>\n               <p>The <code>JobId</code> returned by\n                        <code>GenerateServiceLastAccessedDetail</code> must be used by the same role\n                    within a session, or by the same user when used to call\n                        <code>GetServiceLastAccessedDetail</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <a>GetServiceLastAccessedDetailsWithEntities</a> – Use this\n                    operation for groups and policies to list information about the associated\n                    entities (users or roles) that attempted to access a specific Amazon Web Services service.\n                </p>\n            </li>\n         </ul>\n         <p>To check the status of the <code>GenerateServiceLastAccessedDetails</code> request,\n            use the <code>JobId</code> parameter in the same operations and test the\n                <code>JobStatus</code> response parameter.</p>\n         <p>For additional information about the permissions policies that allow an identity\n            (user, group, or role) to access specific services, use the <a>ListPoliciesGrantingServiceAccess</a> operation.</p>\n         <note>\n            <p>Service last accessed data does not use other policy types when determining\n                whether a resource could access a service. These other policy types include\n                resource-based policies, access control lists, Organizations policies, IAM permissions\n                boundaries, and STS assume role policies. It only applies permissions policy\n                logic. For more about the evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n         </note>\n         <p>For more information about service and action last accessed data, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing permissions using service last accessed data</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GenerateServiceLastAccessedDetailsRequest": {
@@ -5694,6 +5904,9 @@
                         "smithy.api#documentation": "<p>The level of detail that you want to generate. You can specify whether you want to\n            generate information about the last attempt to access services or actions. If you\n            specify service-level granularity, this operation generates only service data. If you\n            specify action-level granularity, it generates service and action data. If you don't\n            include this optional parameter, the operation generates service data.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GenerateServiceLastAccessedDetailsResponse": {
@@ -5705,6 +5918,9 @@
                         "smithy.api#documentation": "<p>The <code>JobId</code> that you can use in the <a>GetServiceLastAccessedDetails</a> or <a>GetServiceLastAccessedDetailsWithEntities</a> operations. The\n                <code>JobId</code> returned by <code>GenerateServiceLastAccessedDetail</code> must\n            be used by the same role within a session, or by the same user when used to call\n                <code>GetServiceLastAccessedDetail</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetAccessKeyLastUsed": {
@@ -5730,10 +5946,13 @@
                 "AccessKeyId": {
                     "target": "com.amazonaws.iam#accessKeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier of an access key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The identifier of an access key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetAccessKeyLastUsedResponse": {
@@ -5742,7 +5961,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user that owns this access key.</p>\n        <p></p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user that owns this access key.</p>\n         <p></p>"
                     }
                 },
                 "AccessKeyLastUsed": {
@@ -5753,7 +5972,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccessKeyLastUsed</a> request.\n      It is also returned as a member of the <a>AccessKeyMetaData</a> structure returned\n      by the <a>ListAccessKeys</a> action.</p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccessKeyLastUsed</a> request.\n      It is also returned as a member of the <a>AccessKeyMetaData</a> structure returned\n      by the <a>ListAccessKeys</a> action.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetAccountAuthorizationDetails": {
@@ -5770,7 +5990,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about all IAM users, groups, roles, and policies in your Amazon Web Services\n            account, including their relationships to one another. Use this operation to obtain a\n            snapshot of the configuration of IAM permissions (users, groups, roles, and policies)\n            in your account.</p>\n        <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n        <p>You can optionally filter the results using the <code>Filter</code> parameter. You can\n            paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Retrieves information about all IAM users, groups, roles, and policies in your Amazon Web Services\n            account, including their relationships to one another. Use this operation to obtain a\n            snapshot of the configuration of IAM permissions (users, groups, roles, and policies)\n            in your account.</p>\n         <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n         <p>You can optionally filter the results using the <code>Filter</code> parameter. You can\n            paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -5784,7 +6004,7 @@
                 "Filter": {
                     "target": "com.amazonaws.iam#entityListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of entity types used to filter the results. Only the entities that match the\n            types you specify are included in the output. Use the value\n                <code>LocalManagedPolicy</code> to include customer managed policies.</p>\n        <p>The format for this parameter is a comma-separated (if more than one) list of strings.\n            Each string value in the list must be one of the valid values listed below.</p>"
+                        "smithy.api#documentation": "<p>A list of entity types used to filter the results. Only the entities that match the\n            types you specify are included in the output. Use the value\n                <code>LocalManagedPolicy</code> to include customer managed policies.</p>\n         <p>The format for this parameter is a comma-separated (if more than one) list of strings.\n            Each string value in the list must be one of the valid values listed below.</p>"
                     }
                 },
                 "MaxItems": {
@@ -5799,6 +6019,9 @@
                         "smithy.api#documentation": "<p>Use this parameter only when paginating results and only after \n    you receive a response indicating that the results are truncated. Set it to the value of the\n    <code>Marker</code> element in the response that you received to indicate where the next call \n    should start.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetAccountAuthorizationDetailsResponse": {
@@ -5843,7 +6066,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccountAuthorizationDetails</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccountAuthorizationDetails</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetAccountPasswordPolicy": {
@@ -5878,7 +6102,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccountPasswordPolicy</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccountPasswordPolicy</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetAccountSummary": {
@@ -5895,7 +6120,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about IAM entity usage and IAM quotas in the Amazon Web Services\n            account.</p>\n        <p> For information about IAM quotas, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Retrieves information about IAM entity usage and IAM quotas in the Amazon Web Services\n            account.</p>\n         <p> For information about IAM quotas, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GetAccountSummaryResponse": {
@@ -5909,7 +6134,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccountSummary</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetAccountSummary</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetContextKeysForCustomPolicy": {
@@ -5926,7 +6152,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a list of all of the context keys referenced in the input policies. The policies\n            are supplied as a list of one or more strings. To get the context keys from policies\n            associated with an IAM user, group, or role, use <a>GetContextKeysForPrincipalPolicy</a>.</p>\n        <p>Context keys are variables maintained by Amazon Web Services and its services that provide details\n            about the context of an API query request. Context keys can be evaluated by testing\n            against a value specified in an IAM policy. Use\n                <code>GetContextKeysForCustomPolicy</code> to understand what key names and values\n            you must supply when you call <a>SimulateCustomPolicy</a>. Note that all\n            parameters are shown in unencoded form here for clarity but must be URL encoded to be\n            included as a part of a real HTML request.</p>"
+                "smithy.api#documentation": "<p>Gets a list of all of the context keys referenced in the input policies. The policies\n            are supplied as a list of one or more strings. To get the context keys from policies\n            associated with an IAM user, group, or role, use <a>GetContextKeysForPrincipalPolicy</a>.</p>\n         <p>Context keys are variables maintained by Amazon Web Services and its services that provide details\n            about the context of an API query request. Context keys can be evaluated by testing\n            against a value specified in an IAM policy. Use\n                <code>GetContextKeysForCustomPolicy</code> to understand what key names and values\n            you must supply when you call <a>SimulateCustomPolicy</a>. Note that all\n            parameters are shown in unencoded form here for clarity but must be URL encoded to be\n            included as a part of a real HTML request.</p>"
             }
         },
         "com.amazonaws.iam#GetContextKeysForCustomPolicyRequest": {
@@ -5935,10 +6161,13 @@
                 "PolicyInputList": {
                     "target": "com.amazonaws.iam#SimulationPolicyListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of policies for which you want the list of context keys referenced in those\n            policies. Each document is specified as a string containing the complete, valid JSON\n            text of an IAM policy.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>A list of policies for which you want the list of context keys referenced in those\n            policies. Each document is specified as a string containing the complete, valid JSON\n            text of an IAM policy.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetContextKeysForPolicyResponse": {
@@ -5972,7 +6201,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a list of all of the context keys referenced in all the IAM policies that are\n            attached to the specified IAM entity. The entity can be an IAM user, group, or role.\n            If you specify a user, then the request also includes all of the policies attached to\n            groups that the user is a member of.</p>\n        <p>You can optionally include a list of one or more additional policies, specified as\n            strings. If you want to include <i>only</i> a list of policies by string,\n            use <a>GetContextKeysForCustomPolicy</a> instead.</p>\n        <p>\n            <b>Note:</b> This operation discloses information about the\n            permissions granted to other users. If you do not want users to see other user's\n            permissions, then consider allowing them to use <a>GetContextKeysForCustomPolicy</a> instead.</p>\n        <p>Context keys are variables maintained by Amazon Web Services and its services that provide details\n            about the context of an API query request. Context keys can be evaluated by testing\n            against a value in an IAM policy. Use <a>GetContextKeysForPrincipalPolicy</a> to understand what key names and values you must supply when you call <a>SimulatePrincipalPolicy</a>.</p>"
+                "smithy.api#documentation": "<p>Gets a list of all of the context keys referenced in all the IAM policies that are\n            attached to the specified IAM entity. The entity can be an IAM user, group, or role.\n            If you specify a user, then the request also includes all of the policies attached to\n            groups that the user is a member of.</p>\n         <p>You can optionally include a list of one or more additional policies, specified as\n            strings. If you want to include <i>only</i> a list of policies by string,\n            use <a>GetContextKeysForCustomPolicy</a> instead.</p>\n         <p>\n            <b>Note:</b> This operation discloses information about the\n            permissions granted to other users. If you do not want users to see other user's\n            permissions, then consider allowing them to use <a>GetContextKeysForCustomPolicy</a> instead.</p>\n         <p>Context keys are variables maintained by Amazon Web Services and its services that provide details\n            about the context of an API query request. Context keys can be evaluated by testing\n            against a value in an IAM policy. Use <a>GetContextKeysForPrincipalPolicy</a> to understand what key names and values you must supply when you call <a>SimulatePrincipalPolicy</a>.</p>"
             }
         },
         "com.amazonaws.iam#GetContextKeysForPrincipalPolicyRequest": {
@@ -5981,16 +6210,19 @@
                 "PolicySourceArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of a user, group, or role whose policies contain the context keys that you\n            want listed. If you specify a user, the list includes context keys that are found in all\n            policies that are attached to the user. The list also includes all groups that the user\n            is a member of. If you pick a group or a role, then it includes only those context keys\n            that are found in policies attached to that entity. Note that all parameters are shown\n            in unencoded form here for clarity, but must be URL encoded to be included as a part of\n            a real HTML request.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The ARN of a user, group, or role whose policies contain the context keys that you\n            want listed. If you specify a user, the list includes context keys that are found in all\n            policies that are attached to the user. The list also includes all groups that the user\n            is a member of. If you pick a group or a role, then it includes only those context keys\n            that are found in policies attached to that entity. Note that all parameters are shown\n            in unencoded form here for clarity, but must be URL encoded to be included as a part of\n            a real HTML request.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyInputList": {
                     "target": "com.amazonaws.iam#SimulationPolicyListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An optional list of additional policies for which you want the list of context keys\n            that are referenced.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>An optional list of additional policies for which you want the list of context keys\n            that are referenced.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetCredentialReport": {
@@ -6042,7 +6274,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetCredentialReport</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetCredentialReport</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetGroup": {
@@ -6088,7 +6321,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves the specified inline policy document that is embedded in the specified IAM\n            group.</p>\n        <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n        <p>An IAM group can also have managed policies attached to it. To retrieve a managed\n            policy document that is attached to a group, use <a>GetPolicy</a> to\n            determine the policy's default version, then use <a>GetPolicyVersion</a> to\n            retrieve the policy document.</p>\n        <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Retrieves the specified inline policy document that is embedded in the specified IAM\n            group.</p>\n         <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n         <p>An IAM group can also have managed policies attached to it. To retrieve a managed\n            policy document that is attached to a group, use <a>GetPolicy</a> to\n            determine the policy's default version, then use <a>GetPolicyVersion</a> to\n            retrieve the policy document.</p>\n         <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GetGroupPolicyRequest": {
@@ -6097,17 +6330,20 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group the policy is associated with.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the group the policy is associated with.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the policy document to get.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the policy document to get.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetGroupPolicyResponse": {
@@ -6130,13 +6366,14 @@
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy document.</p>\n\n        <p>IAM stores policies in JSON format. However, resources that were created using CloudFormation\n            templates can be formatted in YAML. CloudFormation always converts a YAML policy to JSON format\n            before submitting it to IAM.</p>",
+                        "smithy.api#documentation": "<p>The policy document.</p>\n         <p>IAM stores policies in JSON format. However, resources that were created using CloudFormation\n            templates can be formatted in YAML. CloudFormation always converts a YAML policy to JSON format\n            before submitting it to IAM.</p>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetGroupPolicy</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetGroupPolicy</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetGroupRequest": {
@@ -6145,7 +6382,7 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the group.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -6161,6 +6398,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetGroupResponse": {
@@ -6195,7 +6435,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetGroup</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetGroup</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetInstanceProfile": {
@@ -6243,10 +6484,13 @@
                 "InstanceProfileName": {
                     "target": "com.amazonaws.iam#instanceProfileNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the instance profile to get information about.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the instance profile to get information about.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetInstanceProfileResponse": {
@@ -6261,7 +6505,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetInstanceProfile</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetInstanceProfile</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetLoginProfile": {
@@ -6281,7 +6526,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves the user name for the specified IAM user. A login profile is created when\n            you create a password for the user to access the Amazon Web Services Management Console. If the user does not exist\n            or does not have a password, the operation returns a 404 (<code>NoSuchEntity</code>)\n            error.</p>\n        <p>If you create an IAM user with access to the console, the <code>CreateDate</code>\n            reflects the date you created the initial password for the user.</p>\n        <p>If you create an IAM user with programmatic access, and then later add a password\n            for the user to access the Amazon Web Services Management Console, the <code>CreateDate</code> reflects the initial\n            password creation date. A user with programmatic access does not have a login profile\n            unless you create a password for the user to access the Amazon Web Services Management Console.</p>"
+                "smithy.api#documentation": "<p>Retrieves the user name for the specified IAM user. A login profile is created when\n            you create a password for the user to access the Amazon Web Services Management Console. If the user does not exist\n            or does not have a password, the operation returns a 404 (<code>NoSuchEntity</code>)\n            error.</p>\n         <p>If you create an IAM user with access to the console, the <code>CreateDate</code>\n            reflects the date you created the initial password for the user.</p>\n         <p>If you create an IAM user with programmatic access, and then later add a password\n            for the user to access the Amazon Web Services Management Console, the <code>CreateDate</code> reflects the initial\n            password creation date. A user with programmatic access does not have a login profile\n            unless you create a password for the user to access the Amazon Web Services Management Console.</p>"
             }
         },
         "com.amazonaws.iam#GetLoginProfileRequest": {
@@ -6290,10 +6535,13 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose login profile you want to retrieve.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user whose login profile you want to retrieve.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetLoginProfileResponse": {
@@ -6308,7 +6556,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetLoginProfile</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetLoginProfile</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetOpenIDConnectProvider": {
@@ -6340,10 +6589,13 @@
                 "OpenIDConnectProviderArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the OIDC provider resource object in IAM to get\n            information for. You can get a list of OIDC provider resource ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the OIDC provider resource object in IAM to get\n            information for. You can get a list of OIDC provider resource ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetOpenIDConnectProviderResponse": {
@@ -6381,7 +6633,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetOpenIDConnectProvider</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetOpenIDConnectProvider</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetOrganizationsAccessReport": {
@@ -6398,7 +6651,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves the service last accessed data report for Organizations that was previously\n            generated using the <code>\n               <a>GenerateOrganizationsAccessReport</a>\n            </code>\n            operation. This operation retrieves the status of your report job and the report\n            contents.</p>\n        <p>Depending on the parameters that you passed when you generated the report, the data\n            returned could include different information. For details, see <a>GenerateOrganizationsAccessReport</a>.</p>\n        <p>To call this operation, you must be signed in to the management account in your\n            organization. SCPs must be enabled for your organization root. You must have permissions\n            to perform this operation. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Refining permissions using\n                service last accessed data</a> in the\n            <i>IAM User Guide</i>.</p>\n        <p>For each service that principals in an account (root users, IAM users, or IAM\n            roles) could access using SCPs, the operation returns details about the most recent\n            access attempt. If there was no attempt, the service is listed without details about the\n            most recent attempt to access the service. If the operation fails, it returns the reason\n            that it failed.</p>\n        <p>By default, the list is sorted by service namespace.</p>"
+                "smithy.api#documentation": "<p>Retrieves the service last accessed data report for Organizations that was previously\n            generated using the <code>\n               <a>GenerateOrganizationsAccessReport</a>\n            </code>\n            operation. This operation retrieves the status of your report job and the report\n            contents.</p>\n         <p>Depending on the parameters that you passed when you generated the report, the data\n            returned could include different information. For details, see <a>GenerateOrganizationsAccessReport</a>.</p>\n         <p>To call this operation, you must be signed in to the management account in your\n            organization. SCPs must be enabled for your organization root. You must have permissions\n            to perform this operation. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Refining permissions using\n                service last accessed data</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>For each service that principals in an account (root user, IAM users, or IAM roles)\n            could access using SCPs, the operation returns details about the most recent access\n            attempt. If there was no attempt, the service is listed without details about the most\n            recent attempt to access the service. If the operation fails, it returns the reason that\n            it failed.</p>\n         <p>By default, the list is sorted by service namespace.</p>"
             }
         },
         "com.amazonaws.iam#GetOrganizationsAccessReportRequest": {
@@ -6429,6 +6682,9 @@
                         "smithy.api#documentation": "<p>The key that is used to sort the results. If you choose the namespace key, the results\n            are returned in alphabetical order. If you choose the time key, the results are sorted\n            numerically by the date and time.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetOrganizationsAccessReportResponse": {
@@ -6451,7 +6707,7 @@
                 "JobCompletionDate": {
                     "target": "com.amazonaws.iam#dateType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time\n                format</a>, when the generated report job was completed or failed.</p>\n        <p>This field is null if the job is still in progress, as indicated by a job status value\n            of <code>IN_PROGRESS</code>.</p>"
+                        "smithy.api#documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time\n                format</a>, when the generated report job was completed or failed.</p>\n         <p>This field is null if the job is still in progress, as indicated by a job status value\n            of <code>IN_PROGRESS</code>.</p>"
                     }
                 },
                 "NumberOfServicesAccessible": {
@@ -6488,6 +6744,9 @@
                 "ErrorDetails": {
                     "target": "com.amazonaws.iam#ErrorDetails"
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetPolicy": {
@@ -6510,7 +6769,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about the specified managed policy, including the policy's\n            default version and the total number of IAM users, groups, and roles to which the\n            policy is attached. To retrieve the list of the specific users, groups, and roles that\n            the policy is attached to, use <a>ListEntitiesForPolicy</a>. This operation\n            returns metadata about the policy. To retrieve the actual policy document for a specific\n            version of the policy, use <a>GetPolicyVersion</a>.</p>\n        <p>This operation retrieves information about managed policies. To retrieve information\n            about an inline policy that is embedded with an IAM user, group, or role, use <a>GetUserPolicy</a>, <a>GetGroupPolicy</a>, or <a>GetRolePolicy</a>.</p>\n        <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>",
+                "smithy.api#documentation": "<p>Retrieves information about the specified managed policy, including the policy's\n            default version and the total number of IAM users, groups, and roles to which the\n            policy is attached. To retrieve the list of the specific users, groups, and roles that\n            the policy is attached to, use <a>ListEntitiesForPolicy</a>. This operation\n            returns metadata about the policy. To retrieve the actual policy document for a specific\n            version of the policy, use <a>GetPolicyVersion</a>.</p>\n         <p>This operation retrieves information about managed policies. To retrieve information\n            about an inline policy that is embedded with an IAM user, group, or role, use <a>GetUserPolicy</a>, <a>GetGroupPolicy</a>, or <a>GetRolePolicy</a>.</p>\n         <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>",
                 "smithy.api#suppress": [
                     "WaitableTraitInvalidErrorType"
                 ],
@@ -6541,10 +6800,13 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the managed policy that you want information\n            about.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the managed policy that you want information\n            about.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetPolicyResponse": {
@@ -6558,7 +6820,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetPolicy</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetPolicy</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetPolicyVersion": {
@@ -6581,7 +6844,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about the specified version of the specified managed policy,\n            including the policy document.</p>\n        <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n        <p>To list the available versions for a policy, use <a>ListPolicyVersions</a>.</p>\n        <p>This operation retrieves information about managed policies. To retrieve information\n            about an inline policy that is embedded in a user, group, or role, use <a>GetUserPolicy</a>, <a>GetGroupPolicy</a>, or <a>GetRolePolicy</a>.</p>\n        <p>For more information about the types of policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Retrieves information about the specified version of the specified managed policy,\n            including the policy document.</p>\n         <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n         <p>To list the available versions for a policy, use <a>ListPolicyVersions</a>.</p>\n         <p>This operation retrieves information about managed policies. To retrieve information\n            about an inline policy that is embedded in a user, group, or role, use <a>GetUserPolicy</a>, <a>GetGroupPolicy</a>, or <a>GetRolePolicy</a>.</p>\n         <p>For more information about the types of policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GetPolicyVersionRequest": {
@@ -6590,17 +6853,20 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the managed policy that you want information\n            about.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the managed policy that you want information\n            about.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "VersionId": {
                     "target": "com.amazonaws.iam#policyVersionIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the policy version to retrieve.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that \n    consists of the lowercase letter 'v' followed by one or two digits, and optionally \n    followed by a period '.' and a string of letters and digits.</p>",
+                        "smithy.api#documentation": "<p>Identifies the policy version to retrieve.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that \n    consists of the lowercase letter 'v' followed by one or two digits, and optionally \n    followed by a period '.' and a string of letters and digits.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetPolicyVersionResponse": {
@@ -6614,7 +6880,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetPolicyVersion</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetPolicyVersion</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetRole": {
@@ -6634,7 +6901,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about the specified role, including the role's path, GUID, ARN,\n            and the role's trust policy that grants permission to assume the role. For more\n            information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>.</p>\n        <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>",
+                "smithy.api#documentation": "<p>Retrieves information about the specified role, including the role's path, GUID, ARN,\n            and the role's trust policy that grants permission to assume the role. For more\n            information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>.</p>\n         <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>",
                 "smithy.api#suppress": [
                     "WaitableTraitInvalidErrorType"
                 ],
@@ -6676,7 +6943,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves the specified inline policy document that is embedded with the specified\n            IAM role.</p>\n        <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n        <p>An IAM role can also have managed policies attached to it. To retrieve a managed\n            policy document that is attached to a role, use <a>GetPolicy</a> to determine\n            the policy's default version, then use <a>GetPolicyVersion</a> to retrieve\n            the policy document.</p>\n        <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>For more information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html\">Using roles to delegate permissions and\n                federate identities</a>.</p>"
+                "smithy.api#documentation": "<p>Retrieves the specified inline policy document that is embedded with the specified\n            IAM role.</p>\n         <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n         <p>An IAM role can also have managed policies attached to it. To retrieve a managed\n            policy document that is attached to a role, use <a>GetPolicy</a> to determine\n            the policy's default version, then use <a>GetPolicyVersion</a> to retrieve\n            the policy document.</p>\n         <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>For more information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html\">Using roles to delegate permissions and\n                federate identities</a>.</p>"
             }
         },
         "com.amazonaws.iam#GetRolePolicyRequest": {
@@ -6685,17 +6952,20 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role associated with the policy.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role associated with the policy.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the policy document to get.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the policy document to get.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetRolePolicyResponse": {
@@ -6718,13 +6988,14 @@
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy document.</p>\n        <p>IAM stores policies in JSON format. However, resources that were created using CloudFormation\n            templates can be formatted in YAML. CloudFormation always converts a YAML policy to JSON format\n            before submitting it to IAM.</p>",
+                        "smithy.api#documentation": "<p>The policy document.</p>\n         <p>IAM stores policies in JSON format. However, resources that were created using CloudFormation\n            templates can be formatted in YAML. CloudFormation always converts a YAML policy to JSON format\n            before submitting it to IAM.</p>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetRolePolicy</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetRolePolicy</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetRoleRequest": {
@@ -6733,10 +7004,13 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM role to get information about.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM role to get information about.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetRoleResponse": {
@@ -6751,7 +7025,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetRole</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetRole</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetSAMLProvider": {
@@ -6774,7 +7049,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns the SAML provider metadocument that was uploaded when the IAM SAML provider\n            resource object was created or updated.</p>\n        <note>\n            <p>This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Returns the SAML provider metadocument that was uploaded when the IAM SAML provider\n            resource object was created or updated.</p>\n         <note>\n            <p>This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#GetSAMLProviderRequest": {
@@ -6783,10 +7058,13 @@
                 "SAMLProviderArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the SAML provider resource object in IAM to get\n            information about.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the SAML provider resource object in IAM to get\n            information about.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetSAMLProviderResponse": {
@@ -6818,7 +7096,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetSAMLProvider</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetSAMLProvider</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetSSHPublicKey": {
@@ -6838,7 +7117,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves the specified SSH public key, including metadata about the key.</p>\n        <p>The SSH public key retrieved by this operation is used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for SSH\n                connections</a> in the <i>CodeCommit User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Retrieves the specified SSH public key, including metadata about the key.</p>\n         <p>The SSH public key retrieved by this operation is used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for SSH\n                connections</a> in the <i>CodeCommit User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GetSSHPublicKeyRequest": {
@@ -6847,14 +7126,14 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user associated with the SSH public key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user associated with the SSH public key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SSHPublicKeyId": {
                     "target": "com.amazonaws.iam#publicKeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier for the SSH public key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier for the SSH public key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -6865,6 +7144,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetSSHPublicKeyResponse": {
@@ -6878,7 +7160,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetSSHPublicKey</a>\n      request.</p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetSSHPublicKey</a>\n      request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetServerCertificate": {
@@ -6898,7 +7181,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about the specified server certificate stored in IAM.</p>\n        <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic includes a list of Amazon Web Services services that can use the server certificates that you\n            manage with IAM.</p>"
+                "smithy.api#documentation": "<p>Retrieves information about the specified server certificate stored in IAM.</p>\n         <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic includes a list of Amazon Web Services services that can use the server certificates that you\n            manage with IAM.</p>"
             }
         },
         "com.amazonaws.iam#GetServerCertificateRequest": {
@@ -6907,10 +7190,13 @@
                 "ServerCertificateName": {
                     "target": "com.amazonaws.iam#serverCertificateNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the server certificate you want to retrieve information about.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the server certificate you want to retrieve information about.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetServerCertificateResponse": {
@@ -6925,7 +7211,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetServerCertificate</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetServerCertificate</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetServiceLastAccessedDetails": {
@@ -6945,7 +7232,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves a service last accessed report that was created using the\n                <code>GenerateServiceLastAccessedDetails</code> operation. You can use the\n                <code>JobId</code> parameter in <code>GetServiceLastAccessedDetails</code> to\n            retrieve the status of your report job. When the report is complete, you can retrieve\n            the generated report. The report includes a list of Amazon Web Services services that the resource\n            (user, group, role, or managed policy) can access.</p>\n        <note>\n            <p>Service last accessed data does not use other policy types when determining\n                whether a resource could access a service. These other policy types include\n                resource-based policies, access control lists, Organizations policies, IAM permissions\n                boundaries, and STS assume role policies. It only applies permissions policy\n                logic. For more about the evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n        </note>\n        <p>For each service that the resource could access using permissions policies, the\n            operation returns details about the most recent access attempt. If there was no attempt,\n            the service is listed without details about the most recent attempt to access the\n            service. If the operation fails, the <code>GetServiceLastAccessedDetails</code>\n            operation returns the reason that it failed.</p>\n        <p>The <code>GetServiceLastAccessedDetails</code> operation returns a list of services.\n            This list includes the number of entities that have attempted to access the service and\n            the date and time of the last attempt. It also returns the ARN of the following entity,\n            depending on the resource ARN that you used to generate the report:</p>\n        <ul>\n            <li>\n                <p>\n                  <b>User</b> – Returns the user ARN that you\n                    used to generate the report</p>\n            </li>\n            <li>\n                <p>\n                  <b>Group</b> – Returns the ARN of the group\n                    member (user) that last attempted to access the service</p>\n            </li>\n            <li>\n                <p>\n                  <b>Role</b> – Returns the role ARN that you\n                    used to generate the report</p>\n            </li>\n            <li>\n                <p>\n                  <b>Policy</b> – Returns the ARN of the user\n                    or role that last used the policy to attempt to access the service</p>\n            </li>\n         </ul>\n        <p>By default, the list is sorted by service namespace.</p>\n        <p>If you specified <code>ACTION_LEVEL</code> granularity when you generated the report,\n            this operation returns service and action last accessed data. This includes the most\n            recent access attempt for each tracked action within a service. Otherwise, this\n            operation returns only service data.</p>\n        <p>For more information about service and action last accessed data, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing permissions using service last accessed data</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Retrieves a service last accessed report that was created using the\n                <code>GenerateServiceLastAccessedDetails</code> operation. You can use the\n                <code>JobId</code> parameter in <code>GetServiceLastAccessedDetails</code> to\n            retrieve the status of your report job. When the report is complete, you can retrieve\n            the generated report. The report includes a list of Amazon Web Services services that the resource\n            (user, group, role, or managed policy) can access.</p>\n         <note>\n            <p>Service last accessed data does not use other policy types when determining\n                whether a resource could access a service. These other policy types include\n                resource-based policies, access control lists, Organizations policies, IAM permissions\n                boundaries, and STS assume role policies. It only applies permissions policy\n                logic. For more about the evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n         </note>\n         <p>For each service that the resource could access using permissions policies, the\n            operation returns details about the most recent access attempt. If there was no attempt,\n            the service is listed without details about the most recent attempt to access the\n            service. If the operation fails, the <code>GetServiceLastAccessedDetails</code>\n            operation returns the reason that it failed.</p>\n         <p>The <code>GetServiceLastAccessedDetails</code> operation returns a list of services.\n            This list includes the number of entities that have attempted to access the service and\n            the date and time of the last attempt. It also returns the ARN of the following entity,\n            depending on the resource ARN that you used to generate the report:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>User</b> – Returns the user ARN that you\n                    used to generate the report</p>\n            </li>\n            <li>\n               <p>\n                  <b>Group</b> – Returns the ARN of the group\n                    member (user) that last attempted to access the service</p>\n            </li>\n            <li>\n               <p>\n                  <b>Role</b> – Returns the role ARN that you\n                    used to generate the report</p>\n            </li>\n            <li>\n               <p>\n                  <b>Policy</b> – Returns the ARN of the user\n                    or role that last used the policy to attempt to access the service</p>\n            </li>\n         </ul>\n         <p>By default, the list is sorted by service namespace.</p>\n         <p>If you specified <code>ACTION_LEVEL</code> granularity when you generated the report,\n            this operation returns service and action last accessed data. This includes the most\n            recent access attempt for each tracked action within a service. Otherwise, this\n            operation returns only service data.</p>\n         <p>For more information about service and action last accessed data, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html\">Reducing permissions using service last accessed data</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GetServiceLastAccessedDetailsRequest": {
@@ -6970,6 +7257,9 @@
                         "smithy.api#documentation": "<p>Use this parameter only when paginating results and only after \n    you receive a response indicating that the results are truncated. Set it to the value of the\n    <code>Marker</code> element in the response that you received to indicate where the next call \n    should start.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetServiceLastAccessedDetailsResponse": {
@@ -7005,7 +7295,7 @@
                 "JobCompletionDate": {
                     "target": "com.amazonaws.iam#dateType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time\n                format</a>, when the generated report job was completed or failed.</p>\n        <p>This field is null if the job is still in progress, as indicated by a job status value\n            of <code>IN_PROGRESS</code>.</p>",
+                        "smithy.api#documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time\n                format</a>, when the generated report job was completed or failed.</p>\n         <p>This field is null if the job is still in progress, as indicated by a job status value\n            of <code>IN_PROGRESS</code>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7028,6 +7318,9 @@
                         "smithy.api#documentation": "<p>An object that contains details about the reason the operation failed.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetServiceLastAccessedDetailsWithEntities": {
@@ -7047,7 +7340,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>After you generate a group or policy report using the\n                <code>GenerateServiceLastAccessedDetails</code> operation, you can use the\n                <code>JobId</code> parameter in\n                <code>GetServiceLastAccessedDetailsWithEntities</code>. This operation retrieves the\n            status of your report job and a list of entities that could have used group or policy\n            permissions to access the specified service.</p>\n        <ul>\n            <li>\n                <p>\n                  <b>Group</b> – For a group report, this\n                    operation returns a list of users in the group that could have used the group’s\n                    policies in an attempt to access the service.</p>\n            </li>\n            <li>\n                <p>\n                  <b>Policy</b> – For a policy report, this\n                    operation returns a list of entities (users or roles) that could have used the\n                    policy in an attempt to access the service.</p>\n            </li>\n         </ul>\n        <p>You can also use this operation for user or role reports to retrieve details about\n            those entities.</p>\n        <p>If the operation fails, the <code>GetServiceLastAccessedDetailsWithEntities</code>\n            operation returns the reason that it failed.</p>\n        <p>By default, the list of associated entities is sorted by date, with the most recent\n            access listed first.</p>"
+                "smithy.api#documentation": "<p>After you generate a group or policy report using the\n                <code>GenerateServiceLastAccessedDetails</code> operation, you can use the\n                <code>JobId</code> parameter in\n                <code>GetServiceLastAccessedDetailsWithEntities</code>. This operation retrieves the\n            status of your report job and a list of entities that could have used group or policy\n            permissions to access the specified service.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Group</b> – For a group report, this\n                    operation returns a list of users in the group that could have used the group’s\n                    policies in an attempt to access the service.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Policy</b> – For a policy report, this\n                    operation returns a list of entities (users or roles) that could have used the\n                    policy in an attempt to access the service.</p>\n            </li>\n         </ul>\n         <p>You can also use this operation for user or role reports to retrieve details about\n            those entities.</p>\n         <p>If the operation fails, the <code>GetServiceLastAccessedDetailsWithEntities</code>\n            operation returns the reason that it failed.</p>\n         <p>By default, the list of associated entities is sorted by date, with the most recent\n            access listed first.</p>"
             }
         },
         "com.amazonaws.iam#GetServiceLastAccessedDetailsWithEntitiesRequest": {
@@ -7063,7 +7356,7 @@
                 "ServiceNamespace": {
                     "target": "com.amazonaws.iam#serviceNamespaceType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The service namespace for an Amazon Web Services service. Provide the service namespace to learn\n            when the IAM entity last attempted to access the specified service.</p>\n        <p>To learn the service namespace for a service, see <a href=\"https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html\">Actions, resources, and condition keys for Amazon Web Services services</a> in the\n                <i>IAM User Guide</i>. Choose the name of the service to view\n            details for that service. In the first paragraph, find the service prefix. For example,\n                <code>(service prefix: a4b)</code>. For more information about service namespaces,\n            see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces\">Amazon Web Services\n                service namespaces</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The service namespace for an Amazon Web Services service. Provide the service namespace to learn\n            when the IAM entity last attempted to access the specified service.</p>\n         <p>To learn the service namespace for a service, see <a href=\"https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html\">Actions, resources, and condition keys for Amazon Web Services services</a> in the\n                <i>IAM User Guide</i>. Choose the name of the service to view\n            details for that service. In the first paragraph, find the service prefix. For example,\n                <code>(service prefix: a4b)</code>. For more information about service namespaces,\n            see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces\">Amazon Web Services\n                service namespaces</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7079,6 +7372,9 @@
                         "smithy.api#documentation": "<p>Use this parameter only when paginating results and only after \n    you receive a response indicating that the results are truncated. Set it to the value of the\n    <code>Marker</code> element in the response that you received to indicate where the next call \n    should start.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetServiceLastAccessedDetailsWithEntitiesResponse": {
@@ -7101,7 +7397,7 @@
                 "JobCompletionDate": {
                     "target": "com.amazonaws.iam#dateType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time\n                format</a>, when the generated report job was completed or failed.</p>\n        <p>This field is null if the job is still in progress, as indicated by a job status value\n            of <code>IN_PROGRESS</code>.</p>",
+                        "smithy.api#documentation": "<p>The date and time, in <a href=\"http://www.iso.org/iso/iso8601\">ISO 8601 date-time\n                format</a>, when the generated report job was completed or failed.</p>\n         <p>This field is null if the job is still in progress, as indicated by a job status value\n            of <code>IN_PROGRESS</code>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7131,6 +7427,9 @@
                         "smithy.api#documentation": "<p>An object that contains details about the reason the operation failed.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetServiceLinkedRoleDeletionStatus": {
@@ -7166,6 +7465,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetServiceLinkedRoleDeletionStatusResponse": {
@@ -7184,6 +7486,9 @@
                         "smithy.api#documentation": "<p>An object that contains details about the reason the deletion failed.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetUser": {
@@ -7203,7 +7508,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves information about the specified IAM user, including the user's creation\n            date, path, unique ID, and ARN.</p>\n        <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID used to sign the request to this operation.</p>",
+                "smithy.api#documentation": "<p>Retrieves information about the specified IAM user, including the user's creation\n            date, path, unique ID, and ARN.</p>\n         <p>If you do not specify a user name, IAM determines the user name implicitly based on\n            the Amazon Web Services access key ID used to sign the request to this operation.</p>",
                 "smithy.api#suppress": [
                     "WaitableTraitInvalidErrorType"
                 ],
@@ -7245,7 +7550,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves the specified inline policy document that is embedded in the specified IAM\n            user.</p>\n        <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n        <p>An IAM user can also have managed policies attached to it. To retrieve a managed\n            policy document that is attached to a user, use <a>GetPolicy</a> to determine\n            the policy's default version. Then use <a>GetPolicyVersion</a> to retrieve\n            the policy document.</p>\n        <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Retrieves the specified inline policy document that is embedded in the specified IAM\n            user.</p>\n         <note>\n            <p>Policies returned by this operation are URL-encoded compliant \n    with <a href=\"https://tools.ietf.org/html/rfc3986\">RFC 3986</a>. You can use a URL \n    decoding method to convert the policy back to plain JSON text. For example, if you use Java, you \n    can use the <code>decode</code> method of the <code>java.net.URLDecoder</code> utility class in \n    the Java SDK. Other languages and SDKs provide similar functionality.</p>\n         </note>\n         <p>An IAM user can also have managed policies attached to it. To retrieve a managed\n            policy document that is attached to a user, use <a>GetPolicy</a> to determine\n            the policy's default version. Then use <a>GetPolicyVersion</a> to retrieve\n            the policy document.</p>\n         <p>For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#GetUserPolicyRequest": {
@@ -7254,17 +7559,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user who the policy is associated with.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user who the policy is associated with.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the policy document to get.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the policy document to get.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetUserPolicyResponse": {
@@ -7287,13 +7595,14 @@
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy document.</p>\n\n        <p>IAM stores policies in JSON format. However, resources that were created using CloudFormation\n            templates can be formatted in YAML. CloudFormation always converts a YAML policy to JSON format\n            before submitting it to IAM.</p>",
+                        "smithy.api#documentation": "<p>The policy document.</p>\n         <p>IAM stores policies in JSON format. However, resources that were created using CloudFormation\n            templates can be formatted in YAML. CloudFormation always converts a YAML policy to JSON format\n            before submitting it to IAM.</p>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetUserPolicy</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetUserPolicy</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#GetUserRequest": {
@@ -7302,9 +7611,12 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to get information about.</p>\n        <p>This parameter is optional. If it is not included, it defaults to the user making the\n            request. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user to get information about.</p>\n         <p>This parameter is optional. If it is not included, it defaults to the user making the\n            request. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#GetUserResponse": {
@@ -7313,13 +7625,14 @@
                 "User": {
                     "target": "com.amazonaws.iam#User",
                     "traits": {
-                        "smithy.api#documentation": "<p>A structure containing details about the IAM user.</p>\n        <important>\n            <p>Due to a service issue, password last used data does not include password use from\n                May 3, 2018 22:50 PDT to May 23, 2018 14:08 PDT. This affects <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html\">last sign-in</a> dates shown in the IAM console and password last used\n                dates in the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html\">IAM credential\n                    report</a>, and returned by this operation. If users signed in during the\n                affected time, the password last used date that is returned is the date the user\n                last signed in before May 3, 2018. For users that signed in after May 23, 2018 14:08\n                PDT, the returned password last used date is accurate.</p>\n            <p>You can use password last used information to identify unused credentials for\n                deletion. For example, you might delete users who did not sign in to Amazon Web Services in the\n                last 90 days. In cases like this, we recommend that you adjust your evaluation\n                window to include dates after May 23, 2018. Alternatively, if your users use access\n                keys to access Amazon Web Services programmatically you can refer to access key last used\n                information because it is accurate for all dates. </p>\n        </important>",
+                        "smithy.api#documentation": "<p>A structure containing details about the IAM user.</p>\n         <important>\n            <p>Due to a service issue, password last used data does not include password use from\n                May 3, 2018 22:50 PDT to May 23, 2018 14:08 PDT. This affects <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_finding-unused.html\">last sign-in</a> dates shown in the IAM console and password last used\n                dates in the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_getting-report.html\">IAM credential\n                    report</a>, and returned by this operation. If users signed in during the\n                affected time, the password last used date that is returned is the date the user\n                last signed in before May 3, 2018. For users that signed in after May 23, 2018 14:08\n                PDT, the returned password last used date is accurate.</p>\n            <p>You can use password last used information to identify unused credentials for\n                deletion. For example, you might delete users who did not sign in to Amazon Web Services in the\n                last 90 days. In cases like this, we recommend that you adjust your evaluation\n                window to include dates after May 23, 2018. Alternatively, if your users use access\n                keys to access Amazon Web Services programmatically you can refer to access key last used\n                information because it is accurate for all dates. </p>\n         </important>",
                         "smithy.api#required": {}
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetUser</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>GetUser</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#Group": {
@@ -7582,7 +7895,7 @@
                     "code": "LimitExceeded",
                     "httpResponseCode": 409
                 },
-                "smithy.api#documentation": "<p>The request was rejected because it attempted to create resources beyond the current Amazon Web Services\n      account limits. The error message describes the limit exceeded.</p>",
+                "smithy.api#documentation": "<p>The request was rejected because it attempted to create resources beyond the current\n      Amazon Web Services account limits. The error message describes the limit exceeded.</p>",
                 "smithy.api#error": "client",
                 "smithy.api#httpError": 409
             }
@@ -7610,7 +7923,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns information about the access key IDs associated with the specified IAM user.\n            If there is none, the operation returns an empty list.</p>\n        <p>Although each user is limited to a small number of keys, you can still paginate the\n            results using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>\n        <p>If the <code>UserName</code> is not specified, the user name is determined implicitly\n            based on the Amazon Web Services access key ID used to sign the request. If a temporary access key is\n            used, then <code>UserName</code> is required. If a long-term key is assigned to the\n            user, then <code>UserName</code> is not required. This operation works for access keys\n            under the Amazon Web Services account. Consequently, you can use this operation to manage\n            Amazon Web Services account root user credentials even if the Amazon Web Services account has no associated\n            users.</p>\n        <note>\n            <p>To ensure the security of your Amazon Web Services account, the secret access key is accessible\n                only during key and user creation.</p>\n        </note>",
+                "smithy.api#documentation": "<p>Returns information about the access key IDs associated with the specified IAM user.\n            If there is none, the operation returns an empty list.</p>\n         <p>Although each user is limited to a small number of keys, you can still paginate the\n            results using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>\n         <p>If the <code>UserName</code> is not specified, the user name is determined implicitly\n            based on the Amazon Web Services access key ID used to sign the request. If a temporary access key is\n            used, then <code>UserName</code> is required. If a long-term key is assigned to the\n            user, then <code>UserName</code> is not required. This operation works for access keys\n            under the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root user\n            credentials even if the Amazon Web Services account has no associated users.</p>\n         <note>\n            <p>To ensure the security of your Amazon Web Services account, the secret access key is accessible\n                only during key and user creation.</p>\n         </note>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -7625,7 +7938,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "Marker": {
@@ -7640,6 +7953,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListAccessKeysResponse": {
@@ -7667,7 +7983,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAccessKeys</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAccessKeys</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListAccountAliases": {
@@ -7708,6 +8025,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListAccountAliasesResponse": {
@@ -7735,7 +8055,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAccountAliases</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAccountAliases</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListAttachedGroupPolicies": {
@@ -7758,7 +8079,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists all managed policies that are attached to the specified IAM group.</p>\n        <p>An IAM group can also have inline policies embedded with it. To list the inline\n            policies for a group, use <a>ListGroupPolicies</a>. For information about\n            policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. You can use the <code>PathPrefix</code> parameter to limit the list of\n            policies to only those matching the specified path prefix. If there are no policies\n            attached to the specified group (or none that match the specified path prefix), the\n            operation returns an empty list.</p>",
+                "smithy.api#documentation": "<p>Lists all managed policies that are attached to the specified IAM group.</p>\n         <p>An IAM group can also have inline policies embedded with it. To list the inline\n            policies for a group, use <a>ListGroupPolicies</a>. For information about\n            policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. You can use the <code>PathPrefix</code> parameter to limit the list of\n            policies to only those matching the specified path prefix. If there are no policies\n            attached to the specified group (or none that match the specified path prefix), the\n            operation returns an empty list.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -7773,14 +8094,14 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the group to list attached policies for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the group to list attached policies for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#policyPathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all policies.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all policies.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -7795,6 +8116,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListAttachedGroupPoliciesResponse": {
@@ -7821,7 +8145,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAttachedGroupPolicies</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAttachedGroupPolicies</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListAttachedRolePolicies": {
@@ -7844,7 +8169,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists all managed policies that are attached to the specified IAM role.</p>\n        <p>An IAM role can also have inline policies embedded with it. To list the inline\n            policies for a role, use <a>ListRolePolicies</a>. For information about\n            policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. You can use the <code>PathPrefix</code> parameter to limit the list of\n            policies to only those matching the specified path prefix. If there are no policies\n            attached to the specified role (or none that match the specified path prefix), the\n            operation returns an empty list.</p>",
+                "smithy.api#documentation": "<p>Lists all managed policies that are attached to the specified IAM role.</p>\n         <p>An IAM role can also have inline policies embedded with it. To list the inline\n            policies for a role, use <a>ListRolePolicies</a>. For information about\n            policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. You can use the <code>PathPrefix</code> parameter to limit the list of\n            policies to only those matching the specified path prefix. If there are no policies\n            attached to the specified role (or none that match the specified path prefix), the\n            operation returns an empty list.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -7859,14 +8184,14 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the role to list attached policies for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the role to list attached policies for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#policyPathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all policies.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all policies.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -7881,6 +8206,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListAttachedRolePoliciesResponse": {
@@ -7907,7 +8235,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAttachedRolePolicies</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAttachedRolePolicies</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListAttachedUserPolicies": {
@@ -7930,7 +8259,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists all managed policies that are attached to the specified IAM user.</p>\n        <p>An IAM user can also have inline policies embedded with it. To list the inline\n            policies for a user, use <a>ListUserPolicies</a>. For information about\n            policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. You can use the <code>PathPrefix</code> parameter to limit the list of\n            policies to only those matching the specified path prefix. If there are no policies\n            attached to the specified group (or none that match the specified path prefix), the\n            operation returns an empty list.</p>",
+                "smithy.api#documentation": "<p>Lists all managed policies that are attached to the specified IAM user.</p>\n         <p>An IAM user can also have inline policies embedded with it. To list the inline\n            policies for a user, use <a>ListUserPolicies</a>. For information about\n            policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. You can use the <code>PathPrefix</code> parameter to limit the list of\n            policies to only those matching the specified path prefix. If there are no policies\n            attached to the specified group (or none that match the specified path prefix), the\n            operation returns an empty list.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -7945,14 +8274,14 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the user to list attached policies for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name (friendly name, not ARN) of the user to list attached policies for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#policyPathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all policies.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all policies.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -7967,6 +8296,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListAttachedUserPoliciesResponse": {
@@ -7993,7 +8325,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAttachedUserPolicies</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListAttachedUserPolicies</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListEntitiesForPolicy": {
@@ -8016,7 +8349,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists all IAM users, groups, and roles that the specified managed policy is attached\n            to.</p>\n        <p>You can use the optional <code>EntityFilter</code> parameter to limit the results to a\n            particular type of entity (users, groups, or roles). For example, to list only the roles\n            that are attached to the specified policy, set <code>EntityFilter</code> to\n                <code>Role</code>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists all IAM users, groups, and roles that the specified managed policy is attached\n            to.</p>\n         <p>You can use the optional <code>EntityFilter</code> parameter to limit the results to a\n            particular type of entity (users, groups, or roles). For example, to list only the roles\n            that are attached to the specified policy, set <code>EntityFilter</code> to\n                <code>Role</code>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8030,26 +8363,26 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy for which you want the\n            versions.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy for which you want the\n            versions.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "EntityFilter": {
                     "target": "com.amazonaws.iam#EntityType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The entity type to use for filtering the results.</p>\n        <p>For example, when <code>EntityFilter</code> is <code>Role</code>, only the roles that\n            are attached to the specified policy are returned. This parameter is optional. If it is\n            not included, all attached entities (users, groups, and roles) are returned. The\n            argument for this parameter must be one of the valid values listed below.</p>"
+                        "smithy.api#documentation": "<p>The entity type to use for filtering the results.</p>\n         <p>For example, when <code>EntityFilter</code> is <code>Role</code>, only the roles that\n            are attached to the specified policy are returned. This parameter is optional. If it is\n            not included, all attached entities (users, groups, and roles) are returned. The\n            argument for this parameter must be one of the valid values listed below.</p>"
                     }
                 },
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all entities.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>The path prefix for filtering the results. This parameter is optional. If it is not\n            included, it defaults to a slash (/), listing all entities.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "PolicyUsageFilter": {
                     "target": "com.amazonaws.iam#PolicyUsageType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy usage method to use for filtering the results.</p>\n        <p>To list only permissions policies,\n                set <code>PolicyUsageFilter</code> to <code>PermissionsPolicy</code>. To list only\n            the policies used to set permissions boundaries, set the value\n                to <code>PermissionsBoundary</code>.</p>\n        <p>This parameter is optional. If it is not included, all policies are returned. </p>"
+                        "smithy.api#documentation": "<p>The policy usage method to use for filtering the results.</p>\n         <p>To list only permissions policies,\n                set <code>PolicyUsageFilter</code> to <code>PermissionsPolicy</code>. To list only\n            the policies used to set permissions boundaries, set the value\n                to <code>PermissionsBoundary</code>.</p>\n         <p>This parameter is optional. If it is not included, all policies are returned. </p>"
                     }
                 },
                 "Marker": {
@@ -8064,6 +8397,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListEntitiesForPolicyResponse": {
@@ -8102,7 +8438,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListEntitiesForPolicy</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListEntitiesForPolicy</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListGroupPolicies": {
@@ -8122,7 +8459,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the names of the inline policies that are embedded in the specified IAM\n            group.</p>\n        <p>An IAM group can also have managed policies attached to it. To list the managed\n            policies that are attached to a group, use <a>ListAttachedGroupPolicies</a>.\n            For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. If there are no inline policies embedded with the specified group, the\n            operation returns an empty list.</p>",
+                "smithy.api#documentation": "<p>Lists the names of the inline policies that are embedded in the specified IAM\n            group.</p>\n         <p>An IAM group can also have managed policies attached to it. To list the managed\n            policies that are attached to a group, use <a>ListAttachedGroupPolicies</a>.\n            For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. If there are no inline policies embedded with the specified group, the\n            operation returns an empty list.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8137,7 +8474,7 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group to list policies for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the group to list policies for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -8153,6 +8490,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListGroupPoliciesResponse": {
@@ -8161,7 +8501,7 @@
                 "PolicyNames": {
                     "target": "com.amazonaws.iam#policyNameListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of policy names.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>A list of policy names.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -8180,7 +8520,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListGroupPolicies</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListGroupPolicies</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListGroups": {
@@ -8197,7 +8538,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the IAM groups that have the specified path prefix.</p>\n        <p> You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the IAM groups that have the specified path prefix.</p>\n         <p> You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8223,7 +8564,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the IAM groups that the specified IAM user belongs to.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the IAM groups that the specified IAM user belongs to.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8238,7 +8579,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to list groups for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user to list groups for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -8254,6 +8595,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListGroupsForUserResponse": {
@@ -8281,7 +8625,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListGroupsForUser</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListGroupsForUser</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListGroupsRequest": {
@@ -8290,7 +8635,7 @@
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#pathPrefixType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example, the prefix\n                <code>/division_abc/subdivision_xyz/</code> gets all groups whose path starts with\n                <code>/division_abc/subdivision_xyz/</code>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all groups. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example, the prefix\n                <code>/division_abc/subdivision_xyz/</code> gets all groups whose path starts with\n                <code>/division_abc/subdivision_xyz/</code>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all groups. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -8305,6 +8650,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListGroupsResponse": {
@@ -8332,7 +8680,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListGroups</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListGroups</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListInstanceProfileTags": {
@@ -8377,6 +8726,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListInstanceProfileTagsResponse": {
@@ -8402,6 +8754,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListInstanceProfiles": {
@@ -8418,7 +8773,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the instance profiles that have the specified path prefix. If there are none,\n            the operation returns an empty list. For more information about instance profiles, see\n                <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About\n                instance profiles</a>.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for an instance profile, see <a>GetInstanceProfile</a>.</p>\n        </note>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the instance profiles that have the specified path prefix. If there are none,\n            the operation returns an empty list. For more information about instance profiles, see\n                <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About\n                instance profiles</a>.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for an instance profile, see <a>GetInstanceProfile</a>.</p>\n         </note>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8444,7 +8799,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the instance profiles that have the specified associated IAM role. If there\n            are none, the operation returns an empty list. For more information about instance\n            profiles, go to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the instance profiles that have the specified associated IAM role. If there\n            are none, the operation returns an empty list. For more information about instance\n            profiles, go to <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8459,7 +8814,7 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to list instance profiles for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to list instance profiles for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -8475,6 +8830,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListInstanceProfilesForRoleResponse": {
@@ -8502,7 +8860,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListInstanceProfilesForRole</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListInstanceProfilesForRole</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListInstanceProfilesRequest": {
@@ -8511,7 +8870,7 @@
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#pathPrefixType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example, the prefix\n                <code>/application_abc/component_xyz/</code> gets all instance profiles whose path\n            starts with <code>/application_abc/component_xyz/</code>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all instance profiles. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example, the prefix\n                <code>/application_abc/component_xyz/</code> gets all instance profiles whose path\n            starts with <code>/application_abc/component_xyz/</code>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all instance profiles. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -8526,6 +8885,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListInstanceProfilesResponse": {
@@ -8553,7 +8915,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListInstanceProfiles</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListInstanceProfiles</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListMFADeviceTags": {
@@ -8601,6 +8964,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListMFADeviceTagsResponse": {
@@ -8626,6 +8992,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListMFADevices": {
@@ -8645,7 +9014,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the MFA devices for an IAM user. If the request includes a IAM user name,\n            then this operation lists all the MFA devices associated with the specified user. If you\n            do not specify a user name, IAM determines the user name implicitly based on the Amazon Web Services\n            access key ID signing the request for this operation.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the MFA devices for an IAM user. If the request includes a IAM user name,\n            then this operation lists all the MFA devices associated with the specified user. If you\n            do not specify a user name, IAM determines the user name implicitly based on the Amazon Web Services\n            access key ID signing the request for this operation.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8660,7 +9029,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose MFA devices you want to list.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user whose MFA devices you want to list.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "Marker": {
@@ -8675,6 +9044,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListMFADevicesResponse": {
@@ -8702,7 +9074,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListMFADevices</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListMFADevices</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListOpenIDConnectProviderTags": {
@@ -8750,6 +9123,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListOpenIDConnectProviderTagsResponse": {
@@ -8775,6 +9151,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListOpenIDConnectProviders": {
@@ -8791,12 +9170,15 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists information about the IAM OpenID Connect (OIDC) provider resource objects\n            defined in the Amazon Web Services account.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for an OIDC provider, see <a>GetOpenIDConnectProvider</a>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Lists information about the IAM OpenID Connect (OIDC) provider resource objects\n            defined in the Amazon Web Services account.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for an OIDC provider, see <a>GetOpenIDConnectProvider</a>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#ListOpenIDConnectProvidersRequest": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.amazonaws.iam#ListOpenIDConnectProvidersResponse": {
             "type": "structure",
@@ -8809,7 +9191,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListOpenIDConnectProviders</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListOpenIDConnectProviders</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListPolicies": {
@@ -8826,7 +9209,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists all the managed policies that are available in your Amazon Web Services account, including\n            your own customer-defined managed policies and all Amazon Web Services managed policies.</p>\n        <p>You can filter the list of policies that is returned using the optional\n                <code>OnlyAttached</code>, <code>Scope</code>, and <code>PathPrefix</code>\n            parameters. For example, to list only the customer managed policies in your Amazon Web Services\n            account, set <code>Scope</code> to <code>Local</code>. To list only Amazon Web Services managed\n            policies, set <code>Scope</code> to <code>AWS</code>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>\n        <p>For more information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a customer manged policy, see\n                    <a>GetPolicy</a>.</p>\n        </note>",
+                "smithy.api#documentation": "<p>Lists all the managed policies that are available in your Amazon Web Services account, including\n            your own customer-defined managed policies and all Amazon Web Services managed policies.</p>\n         <p>You can filter the list of policies that is returned using the optional\n                <code>OnlyAttached</code>, <code>Scope</code>, and <code>PathPrefix</code>\n            parameters. For example, to list only the customer managed policies in your Amazon Web Services\n            account, set <code>Scope</code> to <code>Local</code>. To list only Amazon Web Services managed\n            policies, set <code>Scope</code> to <code>AWS</code>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>\n         <p>For more information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a customer manged policy, see\n                    <a>GetPolicy</a>.</p>\n         </note>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -8852,7 +9235,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Retrieves a list of policies that the IAM identity (user, group, or role) can use to\n            access each specified service.</p>\n        <note>\n            <p>This operation does not use other policy types when determining whether a resource\n                could access a service. These other policy types include resource-based policies,\n                access control lists, Organizations policies, IAM permissions boundaries, and STS\n                assume role policies. It only applies permissions policy logic. For more about the\n                evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n        </note>\n        <p>The list of policies returned by the operation depends on the ARN of the identity that\n            you provide.</p>\n        <ul>\n            <li>\n                <p>\n                  <b>User</b> – The list of policies includes\n                    the managed and inline policies that are attached to the user directly. The list\n                    also includes any additional managed and inline policies that are attached to\n                    the group to which the user belongs. </p>\n            </li>\n            <li>\n                <p>\n                  <b>Group</b> – The list of policies includes\n                    only the managed and inline policies that are attached to the group directly.\n                    Policies that are attached to the group’s user are not included.</p>\n            </li>\n            <li>\n                <p>\n                  <b>Role</b> – The list of policies includes\n                    only the managed and inline policies that are attached to the role.</p>\n            </li>\n         </ul>\n        <p>For each managed policy, this operation returns the ARN and policy name. For each\n            inline policy, it returns the policy name and the entity to which it is attached. Inline\n            policies do not have an ARN. For more information about these policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html\">Managed policies and inline policies</a> in the\n                <i>IAM User Guide</i>.</p>\n        <p>Policies that are attached to users and roles as permissions boundaries are not\n            returned. To view which managed policy is currently used to set the permissions boundary\n            for a user or role, use the <a>GetUser</a> or <a>GetRole</a>\n            operations.</p>"
+                "smithy.api#documentation": "<p>Retrieves a list of policies that the IAM identity (user, group, or role) can use to\n            access each specified service.</p>\n         <note>\n            <p>This operation does not use other policy types when determining whether a resource\n                could access a service. These other policy types include resource-based policies,\n                access control lists, Organizations policies, IAM permissions boundaries, and STS\n                assume role policies. It only applies permissions policy logic. For more about the\n                evaluation of policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html#policy-eval-basics\">Evaluating policies</a> in the\n                <i>IAM User Guide</i>.</p>\n         </note>\n         <p>The list of policies returned by the operation depends on the ARN of the identity that\n            you provide.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>User</b> – The list of policies includes\n                    the managed and inline policies that are attached to the user directly. The list\n                    also includes any additional managed and inline policies that are attached to\n                    the group to which the user belongs. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Group</b> – The list of policies includes\n                    only the managed and inline policies that are attached to the group directly.\n                    Policies that are attached to the group’s user are not included.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Role</b> – The list of policies includes\n                    only the managed and inline policies that are attached to the role.</p>\n            </li>\n         </ul>\n         <p>For each managed policy, this operation returns the ARN and policy name. For each\n            inline policy, it returns the policy name and the entity to which it is attached. Inline\n            policies do not have an ARN. For more information about these policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html\">Managed policies and inline policies</a> in the\n                <i>IAM User Guide</i>.</p>\n         <p>Policies that are attached to users and roles as permissions boundaries are not\n            returned. To view which managed policy is currently used to set the permissions boundary\n            for a user or role, use the <a>GetUser</a> or <a>GetRole</a>\n            operations.</p>"
             }
         },
         "com.amazonaws.iam#ListPoliciesGrantingServiceAccessEntry": {
@@ -8894,10 +9277,13 @@
                 "ServiceNamespaces": {
                     "target": "com.amazonaws.iam#serviceNamespaceListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The service namespace for the Amazon Web Services services whose policies you want to list.</p>\n        <p>To learn the service namespace for a service, see <a href=\"https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html\">Actions, resources, and condition keys for Amazon Web Services services</a> in the\n                <i>IAM User Guide</i>. Choose the name of the service to view\n            details for that service. In the first paragraph, find the service prefix. For example,\n                <code>(service prefix: a4b)</code>. For more information about service namespaces,\n            see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces\">Amazon Web Services\n                service namespaces</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The service namespace for the Amazon Web Services services whose policies you want to list.</p>\n         <p>To learn the service namespace for a service, see <a href=\"https://docs.aws.amazon.com/service-authorization/latest/reference/reference_policies_actions-resources-contextkeys.html\">Actions, resources, and condition keys for Amazon Web Services services</a> in the\n                <i>IAM User Guide</i>. Choose the name of the service to view\n            details for that service. In the first paragraph, find the service prefix. For example,\n                <code>(service prefix: a4b)</code>. For more information about service namespaces,\n            see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#genref-aws-service-namespaces\">Amazon Web Services\n                service namespaces</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListPoliciesGrantingServiceAccessResponse": {
@@ -8923,6 +9309,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListPoliciesRequest": {
@@ -8931,14 +9320,14 @@
                 "Scope": {
                     "target": "com.amazonaws.iam#policyScopeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The scope to use for filtering the results.</p>\n        <p>To list only Amazon Web Services managed policies, set <code>Scope</code> to <code>AWS</code>. To\n            list only the customer managed policies in your Amazon Web Services account, set <code>Scope</code> to\n                <code>Local</code>.</p>\n        <p>This parameter is optional. If it is not included, or if it is set to\n            <code>All</code>, all policies are returned.</p>"
+                        "smithy.api#documentation": "<p>The scope to use for filtering the results.</p>\n         <p>To list only Amazon Web Services managed policies, set <code>Scope</code> to <code>AWS</code>. To\n            list only the customer managed policies in your Amazon Web Services account, set <code>Scope</code> to\n                <code>Local</code>.</p>\n         <p>This parameter is optional. If it is not included, or if it is set to\n            <code>All</code>, all policies are returned.</p>"
                     }
                 },
                 "OnlyAttached": {
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>A flag to filter the results to only the attached policies.</p>\n        <p>When <code>OnlyAttached</code> is <code>true</code>, the returned list contains only\n            the policies that are attached to an IAM user, group, or role. When\n                <code>OnlyAttached</code> is <code>false</code>, or when the parameter is not\n            included, all policies are returned.</p>"
+                        "smithy.api#documentation": "<p>A flag to filter the results to only the attached policies.</p>\n         <p>When <code>OnlyAttached</code> is <code>true</code>, the returned list contains only\n            the policies that are attached to an IAM user, group, or role. When\n                <code>OnlyAttached</code> is <code>false</code>, or when the parameter is not\n            included, all policies are returned.</p>"
                     }
                 },
                 "PathPrefix": {
@@ -8950,7 +9339,7 @@
                 "PolicyUsageFilter": {
                     "target": "com.amazonaws.iam#PolicyUsageType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy usage method to use for filtering the results.</p>\n        <p>To list only permissions policies,\n                set <code>PolicyUsageFilter</code> to <code>PermissionsPolicy</code>. To list only\n            the policies used to set permissions boundaries, set the value\n                to <code>PermissionsBoundary</code>.</p>\n        <p>This parameter is optional. If it is not included, all policies are returned. </p>"
+                        "smithy.api#documentation": "<p>The policy usage method to use for filtering the results.</p>\n         <p>To list only permissions policies,\n                set <code>PolicyUsageFilter</code> to <code>PermissionsPolicy</code>. To list only\n            the policies used to set permissions boundaries, set the value\n                to <code>PermissionsBoundary</code>.</p>\n         <p>This parameter is optional. If it is not included, all policies are returned. </p>"
                     }
                 },
                 "Marker": {
@@ -8965,6 +9354,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListPoliciesResponse": {
@@ -8991,7 +9383,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListPolicies</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListPolicies</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListPolicyTags": {
@@ -9039,6 +9432,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListPolicyTagsResponse": {
@@ -9064,6 +9460,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListPolicyVersions": {
@@ -9086,7 +9485,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists information about the versions of the specified managed policy, including the\n            version that is currently set as the policy's default version.</p>\n        <p>For more information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>",
+                "smithy.api#documentation": "<p>Lists information about the versions of the specified managed policy, including the\n            version that is currently set as the policy's default version.</p>\n         <p>For more information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9101,7 +9500,7 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy for which you want the\n            versions.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy for which you want the\n            versions.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -9117,6 +9516,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListPolicyVersionsResponse": {
@@ -9125,7 +9527,7 @@
                 "Versions": {
                     "target": "com.amazonaws.iam#policyDocumentVersionListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of policy versions.</p>\n        <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>A list of policy versions.</p>\n         <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>"
                     }
                 },
                 "IsTruncated": {
@@ -9143,7 +9545,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListPolicyVersions</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListPolicyVersions</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListRolePolicies": {
@@ -9163,7 +9566,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the names of the inline policies that are embedded in the specified IAM\n            role.</p>\n        <p>An IAM role can also have managed policies attached to it. To list the managed\n            policies that are attached to a role, use <a>ListAttachedRolePolicies</a>.\n            For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. If there are no inline policies embedded with the specified role, the\n            operation returns an empty list.</p>",
+                "smithy.api#documentation": "<p>Lists the names of the inline policies that are embedded in the specified IAM\n            role.</p>\n         <p>An IAM role can also have managed policies attached to it. To list the managed\n            policies that are attached to a role, use <a>ListAttachedRolePolicies</a>.\n            For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. If there are no inline policies embedded with the specified role, the\n            operation returns an empty list.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9178,7 +9581,7 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to list policies for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to list policies for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -9194,6 +9597,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListRolePoliciesResponse": {
@@ -9221,7 +9627,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListRolePolicies</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListRolePolicies</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListRoleTags": {
@@ -9266,6 +9673,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListRoleTagsResponse": {
@@ -9291,6 +9701,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListRoles": {
@@ -9307,7 +9720,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the IAM roles that have the specified path prefix. If there are none, the\n            operation returns an empty list. For more information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with\n                roles</a>.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a role, see <a>GetRole</a>.</p>\n        </note>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the IAM roles that have the specified path prefix. If there are none, the\n            operation returns an empty list. For more information about roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with\n                roles</a>.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a role, see <a>GetRole</a>.</p>\n         </note>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9322,7 +9735,7 @@
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#pathPrefixType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example, the prefix\n                <code>/application_abc/component_xyz/</code> gets all roles whose path starts with\n                <code>/application_abc/component_xyz/</code>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all roles. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example, the prefix\n                <code>/application_abc/component_xyz/</code> gets all roles whose path starts with\n                <code>/application_abc/component_xyz/</code>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all roles. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -9337,6 +9750,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListRolesResponse": {
@@ -9364,7 +9780,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListRoles</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListRoles</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListSAMLProviderTags": {
@@ -9412,6 +9829,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListSAMLProviderTagsResponse": {
@@ -9437,6 +9857,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListSAMLProviders": {
@@ -9453,12 +9876,15 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the SAML provider resource objects defined in IAM in the account.\n            IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a SAML provider, see <a>GetSAMLProvider</a>.</p>\n        <important>\n            <p> This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n        </important>"
+                "smithy.api#documentation": "<p>Lists the SAML provider resource objects defined in IAM in the account.\n            IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a SAML provider, see <a>GetSAMLProvider</a>.</p>\n         <important>\n            <p> This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         </important>"
             }
         },
         "com.amazonaws.iam#ListSAMLProvidersRequest": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.amazonaws.iam#ListSAMLProvidersResponse": {
             "type": "structure",
@@ -9471,7 +9897,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListSAMLProviders</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListSAMLProviders</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListSSHPublicKeys": {
@@ -9488,7 +9915,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns information about the SSH public keys associated with the specified IAM\n            user. If none exists, the operation returns an empty list.</p>\n        <p>The SSH public keys returned by this operation are used only for authenticating the\n            IAM user to an CodeCommit repository. For more information about using SSH keys to\n            authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>\n        <p>Although each user is limited to a small number of keys, you can still paginate the\n            results using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>",
+                "smithy.api#documentation": "<p>Returns information about the SSH public keys associated with the specified IAM\n            user. If none exists, the operation returns an empty list.</p>\n         <p>The SSH public keys returned by this operation are used only for authenticating the\n            IAM user to an CodeCommit repository. For more information about using SSH keys to\n            authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>\n         <p>Although each user is limited to a small number of keys, you can still paginate the\n            results using the <code>MaxItems</code> and <code>Marker</code> parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9503,7 +9930,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user to list SSH public keys for. If none is specified, the\n                <code>UserName</code> field is determined implicitly based on the Amazon Web Services access key\n            used to sign the request.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user to list SSH public keys for. If none is specified, the\n                <code>UserName</code> field is determined implicitly based on the Amazon Web Services access key\n            used to sign the request.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "Marker": {
@@ -9518,6 +9945,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListSSHPublicKeysResponse": {
@@ -9544,7 +9974,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListSSHPublicKeys</a>\n      request.</p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListSSHPublicKeys</a>\n      request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListServerCertificateTags": {
@@ -9589,6 +10020,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListServerCertificateTagsResponse": {
@@ -9614,6 +10048,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListServerCertificates": {
@@ -9630,7 +10067,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the server certificates stored in IAM that have the specified path prefix. If\n            none exist, the operation returns an empty list.</p>\n        <p> You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>\n        <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic also includes a list of Amazon Web Services services that can use the server certificates that\n            you manage with IAM.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a servercertificate, see <a>GetServerCertificate</a>.</p>\n        </note>",
+                "smithy.api#documentation": "<p>Lists the server certificates stored in IAM that have the specified path prefix. If\n            none exist, the operation returns an empty list.</p>\n         <p> You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>\n         <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic also includes a list of Amazon Web Services services that can use the server certificates that\n            you manage with IAM.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a servercertificate, see <a>GetServerCertificate</a>.</p>\n         </note>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9645,7 +10082,7 @@
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#pathPrefixType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example:\n                <code>/company/servercerts</code> would get all server certificates for which the\n            path starts with <code>/company/servercerts</code>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all server certificates. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example:\n                <code>/company/servercerts</code> would get all server certificates for which the\n            path starts with <code>/company/servercerts</code>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all server certificates. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -9660,6 +10097,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListServerCertificatesResponse": {
@@ -9687,7 +10127,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListServerCertificates</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListServerCertificates</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListServiceSpecificCredentials": {
@@ -9716,7 +10157,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose service-specific credentials you want information about. If\n            this value is not specified, then the operation assumes the user whose credentials are\n            used to call the operation.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user whose service-specific credentials you want information about. If\n            this value is not specified, then the operation assumes the user whose credentials are\n            used to call the operation.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "ServiceName": {
@@ -9725,6 +10166,9 @@
                         "smithy.api#documentation": "<p>Filters the returned results to only those for the specified Amazon Web Services service. If not\n            specified, then Amazon Web Services returns service-specific credentials for all services.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListServiceSpecificCredentialsResponse": {
@@ -9736,6 +10180,9 @@
                         "smithy.api#documentation": "<p>A list of structures that each contain details about a service-specific\n            credential.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListSigningCertificates": {
@@ -9755,7 +10202,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns information about the signing certificates associated with the specified IAM\n            user. If none exists, the operation returns an empty list.</p>\n        <p>Although each user is limited to a small number of signing certificates, you can still\n            paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>\n        <p>If the <code>UserName</code> field is not specified, the user name is determined\n            implicitly based on the Amazon Web Services access key ID used to sign the request for this operation.\n            This operation works for access keys under the Amazon Web Services account. Consequently, you can use\n            this operation to manage Amazon Web Services account root user credentials even if the Amazon Web Services account\n            has no associated users.</p>",
+                "smithy.api#documentation": "<p>Returns information about the signing certificates associated with the specified IAM\n            user. If none exists, the operation returns an empty list.</p>\n         <p>Although each user is limited to a small number of signing certificates, you can still\n            paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>\n         <p>If the <code>UserName</code> field is not specified, the user name is determined\n            implicitly based on the Amazon Web Services access key ID used to sign the request for this operation.\n            This operation works for access keys under the Amazon Web Services account. Consequently, you can use\n            this operation to manage Amazon Web Services account root user credentials even if the Amazon Web Services account has no\n            associated users.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9770,7 +10217,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user whose signing certificates you want to examine.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user whose signing certificates you want to examine.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "Marker": {
@@ -9785,6 +10232,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListSigningCertificatesResponse": {
@@ -9812,7 +10262,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListSigningCertificates</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListSigningCertificates</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListUserPolicies": {
@@ -9832,7 +10283,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the names of the inline policies embedded in the specified IAM user.</p>\n        <p>An IAM user can also have managed policies attached to it. To list the managed\n            policies that are attached to a user, use <a>ListAttachedUserPolicies</a>.\n            For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. If there are no inline policies embedded with the specified user, the\n            operation returns an empty list.</p>",
+                "smithy.api#documentation": "<p>Lists the names of the inline policies embedded in the specified IAM user.</p>\n         <p>An IAM user can also have managed policies attached to it. To list the managed\n            policies that are attached to a user, use <a>ListAttachedUserPolicies</a>.\n            For more information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters. If there are no inline policies embedded with the specified user, the\n            operation returns an empty list.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9847,7 +10298,7 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to list policies for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user to list policies for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -9863,6 +10314,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListUserPoliciesResponse": {
@@ -9890,7 +10344,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListUserPolicies</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListUserPolicies</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListUserTags": {
@@ -9941,6 +10396,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListUserTagsResponse": {
@@ -9966,6 +10424,9 @@
                         "smithy.api#documentation": "<p>When <code>IsTruncated</code> is <code>true</code>, this element\n    is present and contains the value to use for the <code>Marker</code> parameter in a subsequent \n    pagination request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListUsers": {
@@ -9982,7 +10443,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Lists the IAM users that have the specified path prefix. If no path prefix is\n            specified, the operation returns all users in the Amazon Web Services account. If there are none, the\n            operation returns an empty list.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a user, see <a>GetUser</a>.</p>\n        </note>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the IAM users that have the specified path prefix. If no path prefix is\n            specified, the operation returns all users in the Amazon Web Services account. If there are none, the\n            operation returns an empty list.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view all of the information for a user, see <a>GetUser</a>.</p>\n         </note>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -9997,7 +10458,7 @@
                 "PathPrefix": {
                     "target": "com.amazonaws.iam#pathPrefixType",
                     "traits": {
-                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example:\n                <code>/division_abc/subdivision_xyz/</code>, which would get all user names whose\n            path starts with <code>/division_abc/subdivision_xyz/</code>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all user names. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p> The path prefix for filtering the results. For example:\n                <code>/division_abc/subdivision_xyz/</code>, which would get all user names whose\n            path starts with <code>/division_abc/subdivision_xyz/</code>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/), listing\n            all user names. This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "Marker": {
@@ -10012,6 +10473,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListUsersResponse": {
@@ -10039,7 +10503,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListUsers</a> request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListUsers</a> request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ListVirtualMFADevices": {
@@ -10051,7 +10516,7 @@
                 "target": "com.amazonaws.iam#ListVirtualMFADevicesResponse"
             },
             "traits": {
-                "smithy.api#documentation": "<p>Lists the virtual MFA devices defined in the Amazon Web Services account by assignment status. If\n            you do not specify an assignment status, the operation returns a list of all virtual MFA\n            devices. Assignment status can be <code>Assigned</code>, <code>Unassigned</code>, or\n                <code>Any</code>.</p>\n        <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view tag information for a virtual MFA device, see <a>ListMFADeviceTags</a>.</p>\n        </note>\n        <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
+                "smithy.api#documentation": "<p>Lists the virtual MFA devices defined in the Amazon Web Services account by assignment status. If\n            you do not specify an assignment status, the operation returns a list of all virtual MFA\n            devices. Assignment status can be <code>Assigned</code>, <code>Unassigned</code>, or\n                <code>Any</code>.</p>\n         <note>\n            <p>IAM resource-listing operations return a subset of the available \n   attributes for the resource. For example, this operation does not return tags, even though they are an attribute of the returned object. To view tag information for a virtual MFA device, see <a>ListMFADeviceTags</a>.</p>\n         </note>\n         <p>You can paginate the results using the <code>MaxItems</code> and <code>Marker</code>\n            parameters.</p>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -10081,6 +10546,9 @@
                         "smithy.api#documentation": "<p>Use this only when paginating results to indicate the \n    maximum number of items you want in the response. If additional items exist beyond the maximum \n    you specify, the <code>IsTruncated</code> response element is <code>true</code>.</p>\n         <p>If you do not include this parameter, the number of items defaults to 100. Note that\n    IAM might return fewer results, even when there are more results available. In that case, the\n    <code>IsTruncated</code> response element returns <code>true</code>, and <code>Marker</code> \n    contains a value to include in the subsequent call that tells the service where to continue \n    from.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ListVirtualMFADevicesResponse": {
@@ -10108,7 +10576,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListVirtualMFADevices</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>ListVirtualMFADevices</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#LoginProfile": {
@@ -10884,7 +11353,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds or updates an inline policy document that is embedded in the specified IAM\n            group.</p>\n        <p>A user can also have managed policies attached to it. To attach a managed policy to a\n            group, use <a>AttachGroupPolicy</a>. To create a new managed policy, use\n                <a>CreatePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>\n        <p>For information about the maximum number of inline policies that you can embed in a\n            group, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the <i>IAM User Guide</i>.</p>\n        <note>\n            <p>Because policy documents can be large, you should use POST rather than GET when\n                calling <code>PutGroupPolicy</code>. For general information about using the Query\n                API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query requests</a> in the\n                    <i>IAM User Guide</i>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Adds or updates an inline policy document that is embedded in the specified IAM\n            group.</p>\n         <p>A user can also have managed policies attached to it. To attach a managed policy to a\n            group, use <a>AttachGroupPolicy</a>. To create a new managed policy, use\n                <a>CreatePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>For information about the maximum number of inline policies that you can embed in a\n            group, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>Because policy documents can be large, you should use POST rather than GET when\n                calling <code>PutGroupPolicy</code>. For general information about using the Query\n                API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query requests</a> in the\n                    <i>IAM User Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#PutGroupPolicyRequest": {
@@ -10893,24 +11362,27 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group to associate the policy with.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-.</p>",
+                        "smithy.api#documentation": "<p>The name of the group to associate the policy with.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the policy document.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the policy document.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy document.</p>\n\n        <p>You must provide policies in JSON format in IAM. However, for CloudFormation templates\n            formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always\n            converts a YAML policy to JSON format before submitting it to = IAM.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The policy document.</p>\n         <p>You must provide policies in JSON format in IAM. However, for CloudFormation templates\n            formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always\n            converts a YAML policy to JSON format before submitting it to = IAM.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#PutRolePermissionsBoundary": {
@@ -10939,7 +11411,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds or updates the policy that is specified as the IAM role's permissions boundary.\n            You can use an Amazon Web Services managed policy or a customer managed policy to set the boundary for\n            a role. Use the boundary to control the maximum permissions that the role can have.\n            Setting a permissions boundary is an advanced feature that can affect the permissions\n            for the role.</p>\n        <p>You cannot set the boundary for a service-linked role. </p>\n        <important>\n            <p>Policies used as permissions boundaries do not provide permissions. You must also\n                attach a permissions policy to the role. To learn how the effective permissions for\n                a role are evaluated, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html\">IAM JSON policy\n                    evaluation logic</a> in the IAM User Guide. </p>\n        </important>"
+                "smithy.api#documentation": "<p>Adds or updates the policy that is specified as the IAM role's permissions boundary.\n            You can use an Amazon Web Services managed policy or a customer managed policy to set the boundary for\n            a role. Use the boundary to control the maximum permissions that the role can have.\n            Setting a permissions boundary is an advanced feature that can affect the permissions\n            for the role.</p>\n         <p>You cannot set the boundary for a service-linked role. </p>\n         <important>\n            <p>Policies used as permissions boundaries do not provide permissions. You must also\n                attach a permissions policy to the role. To learn how the effective permissions for\n                a role are evaluated, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html\">IAM JSON policy\n                    evaluation logic</a> in the IAM User Guide. </p>\n         </important>"
             }
         },
         "com.amazonaws.iam#PutRolePermissionsBoundaryRequest": {
@@ -10955,10 +11427,13 @@
                 "PermissionsBoundary": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the policy that is used to set the permissions boundary for the\n            role.</p>",
+                        "smithy.api#documentation": "<p>The ARN of the managed policy that is used to set the permissions boundary for the\n            role.</p>\n         <p>A permissions boundary policy defines the maximum permissions that identity-based\n            policies can grant to an entity, but does not grant permissions. Permissions boundaries\n            do not define the maximum permissions that a resource-based policy can grant to an\n            entity. To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries\n                for IAM entities</a> in the <i>IAM User Guide</i>.</p>\n         <p>For more information about policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types\">Policy types\n            </a> in the <i>IAM User Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#PutRolePolicy": {
@@ -10987,7 +11462,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds or updates an inline policy document that is embedded in the specified IAM\n            role.</p>\n        <p>When you embed an inline policy in a role, the inline policy is used as part of the\n            role's access (permissions) policy. The role's trust policy is created at the same time\n            as the role, using <a>CreateRole</a>. You can update a role's trust policy\n            using <a>UpdateAssumeRolePolicy</a>. For more information about IAM roles,\n            see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html\">Using roles to\n                delegate permissions and federate identities</a>.</p>\n        <p>A role can also have a managed policy attached to it. To attach a managed policy to a\n            role, use <a>AttachRolePolicy</a>. To create a new managed policy, use <a>CreatePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>\n        <p>For information about the maximum number of inline policies that you can embed with a\n            role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the <i>IAM User Guide</i>.</p>\n        <note>\n            <p>Because policy documents can be large, you should use POST rather than GET when\n                calling <code>PutRolePolicy</code>. For general information about using the Query\n                API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query requests</a> in the\n                    <i>IAM User Guide</i>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Adds or updates an inline policy document that is embedded in the specified IAM\n            role.</p>\n         <p>When you embed an inline policy in a role, the inline policy is used as part of the\n            role's access (permissions) policy. The role's trust policy is created at the same time\n            as the role, using <a>CreateRole</a>. You can update a role's trust policy\n            using <a>UpdateAssumeRolePolicy</a>. For more information about IAM roles,\n            see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/roles-toplevel.html\">Using roles to\n                delegate permissions and federate identities</a>.</p>\n         <p>A role can also have a managed policy attached to it. To attach a managed policy to a\n            role, use <a>AttachRolePolicy</a>. To create a new managed policy, use <a>CreatePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>For information about the maximum number of inline policies that you can embed with a\n            role, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>Because policy documents can be large, you should use POST rather than GET when\n                calling <code>PutRolePolicy</code>. For general information about using the Query\n                API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query requests</a> in the\n                    <i>IAM User Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#PutRolePolicyRequest": {
@@ -10996,24 +11471,27 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to associate the policy with.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to associate the policy with.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the policy document.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the policy document.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy document.</p>\n        <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The policy document.</p>\n         <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#PutUserPermissionsBoundary": {
@@ -11039,7 +11517,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds or updates the policy that is specified as the IAM user's permissions boundary.\n            You can use an Amazon Web Services managed policy or a customer managed policy to set the boundary for\n            a user. Use the boundary to control the maximum permissions that the user can have.\n            Setting a permissions boundary is an advanced feature that can affect the permissions\n            for the user.</p>\n        <important>\n            <p>Policies that are used as permissions boundaries do not provide permissions. You\n                must also attach a permissions policy to the user. To learn how the effective\n                permissions for a user are evaluated, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html\">IAM JSON policy\n                    evaluation logic</a> in the IAM User Guide. </p>\n        </important>"
+                "smithy.api#documentation": "<p>Adds or updates the policy that is specified as the IAM user's permissions\n            boundary. You can use an Amazon Web Services managed policy or a customer managed policy to set the\n            boundary for a user. Use the boundary to control the maximum permissions that the user\n            can have. Setting a permissions boundary is an advanced feature that can affect the\n            permissions for the user.</p>\n         <important>\n            <p>Policies that are used as permissions boundaries do not provide permissions. You\n                must also attach a permissions policy to the user. To learn how the effective\n                permissions for a user are evaluated, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_evaluation-logic.html\">IAM JSON policy\n                    evaluation logic</a> in the IAM User Guide. </p>\n         </important>"
             }
         },
         "com.amazonaws.iam#PutUserPermissionsBoundaryRequest": {
@@ -11055,10 +11533,13 @@
                 "PermissionsBoundary": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the policy that is used to set the permissions boundary for the\n            user.</p>",
+                        "smithy.api#documentation": "<p>The ARN of the managed policy that is used to set the permissions boundary for the\n            user.</p>\n         <p>A permissions boundary policy defines the maximum permissions that identity-based\n            policies can grant to an entity, but does not grant permissions. Permissions boundaries\n            do not define the maximum permissions that a resource-based policy can grant to an\n            entity. To learn more, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries\n                for IAM entities</a> in the <i>IAM User Guide</i>.</p>\n         <p>For more information about policy types, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html#access_policy-types\">Policy types\n            </a> in the <i>IAM User Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#PutUserPolicy": {
@@ -11084,7 +11565,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds or updates an inline policy document that is embedded in the specified IAM\n            user.</p>\n        <p>An IAM user can also have a managed policy attached to it. To attach a managed\n            policy to a user, use <a>AttachUserPolicy</a>. To create a new managed\n            policy, use <a>CreatePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>\n        <p>For information about the maximum number of inline policies that you can embed in a\n            user, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the <i>IAM User Guide</i>.</p>\n        <note>\n            <p>Because policy documents can be large, you should use POST rather than GET when\n                calling <code>PutUserPolicy</code>. For general information about using the Query\n                API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query requests</a> in the\n                    <i>IAM User Guide</i>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Adds or updates an inline policy document that is embedded in the specified IAM\n            user.</p>\n         <p>An IAM user can also have a managed policy attached to it. To attach a managed\n            policy to a user, use <a>AttachUserPolicy</a>. To create a new managed\n            policy, use <a>CreatePolicy</a>. For information about policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed\n                policies and inline policies</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>For information about the maximum number of inline policies that you can embed in a\n            user, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS quotas</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>Because policy documents can be large, you should use POST rather than GET when\n                calling <code>PutUserPolicy</code>. For general information about using the Query\n                API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query requests</a> in the\n                    <i>IAM User Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#PutUserPolicyRequest": {
@@ -11093,24 +11574,27 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to associate the policy with.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user to associate the policy with.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyName": {
                     "target": "com.amazonaws.iam#policyNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the policy document.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the policy document.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy document.</p>\n\n        <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The policy document.</p>\n         <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ReasonType": {
@@ -11151,7 +11635,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Removes the specified client ID (also known as audience) from the list of client IDs\n            registered for the specified IAM OpenID Connect (OIDC) provider resource\n            object.</p>\n        <p>This operation is idempotent; it does not fail or return an error if you try to remove\n            a client ID that does not exist.</p>"
+                "smithy.api#documentation": "<p>Removes the specified client ID (also known as audience) from the list of client IDs\n            registered for the specified IAM OpenID Connect (OIDC) provider resource\n            object.</p>\n         <p>This operation is idempotent; it does not fail or return an error if you try to remove\n            a client ID that does not exist.</p>"
             }
         },
         "com.amazonaws.iam#RemoveClientIDFromOpenIDConnectProviderRequest": {
@@ -11160,7 +11644,7 @@
                 "OpenIDConnectProviderArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource to remove the\n            client ID from. You can get a list of OIDC provider ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource to remove the\n            client ID from. You can get a list of OIDC provider ARNs by using the <a>ListOpenIDConnectProviders</a> operation.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -11171,6 +11655,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#RemoveRoleFromInstanceProfile": {
@@ -11196,7 +11683,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Removes the specified IAM role from the specified EC2 instance profile.</p>\n        <important>\n            <p>Make sure that you do not have any Amazon EC2 instances running with the role you\n                are about to remove from the instance profile. Removing a role from an instance\n                profile that is associated with a running instance might break any applications\n                running on the instance.</p>\n        </important>\n        <p> For more information about IAM roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>. For more\n            information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>"
+                "smithy.api#documentation": "<p>Removes the specified IAM role from the specified EC2 instance profile.</p>\n         <important>\n            <p>Make sure that you do not have any Amazon EC2 instances running with the role you\n                are about to remove from the instance profile. Removing a role from an instance\n                profile that is associated with a running instance might break any applications\n                running on the instance.</p>\n         </important>\n         <p> For more information about IAM roles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/WorkingWithRoles.html\">Working with roles</a>. For more\n            information about instance profiles, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/AboutInstanceProfiles.html\">About instance\n            profiles</a>.</p>"
             }
         },
         "com.amazonaws.iam#RemoveRoleFromInstanceProfileRequest": {
@@ -11205,17 +11692,20 @@
                 "InstanceProfileName": {
                     "target": "com.amazonaws.iam#instanceProfileNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the instance profile to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the instance profile to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to remove.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to remove.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#RemoveUserFromGroup": {
@@ -11247,17 +11737,20 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the group to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the group to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user to remove.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user to remove.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ReportContentType": {
@@ -11340,16 +11833,19 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user associated with the service-specific credential. If this\n            value is not specified, then the operation assumes the user whose credentials are used\n            to call the operation.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user associated with the service-specific credential. If this\n            value is not specified, then the operation assumes the user whose credentials are used\n            to call the operation.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "ServiceSpecificCredentialId": {
                     "target": "com.amazonaws.iam#serviceSpecificCredentialId",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier of the service-specific credential.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier of the service-specific credential.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#ResetServiceSpecificCredentialResponse": {
@@ -11358,9 +11854,12 @@
                 "ServiceSpecificCredential": {
                     "target": "com.amazonaws.iam#ServiceSpecificCredential",
                     "traits": {
-                        "smithy.api#documentation": "<p>A structure with details about the updated service-specific credential, including the\n            new password.</p>\n        <important>\n            <p>This is the <b>only</b> time that you can access the\n                password. You cannot recover the password later, but you can reset it again.</p>\n        </important>"
+                        "smithy.api#documentation": "<p>A structure with details about the updated service-specific credential, including the\n            new password.</p>\n         <important>\n            <p>This is the <b>only</b> time that you can access the\n                password. You cannot recover the password later, but you can reset it again.</p>\n         </important>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#ResourceHandlingOptionType": {
@@ -11462,7 +11961,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Synchronizes the specified MFA device with its IAM resource object on the Amazon Web Services\n            servers.</p>\n        <p>For more information about creating and working with virtual MFA devices, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html\">Using a virtual MFA\n                device</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Synchronizes the specified MFA device with its IAM resource object on the Amazon Web Services\n            servers.</p>\n         <p>For more information about creating and working with virtual MFA devices, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_VirtualMFA.html\">Using a virtual MFA\n                device</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#ResyncMFADeviceRequest": {
@@ -11471,31 +11970,34 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose MFA device you want to resynchronize.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user whose MFA device you want to resynchronize.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SerialNumber": {
                     "target": "com.amazonaws.iam#serialNumberType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Serial number that uniquely identifies the MFA device.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>Serial number that uniquely identifies the MFA device.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "AuthenticationCode1": {
                     "target": "com.amazonaws.iam#authenticationCodeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An authentication code emitted by the device.</p>\n        <p>The format for this parameter is a sequence of six digits.</p>",
+                        "smithy.api#documentation": "<p>An authentication code emitted by the device.</p>\n         <p>The format for this parameter is a sequence of six digits.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "AuthenticationCode2": {
                     "target": "com.amazonaws.iam#authenticationCodeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A subsequent authentication code emitted by the device.</p>\n        <p>The format for this parameter is a sequence of six digits.</p>",
+                        "smithy.api#documentation": "<p>A subsequent authentication code emitted by the device.</p>\n         <p>The format for this parameter is a sequence of six digits.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#Role": {
@@ -11569,7 +12071,7 @@
                 "RoleLastUsed": {
                     "target": "com.amazonaws.iam#RoleLastUsed",
                     "traits": {
-                        "smithy.api#documentation": "<p>Contains information about the last time that an IAM role was used. This includes the\n         date and time and the Region in which the role was last used. Activity is only reported for\n         the trailing 400 days. This period can be shorter if your Region began supporting these\n         features within the last year. The role might have been used more than 400 days ago. For\n         more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a> in the <i>IAM User\n         Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Contains information about the last time that an IAM role was used. This includes the\n         date and time and the Region in which the role was last used. Activity is only reported for\n         the trailing 400 days. This period can be shorter if your Region began supporting these\n         features within the last year. The role might have been used more than 400 days ago. For\n         more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a> in the <i>IAM user\n         Guide</i>.</p>"
                     }
                 }
             },
@@ -11646,7 +12148,7 @@
                 "RoleLastUsed": {
                     "target": "com.amazonaws.iam#RoleLastUsed",
                     "traits": {
-                        "smithy.api#documentation": "<p>Contains information about the last time that an IAM role was used. This includes the\n         date and time and the Region in which the role was last used. Activity is only reported for\n         the trailing 400 days. This period can be shorter if your Region began supporting these\n         features within the last year. The role might have been used more than 400 days ago. For\n         more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a> in the <i>IAM User\n         Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Contains information about the last time that an IAM role was used. This includes the\n         date and time and the Region in which the role was last used. Activity is only reported for\n         the trailing 400 days. This period can be shorter if your Region began supporting these\n         features within the last year. The role might have been used more than 400 days ago. For\n         more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a> in the <i>IAM User Guide</i>.</p>"
                     }
                 }
             },
@@ -11671,7 +12173,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains information about the last time that an IAM role was used. This includes the\n         date and time and the Region in which the role was last used. Activity is only reported for\n         the trailing 400 days. This period can be shorter if your Region began supporting these\n         features within the last year. The role might have been used more than 400 days ago. For\n         more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a> in the <i>IAM User\n         Guide</i>.</p>\n         <p>This data type is returned as a response element in the <a>GetRole</a> and\n            <a>GetAccountAuthorizationDetails</a> operations.</p>"
+                "smithy.api#documentation": "<p>Contains information about the last time that an IAM role was used. This includes the\n         date and time and the Region in which the role was last used. Activity is only reported for\n         the trailing 400 days. This period can be shorter if your Region began supporting these\n         features within the last year. The role might have been used more than 400 days ago. For\n         more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_access-advisor.html#access-advisor_tracking-period\">Regions where data is tracked</a> in the <i>IAM user\n         Guide</i>.</p>\n         <p>This data type is returned as a response element in the <a>GetRole</a> and\n            <a>GetAccountAuthorizationDetails</a> operations.</p>"
             }
         },
         "com.amazonaws.iam#RoleUsageListType": {
@@ -12152,7 +12654,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Sets the specified version of the specified policy as the policy's default (operative)\n            version.</p>\n        <p>This operation affects all users, groups, and roles that the policy is attached to. To\n            list the users, groups, and roles that the policy is attached to, use <a>ListEntitiesForPolicy</a>.</p>\n        <p>For information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Sets the specified version of the specified policy as the policy's default (operative)\n            version.</p>\n         <p>This operation affects all users, groups, and roles that the policy is attached to. To\n            list the users, groups, and roles that the policy is attached to, use <a>ListEntitiesForPolicy</a>.</p>\n         <p>For information about managed policies, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-vs-inline.html\">Managed policies and inline\n                policies</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#SetDefaultPolicyVersionRequest": {
@@ -12161,17 +12663,20 @@
                 "PolicyArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy whose default version you want to\n            set.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM policy whose default version you want to\n            set.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "VersionId": {
                     "target": "com.amazonaws.iam#policyVersionIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The version of the policy to set as the default (operative) version.</p>\n        <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>The version of the policy to set as the default (operative) version.</p>\n         <p>For more information about managed policy versions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-managed-versions.html\">Versioning for managed\n                policies</a> in the <i>IAM User Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#SetSecurityTokenServicePreferences": {
@@ -12188,7 +12693,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Sets the specified version of the global endpoint token as the token version used for\n            the Amazon Web Services account.</p>\n        <p>By default, Security Token Service (STS) is available as a global service, and all STS requests\n            go to a single endpoint at <code>https://sts.amazonaws.com</code>. Amazon Web Services recommends\n            using Regional STS endpoints to reduce latency, build in redundancy, and increase\n            session token availability. For information about Regional endpoints for STS, see\n                <a href=\"https://docs.aws.amazon.com/general/latest/gr/sts.html\">Security Token Service\n                endpoints and quotas</a> in the <i>Amazon Web Services General Reference</i>.</p>\n        <p>If you make an STS call to the global endpoint, the resulting session tokens might\n            be valid in some Regions but not others. It depends on the version that is set in this\n            operation. Version 1 tokens are valid only in Amazon Web Services Regions that are\n            available by default. These tokens do not work in manually enabled Regions, such as Asia\n            Pacific (Hong Kong). Version 2 tokens are valid in all Regions. However, version 2\n            tokens are longer and might affect systems where you temporarily store tokens. For\n            information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and\n                deactivating STS in an Amazon Web Services Region</a> in the\n                <i>IAM User Guide</i>.</p>\n        <p>To view the current session token version, see the\n                <code>GlobalEndpointTokenVersion</code> entry in the response of the <a>GetAccountSummary</a> operation.</p>"
+                "smithy.api#documentation": "<p>Sets the specified version of the global endpoint token as the token version used for\n            the Amazon Web Services account.</p>\n         <p>By default, Security Token Service (STS) is available as a global service, and all STS requests\n            go to a single endpoint at <code>https://sts.amazonaws.com</code>. Amazon Web Services recommends\n            using Regional STS endpoints to reduce latency, build in redundancy, and increase\n            session token availability. For information about Regional endpoints for STS, see\n                <a href=\"https://docs.aws.amazon.com/general/latest/gr/sts.html\">Security Token Service\n                endpoints and quotas</a> in the <i>Amazon Web Services General Reference</i>.</p>\n         <p>If you make an STS call to the global endpoint, the resulting session tokens might\n            be valid in some Regions but not others. It depends on the version that is set in this\n            operation. Version 1 tokens are valid only in Amazon Web Services Regions that are\n            available by default. These tokens do not work in manually enabled Regions, such as Asia\n            Pacific (Hong Kong). Version 2 tokens are valid in all Regions. However, version 2\n            tokens are longer and might affect systems where you temporarily store tokens. For\n            information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and\n                deactivating STS in an Amazon Web Services Region</a> in the\n                <i>IAM User Guide</i>.</p>\n         <p>To view the current session token version, see the\n                <code>GlobalEndpointTokenVersion</code> entry in the response of the <a>GetAccountSummary</a> operation.</p>"
             }
         },
         "com.amazonaws.iam#SetSecurityTokenServicePreferencesRequest": {
@@ -12197,10 +12702,13 @@
                 "GlobalEndpointTokenVersion": {
                     "target": "com.amazonaws.iam#globalEndpointTokenVersion",
                     "traits": {
-                        "smithy.api#documentation": "<p>The version of the global endpoint token. Version 1 tokens are valid only in Amazon Web Services Regions that are available by default. These tokens do not work in\n            manually enabled Regions, such as Asia Pacific (Hong Kong). Version 2 tokens are valid\n            in all Regions. However, version 2 tokens are longer and might affect systems where you\n            temporarily store tokens.</p>\n        <p>For information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and\n                deactivating STS in an Amazon Web Services Region</a> in the\n                <i>IAM User Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>The version of the global endpoint token. Version 1 tokens are valid only in Amazon Web Services Regions that are available by default. These tokens do not work in\n            manually enabled Regions, such as Asia Pacific (Hong Kong). Version 2 tokens are valid\n            in all Regions. However, version 2 tokens are longer and might affect systems where you\n            temporarily store tokens.</p>\n         <p>For information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html\">Activating and\n                deactivating STS in an Amazon Web Services Region</a> in the\n                <i>IAM User Guide</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#SigningCertificate": {
@@ -12262,7 +12770,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Simulate how a set of IAM policies and optionally a resource-based policy works with\n            a list of API operations and Amazon Web Services resources to determine the policies' effective\n            permissions. The policies are provided as strings.</p>\n        <p>The simulation does not perform the API operations; it only checks the authorization\n            to determine if the simulated policies allow or deny the operations. You can simulate\n            resources that don't exist in your account.</p>\n        <p>If you want to simulate existing policies that are attached to an IAM user, group,\n            or role, use <a>SimulatePrincipalPolicy</a> instead.</p>\n        <p>Context keys are variables that are maintained by Amazon Web Services and its services and which\n            provide details about the context of an API query request. You can use the\n                <code>Condition</code> element of an IAM policy to evaluate context keys. To get\n            the list of context keys that the policies require for correct simulation, use <a>GetContextKeysForCustomPolicy</a>.</p>\n        <p>If the output is long, you can use <code>MaxItems</code> and <code>Marker</code>\n            parameters to paginate the results.</p>\n        <p>For more information about using the policy simulator, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html\">Testing IAM policies\n                with the IAM policy simulator </a>in the\n            <i>IAM User Guide</i>.</p>",
+                "smithy.api#documentation": "<p>Simulate how a set of IAM policies and optionally a resource-based policy works with\n            a list of API operations and Amazon Web Services resources to determine the policies' effective\n            permissions. The policies are provided as strings.</p>\n         <p>The simulation does not perform the API operations; it only checks the authorization\n            to determine if the simulated policies allow or deny the operations. You can simulate\n            resources that don't exist in your account.</p>\n         <p>If you want to simulate existing policies that are attached to an IAM user, group,\n            or role, use <a>SimulatePrincipalPolicy</a> instead.</p>\n         <p>Context keys are variables that are maintained by Amazon Web Services and its services and which\n            provide details about the context of an API query request. You can use the\n                <code>Condition</code> element of an IAM policy to evaluate context keys. To get\n            the list of context keys that the policies require for correct simulation, use <a>GetContextKeysForCustomPolicy</a>.</p>\n         <p>If the output is long, you can use <code>MaxItems</code> and <code>Marker</code>\n            parameters to paginate the results.</p>\n         <note>\n            <p>The IAM policy simulator evaluates statements in the identity-based policy and\n                the inputs that you provide during simulation. The policy simulator results can\n                differ from your live Amazon Web Services environment. We recommend that you check your policies\n                against your live Amazon Web Services environment after testing using the policy simulator to\n                confirm that you have the desired results. For more information about using the\n                policy simulator, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html\">Testing IAM\n                    policies with the IAM policy simulator </a>in the\n                    <i>IAM User Guide</i>.</p>\n         </note>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -12277,14 +12785,14 @@
                 "PolicyInputList": {
                     "target": "com.amazonaws.iam#SimulationPolicyListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of policy documents to include in the simulation. Each document is specified as\n            a string containing the complete, valid JSON text of an IAM policy. Do not include any\n            resource-based policies in this parameter. Any resource-based policy must be submitted\n            with the <code>ResourcePolicy</code> parameter. The policies cannot be \"scope-down\"\n            policies, such as you could include in a call to <a href=\"https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetFederationToken.html\">GetFederationToken</a> or one of\n            the <a href=\"https://docs.aws.amazon.com/IAM/latest/APIReference/API_AssumeRole.html\">AssumeRole</a> API operations. In other words, do not use policies designed to\n            restrict what a user can do while using the temporary credentials.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>A list of policy documents to include in the simulation. Each document is specified as\n            a string containing the complete, valid JSON text of an IAM policy. Do not include any\n            resource-based policies in this parameter. Any resource-based policy must be submitted\n            with the <code>ResourcePolicy</code> parameter. The policies cannot be \"scope-down\"\n            policies, such as you could include in a call to <a href=\"https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetFederationToken.html\">GetFederationToken</a> or one of\n            the <a href=\"https://docs.aws.amazon.com/IAM/latest/APIReference/API_AssumeRole.html\">AssumeRole</a> API operations. In other words, do not use policies designed to\n            restrict what a user can do while using the temporary credentials.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
                 "PermissionsBoundaryPolicyInputList": {
                     "target": "com.amazonaws.iam#SimulationPolicyListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The IAM permissions boundary policy to simulate. The permissions boundary sets the\n            maximum permissions that an IAM entity can have. You can input only one permissions\n            boundary when you pass a policy to this operation. For more information about\n            permissions boundaries, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries for IAM\n                entities</a> in the <i>IAM User Guide</i>. The policy input is\n            specified as a string that contains the complete, valid JSON text of a permissions\n            boundary policy.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The IAM permissions boundary policy to simulate. The permissions boundary sets the\n            maximum permissions that an IAM entity can have. You can input only one permissions\n            boundary when you pass a policy to this operation. For more information about\n            permissions boundaries, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries for IAM\n                entities</a> in the <i>IAM User Guide</i>. The policy input is\n            specified as a string that contains the complete, valid JSON text of a permissions\n            boundary policy.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ActionNames": {
@@ -12297,25 +12805,25 @@
                 "ResourceArns": {
                     "target": "com.amazonaws.iam#ResourceNameListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of ARNs of Amazon Web Services resources to include in the simulation. If this parameter is\n            not provided, then the value defaults to <code>*</code> (all resources). Each API in the\n                <code>ActionNames</code> parameter is evaluated for each resource in this list. The\n            simulation determines the access result (allowed or denied) of each combination and\n            reports it in the response. You can simulate resources that don't exist in your\n            account.</p>\n        <p>The simulation does not automatically retrieve policies for the specified resources.\n            If you want to include a resource policy in the simulation, then you must include the\n            policy as a string in the <code>ResourcePolicy</code> parameter.</p>\n        <p>If you include a <code>ResourcePolicy</code>, then it must be applicable to all of the\n            resources included in the simulation or you receive an invalid input error.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>"
+                        "smithy.api#documentation": "<p>A list of ARNs of Amazon Web Services resources to include in the simulation. If this parameter is\n            not provided, then the value defaults to <code>*</code> (all resources). Each API in the\n                <code>ActionNames</code> parameter is evaluated for each resource in this list. The\n            simulation determines the access result (allowed or denied) of each combination and\n            reports it in the response. You can simulate resources that don't exist in your\n            account.</p>\n         <p>The simulation does not automatically retrieve policies for the specified resources.\n            If you want to include a resource policy in the simulation, then you must include the\n            policy as a string in the <code>ResourcePolicy</code> parameter.</p>\n         <p>If you include a <code>ResourcePolicy</code>, then it must be applicable to all of the\n            resources included in the simulation or you receive an invalid input error.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>\n         <note>\n            <p>Simulation of resource-based policies isn't supported for IAM roles.</p>\n         </note>"
                     }
                 },
                 "ResourcePolicy": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A resource-based policy to include in the simulation provided as a string. Each\n            resource in the simulation is treated as if it had this policy attached. You can include\n            only one resource-based policy in a simulation.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>A resource-based policy to include in the simulation provided as a string. Each\n            resource in the simulation is treated as if it had this policy attached. You can include\n            only one resource-based policy in a simulation.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>\n         <note>\n            <p>Simulation of resource-based policies isn't supported for IAM roles.</p>\n         </note>"
                     }
                 },
                 "ResourceOwner": {
                     "target": "com.amazonaws.iam#ResourceNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An ARN representing the Amazon Web Services account ID that specifies the owner of any simulated\n            resource that does not identify its owner in the resource ARN. Examples of resource ARNs\n            include an S3 bucket or object. If <code>ResourceOwner</code> is specified, it is also\n            used as the account owner of any <code>ResourcePolicy</code> included in the simulation.\n            If the <code>ResourceOwner</code> parameter is not specified, then the owner of the\n            resources and the resource policy defaults to the account of the identity provided in\n                <code>CallerArn</code>. This parameter is required only if you specify a\n            resource-based policy and account that owns the resource is different from the account\n            that owns the simulated calling user <code>CallerArn</code>.</p>\n        <p>The ARN for an account uses the following syntax:\n                    <code>arn:aws:iam::<i>AWS-account-ID</i>:root</code>. For example,\n            to represent the account with the 112233445566 ID, use the following ARN:\n                <code>arn:aws:iam::112233445566-ID:root</code>. </p>"
+                        "smithy.api#documentation": "<p>An ARN representing the Amazon Web Services account ID that specifies the owner of any simulated\n            resource that does not identify its owner in the resource ARN. Examples of resource ARNs\n            include an S3 bucket or object. If <code>ResourceOwner</code> is specified, it is also\n            used as the account owner of any <code>ResourcePolicy</code> included in the simulation.\n            If the <code>ResourceOwner</code> parameter is not specified, then the owner of the\n            resources and the resource policy defaults to the account of the identity provided in\n                <code>CallerArn</code>. This parameter is required only if you specify a\n            resource-based policy and account that owns the resource is different from the account\n            that owns the simulated calling user <code>CallerArn</code>.</p>\n         <p>The ARN for an account uses the following syntax:\n                    <code>arn:aws:iam::<i>AWS-account-ID</i>:root</code>. For example,\n            to represent the account with the 112233445566 ID, use the following ARN:\n                <code>arn:aws:iam::112233445566-ID:root</code>. </p>"
                     }
                 },
                 "CallerArn": {
                     "target": "com.amazonaws.iam#ResourceNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the IAM user that you want to use as the simulated caller of the API\n            operations. <code>CallerArn</code> is required if you include a\n                <code>ResourcePolicy</code> so that the policy's <code>Principal</code> element has\n            a value to use in evaluating the policy.</p>\n        <p>You can specify only the ARN of an IAM user. You cannot specify the ARN of an\n            assumed role, federated user, or a service principal.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the IAM user that you want to use as the simulated caller of the API\n            operations. <code>CallerArn</code> is required if you include a\n                <code>ResourcePolicy</code> so that the policy's <code>Principal</code> element has\n            a value to use in evaluating the policy.</p>\n         <p>You can specify only the ARN of an IAM user. You cannot specify the ARN of an\n            assumed role, federated user, or a service principal.</p>"
                     }
                 },
                 "ContextEntries": {
@@ -12327,7 +12835,7 @@
                 "ResourceHandlingOption": {
                     "target": "com.amazonaws.iam#ResourceHandlingOptionType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the type of simulation to run. Different API operations that support\n            resource-based policies require different combinations of resources. By specifying the\n            type of simulation to run, you enable the policy simulator to enforce the presence of\n            the required resources to ensure reliable simulation results. If your simulation does\n            not match one of the following scenarios, then you can omit this parameter. The\n            following list shows each of the supported scenario values and the resources that you\n            must define to run the simulation.</p>\n        <p>Each of the EC2 scenarios requires that you specify instance, image, and security\n            group resources. If your scenario includes an EBS volume, then you must specify that\n            volume as a resource. If the EC2 scenario includes VPC, then you must supply the network\n            interface resource. If it includes an IP subnet, then you must specify the subnet\n            resource. For more information on the EC2 scenario options, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported platforms</a> in the <i>Amazon EC2 User\n            Guide</i>.</p>\n        <ul>\n            <li>\n                <p>\n                    <b>EC2-VPC-InstanceStore</b>\n                </p>\n                <p>instance, image, security group, network interface</p>\n            </li>\n            <li>\n                <p>\n                    <b>EC2-VPC-InstanceStore-Subnet</b>\n                </p>\n                <p>instance, image, security group, network interface, subnet</p>\n            </li>\n            <li>\n                <p>\n                    <b>EC2-VPC-EBS</b>\n                </p>\n                <p>instance, image, security group, network interface, volume</p>\n            </li>\n            <li>\n                <p>\n                    <b>EC2-VPC-EBS-Subnet</b>\n                </p>\n                <p>instance, image, security group, network interface, subnet, volume</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Specifies the type of simulation to run. Different API operations that support\n            resource-based policies require different combinations of resources. By specifying the\n            type of simulation to run, you enable the policy simulator to enforce the presence of\n            the required resources to ensure reliable simulation results. If your simulation does\n            not match one of the following scenarios, then you can omit this parameter. The\n            following list shows each of the supported scenario values and the resources that you\n            must define to run the simulation.</p>\n         <p>Each of the EC2 scenarios requires that you specify instance, image, and security\n            group resources. If your scenario includes an EBS volume, then you must specify that\n            volume as a resource. If the EC2 scenario includes VPC, then you must supply the network\n            interface resource. If it includes an IP subnet, then you must specify the subnet\n            resource. For more information on the EC2 scenario options, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported platforms</a> in the <i>Amazon EC2 User\n            Guide</i>.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>EC2-VPC-InstanceStore</b>\n               </p>\n               <p>instance, image, security group, network interface</p>\n            </li>\n            <li>\n               <p>\n                  <b>EC2-VPC-InstanceStore-Subnet</b>\n               </p>\n               <p>instance, image, security group, network interface, subnet</p>\n            </li>\n            <li>\n               <p>\n                  <b>EC2-VPC-EBS</b>\n               </p>\n               <p>instance, image, security group, network interface, volume</p>\n            </li>\n            <li>\n               <p>\n                  <b>EC2-VPC-EBS-Subnet</b>\n               </p>\n               <p>instance, image, security group, network interface, subnet, volume</p>\n            </li>\n         </ul>"
                     }
                 },
                 "MaxItems": {
@@ -12342,6 +12850,9 @@
                         "smithy.api#documentation": "<p>Use this parameter only when paginating results and only after \n    you receive a response indicating that the results are truncated. Set it to the value of the\n    <code>Marker</code> element in the response that you received to indicate where the next call \n    should start.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#SimulatePolicyResponse": {
@@ -12391,7 +12902,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Simulate how a set of IAM policies attached to an IAM entity works with a list of\n            API operations and Amazon Web Services resources to determine the policies' effective permissions. The\n            entity can be an IAM user, group, or role. If you specify a user, then the simulation\n            also includes all of the policies that are attached to groups that the user belongs to.\n            You can simulate resources that don't exist in your account.</p>\n        <p>You can optionally include a list of one or more additional policies specified as\n            strings to include in the simulation. If you want to simulate only policies specified as\n            strings, use <a>SimulateCustomPolicy</a> instead.</p>\n        <p>You can also optionally include one resource-based policy to be evaluated with each of\n            the resources included in the simulation.</p>\n        <p>The simulation does not perform the API operations; it only checks the authorization\n            to determine if the simulated policies allow or deny the operations.</p>\n        <p>\n            <b>Note:</b> This operation discloses information about the\n            permissions granted to other users. If you do not want users to see other user's\n            permissions, then consider allowing them to use <a>SimulateCustomPolicy</a>\n            instead.</p>\n        <p>Context keys are variables maintained by Amazon Web Services and its services that provide details\n            about the context of an API query request. You can use the <code>Condition</code>\n            element of an IAM policy to evaluate context keys. To get the list of context keys\n            that the policies require for correct simulation, use <a>GetContextKeysForPrincipalPolicy</a>.</p>\n        <p>If the output is long, you can use the <code>MaxItems</code> and <code>Marker</code>\n            parameters to paginate the results.</p>\n        <p>For more information about using the policy simulator, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html\">Testing IAM policies\n                with the IAM policy simulator </a>in the\n            <i>IAM User Guide</i>.</p>",
+                "smithy.api#documentation": "<p>Simulate how a set of IAM policies attached to an IAM entity works with a list of\n            API operations and Amazon Web Services resources to determine the policies' effective permissions. The\n            entity can be an IAM user, group, or role. If you specify a user, then the simulation\n            also includes all of the policies that are attached to groups that the user belongs to.\n            You can simulate resources that don't exist in your account.</p>\n         <p>You can optionally include a list of one or more additional policies specified as\n            strings to include in the simulation. If you want to simulate only policies specified as\n            strings, use <a>SimulateCustomPolicy</a> instead.</p>\n         <p>You can also optionally include one resource-based policy to be evaluated with each of\n            the resources included in the simulation for IAM users only.</p>\n         <p>The simulation does not perform the API operations; it only checks the authorization\n            to determine if the simulated policies allow or deny the operations.</p>\n         <p>\n            <b>Note:</b> This operation discloses information about the\n            permissions granted to other users. If you do not want users to see other user's\n            permissions, then consider allowing them to use <a>SimulateCustomPolicy</a>\n            instead.</p>\n         <p>Context keys are variables maintained by Amazon Web Services and its services that provide details\n            about the context of an API query request. You can use the <code>Condition</code>\n            element of an IAM policy to evaluate context keys. To get the list of context keys\n            that the policies require for correct simulation, use <a>GetContextKeysForPrincipalPolicy</a>.</p>\n         <p>If the output is long, you can use the <code>MaxItems</code> and <code>Marker</code>\n            parameters to paginate the results.</p>\n         <note>\n            <p>The IAM policy simulator evaluates statements in the identity-based policy and\n                the inputs that you provide during simulation. The policy simulator results can\n                differ from your live Amazon Web Services environment. We recommend that you check your policies\n                against your live Amazon Web Services environment after testing using the policy simulator to\n                confirm that you have the desired results. For more information about using the\n                policy simulator, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_testing-policies.html\">Testing IAM\n                    policies with the IAM policy simulator </a>in the\n                    <i>IAM User Guide</i>.</p>\n         </note>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "Marker",
@@ -12406,20 +12917,20 @@
                 "PolicySourceArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a user, group, or role whose policies you want to\n            include in the simulation. If you specify a user, group, or role, the simulation\n            includes all policies that are associated with that entity. If you specify a user, the\n            simulation also includes all policies that are attached to any groups the user belongs\n            to.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of a user, group, or role whose policies you want to\n            include in the simulation. If you specify a user, group, or role, the simulation\n            includes all policies that are associated with that entity. If you specify a user, the\n            simulation also includes all policies that are attached to any groups the user belongs\n            to.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyInputList": {
                     "target": "com.amazonaws.iam#SimulationPolicyListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>An optional list of additional policy documents to include in the simulation. Each\n            document is specified as a string containing the complete, valid JSON text of an IAM\n            policy.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>An optional list of additional policy documents to include in the simulation. Each\n            document is specified as a string containing the complete, valid JSON text of an IAM\n            policy.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
                     }
                 },
                 "PermissionsBoundaryPolicyInputList": {
                     "target": "com.amazonaws.iam#SimulationPolicyListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The IAM permissions boundary policy to simulate. The permissions boundary sets the\n            maximum permissions that the entity can have. You can input only one permissions\n            boundary when you pass a policy to this operation. An IAM entity can only have one\n            permissions boundary in effect at a time. For example, if a permissions boundary is\n            attached to an entity and you pass in a different permissions boundary policy using this\n            parameter, then the new permissions boundary policy is used for the simulation. For more\n            information about permissions boundaries, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries for IAM\n                entities</a> in the <i>IAM User Guide</i>. The policy input is\n            specified as a string containing the complete, valid JSON text of a permissions boundary\n            policy.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The IAM permissions boundary policy to simulate. The permissions boundary sets the\n            maximum permissions that the entity can have. You can input only one permissions\n            boundary when you pass a policy to this operation. An IAM entity can only have one\n            permissions boundary in effect at a time. For example, if a permissions boundary is\n            attached to an entity and you pass in a different permissions boundary policy using this\n            parameter, then the new permissions boundary policy is used for the simulation. For more\n            information about permissions boundaries, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html\">Permissions boundaries for IAM\n                entities</a> in the <i>IAM User Guide</i>. The policy input is\n            specified as a string containing the complete, valid JSON text of a permissions boundary\n            policy.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
                     }
                 },
                 "ActionNames": {
@@ -12432,13 +12943,13 @@
                 "ResourceArns": {
                     "target": "com.amazonaws.iam#ResourceNameListType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A list of ARNs of Amazon Web Services resources to include in the simulation. If this parameter is\n            not provided, then the value defaults to <code>*</code> (all resources). Each API in the\n                <code>ActionNames</code> parameter is evaluated for each resource in this list. The\n            simulation determines the access result (allowed or denied) of each combination and\n            reports it in the response. You can simulate resources that don't exist in your\n            account.</p>\n        <p>The simulation does not automatically retrieve policies for the specified resources.\n            If you want to include a resource policy in the simulation, then you must include the\n            policy as a string in the <code>ResourcePolicy</code> parameter.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>"
+                        "smithy.api#documentation": "<p>A list of ARNs of Amazon Web Services resources to include in the simulation. If this parameter is\n            not provided, then the value defaults to <code>*</code> (all resources). Each API in the\n                <code>ActionNames</code> parameter is evaluated for each resource in this list. The\n            simulation determines the access result (allowed or denied) of each combination and\n            reports it in the response. You can simulate resources that don't exist in your\n            account.</p>\n         <p>The simulation does not automatically retrieve policies for the specified resources.\n            If you want to include a resource policy in the simulation, then you must include the\n            policy as a string in the <code>ResourcePolicy</code> parameter.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>\n         <note>\n            <p>Simulation of resource-based policies isn't supported for IAM roles.</p>\n         </note>"
                     }
                 },
                 "ResourcePolicy": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A resource-based policy to include in the simulation provided as a string. Each\n            resource in the simulation is treated as if it had this policy attached. You can include\n            only one resource-based policy in a simulation.</p>\n        <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>A resource-based policy to include in the simulation provided as a string. Each\n            resource in the simulation is treated as if it had this policy attached. You can include\n            only one resource-based policy in a simulation.</p>\n         <p>The maximum length of the policy document that you can pass in this operation,\n            including whitespace, is listed below. To view the maximum character counts of a managed policy with no whitespaces, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#reference_iam-quotas-entity-length\">IAM and STS character quotas</a>.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>\n         <note>\n            <p>Simulation of resource-based policies isn't supported for IAM roles.</p>\n         </note>"
                     }
                 },
                 "ResourceOwner": {
@@ -12450,7 +12961,7 @@
                 "CallerArn": {
                     "target": "com.amazonaws.iam#ResourceNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the IAM user that you want to specify as the simulated caller of the API\n            operations. If you do not specify a <code>CallerArn</code>, it defaults to the ARN of\n            the user that you specify in <code>PolicySourceArn</code>, if you specified a user. If\n            you include both a <code>PolicySourceArn</code> (for example,\n                <code>arn:aws:iam::123456789012:user/David</code>) and a <code>CallerArn</code> (for\n            example, <code>arn:aws:iam::123456789012:user/Bob</code>), the result is that you\n            simulate calling the API operations as Bob, as if Bob had David's policies.</p>\n        <p>You can specify only the ARN of an IAM user. You cannot specify the ARN of an\n            assumed role, federated user, or a service principal.</p>\n        <p>\n            <code>CallerArn</code> is required if you include a <code>ResourcePolicy</code> and\n            the <code>PolicySourceArn</code> is not the ARN for an IAM user. This is required so\n            that the resource-based policy's <code>Principal</code> element has a value to use in\n            evaluating the policy.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the IAM user that you want to specify as the simulated caller of the API\n            operations. If you do not specify a <code>CallerArn</code>, it defaults to the ARN of\n            the user that you specify in <code>PolicySourceArn</code>, if you specified a user. If\n            you include both a <code>PolicySourceArn</code> (for example,\n                <code>arn:aws:iam::123456789012:user/David</code>) and a <code>CallerArn</code> (for\n            example, <code>arn:aws:iam::123456789012:user/Bob</code>), the result is that you\n            simulate calling the API operations as Bob, as if Bob had David's policies.</p>\n         <p>You can specify only the ARN of an IAM user. You cannot specify the ARN of an\n            assumed role, federated user, or a service principal.</p>\n         <p>\n            <code>CallerArn</code> is required if you include a <code>ResourcePolicy</code> and\n            the <code>PolicySourceArn</code> is not the ARN for an IAM user. This is required so\n            that the resource-based policy's <code>Principal</code> element has a value to use in\n            evaluating the policy.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>"
                     }
                 },
                 "ContextEntries": {
@@ -12462,7 +12973,7 @@
                 "ResourceHandlingOption": {
                     "target": "com.amazonaws.iam#ResourceHandlingOptionType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the type of simulation to run. Different API operations that support\n            resource-based policies require different combinations of resources. By specifying the\n            type of simulation to run, you enable the policy simulator to enforce the presence of\n            the required resources to ensure reliable simulation results. If your simulation does\n            not match one of the following scenarios, then you can omit this parameter. The\n            following list shows each of the supported scenario values and the resources that you\n            must define to run the simulation.</p>\n        <p>Each of the EC2 scenarios requires that you specify instance, image, and security\n            group resources. If your scenario includes an EBS volume, then you must specify that\n            volume as a resource. If the EC2 scenario includes VPC, then you must supply the network\n            interface resource. If it includes an IP subnet, then you must specify the subnet\n            resource. For more information on the EC2 scenario options, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported platforms</a> in the <i>Amazon EC2 User\n            Guide</i>.</p>\n        <ul>\n            <li>\n                <p>\n                    <b>EC2-VPC-InstanceStore</b>\n                </p>\n                <p>instance, image, security group, network interface</p>\n            </li>\n            <li>\n                <p>\n                    <b>EC2-VPC-InstanceStore-Subnet</b>\n                </p>\n                <p>instance, image, security group, network interface, subnet</p>\n            </li>\n            <li>\n                <p>\n                    <b>EC2-VPC-EBS</b>\n                </p>\n                <p>instance, image, security group, network interface, volume</p>\n            </li>\n            <li>\n                <p>\n                    <b>EC2-VPC-EBS-Subnet</b>\n                </p>\n                <p>instance, image, security group, network interface, subnet, volume</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Specifies the type of simulation to run. Different API operations that support\n            resource-based policies require different combinations of resources. By specifying the\n            type of simulation to run, you enable the policy simulator to enforce the presence of\n            the required resources to ensure reliable simulation results. If your simulation does\n            not match one of the following scenarios, then you can omit this parameter. The\n            following list shows each of the supported scenario values and the resources that you\n            must define to run the simulation.</p>\n         <p>Each of the EC2 scenarios requires that you specify instance, image, and security\n            group resources. If your scenario includes an EBS volume, then you must specify that\n            volume as a resource. If the EC2 scenario includes VPC, then you must supply the network\n            interface resource. If it includes an IP subnet, then you must specify the subnet\n            resource. For more information on the EC2 scenario options, see <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-supported-platforms.html\">Supported platforms</a> in the <i>Amazon EC2 User\n            Guide</i>.</p>\n         <ul>\n            <li>\n               <p>\n                  <b>EC2-VPC-InstanceStore</b>\n               </p>\n               <p>instance, image, security group, network interface</p>\n            </li>\n            <li>\n               <p>\n                  <b>EC2-VPC-InstanceStore-Subnet</b>\n               </p>\n               <p>instance, image, security group, network interface, subnet</p>\n            </li>\n            <li>\n               <p>\n                  <b>EC2-VPC-EBS</b>\n               </p>\n               <p>instance, image, security group, network interface, volume</p>\n            </li>\n            <li>\n               <p>\n                  <b>EC2-VPC-EBS-Subnet</b>\n               </p>\n               <p>instance, image, security group, network interface, subnet, volume</p>\n            </li>\n         </ul>"
                     }
                 },
                 "MaxItems": {
@@ -12477,6 +12988,9 @@
                         "smithy.api#documentation": "<p>Use this parameter only when paginating results and only after \n    you receive a response indicating that the results are truncated. Set it to the value of the\n    <code>Marker</code> element in the response that you received to indicate where the next call \n    should start.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#SimulationPolicyListType": {
@@ -12591,6 +13105,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagMFADevice": {
@@ -12639,6 +13156,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagOpenIDConnectProvider": {
@@ -12667,7 +13187,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds one or more tags to an OpenID Connect (OIDC)-compatible identity provider. For\n      more information about these providers, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html\">About web identity federation</a>. If\n      a tag with the same key name already exists, then that tag is overwritten with the new\n      value.</p>\n         <p>A tag consists of a key name and an associated value. By assigning tags to your\n      resources, you can do the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Administrative grouping and discovery</b> - Attach\n          tags to resources to aid in organization and search. For example, you could search for all\n          resources with the key name <i>Project</i> and the value\n            <i>MyImportantProject</i>. Or search for all resources with the key name\n            <i>Cost Center</i> and the value <i>41200</i>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Access control</b> - Include tags in IAM user-based\n          and resource-based policies. You can use tags to restrict access to only an OIDC provider\n          that has a specified tag attached. For examples of policies that show how to use tags to\n          control access, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html\">Control access using IAM tags</a> in the\n          <i>IAM User Guide</i>.</p>\n            </li>\n         </ul>\n         <note>\n            <ul>\n               <li>\n                  <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n               </li>\n               <li>\n                  <p>Amazon Web Services always interprets the tag <code>Value</code> as a single string. If you\n            need to store an array, you can store comma-separated values in the string. However, you\n            must interpret the value in your code.</p>\n               </li>\n            </ul>\n         </note>"
+                "smithy.api#documentation": "<p>Adds one or more tags to an OpenID Connect (OIDC)-compatible identity provider. For\n      more information about these providers, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_oidc.html\">About web identity federation</a>. If\n      a tag with the same key name already exists, then that tag is overwritten with the new\n      value.</p>\n         <p>A tag consists of a key name and an associated value. By assigning tags to your\n      resources, you can do the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Administrative grouping and discovery</b> - Attach\n          tags to resources to aid in organization and search. For example, you could search for all\n          resources with the key name <i>Project</i> and the value\n            <i>MyImportantProject</i>. Or search for all resources with the key name\n            <i>Cost Center</i> and the value <i>41200</i>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Access control</b> - Include tags in IAM identity-based\n          and resource-based policies. You can use tags to restrict access to only an OIDC provider\n          that has a specified tag attached. For examples of policies that show how to use tags to\n          control access, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html\">Control access using IAM tags</a> in the\n          <i>IAM User Guide</i>.</p>\n            </li>\n         </ul>\n         <note>\n            <ul>\n               <li>\n                  <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n               </li>\n               <li>\n                  <p>Amazon Web Services always interprets the tag <code>Value</code> as a single string. If you\n            need to store an array, you can store comma-separated values in the string. However, you\n            must interpret the value in your code.</p>\n               </li>\n            </ul>\n         </note>"
             }
         },
         "com.amazonaws.iam#TagOpenIDConnectProviderRequest": {
@@ -12687,6 +13207,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagPolicy": {
@@ -12735,6 +13258,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagRole": {
@@ -12783,6 +13309,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagSAMLProvider": {
@@ -12831,6 +13360,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagServerCertificate": {
@@ -12879,6 +13411,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TagUser": {
@@ -12907,7 +13442,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds one or more tags to an IAM user. If a tag with the same key name already exists,\n      then that tag is overwritten with the new value.</p>\n         <p>A tag consists of a key name and an associated value. By assigning tags to your\n      resources, you can do the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Administrative grouping and discovery</b> - Attach\n          tags to resources to aid in organization and search. For example, you could search for all\n          resources with the key name <i>Project</i> and the value\n            <i>MyImportantProject</i>. Or search for all resources with the key name\n            <i>Cost Center</i> and the value <i>41200</i>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Access control</b> - Include tags in IAM user-based\n          and resource-based policies. You can use tags to restrict access to only an IAM\n          requesting user that has a specified tag attached. You can also restrict access to only\n          those resources that have a certain tag attached. For examples of policies that show how\n          to use tags to control access, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html\">Control access using IAM tags</a> in the\n            <i>IAM User Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Cost allocation</b> - Use tags to help track which\n          individuals and teams are using which Amazon Web Services resources.</p>\n            </li>\n         </ul>\n         <note>\n            <ul>\n               <li>\n                  <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n               </li>\n               <li>\n                  <p>Amazon Web Services always interprets the tag <code>Value</code> as a single string. If you\n            need to store an array, you can store comma-separated values in the string. However, you\n            must interpret the value in your code.</p>\n               </li>\n            </ul>\n         </note>\n         <p>For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM identities</a> in the\n        <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Adds one or more tags to an IAM user. If a tag with the same key name already exists,\n      then that tag is overwritten with the new value.</p>\n         <p>A tag consists of a key name and an associated value. By assigning tags to your\n      resources, you can do the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Administrative grouping and discovery</b> - Attach\n          tags to resources to aid in organization and search. For example, you could search for all\n          resources with the key name <i>Project</i> and the value\n            <i>MyImportantProject</i>. Or search for all resources with the key name\n            <i>Cost Center</i> and the value <i>41200</i>. </p>\n            </li>\n            <li>\n               <p>\n                  <b>Access control</b> - Include tags in IAM identity-based\n          and resource-based policies. You can use tags to restrict access to only an IAM\n          requesting user that has a specified tag attached. You can also restrict access to only\n          those resources that have a certain tag attached. For examples of policies that show how\n          to use tags to control access, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access_tags.html\">Control access using IAM tags</a> in the\n            <i>IAM User Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Cost allocation</b> - Use tags to help track which\n          individuals and teams are using which Amazon Web Services resources.</p>\n            </li>\n         </ul>\n         <note>\n            <ul>\n               <li>\n                  <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n               </li>\n               <li>\n                  <p>Amazon Web Services always interprets the tag <code>Value</code> as a single string. If you\n            need to store an array, you can store comma-separated values in the string. However, you\n            must interpret the value in your code.</p>\n               </li>\n            </ul>\n         </note>\n         <p>For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM identities</a> in the\n        <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#TagUserRequest": {
@@ -12927,6 +13462,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#TrackedActionLastAccessed": {
@@ -13041,6 +13579,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagMFADevice": {
@@ -13086,6 +13627,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagOpenIDConnectProvider": {
@@ -13131,6 +13675,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagPolicy": {
@@ -13176,6 +13723,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagRole": {
@@ -13218,6 +13768,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagSAMLProvider": {
@@ -13263,6 +13816,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagServerCertificate": {
@@ -13308,6 +13864,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UntagUser": {
@@ -13350,6 +13909,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateAccessKey": {
@@ -13372,7 +13934,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Changes the status of the specified access key from Active to Inactive, or vice versa.\n            This operation can be used to disable a user's key as part of a key rotation\n            workflow.</p>\n        <p>If the <code>UserName</code> is not specified, the user name is determined implicitly\n            based on the Amazon Web Services access key ID used to sign the request. If a temporary access key is\n            used, then <code>UserName</code> is required. If a long-term key is assigned to the\n            user, then <code>UserName</code> is not required. This operation works for access keys\n            under the Amazon Web Services account. Consequently, you can use this operation to manage\n            Amazon Web Services account root user credentials even if the Amazon Web Services account has no associated\n            users.</p>\n        <p>For information about rotating keys, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html\">Managing keys and certificates</a>\n            in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Changes the status of the specified access key from Active to Inactive, or vice versa.\n            This operation can be used to disable a user's key as part of a key rotation\n            workflow.</p>\n         <p>If the <code>UserName</code> is not specified, the user name is determined implicitly\n            based on the Amazon Web Services access key ID used to sign the request. If a temporary access key is\n            used, then <code>UserName</code> is required. If a long-term key is assigned to the\n            user, then <code>UserName</code> is not required. This operation works for access keys\n            under the Amazon Web Services account. Consequently, you can use this operation to manage Amazon Web Services account root user\n            credentials even if the Amazon Web Services account has no associated users.</p>\n         <p>For information about rotating keys, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html\">Managing keys and certificates</a>\n            in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#UpdateAccessKeyRequest": {
@@ -13381,13 +13943,13 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose key you want to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user whose key you want to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "AccessKeyId": {
                     "target": "com.amazonaws.iam#accessKeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The access key ID of the secret access key you want to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The access key ID of the secret access key you want to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -13398,6 +13960,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateAccountPasswordPolicy": {
@@ -13423,7 +13988,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates the password policy settings for the Amazon Web Services account.</p>\n        <note>\n            <p>This operation does not support partial updates. No parameters are required, but\n                if you do not specify a parameter, that parameter's value reverts to its default\n                value. See the <b>Request Parameters</b> section for each\n                parameter's default value. Also note that some parameters do not allow the default\n                parameter to be explicitly set. Instead, to invoke the default value, do not include\n                that parameter when you invoke the operation.</p>\n        </note>\n        <p> For more information about using a password policy, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html\">Managing an IAM password\n                policy</a> in the <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Updates the password policy settings for the Amazon Web Services account.</p>\n         <note>\n            <p>This operation does not support partial updates. No parameters are required, but\n                if you do not specify a parameter, that parameter's value reverts to its default\n                value. See the <b>Request Parameters</b> section for each\n                parameter's default value. Also note that some parameters do not allow the default\n                parameter to be explicitly set. Instead, to invoke the default value, do not include\n                that parameter when you invoke the operation.</p>\n         </note>\n         <p> For more information about using a password policy, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingPasswordPolicies.html\">Managing an IAM password\n                policy</a> in the <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#UpdateAccountPasswordPolicyRequest": {
@@ -13432,62 +13997,65 @@
                 "MinimumPasswordLength": {
                     "target": "com.amazonaws.iam#minimumPasswordLengthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The minimum number of characters allowed in an IAM user password.</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>6</code>.</p>"
+                        "smithy.api#documentation": "<p>The minimum number of characters allowed in an IAM user password.</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>6</code>.</p>"
                     }
                 },
                 "RequireSymbols": {
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one of the following\n            non-alphanumeric characters:</p>\n        <p>! @ # $ % ^ & * ( ) _ + - = [ ] { } | '</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            symbol character.</p>"
+                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one of the following\n            non-alphanumeric characters:</p>\n         <p>! @ # $ % ^ & * ( ) _ + - = [ ] { } | '</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            symbol character.</p>"
                     }
                 },
                 "RequireNumbers": {
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one numeric character (0\n            to 9).</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            numeric character.</p>"
+                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one numeric character (0\n            to 9).</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            numeric character.</p>"
                     }
                 },
                 "RequireUppercaseCharacters": {
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one uppercase character\n            from the ISO basic Latin alphabet (A to Z).</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            uppercase character.</p>"
+                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one uppercase character\n            from the ISO basic Latin alphabet (A to Z).</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            uppercase character.</p>"
                     }
                 },
                 "RequireLowercaseCharacters": {
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one lowercase character\n            from the ISO basic Latin alphabet (a to z).</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            lowercase character.</p>"
+                        "smithy.api#documentation": "<p>Specifies whether IAM user passwords must contain at least one lowercase character\n            from the ISO basic Latin alphabet (a to z).</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that passwords do not require at least one\n            lowercase character.</p>"
                     }
                 },
                 "AllowUsersToChangePassword": {
                     "target": "com.amazonaws.iam#booleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p> Allows all IAM users in your account to use the Amazon Web Services Management Console to change their own\n            passwords. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_enable-user-change.html\">Permitting\n                IAM users to change their own passwords</a> in the\n                <i>IAM User Guide</i>.</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that IAM users in the account do not\n            automatically have permissions to change their own password.</p>"
+                        "smithy.api#documentation": "<p> Allows all IAM users in your account to use the Amazon Web Services Management Console to change their own\n            passwords. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_passwords_enable-user-change.html\">Permitting\n                IAM users to change their own passwords</a> in the\n                <i>IAM User Guide</i>.</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that IAM users in the account do not\n            automatically have permissions to change their own password.</p>"
                     }
                 },
                 "MaxPasswordAge": {
                     "target": "com.amazonaws.iam#maxPasswordAgeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The number of days that an IAM user password is valid.</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>0</code>. The result is that IAM user passwords never expire.</p>"
+                        "smithy.api#documentation": "<p>The number of days that an IAM user password is valid.</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>0</code>. The result is that IAM user passwords never expire.</p>"
                     }
                 },
                 "PasswordReusePrevention": {
                     "target": "com.amazonaws.iam#passwordReusePreventionType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the number of previous passwords that IAM users are prevented from\n            reusing.</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>0</code>. The result is that IAM users are not prevented from reusing\n            previous passwords.</p>"
+                        "smithy.api#documentation": "<p>Specifies the number of previous passwords that IAM users are prevented from\n            reusing.</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>0</code>. The result is that IAM users are not prevented from reusing\n            previous passwords.</p>"
                     }
                 },
                 "HardExpiry": {
                     "target": "com.amazonaws.iam#booleanObjectType",
                     "traits": {
-                        "smithy.api#documentation": "<p> Prevents IAM users who are accessing the account via the Amazon Web Services Management Console from setting a\n            new console password after their password has expired. The IAM user cannot access the\n            console until an administrator resets the password.</p>\n        <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that IAM users can change their passwords\n            after they expire and continue to sign in as the user.</p>\n        <note>\n            <p> In the Amazon Web Services Management Console, the custom password policy option <b>Allow\n                    users to change their own password</b> gives IAM users permissions to\n                    <code>iam:ChangePassword</code> for only their user and to the\n                    <code>iam:GetAccountPasswordPolicy</code> action. This option does not attach a\n                permissions policy to each user, rather the permissions are applied at the\n                account-level for all users by IAM. IAM users with\n                    <code>iam:ChangePassword</code> permission and active access keys can reset\n                their own expired console password using the CLI or API.</p>\n        </note>"
+                        "smithy.api#documentation": "<p> Prevents IAM users who are accessing the account via the Amazon Web Services Management Console from setting a\n            new console password after their password has expired. The IAM user cannot access the\n            console until an administrator resets the password.</p>\n         <p>If you do not specify a value for this parameter, then the operation uses the default\n            value of <code>false</code>. The result is that IAM users can change their passwords\n            after they expire and continue to sign in as the user.</p>\n         <note>\n            <p> In the Amazon Web Services Management Console, the custom password policy option <b>Allow\n                    users to change their own password</b> gives IAM users permissions to\n                    <code>iam:ChangePassword</code> for only their user and to the\n                    <code>iam:GetAccountPasswordPolicy</code> action. This option does not attach a\n                permissions policy to each user, rather the permissions are applied at the\n                account-level for all users by IAM. IAM users with\n                    <code>iam:ChangePassword</code> permission and active access keys can reset\n                their own expired console password using the CLI or API.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateAssumeRolePolicy": {
@@ -13525,17 +14093,20 @@
                 "RoleName": {
                     "target": "com.amazonaws.iam#roleNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the role to update with the new policy.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the role to update with the new policy.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "PolicyDocument": {
                     "target": "com.amazonaws.iam#policyDocumentType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The policy that grants an entity permission to assume the role.</p>\n        <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The policy that grants an entity permission to assume the role.</p>\n         <p>You must provide policies in JSON format in IAM. However, for CloudFormation\n            templates formatted in YAML, you can provide the policy in JSON or YAML format. CloudFormation always converts a YAML policy to JSON format before submitting it to\n            IAM.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateGroup": {
@@ -13561,7 +14132,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates the name and/or the path of the specified IAM group.</p>\n        <important>\n            <p> You should understand the implications of changing a group's path or name. For\n                more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html\">Renaming users and\n                    groups</a> in the <i>IAM User Guide</i>.</p>\n        </important>\n        <note>\n            <p>The person making the request (the principal), must have permission to change the\n                role group with the old name and the new name. For example, to change the group\n                named <code>Managers</code> to <code>MGRs</code>, the principal must have a policy\n                that allows them to update both groups. If the principal has permission to update\n                the <code>Managers</code> group, but not the <code>MGRs</code> group, then the\n                update fails. For more information about permissions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html\">Access management</a>.\n            </p>\n        </note>"
+                "smithy.api#documentation": "<p>Updates the name and/or the path of the specified IAM group.</p>\n         <important>\n            <p> You should understand the implications of changing a group's path or name. For\n                more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_WorkingWithGroupsAndUsers.html\">Renaming users and\n                    groups</a> in the <i>IAM User Guide</i>.</p>\n         </important>\n         <note>\n            <p>The person making the request (the principal), must have permission to change the\n                role group with the old name and the new name. For example, to change the group\n                named <code>Managers</code> to <code>MGRs</code>, the principal must have a policy\n                that allows them to update both groups. If the principal has permission to update\n                the <code>Managers</code> group, but not the <code>MGRs</code> group, then the\n                update fails. For more information about permissions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html\">Access management</a>.\n            </p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UpdateGroupRequest": {
@@ -13570,22 +14141,25 @@
                 "GroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Name of the IAM group to update. If you're changing the name of the group, this is\n            the original name.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>Name of the IAM group to update. If you're changing the name of the group, this is\n            the original name.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "NewPath": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>New path for the IAM group. Only include this if changing the group's path.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>New path for the IAM group. Only include this if changing the group's path.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "NewGroupName": {
                     "target": "com.amazonaws.iam#groupNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>New name for the IAM group. Only include this if changing the group's name.</p>\n        <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>"
+                        "smithy.api#documentation": "<p>New name for the IAM group. Only include this if changing the group's name.</p>\n         <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateLoginProfile": {
@@ -13614,7 +14188,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Changes the password for the specified IAM user. You can use the CLI,\n            the Amazon Web Services API, or the <b>Users</b> page in the IAM console\n            to change the password for any IAM user. Use <a>ChangePassword</a> to\n            change your own password in the <b>My Security Credentials</b>\n            page in the Amazon Web Services Management Console.</p>\n        <p>For more information about modifying passwords, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html\">Managing passwords</a> in the\n                <i>IAM User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Changes the password for the specified IAM user. You can use the CLI, the Amazon Web Services\n            API, or the <b>Users</b> page in the IAM console to change\n            the password for any IAM user. Use <a>ChangePassword</a> to change your own\n            password in the <b>My Security Credentials</b> page in the\n            Amazon Web Services Management Console.</p>\n         <p>For more information about modifying passwords, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_ManagingLogins.html\">Managing passwords</a> in the\n                <i>IAM User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#UpdateLoginProfileRequest": {
@@ -13623,14 +14197,14 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user whose password you want to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the user whose password you want to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Password": {
                     "target": "com.amazonaws.iam#passwordType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The new password for the specified IAM user.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>\n        <p>However, the format can be further restricted by the account administrator by setting\n            a password policy on the Amazon Web Services account. For more information, see <a>UpdateAccountPasswordPolicy</a>.</p>"
+                        "smithy.api#documentation": "<p>The new password for the specified IAM user.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>\n         <p>However, the format can be further restricted by the account administrator by setting\n            a password policy on the Amazon Web Services account. For more information, see <a>UpdateAccountPasswordPolicy</a>.</p>"
                     }
                 },
                 "PasswordResetRequired": {
@@ -13639,6 +14213,9 @@
                         "smithy.api#documentation": "<p>Allows this new password to be used only once by requiring the specified IAM user to\n            set a new password on next sign-in.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateOpenIDConnectProviderThumbprint": {
@@ -13661,7 +14238,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Replaces the existing list of server certificate thumbprints associated with an OpenID\n            Connect (OIDC) provider resource object with a new list of thumbprints.</p>\n        <p>The list that you pass with this operation completely replaces the existing list of\n            thumbprints. (The lists are not merged.)</p>\n        <p>Typically, you need to update a thumbprint only when the identity provider certificate\n            changes, which occurs rarely. However, if the provider's certificate\n                <i>does</i> change, any attempt to assume an IAM role that specifies\n            the OIDC provider as a principal fails until the certificate thumbprint is\n            updated.</p>\n        <note>\n            <p>Amazon Web Services secures communication with some OIDC identity providers (IdPs) through our\n            library of trusted certificate authorities (CAs) instead of using a certificate\n            thumbprint to verify your IdP server certificate. These OIDC IdPs include Google, and\n            those that use an Amazon S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these\n            cases, your legacy thumbprint remains in your configuration, but is no longer used for validation.</p> \n         </note>\n        <note>\n            <p>Trust for the OIDC provider is derived from the provider certificate and is\n                validated by the thumbprint. Therefore, it is best to limit access to the\n                    <code>UpdateOpenIDConnectProviderThumbprint</code> operation to highly\n                privileged users.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Replaces the existing list of server certificate thumbprints associated with an OpenID\n            Connect (OIDC) provider resource object with a new list of thumbprints.</p>\n         <p>The list that you pass with this operation completely replaces the existing list of\n            thumbprints. (The lists are not merged.)</p>\n         <p>Typically, you need to update a thumbprint only when the identity provider certificate\n            changes, which occurs rarely. However, if the provider's certificate\n                <i>does</i> change, any attempt to assume an IAM role that specifies\n            the OIDC provider as a principal fails until the certificate thumbprint is\n            updated.</p>\n         <note>\n            <p>Amazon Web Services secures communication with some OIDC identity providers (IdPs) through our\n            library of trusted certificate authorities (CAs) instead of using a certificate\n            thumbprint to verify your IdP server certificate. These OIDC IdPs include Google, Auth0,\n            and those that use an Amazon S3 bucket to host a JSON Web Key Set (JWKS) endpoint. In these\n            cases, your legacy thumbprint remains in your configuration, but is no longer used for\n            validation.</p>\n         </note>\n         <note>\n            <p>Trust for the OIDC provider is derived from the provider certificate and is\n                validated by the thumbprint. Therefore, it is best to limit access to the\n                    <code>UpdateOpenIDConnectProviderThumbprint</code> operation to highly\n                privileged users.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UpdateOpenIDConnectProviderThumbprintRequest": {
@@ -13670,7 +14247,7 @@
                 "OpenIDConnectProviderArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource object for which\n            you want to update the thumbprint. You can get a list of OIDC provider ARNs by using the\n                <a>ListOpenIDConnectProviders</a> operation.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM OIDC provider resource object for which\n            you want to update the thumbprint. You can get a list of OIDC provider ARNs by using the\n                <a>ListOpenIDConnectProviders</a> operation.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -13681,6 +14258,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateRole": {
@@ -13726,7 +14306,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Use <a>UpdateRole</a> instead.</p>\n        <p>Modifies only the description of a role. This operation performs the same function as\n            the <code>Description</code> parameter in the <code>UpdateRole</code> operation.</p>"
+                "smithy.api#documentation": "<p>Use <a>UpdateRole</a> instead.</p>\n         <p>Modifies only the description of a role. This operation performs the same function as\n            the <code>Description</code> parameter in the <code>UpdateRole</code> operation.</p>"
             }
         },
         "com.amazonaws.iam#UpdateRoleDescriptionRequest": {
@@ -13746,6 +14326,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateRoleDescriptionResponse": {
@@ -13757,6 +14340,9 @@
                         "smithy.api#documentation": "<p>A structure that contains details about the modified role.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#UpdateRoleRequest": {
@@ -13778,14 +14364,20 @@
                 "MaxSessionDuration": {
                     "target": "com.amazonaws.iam#roleMaxSessionDurationType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The maximum session duration (in seconds) that you want to set for the specified role.\n            If you do not specify a value for this setting, the default value of one hour is\n            applied. This setting can have a value from 1 hour to 12 hours.</p>\n        <p>Anyone who assumes the role from the CLI or API can use the\n                <code>DurationSeconds</code> API parameter or the <code>duration-seconds</code> CLI\n            parameter to request a longer session. The <code>MaxSessionDuration</code> setting\n            determines the maximum duration that can be requested using the\n                <code>DurationSeconds</code> parameter. If users don't specify a value for the\n                <code>DurationSeconds</code> parameter, their security credentials are valid for one\n            hour by default. This applies when you use the <code>AssumeRole*</code> API operations\n            or the <code>assume-role*</code> CLI operations but does not apply when you use those\n            operations to create a console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM\n                roles</a> in the <i>IAM User Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>The maximum session duration (in seconds) that you want to set for the specified role.\n            If you do not specify a value for this setting, the default value of one hour is\n            applied. This setting can have a value from 1 hour to 12 hours.</p>\n         <p>Anyone who assumes the role from the CLI or API can use the\n                <code>DurationSeconds</code> API parameter or the <code>duration-seconds</code>\n            CLI parameter to request a longer session. The <code>MaxSessionDuration</code> setting\n            determines the maximum duration that can be requested using the\n                <code>DurationSeconds</code> parameter. If users don't specify a value for the\n                <code>DurationSeconds</code> parameter, their security credentials are valid for one\n            hour by default. This applies when you use the <code>AssumeRole*</code> API operations\n            or the <code>assume-role*</code> CLI operations but does not apply when you use those\n            operations to create a console URL. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use.html\">Using IAM\n                roles</a> in the <i>IAM User Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateRoleResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.iam#UpdateSAMLProvider": {
             "type": "operation",
@@ -13810,7 +14402,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates the metadata document for an existing SAML provider resource object.</p>\n        <note>\n            <p>This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Updates the metadata document for an existing SAML provider resource object.</p>\n         <note>\n            <p>This operation requires <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UpdateSAMLProviderRequest": {
@@ -13826,10 +14418,13 @@
                 "SAMLProviderArn": {
                     "target": "com.amazonaws.iam#arnType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the SAML provider to update.</p>\n        <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the SAML provider to update.</p>\n         <p>For more information about ARNs, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Names (ARNs)</a> in the <i>Amazon Web Services General Reference</i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateSAMLProviderResponse": {
@@ -13843,7 +14438,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>UpdateSAMLProvider</a> request.\n    </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>UpdateSAMLProvider</a> request.\n    </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#UpdateSSHPublicKey": {
@@ -13860,7 +14456,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Sets the status of an IAM user's SSH public key to active or inactive. SSH public\n            keys that are inactive cannot be used for authentication. This operation can be used to\n            disable a user's SSH public key as part of a key rotation work flow.</p>\n        <p>The SSH public key affected by this operation is used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Sets the status of an IAM user's SSH public key to active or inactive. SSH public\n            keys that are inactive cannot be used for authentication. This operation can be used to\n            disable a user's SSH public key as part of a key rotation work flow.</p>\n         <p>The SSH public key affected by this operation is used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#UpdateSSHPublicKeyRequest": {
@@ -13869,14 +14465,14 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user associated with the SSH public key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user associated with the SSH public key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SSHPublicKeyId": {
                     "target": "com.amazonaws.iam#publicKeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier for the SSH public key.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier for the SSH public key.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -13887,6 +14483,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateServerCertificate": {
@@ -13912,7 +14511,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates the name and/or the path of the specified server certificate stored in\n            IAM.</p>\n        <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic also includes a list of Amazon Web Services services that can use the server certificates that\n            you manage with IAM.</p>\n        <important>\n            <p>You should understand the implications of changing a server certificate's path or\n                name. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs_manage.html#RenamingServerCerts\">Renaming a server certificate</a> in the\n                    <i>IAM User Guide</i>.</p>\n        </important>\n        <note>\n            <p>The person making the request (the principal), must have permission to change the\n                server certificate with the old name and the new name. For example, to change the\n                certificate named <code>ProductionCert</code> to <code>ProdCert</code>, the\n                principal must have a policy that allows them to update both certificates. If the\n                principal has permission to update the <code>ProductionCert</code> group, but not\n                the <code>ProdCert</code> certificate, then the update fails. For more information\n                about permissions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html\">Access management</a> in the <i>IAM User Guide</i>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Updates the name and/or the path of the specified server certificate stored in\n            IAM.</p>\n         <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic also includes a list of Amazon Web Services services that can use the server certificates that\n            you manage with IAM.</p>\n         <important>\n            <p>You should understand the implications of changing a server certificate's path or\n                name. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs_manage.html#RenamingServerCerts\">Renaming a server certificate</a> in the\n                    <i>IAM User Guide</i>.</p>\n         </important>\n         <note>\n            <p>The person making the request (the principal), must have permission to change the\n                server certificate with the old name and the new name. For example, to change the\n                certificate named <code>ProductionCert</code> to <code>ProdCert</code>, the\n                principal must have a policy that allows them to update both certificates. If the\n                principal has permission to update the <code>ProductionCert</code> group, but not\n                the <code>ProdCert</code> certificate, then the update fails. For more information\n                about permissions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/access.html\">Access management</a> in the <i>IAM User Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UpdateServerCertificateRequest": {
@@ -13921,22 +14520,25 @@
                 "ServerCertificateName": {
                     "target": "com.amazonaws.iam#serverCertificateNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the server certificate that you want to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the server certificate that you want to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "NewPath": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The new path for the server certificate. Include this only if you are updating the\n            server certificate's path.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>The new path for the server certificate. Include this only if you are updating the\n            server certificate's path.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "NewServerCertificateName": {
                     "target": "com.amazonaws.iam#serverCertificateNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The new name for the server certificate. Include this only if you are updating the\n            server certificate's name. The name of the certificate cannot contain any spaces.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The new name for the server certificate. Include this only if you are updating the\n            server certificate's name. The name of the certificate cannot contain any spaces.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateServiceSpecificCredential": {
@@ -13962,13 +14564,13 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user associated with the service-specific credential. If you do\n            not specify this value, then the operation assumes the user whose credentials are used\n            to call the operation.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user associated with the service-specific credential. If you do\n            not specify this value, then the operation assumes the user whose credentials are used\n            to call the operation.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "ServiceSpecificCredentialId": {
                     "target": "com.amazonaws.iam#serviceSpecificCredentialId",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier of the service-specific credential.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier of the service-specific credential.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -13979,6 +14581,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateSigningCertificate": {
@@ -14001,7 +14606,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Changes the status of the specified user signing certificate from active to disabled,\n            or vice versa. This operation can be used to disable an IAM user's signing certificate\n            as part of a certificate rotation work flow.</p>\n        <p>If the <code>UserName</code> field is not specified, the user name is determined\n            implicitly based on the Amazon Web Services access key ID used to sign the request. This operation\n            works for access keys under the Amazon Web Services account. Consequently, you can use this operation\n            to manage Amazon Web Services account root user credentials even if the Amazon Web Services account has no\n            associated users.</p>"
+                "smithy.api#documentation": "<p>Changes the status of the specified user signing certificate from active to disabled,\n            or vice versa. This operation can be used to disable an IAM user's signing\n            certificate as part of a certificate rotation work flow.</p>\n         <p>If the <code>UserName</code> field is not specified, the user name is determined\n            implicitly based on the Amazon Web Services access key ID used to sign the request. This operation\n            works for access keys under the Amazon Web Services account. Consequently, you can use this operation\n            to manage Amazon Web Services account root user credentials even if the Amazon Web Services account has no associated\n            users.</p>"
             }
         },
         "com.amazonaws.iam#UpdateSigningCertificateRequest": {
@@ -14010,13 +14615,13 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user the signing certificate belongs to.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the IAM user the signing certificate belongs to.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "CertificateId": {
                     "target": "com.amazonaws.iam#certificateIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ID of the signing certificate you want to update.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
+                        "smithy.api#documentation": "<p>The ID of the signing certificate you want to update.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters that can \n    consist of any upper or lowercased letter or digit.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -14027,6 +14632,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UpdateUser": {
@@ -14058,7 +14666,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates the name and/or the path of the specified IAM user.</p>\n        <important>\n            <p> You should understand the implications of changing an IAM user's path or name.\n                For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_renaming\">Renaming an IAM\n                    user</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage_rename.html\">Renaming an IAM\n                    group</a> in the <i>IAM User Guide</i>.</p>\n        </important>\n        <note>\n            <p> To change a user name, the requester must have appropriate permissions on both\n                the source object and the target object. For example, to change Bob to Robert, the\n                entity making the request must have permission on Bob and Robert, or must have\n                permission on all (*). For more information about permissions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/PermissionsAndPolicies.html\">Permissions and policies</a>. </p>\n        </note>"
+                "smithy.api#documentation": "<p>Updates the name and/or the path of the specified IAM user.</p>\n         <important>\n            <p> You should understand the implications of changing an IAM user's path or\n                name. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_users_manage.html#id_users_renaming\">Renaming an IAM\n                    user</a> and <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_groups_manage_rename.html\">Renaming an IAM\n                    group</a> in the <i>IAM User Guide</i>.</p>\n         </important>\n         <note>\n            <p> To change a user name, the requester must have appropriate permissions on both\n                the source object and the target object. For example, to change Bob to Robert, the\n                entity making the request must have permission on Bob and Robert, or must have\n                permission on all (*). For more information about permissions, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/PermissionsAndPolicies.html\">Permissions and policies</a>. </p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UpdateUserRequest": {
@@ -14067,22 +14675,25 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Name of the user to update. If you're changing the name of the user, this is the\n            original user name.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>Name of the user to update. If you're changing the name of the user, this is the\n            original user name.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "NewPath": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>New path for the IAM user. Include this parameter only if you're changing the user's\n            path.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
+                        "smithy.api#documentation": "<p>New path for the IAM user. Include this parameter only if you're changing the user's\n            path.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>"
                     }
                 },
                 "NewUserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>New name for the user. Include this parameter only if you're changing the user's\n            name.</p>\n        <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>"
+                        "smithy.api#documentation": "<p>New name for the user. Include this parameter only if you're changing the user's\n            name.</p>\n         <p>IAM user, group, role, and policy names must be unique within the account. Names are\n            not distinguished by case. For example, you cannot create resources named both\n            \"MyResource\" and \"myresource\".</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UploadSSHPublicKey": {
@@ -14111,7 +14722,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Uploads an SSH public key and associates it with the specified IAM user.</p>\n        <p>The SSH public key uploaded by this operation can be used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Uploads an SSH public key and associates it with the specified IAM user.</p>\n         <p>The SSH public key uploaded by this operation can be used only for authenticating the\n            associated IAM user to an CodeCommit repository. For more information about using SSH keys\n            to authenticate to an CodeCommit repository, see <a href=\"https://docs.aws.amazon.com/codecommit/latest/userguide/setting-up-credentials-ssh.html\">Set up CodeCommit for\n                SSH connections</a> in the <i>CodeCommit User Guide</i>.</p>"
             }
         },
         "com.amazonaws.iam#UploadSSHPublicKeyRequest": {
@@ -14120,17 +14731,20 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#userNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the IAM user to associate the SSH public key with.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name of the IAM user to associate the SSH public key with.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "SSHPublicKeyBody": {
                     "target": "com.amazonaws.iam#publicKeyMaterialType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n            The minimum bit-length of the public key is 2048 bits. For example, you can generate a\n            2048-bit key, and the resulting PEM file is 1679 bytes long.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The SSH public key. The public key must be encoded in ssh-rsa format or PEM format.\n            The minimum bit-length of the public key is 2048 bits. For example, you can generate a\n            2048-bit key, and the resulting PEM file is 1679 bytes long.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UploadSSHPublicKeyResponse": {
@@ -14144,7 +14758,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>UploadSSHPublicKey</a>\n      request.</p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>UploadSSHPublicKey</a>\n      request.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#UploadServerCertificate": {
@@ -14179,7 +14794,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Uploads a server certificate entity for the Amazon Web Services account. The server certificate\n            entity includes a public key certificate, a private key, and an optional certificate\n            chain, which should all be PEM-encoded.</p>\n        <p>We recommend that you use <a href=\"https://docs.aws.amazon.com/acm/\">Certificate Manager</a> to\n            provision, manage, and deploy your server certificates. With ACM you can request a\n            certificate, deploy it to Amazon Web Services resources, and let ACM handle certificate renewals for\n            you. Certificates provided by ACM are free. For more information about using ACM,\n            see the <a href=\"https://docs.aws.amazon.com/acm/latest/userguide/\">Certificate Manager User\n                Guide</a>.</p>\n        <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic includes a list of Amazon Web Services services that can use the server certificates that you\n            manage with IAM.</p>\n        <p>For information about the number of server certificates you can upload, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>\n        <note>\n            <p>Because the body of the public key certificate, private key, and the certificate\n                chain can be large, you should use POST rather than GET when calling\n                    <code>UploadServerCertificate</code>. For information about setting up\n                signatures and authorization through the API, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html\">Signing Amazon Web Services API\n                    requests</a> in the <i>Amazon Web Services General Reference</i>. For general\n                information about using the Query API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/programming.html\">Calling the API by making HTTP query\n                    requests</a> in the <i>IAM User Guide</i>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Uploads a server certificate entity for the Amazon Web Services account. The server certificate\n            entity includes a public key certificate, a private key, and an optional certificate\n            chain, which should all be PEM-encoded.</p>\n         <p>We recommend that you use <a href=\"https://docs.aws.amazon.com/acm/\">Certificate Manager</a> to\n            provision, manage, and deploy your server certificates. With ACM you can request a\n            certificate, deploy it to Amazon Web Services resources, and let ACM handle certificate renewals for\n            you. Certificates provided by ACM are free. For more information about using ACM,\n            see the <a href=\"https://docs.aws.amazon.com/acm/latest/userguide/\">Certificate Manager User\n                Guide</a>.</p>\n         <p>For more information about working with server certificates, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Working\n                with server certificates</a> in the <i>IAM User Guide</i>. This\n            topic includes a list of Amazon Web Services services that can use the server certificates that you\n            manage with IAM.</p>\n         <p>For information about the number of server certificates you can upload, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html\">IAM and STS\n                quotas</a> in the <i>IAM User Guide</i>.</p>\n         <note>\n            <p>Because the body of the public key certificate, private key, and the certificate\n                chain can be large, you should use POST rather than GET when calling\n                    <code>UploadServerCertificate</code>. For information about setting up\n                signatures and authorization through the API, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html\">Signing Amazon Web Services API\n                    requests</a> in the <i>Amazon Web Services General Reference</i>. For general\n                information about using the Query API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/programming.html\">Calling the API by making HTTP query\n                    requests</a> in the <i>IAM User Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UploadServerCertificateRequest": {
@@ -14188,34 +14803,34 @@
                 "Path": {
                     "target": "com.amazonaws.iam#pathType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The path for the server certificate. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n        <p>This parameter is optional. If it is not included, it defaults to a slash (/).\n            This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>\n        <note>\n            <p> If you are uploading a server certificate specifically for use with Amazon\n                CloudFront distributions, you must specify a path using the <code>path</code>\n                parameter. The path must begin with <code>/cloudfront</code> and must include a\n                trailing slash (for example, <code>/cloudfront/test/</code>).</p>\n        </note>"
+                        "smithy.api#documentation": "<p>The path for the server certificate. For more information about paths, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html\">IAM\n                identifiers</a> in the <i>IAM User Guide</i>.</p>\n         <p>This parameter is optional. If it is not included, it defaults to a slash (/).\n            This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting \n    of either a forward slash (/) by itself or a string that must begin and end with forward slashes.\n    In addition, it can contain any ASCII character from the ! (<code>\\u0021</code>) through the DEL character (<code>\\u007F</code>), including \n    most punctuation characters, digits, and upper and lowercased letters.</p>\n         <note>\n            <p> If you are uploading a server certificate specifically for use with Amazon\n                CloudFront distributions, you must specify a path using the <code>path</code>\n                parameter. The path must begin with <code>/cloudfront</code> and must include a\n                trailing slash (for example, <code>/cloudfront/test/</code>).</p>\n         </note>"
                     }
                 },
                 "ServerCertificateName": {
                     "target": "com.amazonaws.iam#serverCertificateNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name for the server certificate. Do not include the path in this value. The name\n            of the certificate cannot contain any spaces.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
+                        "smithy.api#documentation": "<p>The name for the server certificate. Do not include the path in this value. The name\n            of the certificate cannot contain any spaces.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "CertificateBody": {
                     "target": "com.amazonaws.iam#certificateBodyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The contents of the public key certificate in PEM-encoded format.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The contents of the public key certificate in PEM-encoded format.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
                 "PrivateKey": {
                     "target": "com.amazonaws.iam#privateKeyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The contents of the private key in PEM-encoded format.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The contents of the private key in PEM-encoded format.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 },
                 "CertificateChain": {
                     "target": "com.amazonaws.iam#certificateChainType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The contents of the certificate chain. This is typically a concatenation of the\n            PEM-encoded public key certificates of the chain.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>The contents of the certificate chain. This is typically a concatenation of the\n            PEM-encoded public key certificates of the chain.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>"
                     }
                 },
                 "Tags": {
@@ -14224,6 +14839,9 @@
                         "smithy.api#documentation": "<p>A list of tags that you want to attach to the new IAM server certificate resource.\n      Each tag consists of a key name and an associated value. For more information about tagging, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html\">Tagging IAM resources</a> in the\n      <i>IAM User Guide</i>.</p>\n         <note>\n            <p>If any one of the tags is invalid or if you exceed the allowed maximum number of tags, then the entire request \n   fails and the resource is not created.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UploadServerCertificateResponse": {
@@ -14243,7 +14861,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>UploadServerCertificate</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>UploadServerCertificate</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#UploadSigningCertificate": {
@@ -14278,7 +14897,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Uploads an X.509 signing certificate and associates it with the specified IAM user.\n            Some Amazon Web Services services require you to use certificates to validate requests that are signed\n            with a corresponding private key. When you upload the certificate, its default status is\n                <code>Active</code>.</p>\n        <p>For information about when you would use an X.509 signing certificate, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Managing\n                server certificates in IAM</a> in the\n            <i>IAM User Guide</i>.</p>\n        <p>If the <code>UserName</code> is not specified, the IAM user name is determined\n            implicitly based on the Amazon Web Services access key ID used to sign the request. This operation\n            works for access keys under the Amazon Web Services account. Consequently, you can use this operation\n            to manage Amazon Web Services account root user credentials even if the Amazon Web Services account has no\n            associated users.</p>\n        <note>\n            <p>Because the body of an X.509 certificate can be large, you should use POST rather\n                than GET when calling <code>UploadSigningCertificate</code>. For information about\n                setting up signatures and authorization through the API, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html\">Signing\n                    Amazon Web Services API requests</a> in the <i>Amazon Web Services General Reference</i>. For\n                general information about using the Query API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query\n                    requests</a> in the <i>IAM User Guide</i>.</p>\n        </note>"
+                "smithy.api#documentation": "<p>Uploads an X.509 signing certificate and associates it with the specified IAM user.\n            Some Amazon Web Services services require you to use certificates to validate requests that are signed\n            with a corresponding private key. When you upload the certificate, its default status is\n                <code>Active</code>.</p>\n         <p>For information about when you would use an X.509 signing certificate, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_server-certs.html\">Managing\n                server certificates in IAM</a> in the\n            <i>IAM User Guide</i>.</p>\n         <p>If the <code>UserName</code> is not specified, the IAM user name is determined\n            implicitly based on the Amazon Web Services access key ID used to sign the request. This operation\n            works for access keys under the Amazon Web Services account. Consequently, you can use this operation\n            to manage Amazon Web Services account root user credentials even if the Amazon Web Services account has no associated\n            users.</p>\n         <note>\n            <p>Because the body of an X.509 certificate can be large, you should use POST rather\n                than GET when calling <code>UploadSigningCertificate</code>. For information about\n                setting up signatures and authorization through the API, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html\">Signing\n                    Amazon Web Services API requests</a> in the <i>Amazon Web Services General Reference</i>. For\n                general information about using the Query API with IAM, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/IAM_UsingQueryAPI.html\">Making query\n                    requests</a> in the <i>IAM User Guide</i>.</p>\n         </note>"
             }
         },
         "com.amazonaws.iam#UploadSigningCertificateRequest": {
@@ -14287,16 +14906,19 @@
                 "UserName": {
                     "target": "com.amazonaws.iam#existingUserNameType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the user the signing certificate is for.</p>\n        <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
+                        "smithy.api#documentation": "<p>The name of the user the signing certificate is for.</p>\n         <p>This parameter allows (through its <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a>) a string of characters consisting of upper and lowercase alphanumeric \n    characters with no spaces. You can also include any of the following characters: _+=,.@-</p>"
                     }
                 },
                 "CertificateBody": {
                     "target": "com.amazonaws.iam#certificateBodyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The contents of the signing certificate.</p>\n        <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
+                        "smithy.api#documentation": "<p>The contents of the signing certificate.</p>\n         <p>The <a href=\"http://wikipedia.org/wiki/regex\">regex pattern</a> \n    used to validate this parameter is a string of characters consisting of the following:</p>\n         <ul>\n            <li>\n               <p>Any printable ASCII \n    character ranging from the space character (<code>\\u0020</code>) through the end of the ASCII character range</p>\n            </li>\n            <li>\n               <p>The printable characters in the Basic Latin and  Latin-1 Supplement character set \n    (through <code>\\u00FF</code>)</p>\n            </li>\n            <li>\n               <p>The special characters tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and \n    carriage return (<code>\\u000D</code>)</p>\n            </li>\n         </ul>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.iam#UploadSigningCertificateResponse": {
@@ -14311,7 +14933,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the response to a successful <a>UploadSigningCertificate</a>\n      request. </p>"
+                "smithy.api#documentation": "<p>Contains the response to a successful <a>UploadSigningCertificate</a>\n      request. </p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.iam#User": {

--- a/aws/sdk/aws-models/kms.json
+++ b/aws/sdk/aws-models/kms.json
@@ -176,10 +176,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key whose deletion is being canceled.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key whose deletion is being canceled.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#CancelKeyDeletionResponse": {
@@ -191,6 +194,9 @@
                         "smithy.api#documentation": "<p>The Amazon Resource Name (<a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">key ARN</a>) of the KMS key whose deletion is canceled.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#CiphertextType": {
@@ -240,7 +246,7 @@
                     "code": "CloudHsmClusterInvalidConfigurationException",
                     "httpResponseCode": 400
                 },
-                "smithy.api#documentation": "<p>The request was rejected because the associated CloudHSM cluster did not meet the\n      configuration requirements for an CloudHSM key store.</p>\n\n         <ul>\n            <li>\n               <p>The CloudHSM cluster must be configured with private subnets in at least two different\n          Availability Zones in the Region.</p>\n            </li>\n            <li>\n               <p>The <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html\">security group for\n            the cluster</a> (cloudhsm-cluster-<i><cluster-id></i>-sg) must\n          include inbound rules and outbound rules that allow TCP traffic on ports 2223-2225. The\n            <b>Source</b> in the inbound rules and the <b>Destination</b> in the outbound rules must match the security group\n          ID. These rules are set by default when you create the CloudHSM cluster. Do not delete or\n          change them. To get information about a particular security group, use the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html\">DescribeSecurityGroups</a> operation.</p>\n            </li>\n            <li>\n               <p>The CloudHSM cluster must contain at least as many HSMs as the operation requires. To add\n          HSMs, use the CloudHSM <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html\">CreateHsm</a> operation.</p>\n               <p>For the <a>CreateCustomKeyStore</a>, <a>UpdateCustomKeyStore</a>, and <a>CreateKey</a> operations, the CloudHSM cluster must have at least two\n          active HSMs, each in a different Availability Zone. For the <a>ConnectCustomKeyStore</a> operation, the CloudHSM must contain at least one active\n          HSM.</p>\n            </li>\n         </ul>\n         <p>For information about the requirements for an CloudHSM cluster that is associated with an\n      CloudHSM key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore\">Assemble the Prerequisites</a>\n      in the <i>Key Management Service Developer Guide</i>. For information about creating a private subnet for an CloudHSM cluster,\n      see <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html\">Create a Private\n        Subnet</a> in the <i>CloudHSM User Guide</i>. For information about cluster security groups, see\n        <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html\">Configure a Default Security\n        Group</a> in the <i>\n               <i>CloudHSM User Guide</i>\n            </i>. </p>",
+                "smithy.api#documentation": "<p>The request was rejected because the associated CloudHSM cluster did not meet the\n      configuration requirements for an CloudHSM key store.</p>\n         <ul>\n            <li>\n               <p>The CloudHSM cluster must be configured with private subnets in at least two different\n          Availability Zones in the Region.</p>\n            </li>\n            <li>\n               <p>The <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html\">security group for\n            the cluster</a> (cloudhsm-cluster-<i><cluster-id></i>-sg) must\n          include inbound rules and outbound rules that allow TCP traffic on ports 2223-2225. The\n            <b>Source</b> in the inbound rules and the <b>Destination</b> in the outbound rules must match the security group\n          ID. These rules are set by default when you create the CloudHSM cluster. Do not delete or\n          change them. To get information about a particular security group, use the <a href=\"https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html\">DescribeSecurityGroups</a> operation.</p>\n            </li>\n            <li>\n               <p>The CloudHSM cluster must contain at least as many HSMs as the operation requires. To add\n          HSMs, use the CloudHSM <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html\">CreateHsm</a> operation.</p>\n               <p>For the <a>CreateCustomKeyStore</a>, <a>UpdateCustomKeyStore</a>, and <a>CreateKey</a> operations, the CloudHSM cluster must have at least two\n          active HSMs, each in a different Availability Zone. For the <a>ConnectCustomKeyStore</a> operation, the CloudHSM must contain at least one active\n          HSM.</p>\n            </li>\n         </ul>\n         <p>For information about the requirements for an CloudHSM cluster that is associated with an\n      CloudHSM key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore\">Assemble the Prerequisites</a>\n      in the <i>Key Management Service Developer Guide</i>. For information about creating a private subnet for an CloudHSM cluster,\n      see <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/create-subnets.html\">Create a Private\n        Subnet</a> in the <i>CloudHSM User Guide</i>. For information about cluster security groups, see\n        <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/configure-sg.html\">Configure a Default Security\n        Group</a> in the <i>\n               <i>CloudHSM User Guide</i>\n            </i>. </p>",
                 "smithy.api#error": "client",
                 "smithy.api#httpError": 400
             }
@@ -322,7 +328,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Connects or reconnects a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> to its backing key store. For an CloudHSM key\n      store, <code>ConnectCustomKeyStore</code> connects the key store to its associated CloudHSM\n      cluster. For an external key store, <code>ConnectCustomKeyStore</code> connects the key store\n      to the external key store proxy that communicates with your external key manager.</p>\n         <p>The custom key store must be connected before you can create KMS keys in the key store or\n      use the KMS keys it contains. You can disconnect and reconnect a custom key store at any\n      time.</p>\n         <p>The connection process for a custom key store can take an extended amount of time to\n      complete. This operation starts the connection process, but it does not wait for it to\n      complete. When it succeeds, this operation quickly returns an HTTP 200 response and a JSON\n      object with no properties. However, this response does not indicate that the custom key store\n      is connected. To get the connection state of the custom key store, use the <a>DescribeCustomKeyStores</a> operation.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>The <code>ConnectCustomKeyStore</code> operation might fail for various reasons. To find\n      the reason, use the <a>DescribeCustomKeyStores</a> operation and see the\n        <code>ConnectionErrorCode</code> in the response. For help interpreting the\n        <code>ConnectionErrorCode</code>, see <a>CustomKeyStoresListEntry</a>.</p>\n         <p>To fix the failure, use the <a>DisconnectCustomKeyStore</a> operation to\n      disconnect the custom key store, correct the error, use the <a>UpdateCustomKeyStore</a> operation if necessary, and then use\n        <code>ConnectCustomKeyStore</code> again.</p>\n         <p>\n            <b>CloudHSM key store</b>\n         </p>\n         <p>During the connection process for an CloudHSM key store, KMS finds the CloudHSM cluster that\n      is associated with the custom key store, creates the connection infrastructure, connects to\n      the cluster, logs into the CloudHSM client as the <code>kmsuser</code> CU, and rotates its\n      password.</p>\n         <p>To connect an CloudHSM key store, its associated CloudHSM cluster must have at least one active\n      HSM. To get the number of active HSMs in a cluster, use the <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html\">DescribeClusters</a> operation. To add HSMs\n      to the cluster, use the <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html\">CreateHsm</a> operation. Also, the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser\">\n               <code>kmsuser</code> crypto\n        user</a> (CU) must not be logged into the cluster. This prevents KMS from using this\n      account to log in.</p>\n         <p>If you are having trouble connecting or disconnecting a CloudHSM key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html\">Troubleshooting an CloudHSM key\n        store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>External key store</b>\n         </p>\n         <p>When you connect an external key store that uses public endpoint connectivity, KMS tests\n      its ability to communicate with your external key manager by sending a request via the\n      external key store proxy.</p>\n         <p>When you connect to an external key store that uses VPC endpoint service connectivity,\n      KMS establishes the networking elements that it needs to communicate with your external key\n      manager via the external key store proxy. This includes creating an interface endpoint to the\n      VPC endpoint service and a private hosted zone for traffic between KMS and the VPC endpoint\n      service.</p>\n         <p>To connect an external key store, KMS must be able to connect to the external key store\n      proxy, the external key store proxy must be able to communicate with your external key\n      manager, and the external key manager must be available for cryptographic operations.</p>\n         <p>If you are having trouble connecting or disconnecting an external key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/xks-troubleshooting.html\">Troubleshooting an external\n        key store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ConnectCustomKeyStore</a> (IAM policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisconnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Connects or reconnects a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> to its backing key store. For an CloudHSM key\n      store, <code>ConnectCustomKeyStore</code> connects the key store to its associated CloudHSM\n      cluster. For an external key store, <code>ConnectCustomKeyStore</code> connects the key store\n      to the external key store proxy that communicates with your external key manager.</p>\n         <p>The custom key store must be connected before you can create KMS keys in the key store or\n      use the KMS keys it contains. You can disconnect and reconnect a custom key store at any\n      time.</p>\n         <p>The connection process for a custom key store can take an extended amount of time to\n      complete. This operation starts the connection process, but it does not wait for it to\n      complete. When it succeeds, this operation quickly returns an HTTP 200 response and a JSON\n      object with no properties. However, this response does not indicate that the custom key store\n      is connected. To get the connection state of the custom key store, use the <a>DescribeCustomKeyStores</a> operation.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>The <code>ConnectCustomKeyStore</code> operation might fail for various reasons. To find\n      the reason, use the <a>DescribeCustomKeyStores</a> operation and see the\n        <code>ConnectionErrorCode</code> in the response. For help interpreting the\n        <code>ConnectionErrorCode</code>, see <a>CustomKeyStoresListEntry</a>.</p>\n         <p>To fix the failure, use the <a>DisconnectCustomKeyStore</a> operation to\n      disconnect the custom key store, correct the error, use the <a>UpdateCustomKeyStore</a> operation if necessary, and then use\n        <code>ConnectCustomKeyStore</code> again.</p>\n         <p>\n            <b>CloudHSM key store</b>\n         </p>\n         <p>During the connection process for an CloudHSM key store, KMS finds the CloudHSM cluster that\n      is associated with the custom key store, creates the connection infrastructure, connects to\n      the cluster, logs into the CloudHSM client as the <code>kmsuser</code> CU, and rotates its\n      password.</p>\n         <p>To connect an CloudHSM key store, its associated CloudHSM cluster must have at least one active\n      HSM. To get the number of active HSMs in a cluster, use the <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_DescribeClusters.html\">DescribeClusters</a> operation. To add HSMs\n      to the cluster, use the <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/APIReference/API_CreateHsm.html\">CreateHsm</a> operation. Also, the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-store-concepts.html#concept-kmsuser\">\n               <code>kmsuser</code> crypto\n        user</a> (CU) must not be logged into the cluster. This prevents KMS from using this\n      account to log in.</p>\n         <p>If you are having trouble connecting or disconnecting a CloudHSM key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html\">Troubleshooting an CloudHSM key\n        store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>External key store</b>\n         </p>\n         <p>When you connect an external key store that uses public endpoint connectivity, KMS tests\n      its ability to communicate with your external key manager by sending a request via the\n      external key store proxy.</p>\n         <p>When you connect to an external key store that uses VPC endpoint service connectivity,\n      KMS establishes the networking elements that it needs to communicate with your external key\n      manager via the external key store proxy. This includes creating an interface endpoint to the\n      VPC endpoint service and a private hosted zone for traffic between KMS and the VPC endpoint\n      service.</p>\n         <p>To connect an external key store, KMS must be able to connect to the external key store\n      proxy, the external key store proxy must be able to communicate with your external key\n      manager, and the external key manager must be available for cryptographic operations.</p>\n         <p>If you are having trouble connecting or disconnecting an external key store, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/xks-troubleshooting.html\">Troubleshooting an external\n        key store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ConnectCustomKeyStore</a> (IAM policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisconnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#ConnectCustomKeyStoreRequest": {
@@ -335,11 +341,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ConnectCustomKeyStoreResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.kms#ConnectionErrorCodeType": {
             "type": "enum",
@@ -521,7 +533,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a friendly name for a KMS key. </p>\n         <note>\n            <p>Adding, deleting, or updating an alias can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>You can use an alias to identify a KMS key in the KMS console, in the <a>DescribeKey</a> operation and in <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>, such as <a>Encrypt</a> and\n        <a>GenerateDataKey</a>. You can also change the KMS key that's associated with\n      the alias (<a>UpdateAlias</a>) or delete the alias (<a>DeleteAlias</a>)\n      at any time. These operations don't affect the underlying KMS key. </p>\n         <p>You can associate the alias with any customer managed key in the same Amazon Web Services Region. Each\n      alias is associated with only one KMS key at a time, but a KMS key can have multiple aliases.\n      A valid KMS key is required. You can't create an alias without a KMS key.</p>\n         <p>The alias must be unique in the account and Region, but you can have aliases with the same\n      name in different Regions. For detailed information about aliases, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html\">Using aliases</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>This operation does not return a response. To get the alias that you created, use the\n        <a>ListAliases</a> operation.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on an alias in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateAlias</a> on\n          the alias (IAM policy).</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateAlias</a> on\n          the KMS key (key policy).</p>\n            </li>\n         </ul>\n         <p>For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access\">Controlling access to aliases</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DeleteAlias</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAliases</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateAlias</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Creates a friendly name for a KMS key. </p>\n         <note>\n            <p>Adding, deleting, or updating an alias can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>You can use an alias to identify a KMS key in the KMS console, in the <a>DescribeKey</a> operation and in <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>, such as <a>Encrypt</a> and\n        <a>GenerateDataKey</a>. You can also change the KMS key that's associated with\n      the alias (<a>UpdateAlias</a>) or delete the alias (<a>DeleteAlias</a>)\n      at any time. These operations don't affect the underlying KMS key. </p>\n         <p>You can associate the alias with any customer managed key in the same Amazon Web Services Region. Each\n      alias is associated with only one KMS key at a time, but a KMS key can have multiple aliases.\n      A valid KMS key is required. You can't create an alias without a KMS key.</p>\n         <p>The alias must be unique in the account and Region, but you can have aliases with the same\n      name in different Regions. For detailed information about aliases, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html\">Using aliases</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>This operation does not return a response. To get the alias that you created, use the\n        <a>ListAliases</a> operation.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on an alias in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateAlias</a> on\n          the alias (IAM policy).</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateAlias</a> on\n          the KMS key (key policy).</p>\n            </li>\n         </ul>\n         <p>For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access\">Controlling access to aliases</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DeleteAlias</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAliases</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateAlias</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#CreateAliasRequest": {
@@ -537,10 +549,13 @@
                 "TargetKeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Associates the alias with the specified <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>. The KMS key must\n      be in the same Amazon Web Services Region. </p>\n         <p>A valid key ID is required. If you supply a null or empty string value, this operation\n      returns an error.</p>\n         <p>For help finding the key ID and ARN, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn\">Finding the Key ID and\n        ARN</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Associates the alias with the specified <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>. The KMS key must\n      be in the same Amazon Web Services Region. </p>\n         <p>A valid key ID is required. If you supply a null or empty string value, this operation\n      returns an error.</p>\n         <p>For help finding the key ID and ARN, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn\">Finding the Key ID and\n        ARN</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#CreateCustomKeyStore": {
@@ -605,7 +620,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> backed by a key store that you own and manage. When you use a\n      KMS key in a custom key store for a cryptographic operation, the cryptographic operation is\n      actually performed in your key store using your keys. KMS supports <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key stores</a>\n      backed by an <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/clusters.html\">CloudHSM cluster</a>\n      and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key stores</a> backed by an external key store proxy and\n      external key manager outside of Amazon Web Services.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>Before you create the custom key store, the required elements must be in place and\n      operational. We recommend that you use the test tools that KMS provides to verify the\n      configuration your external key store proxy. For details about the required elements and\n      verification tests, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore\">Assemble the prerequisites (for\n        CloudHSM key stores)</a> or <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-xks-keystore.html#xks-requirements\">Assemble the prerequisites (for\n        external key stores)</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>To create a custom key store, use the following parameters.</p>\n         <ul>\n            <li>\n               <p>To create an CloudHSM key store, specify the <code>CustomKeyStoreName</code>,\n            <code>CloudHsmClusterId</code>, <code>KeyStorePassword</code>, and\n            <code>TrustAnchorCertificate</code>. The <code>CustomKeyStoreType</code> parameter is\n          optional for CloudHSM key stores. If you include it, set it to the default value,\n            <code>AWS_CLOUDHSM</code>. For help with failures, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html\">Troubleshooting an CloudHSM key store</a> in the\n          <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>To create an external key store, specify the <code>CustomKeyStoreName</code> and a\n            <code>CustomKeyStoreType</code> of <code>EXTERNAL_KEY_STORE</code>. Also, specify values\n          for <code>XksProxyConnectivity</code>, <code>XksProxyAuthenticationCredential</code>,\n            <code>XksProxyUriEndpoint</code>, and <code>XksProxyUriPath</code>. If your\n            <code>XksProxyConnectivity</code> value is <code>VPC_ENDPOINT_SERVICE</code>, specify\n          the <code>XksProxyVpcEndpointServiceName</code> parameter. For help with failures, see\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/xks-troubleshooting.html\">Troubleshooting\n            an external key store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n         </ul>    \n         <note>\n            <p>For external key stores:</p>\n            <p>Some external key managers provide a simpler method for creating an external key store.\n        For details, see your external key manager documentation.</p>\n            <p>When creating an external key store in the KMS console, you can upload a JSON-based\n        proxy configuration file with the desired values. You cannot use a proxy configuration\n        with the <code>CreateCustomKeyStore</code> operation. However, you can use the values in\n        the file to help you determine the correct values for the <code>CreateCustomKeyStore</code>\n        parameters.</p>\n         </note>\n         <p>When the operation completes successfully, it returns the ID of the new custom key store.\n      Before you can use your new custom key store, you need to use the <a>ConnectCustomKeyStore</a> operation to connect a new CloudHSM key store to its CloudHSM\n      cluster, or to connect a new external key store to the external key store proxy for your\n      external key manager. Even if you are not going to use your custom key store immediately, you\n      might want to connect it to verify that all settings are correct and then disconnect it until\n      you are ready to use it.</p>\n         <p>For help with failures, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html\">Troubleshooting a custom key store</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateCustomKeyStore</a> (IAM policy).</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ConnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisconnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Creates a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> backed by a key store that you own and manage. When you use a\n      KMS key in a custom key store for a cryptographic operation, the cryptographic operation is\n      actually performed in your key store using your keys. KMS supports <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key stores</a>\n      backed by an <a href=\"https://docs.aws.amazon.com/cloudhsm/latest/userguide/clusters.html\">CloudHSM cluster</a>\n      and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key stores</a> backed by an external key store proxy and\n      external key manager outside of Amazon Web Services.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>Before you create the custom key store, the required elements must be in place and\n      operational. We recommend that you use the test tools that KMS provides to verify the\n      configuration your external key store proxy. For details about the required elements and\n      verification tests, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-keystore.html#before-keystore\">Assemble the prerequisites (for\n        CloudHSM key stores)</a> or <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/create-xks-keystore.html#xks-requirements\">Assemble the prerequisites (for\n        external key stores)</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>To create a custom key store, use the following parameters.</p>\n         <ul>\n            <li>\n               <p>To create an CloudHSM key store, specify the <code>CustomKeyStoreName</code>,\n            <code>CloudHsmClusterId</code>, <code>KeyStorePassword</code>, and\n            <code>TrustAnchorCertificate</code>. The <code>CustomKeyStoreType</code> parameter is\n          optional for CloudHSM key stores. If you include it, set it to the default value,\n            <code>AWS_CLOUDHSM</code>. For help with failures, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html\">Troubleshooting an CloudHSM key store</a> in the\n          <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>To create an external key store, specify the <code>CustomKeyStoreName</code> and a\n            <code>CustomKeyStoreType</code> of <code>EXTERNAL_KEY_STORE</code>. Also, specify values\n          for <code>XksProxyConnectivity</code>, <code>XksProxyAuthenticationCredential</code>,\n            <code>XksProxyUriEndpoint</code>, and <code>XksProxyUriPath</code>. If your\n            <code>XksProxyConnectivity</code> value is <code>VPC_ENDPOINT_SERVICE</code>, specify\n          the <code>XksProxyVpcEndpointServiceName</code> parameter. For help with failures, see\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/xks-troubleshooting.html\">Troubleshooting\n            an external key store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n         </ul>\n         <note>\n            <p>For external key stores:</p>\n            <p>Some external key managers provide a simpler method for creating an external key store.\n        For details, see your external key manager documentation.</p>\n            <p>When creating an external key store in the KMS console, you can upload a JSON-based\n        proxy configuration file with the desired values. You cannot use a proxy configuration\n        with the <code>CreateCustomKeyStore</code> operation. However, you can use the values in\n        the file to help you determine the correct values for the <code>CreateCustomKeyStore</code>\n        parameters.</p>\n         </note>\n         <p>When the operation completes successfully, it returns the ID of the new custom key store.\n      Before you can use your new custom key store, you need to use the <a>ConnectCustomKeyStore</a> operation to connect a new CloudHSM key store to its CloudHSM\n      cluster, or to connect a new external key store to the external key store proxy for your\n      external key manager. Even if you are not going to use your custom key store immediately, you\n      might want to connect it to verify that all settings are correct and then disconnect it until\n      you are ready to use it.</p>\n         <p>For help with failures, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html\">Troubleshooting a custom key store</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateCustomKeyStore</a> (IAM policy).</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ConnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisconnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#CreateCustomKeyStoreRequest": {
@@ -672,6 +687,9 @@
                         "smithy.api#documentation": "<p>Indicates how KMS communicates with the external key store proxy. This parameter is\n      required for custom key stores with a <code>CustomKeyStoreType</code> of\n        <code>EXTERNAL_KEY_STORE</code>.</p>\n         <p>If the external key store proxy uses a public endpoint, specify\n        <code>PUBLIC_ENDPOINT</code>. If the external key store proxy uses a Amazon VPC\n      endpoint service for communication with KMS, specify <code>VPC_ENDPOINT_SERVICE</code>. For\n      help making this choice, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/plan-xks-keystore.html#choose-xks-connectivity\">Choosing a connectivity option</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>An Amazon VPC endpoint service keeps your communication with KMS in a private address space\n      entirely within Amazon Web Services, but it requires more configuration, including establishing a Amazon VPC with multiple subnets, a VPC endpoint service, a network load balancer, and a\n      verified private DNS name. A public endpoint is simpler to set up, but it might be slower and\n      might not fulfill your security requirements. You might consider testing with a public\n      endpoint, and then establishing a VPC endpoint service for production tasks. Note that this\n      choice does not determine the location of the external key store proxy. Even if you choose a\n      VPC endpoint service, the proxy can be hosted within the VPC or outside of Amazon Web Services such as in\n      your corporate data center.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#CreateCustomKeyStoreResponse": {
@@ -683,6 +701,9 @@
                         "smithy.api#documentation": "<p>A unique identifier for the new custom key store.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#CreateGrant": {
@@ -729,21 +750,21 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key for the grant. The grant gives principals permission to use this\n      KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key for the grant. The grant gives principals permission to use this\n      KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "GranteePrincipal": {
                     "target": "com.amazonaws.kms#PrincipalIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identity that gets the permissions specified in the grant.</p>\n         <p>To specify the principal, use the <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Name (ARN)</a> of an\n      Amazon Web Services principal. Valid Amazon Web Services principals include Amazon Web Services accounts (root), IAM users, IAM roles,\n      federated users, and assumed role users. For examples of the ARN syntax to use for specifying\n      a principal, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam\">Amazon Web Services Identity and Access\n        Management (IAM)</a> in the Example ARNs section of the <i>Amazon Web Services General\n        Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The identity that gets the permissions specified in the grant.</p>\n         <p>To specify the grantee principal, use the Amazon Resource Name (ARN) of an\n      Amazon Web Services principal. Valid principals include Amazon Web Services accounts, IAM users, IAM roles,\n      federated users, and assumed role users. For help with the ARN syntax for a principal, see\n        <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM ARNs</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "RetiringPrincipal": {
                     "target": "com.amazonaws.kms#PrincipalIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The principal that has permission to use the <a>RetireGrant</a> operation to\n      retire the grant. </p>\n         <p>To specify the principal, use the <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Name (ARN)</a> of an\n      Amazon Web Services principal. Valid Amazon Web Services principals include Amazon Web Services accounts (root), IAM users, federated\n      users, and assumed role users. For examples of the ARN syntax to use for specifying a\n      principal, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam\">Amazon Web Services Identity and Access\n        Management (IAM)</a> in the Example ARNs section of the <i>Amazon Web Services General\n        Reference</i>.</p>\n         <p>The grant determines the retiring principal. Other principals might have permission to\n      retire the grant or revoke the grant. For details, see <a>RevokeGrant</a> and\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete\">Retiring and\n        revoking grants</a> in the <i>Key Management Service Developer Guide</i>. </p>"
+                        "smithy.api#documentation": "<p>The principal that has permission to use the <a>RetireGrant</a> operation to\n      retire the grant. </p>\n         <p>To specify the principal, use the <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Name (ARN)</a> of an\n      Amazon Web Services principal. Valid principals include Amazon Web Services accounts, IAM users, IAM roles,\n      federated users, and assumed role users. For help with the ARN syntax for a principal, see\n        <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM ARNs</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>\n         <p>The grant determines the retiring principal. Other principals might have permission to\n      retire the grant or revoke the grant. For details, see <a>RevokeGrant</a> and\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#grant-delete\">Retiring and\n        revoking grants</a> in the <i>Key Management Service Developer Guide</i>. </p>"
                     }
                 },
                 "Operations": {
@@ -771,6 +792,9 @@
                         "smithy.api#documentation": "<p>A friendly name for the grant. Use this value to prevent the unintended creation of\n      duplicate grants when retrying this request.</p>\n         <p>When this value is absent, all <code>CreateGrant</code> requests result in a new grant\n      with a unique <code>GrantId</code> even if all the supplied parameters are identical. This can\n      result in unintended duplicates when you retry the <code>CreateGrant</code> request.</p>\n         <p>When this value is present, you can retry a <code>CreateGrant</code> request with\n      identical parameters; if the grant already exists, the original <code>GrantId</code> is\n      returned without creating a new grant. Note that the returned grant token is unique with every\n        <code>CreateGrant</code> request, even when a duplicate <code>GrantId</code> is returned.\n      All grant tokens for the same grant ID can be used interchangeably.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#CreateGrantResponse": {
@@ -788,6 +812,9 @@
                         "smithy.api#documentation": "<p>The unique identifier for the grant.</p>\n         <p>You can use the <code>GrantId</code> in a <a>ListGrants</a>, <a>RetireGrant</a>, or <a>RevokeGrant</a> operation.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#CreateKey": {
@@ -840,7 +867,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a unique customer managed <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms-keys\">KMS key</a> in your Amazon Web Services account and Region.\n      You can use a KMS key in cryptographic operations, such as encryption and signing. Some Amazon Web Services\n      services let you use KMS keys that you create and manage to protect your service\n      resources.</p>\n         <p>A KMS key is a logical representation of a cryptographic key. In addition to the key\n      material used in cryptographic operations, a KMS key includes metadata, such as the key ID,\n      key policy, creation date, description, and key state. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/getting-started.html\">Managing keys</a> in the\n      <i>Key Management Service Developer Guide</i>\n         </p>\n         <p>Use the parameters of <code>CreateKey</code> to specify the type of KMS key, the source of\n      its key material, its key policy, description, tags, and other properties.</p>\n         <note>\n            <p>KMS has replaced the term <i>customer master key (CMK)</i> with <i>KMS key</i> and <i>KMS key</i>. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.</p>\n         </note>\n\n\n         <p>To create different types of KMS keys, use the following guidance:</p>\n\n         <dl>\n            <dt>Symmetric encryption KMS key</dt>\n            <dd>\n               <p>By default, <code>CreateKey</code> creates a symmetric encryption KMS key with key\n            material that KMS generates. This is the basic and most widely used type of KMS key, and\n            provides the best performance.</p>\n               <p>To create a symmetric encryption KMS key, you don't need to specify any parameters.\n            The default value for <code>KeySpec</code>, <code>SYMMETRIC_DEFAULT</code>, the default\n            value for <code>KeyUsage</code>, <code>ENCRYPT_DECRYPT</code>, and the default value for\n              <code>Origin</code>, <code>AWS_KMS</code>, create a symmetric encryption KMS key with\n            KMS key material.</p>\n               <p>If you need a key for basic encryption and decryption or you are creating a KMS key\n            to protect your resources in an Amazon Web Services service, create a symmetric encryption KMS key.\n            The key material in a symmetric encryption key never leaves KMS unencrypted. You can\n            use a symmetric encryption KMS key to encrypt and decrypt data up to 4,096 bytes, but\n            they are typically used to generate data keys and data keys pairs. For details, see\n              <a>GenerateDataKey</a> and <a>GenerateDataKeyPair</a>.</p>\n               <p> </p>\n            </dd>\n            <dt>Asymmetric KMS keys</dt>\n            <dd>\n               <p>To create an asymmetric KMS key, use the <code>KeySpec</code> parameter to specify\n            the type of key material in the KMS key. Then, use the <code>KeyUsage</code> parameter\n            to determine whether the KMS key will be used to encrypt and decrypt or sign and verify.\n            You can't change these properties after the KMS key is created.</p>\n               <p>Asymmetric KMS keys contain an RSA key pair, Elliptic Curve (ECC) key pair, or an SM2 key pair (China Regions only). The private key in an asymmetric \n            KMS key never leaves KMS unencrypted. However, you can use the <a>GetPublicKey</a> operation to download the public key\n            so it can be used outside of KMS. KMS keys with RSA or SM2 key pairs can be used to encrypt or decrypt data or sign and verify messages (but not both). \n            KMS keys with ECC key pairs can be used only to sign and verify messages. \n            For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dt>HMAC KMS key</dt>\n            <dd>\n               <p>To create an HMAC KMS key, set the <code>KeySpec</code> parameter to a key spec\n            value for HMAC KMS keys. Then set the <code>KeyUsage</code> parameter to\n              <code>GENERATE_VERIFY_MAC</code>. You must set the key usage even though\n              <code>GENERATE_VERIFY_MAC</code> is the only valid key usage value for HMAC KMS keys.\n            You can't change these properties after the KMS key is created.</p>\n               <p>HMAC KMS keys are symmetric keys that never leave KMS unencrypted. You can use\n            HMAC keys to generate (<a>GenerateMac</a>) and verify (<a>VerifyMac</a>) HMAC codes for messages up to 4096 bytes.</p>\n               <p>HMAC KMS keys are not supported in all Amazon Web Services Regions. If you try to create an HMAC\n            KMS key in an Amazon Web Services Region in which HMAC keys are not supported, the\n              <code>CreateKey</code> operation returns an\n            <code>UnsupportedOperationException</code>. For a list of Regions in which HMAC KMS keys\n            are supported, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC keys in\n              KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dt>Multi-Region primary keys</dt>\n            <dt>Imported key material</dt>\n            <dd>\n               <p>To create a multi-Region <i>primary key</i> in the local Amazon Web Services Region,\n            use the <code>MultiRegion</code> parameter with a value of <code>True</code>. To create\n            a multi-Region <i>replica key</i>, that is, a KMS key with the same key ID\n            and key material as a primary key, but in a different Amazon Web Services Region, use the <a>ReplicateKey</a> operation. To change a replica key to a primary key, and its\n            primary key to a replica key, use the <a>UpdatePrimaryRegion</a>\n            operation.</p>\n               <p>You can create multi-Region KMS keys for all supported KMS key types: symmetric\n            encryption KMS keys, HMAC KMS keys, asymmetric encryption KMS keys, and asymmetric\n            signing KMS keys. You can also create multi-Region keys with imported key material.\n            However, you can't create multi-Region keys in a custom key store.</p>\n               <p>This operation supports <i>multi-Region keys</i>, an KMS feature that lets you create multiple\n      interoperable KMS keys in different Amazon Web Services Regions. Because these KMS keys have the same key ID, key\n      material, and other metadata, you can use them interchangeably to encrypt data in one Amazon Web Services Region and decrypt\n      it in a different Amazon Web Services Region without re-encrypting the data or making a cross-Region call. For more information about multi-Region keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html\">Multi-Region keys in KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dd>\n               <p>To import your own key material into a KMS key, begin by creating a symmetric\n            encryption KMS key with no key material. To do this, use the <code>Origin</code>\n            parameter of <code>CreateKey</code> with a value of <code>EXTERNAL</code>. Next, use\n              <a>GetParametersForImport</a> operation to get a public key and import\n            token, and use the public key to encrypt your key material. Then, use <a>ImportKeyMaterial</a> with your import token to import the key material. For\n            step-by-step instructions, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing Key Material</a> in the <i>\n                     <i>Key Management Service Developer Guide</i>\n                  </i>.</p>\n               <p>This feature supports only symmetric encryption KMS keys, including multi-Region\n            symmetric encryption KMS keys. You cannot import key material into any other type of KMS\n            key.</p>\n               <p>To create a multi-Region primary key with imported key material, use the\n              <code>Origin</code> parameter of <code>CreateKey</code> with a value of\n              <code>EXTERNAL</code> and the <code>MultiRegion</code> parameter with a value of\n              <code>True</code>. To create replicas of the multi-Region primary key, use the <a>ReplicateKey</a> operation. For instructions, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-import.html \">Importing key material into\n              multi-Region keys</a>. For more information about multi-Region keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html\">Multi-Region keys in KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dt>Custom key store</dt>\n            <dd>\n               <p>A <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> lets you protect your Amazon Web Services resources using keys in a backing key\n            store that you own and manage. When you request a cryptographic operation with a KMS key\n            in a custom key store, the operation is performed in the backing key store using its\n            cryptographic keys.</p>\n               <p>KMS supports <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key stores</a> backed by an CloudHSM cluster and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key stores</a> backed by an\n            external key manager outside of Amazon Web Services. When you create a KMS key in an CloudHSM key store,\n            KMS generates an encryption key in the CloudHSM cluster and associates it with the KMS\n            key. When you create a KMS key in an external key store, you specify an existing\n            encryption key in the external key manager.</p>\n               <note>\n                  <p>Some external key managers provide a simpler method for creating a KMS key in an\n              external key store. For details, see your external key manager documentation.</p>\n               </note>\n               <p>Before you create a KMS key in a custom key store, the <code>ConnectionState</code>\n            of the key store must be <code>CONNECTED</code>. To connect the custom key store, use\n            the <a>ConnectCustomKeyStore</a> operation. To find the\n              <code>ConnectionState</code>, use the <a>DescribeCustomKeyStores</a>\n            operation.</p>\n               <p>To create a KMS key in a custom key store, use the <code>CustomKeyStoreId</code>.\n            Use the default <code>KeySpec</code> value, <code>SYMMETRIC_DEFAULT</code>, and the\n            default <code>KeyUsage</code> value, <code>ENCRYPT_DECRYPT</code> to create a symmetric\n            encryption key. No other key type is supported in a custom key store.</p>\n               <p>To create a KMS key in an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key store</a>, use the\n              <code>Origin</code> parameter with a value of <code>AWS_CLOUDHSM</code>. The CloudHSM\n            cluster that is associated with the custom key store must have at least two active HSMs\n            in different Availability Zones in the Amazon Web Services Region.</p>\n               <p>To create a KMS key in an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key store</a>, use the <code>Origin</code> parameter\n            with a value of <code>EXTERNAL_KEY_STORE</code> and an <code>XksKeyId</code> parameter\n            that identifies an existing external key.</p>\n               <note>\n                  <p>Some external key managers provide a simpler method for creating a KMS key in an\n              external key store. For details, see your external key manager documentation.</p>\n               </note>\n            </dd>\n         </dl>\n         <p>\n            <b>Cross-account use</b>: No. You cannot use this operation to\n      create a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateKey</a> (IAM policy). To use the\n        <code>Tags</code> parameter, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:TagResource</a> (IAM policy). For examples and information about related\n      permissions, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-create-key\">Allow a user to create\n        KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DescribeKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListKeys</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ScheduleKeyDeletion</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Creates a unique customer managed <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms-keys\">KMS key</a> in your Amazon Web Services account and Region.\n      You can use a KMS key in cryptographic operations, such as encryption and signing. Some Amazon Web Services\n      services let you use KMS keys that you create and manage to protect your service\n      resources.</p>\n         <p>A KMS key is a logical representation of a cryptographic key. In addition to the key\n      material used in cryptographic operations, a KMS key includes metadata, such as the key ID,\n      key policy, creation date, description, and key state. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/getting-started.html\">Managing keys</a> in the\n      <i>Key Management Service Developer Guide</i>\n         </p>\n         <p>Use the parameters of <code>CreateKey</code> to specify the type of KMS key, the source of\n      its key material, its key policy, description, tags, and other properties.</p>\n         <note>\n            <p>KMS has replaced the term <i>customer master key (CMK)</i> with <i>KMS key</i> and <i>KMS key</i>. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.</p>\n         </note>\n         <p>To create different types of KMS keys, use the following guidance:</p>\n         <dl>\n            <dt>Symmetric encryption KMS key</dt>\n            <dd>\n               <p>By default, <code>CreateKey</code> creates a symmetric encryption KMS key with key\n            material that KMS generates. This is the basic and most widely used type of KMS key, and\n            provides the best performance.</p>\n               <p>To create a symmetric encryption KMS key, you don't need to specify any parameters.\n            The default value for <code>KeySpec</code>, <code>SYMMETRIC_DEFAULT</code>, the default\n            value for <code>KeyUsage</code>, <code>ENCRYPT_DECRYPT</code>, and the default value for\n              <code>Origin</code>, <code>AWS_KMS</code>, create a symmetric encryption KMS key with\n            KMS key material.</p>\n               <p>If you need a key for basic encryption and decryption or you are creating a KMS key\n            to protect your resources in an Amazon Web Services service, create a symmetric encryption KMS key.\n            The key material in a symmetric encryption key never leaves KMS unencrypted. You can\n            use a symmetric encryption KMS key to encrypt and decrypt data up to 4,096 bytes, but\n            they are typically used to generate data keys and data keys pairs. For details, see\n              <a>GenerateDataKey</a> and <a>GenerateDataKeyPair</a>.</p>\n               <p> </p>\n            </dd>\n            <dt>Asymmetric KMS keys</dt>\n            <dd>\n               <p>To create an asymmetric KMS key, use the <code>KeySpec</code> parameter to specify\n            the type of key material in the KMS key. Then, use the <code>KeyUsage</code> parameter\n            to determine whether the KMS key will be used to encrypt and decrypt or sign and verify.\n            You can't change these properties after the KMS key is created.</p>\n               <p>Asymmetric KMS keys contain an RSA key pair, Elliptic Curve (ECC) key pair, or an SM2 key pair (China Regions only). The private key in an asymmetric \n            KMS key never leaves KMS unencrypted. However, you can use the <a>GetPublicKey</a> operation to download the public key\n            so it can be used outside of KMS. KMS keys with RSA or SM2 key pairs can be used to encrypt or decrypt data or sign and verify messages (but not both). \n            KMS keys with ECC key pairs can be used only to sign and verify messages. \n            For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dt>HMAC KMS key</dt>\n            <dd>\n               <p>To create an HMAC KMS key, set the <code>KeySpec</code> parameter to a key spec\n            value for HMAC KMS keys. Then set the <code>KeyUsage</code> parameter to\n              <code>GENERATE_VERIFY_MAC</code>. You must set the key usage even though\n              <code>GENERATE_VERIFY_MAC</code> is the only valid key usage value for HMAC KMS keys.\n            You can't change these properties after the KMS key is created.</p>\n               <p>HMAC KMS keys are symmetric keys that never leave KMS unencrypted. You can use\n            HMAC keys to generate (<a>GenerateMac</a>) and verify (<a>VerifyMac</a>) HMAC codes for messages up to 4096 bytes.</p>\n               <p>HMAC KMS keys are not supported in all Amazon Web Services Regions. If you try to create an HMAC\n            KMS key in an Amazon Web Services Region in which HMAC keys are not supported, the\n              <code>CreateKey</code> operation returns an\n            <code>UnsupportedOperationException</code>. For a list of Regions in which HMAC KMS keys\n            are supported, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC keys in\n              KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dt>Multi-Region primary keys</dt>\n            <dt>Imported key material</dt>\n            <dd>\n               <p>To create a multi-Region <i>primary key</i> in the local Amazon Web Services Region,\n            use the <code>MultiRegion</code> parameter with a value of <code>True</code>. To create\n            a multi-Region <i>replica key</i>, that is, a KMS key with the same key ID\n            and key material as a primary key, but in a different Amazon Web Services Region, use the <a>ReplicateKey</a> operation. To change a replica key to a primary key, and its\n            primary key to a replica key, use the <a>UpdatePrimaryRegion</a>\n            operation.</p>\n               <p>You can create multi-Region KMS keys for all supported KMS key types: symmetric\n            encryption KMS keys, HMAC KMS keys, asymmetric encryption KMS keys, and asymmetric\n            signing KMS keys. You can also create multi-Region keys with imported key material.\n            However, you can't create multi-Region keys in a custom key store.</p>\n               <p>This operation supports <i>multi-Region keys</i>, an KMS feature that lets you create multiple\n      interoperable KMS keys in different Amazon Web Services Regions. Because these KMS keys have the same key ID, key\n      material, and other metadata, you can use them interchangeably to encrypt data in one Amazon Web Services Region and decrypt\n      it in a different Amazon Web Services Region without re-encrypting the data or making a cross-Region call. For more information about multi-Region keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html\">Multi-Region keys in KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dd>\n               <p>To import your own key material into a KMS key, begin by creating a symmetric\n            encryption KMS key with no key material. To do this, use the <code>Origin</code>\n            parameter of <code>CreateKey</code> with a value of <code>EXTERNAL</code>. Next, use\n              <a>GetParametersForImport</a> operation to get a public key and import\n            token, and use the public key to encrypt your key material. Then, use <a>ImportKeyMaterial</a> with your import token to import the key material. For\n            step-by-step instructions, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing Key Material</a> in the <i>\n                     <i>Key Management Service Developer Guide</i>\n                  </i>.</p>\n               <p>This feature supports only symmetric encryption KMS keys, including multi-Region\n            symmetric encryption KMS keys. You cannot import key material into any other type of KMS\n            key.</p>\n               <p>To create a multi-Region primary key with imported key material, use the\n              <code>Origin</code> parameter of <code>CreateKey</code> with a value of\n              <code>EXTERNAL</code> and the <code>MultiRegion</code> parameter with a value of\n              <code>True</code>. To create replicas of the multi-Region primary key, use the <a>ReplicateKey</a> operation. For instructions, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-import.html \">Importing key material into\n              multi-Region keys</a>. For more information about multi-Region keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-overview.html\">Multi-Region keys in KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n               <p> </p>\n            </dd>\n            <dt>Custom key store</dt>\n            <dd>\n               <p>A <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> lets you protect your Amazon Web Services resources using keys in a backing key\n            store that you own and manage. When you request a cryptographic operation with a KMS key\n            in a custom key store, the operation is performed in the backing key store using its\n            cryptographic keys.</p>\n               <p>KMS supports <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key stores</a> backed by an CloudHSM cluster and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key stores</a> backed by an\n            external key manager outside of Amazon Web Services. When you create a KMS key in an CloudHSM key store,\n            KMS generates an encryption key in the CloudHSM cluster and associates it with the KMS\n            key. When you create a KMS key in an external key store, you specify an existing\n            encryption key in the external key manager.</p>\n               <note>\n                  <p>Some external key managers provide a simpler method for creating a KMS key in an\n              external key store. For details, see your external key manager documentation.</p>\n               </note>\n               <p>Before you create a KMS key in a custom key store, the <code>ConnectionState</code>\n            of the key store must be <code>CONNECTED</code>. To connect the custom key store, use\n            the <a>ConnectCustomKeyStore</a> operation. To find the\n              <code>ConnectionState</code>, use the <a>DescribeCustomKeyStores</a>\n            operation.</p>\n               <p>To create a KMS key in a custom key store, use the <code>CustomKeyStoreId</code>.\n            Use the default <code>KeySpec</code> value, <code>SYMMETRIC_DEFAULT</code>, and the\n            default <code>KeyUsage</code> value, <code>ENCRYPT_DECRYPT</code> to create a symmetric\n            encryption key. No other key type is supported in a custom key store.</p>\n               <p>To create a KMS key in an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key store</a>, use the\n              <code>Origin</code> parameter with a value of <code>AWS_CLOUDHSM</code>. The CloudHSM\n            cluster that is associated with the custom key store must have at least two active HSMs\n            in different Availability Zones in the Amazon Web Services Region.</p>\n               <p>To create a KMS key in an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key store</a>, use the <code>Origin</code> parameter\n            with a value of <code>EXTERNAL_KEY_STORE</code> and an <code>XksKeyId</code> parameter\n            that identifies an existing external key.</p>\n               <note>\n                  <p>Some external key managers provide a simpler method for creating a KMS key in an\n              external key store. For details, see your external key manager documentation.</p>\n               </note>\n            </dd>\n         </dl>\n         <p>\n            <b>Cross-account use</b>: No. You cannot use this operation to\n      create a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:CreateKey</a> (IAM policy). To use the\n        <code>Tags</code> parameter, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:TagResource</a> (IAM policy). For examples and information about related\n      permissions, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policy-example-create-key\">Allow a user to create\n        KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DescribeKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListKeys</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ScheduleKeyDeletion</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#CreateKeyRequest": {
@@ -849,7 +876,7 @@
                 "Policy": {
                     "target": "com.amazonaws.kms#PolicyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The key policy to attach to the KMS key.</p>\n         <p>If you provide a key policy, it must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>If you don't set <code>BypassPolicyLockoutSafetyCheck</code> to true, the key policy\n          must allow the principal that is making the <code>CreateKey</code> request to make a\n          subsequent <a>PutKeyPolicy</a> request on the KMS key. This reduces the risk\n          that the KMS key becomes unmanageable. For more information, refer to the scenario in the\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section of the <i>\n                     <i>Key Management Service Developer Guide</i>\n                  </i>.</p>\n            </li>\n            <li>\n               <p>Each statement in the key policy must contain one or more principals. The principals\n          in the key policy must exist and be visible to KMS. When you create a new Amazon Web Services\n          principal (for example, an IAM user or role), you might need to enforce a delay before\n          including the new principal in a key policy because the new principal might not be\n          immediately visible to KMS. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>Amazon Web Services\n            Identity and Access Management User Guide</i>.</p>\n            </li>\n         </ul>\n         <p>If you do not provide a key policy, KMS attaches a default key policy to the KMS key.\n      For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default\">Default Key Policy</a> in the\n      <i>Key Management Service Developer Guide</i>. </p>\n         <p>The key policy size quota is 32 kilobytes (32768 bytes).</p>\n         <p>For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>"
+                        "smithy.api#documentation": "<p>The key policy to attach to the KMS key.</p>\n         <p>If you provide a key policy, it must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>The key policy must allow the calling principal to make a\n          subsequent <code>PutKeyPolicy</code> request on the KMS key.  This reduces the risk that\n          the KMS key becomes unmanageable. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key\">Default key policy</a> in the <i>Key Management Service Developer Guide</i>. (To omit\n          this condition, set <code>BypassPolicyLockoutSafetyCheck</code> to true.)</p>\n            </li>\n            <li>\n               <p>Each statement in the key policy must contain one or more principals. The principals\n          in the key policy must exist and be visible to KMS. When you create a new Amazon Web Services\n          principal, you might need to enforce a delay before including the new principal in a key\n          policy because the new principal might not be immediately visible to KMS. For more\n          information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>Amazon Web Services\n            Identity and Access Management User Guide</i>.</p>\n            </li>\n         </ul>\n         <p>If you do not provide a key policy, KMS attaches a default key policy to the KMS key.\n      For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default\">Default key policy</a> in the\n      <i>Key Management Service Developer Guide</i>. </p>\n         <p>The key policy size quota is 32 kilobytes (32768 bytes).</p>\n         <p>For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>"
                     }
                 },
                 "Description": {
@@ -876,7 +903,7 @@
                 "KeySpec": {
                     "target": "com.amazonaws.kms#KeySpec",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the type of KMS key to create. The default value,\n      <code>SYMMETRIC_DEFAULT</code>, creates a KMS key with a 256-bit AES-GCM key that is used for encryption and decryption, except in China Regions, \n      where it creates a 128-bit symmetric key that uses SM4 encryption. For help choosing a key spec for your KMS key, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-types.html#symm-asymm-choose\">Choosing a KMS key type</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <p>The <code>KeySpec</code> determines whether the KMS key contains a symmetric key or an\n      asymmetric key pair. It also determines the algorithms that the KMS key supports. You can't\n      change the <code>KeySpec</code> after the KMS key is created. To further restrict the\n      algorithms that can be used with the KMS key, use a condition key in its key policy or IAM\n      policy. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-encryption-algorithm\">kms:EncryptionAlgorithm</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-mac-algorithm\">kms:MacAlgorithm</a> or <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-signing-algorithm\">kms:Signing Algorithm</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <important>\n            <p>\n               <a href=\"http://aws.amazon.com/kms/features/#AWS_Service_Integration\">Amazon Web Services services that\n          are integrated with KMS</a> use symmetric encryption KMS keys to protect your data.\n        These services do not support asymmetric KMS keys or HMAC KMS keys.</p>\n         </important>\n         <p>KMS supports the following key specs for KMS keys:</p>\n         <ul>\n            <li>\n               <p>Symmetric encryption key (default)</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>SYMMETRIC_DEFAULT</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>HMAC keys (symmetric)</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>HMAC_224</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>HMAC_256</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>HMAC_384</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>HMAC_512</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Asymmetric RSA key pairs</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSA_2048</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSA_3072</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSA_4096</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Asymmetric NIST-recommended elliptic curve key pairs</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ECC_NIST_P256</code> (secp256r1)</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ECC_NIST_P384</code> (secp384r1)</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ECC_NIST_P521</code> (secp521r1)</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Other asymmetric elliptic curve key pairs</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ECC_SECG_P256K1</code> (secp256k1), commonly used for\n              cryptocurrencies.</p>\n                  </li>\n               </ul>        \n            </li>\n            <li>\n               <p>SM2 key pairs (China Regions only)</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>SM2</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Specifies the type of KMS key to create. The default value,\n      <code>SYMMETRIC_DEFAULT</code>, creates a KMS key with a 256-bit AES-GCM key that is used for encryption and decryption, except in China Regions, \n      where it creates a 128-bit symmetric key that uses SM4 encryption. For help choosing a key spec for your KMS key, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-types.html#symm-asymm-choose\">Choosing a KMS key type</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <p>The <code>KeySpec</code> determines whether the KMS key contains a symmetric key or an\n      asymmetric key pair. It also determines the algorithms that the KMS key supports. You can't\n      change the <code>KeySpec</code> after the KMS key is created. To further restrict the\n      algorithms that can be used with the KMS key, use a condition key in its key policy or IAM\n      policy. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-encryption-algorithm\">kms:EncryptionAlgorithm</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-mac-algorithm\">kms:MacAlgorithm</a> or <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/policy-conditions.html#conditions-kms-signing-algorithm\">kms:Signing Algorithm</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <important>\n            <p>\n               <a href=\"http://aws.amazon.com/kms/features/#AWS_Service_Integration\">Amazon Web Services services that\n          are integrated with KMS</a> use symmetric encryption KMS keys to protect your data.\n        These services do not support asymmetric KMS keys or HMAC KMS keys.</p>\n         </important>\n         <p>KMS supports the following key specs for KMS keys:</p>\n         <ul>\n            <li>\n               <p>Symmetric encryption key (default)</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>SYMMETRIC_DEFAULT</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>HMAC keys (symmetric)</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>HMAC_224</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>HMAC_256</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>HMAC_384</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>HMAC_512</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Asymmetric RSA key pairs</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSA_2048</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSA_3072</code>\n                     </p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSA_4096</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Asymmetric NIST-recommended elliptic curve key pairs</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ECC_NIST_P256</code> (secp256r1)</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ECC_NIST_P384</code> (secp384r1)</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>ECC_NIST_P521</code> (secp521r1)</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>Other asymmetric elliptic curve key pairs</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>ECC_SECG_P256K1</code> (secp256k1), commonly used for\n              cryptocurrencies.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>SM2 key pairs (China Regions only)</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>SM2</code>\n                     </p>\n                  </li>\n               </ul>\n            </li>\n         </ul>"
                     }
                 },
                 "Origin": {
@@ -895,7 +922,7 @@
                     "target": "com.amazonaws.kms#BooleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p>\n         <important>\n            <p>Setting this value to true increases the risk that the KMS key becomes unmanageable. Do\n        not set this value to true indiscriminately.</p>\n            <p>For more information, refer to the scenario in the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>\n                  <i>Key Management Service Developer Guide</i>\n               </i>.</p>\n         </important>\n         <p>Use this parameter only when you include a policy in the request and you intend to prevent\n      the principal that is making the request from making a subsequent <a>PutKeyPolicy</a> request on the KMS key.</p>\n         <p>The default value is false.</p>"
+                        "smithy.api#documentation": "<p>Skips (\"bypasses\") the key policy lockout safety check. The default value is false.</p>\n         <important>\n            <p>Setting this value to true increases the risk that the KMS key becomes unmanageable. Do\n        not set this value to true indiscriminately.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key\">Default key policy</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </important>\n         <p>Use this parameter only when you intend to prevent the principal that is making the\n      request from making a subsequent <a>PutKeyPolicy</a> request on the KMS key.</p>"
                     }
                 },
                 "Tags": {
@@ -916,6 +943,9 @@
                         "smithy.api#documentation": "<p>Identifies the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html#concept-external-key\">external key</a> that\n      serves as key material for the KMS key in an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html\">external key store</a>. Specify the ID that\n      the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html#concept-xks-proxy\">external key store proxy</a> uses to refer to the external key. For help, see the\n      documentation for your external key store proxy.</p>\n         <p>This parameter is required for a KMS key with an <code>Origin</code> value of\n        <code>EXTERNAL_KEY_STORE</code>. It is not valid for KMS keys with any other\n        <code>Origin</code> value.</p>\n         <p>The external key must be an existing 256-bit AES symmetric encryption key hosted outside\n      of Amazon Web Services in an external key manager associated with the external key store specified by the\n        <code>CustomKeyStoreId</code> parameter. This key must be enabled and configured to perform\n      encryption and decryption. Each KMS key in an external key store must use a different external\n      key. For details, see <a href=\"https://docs.aws.amazon.com/create-xks-keys.html#xks-key-requirements\">Requirements for a KMS key in an external\n        key store</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>Each KMS key in an external key store is associated two backing keys. One is key material\n      that KMS generates. The other is the external key specified by this parameter. When you use\n      the KMS key in an external key store to encrypt data, the encryption operation is performed\n      first by KMS using the KMS key material, and then by the external key manager using the\n      specified external key, a process known as <i>double encryption</i>. For\n      details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/keystore-external.html#concept-double-encryption\">Double\n        encryption</a> in the <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#CreateKeyResponse": {
@@ -927,6 +957,9 @@
                         "smithy.api#documentation": "<p>Metadata associated with the KMS key.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#CustomKeyStoreHasCMKsException": {
@@ -1074,7 +1107,7 @@
                 "ConnectionErrorCode": {
                     "target": "com.amazonaws.kms#ConnectionErrorCodeType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Describes the connection error. This field appears in the response only when the\n        <code>ConnectionState</code> is <code>FAILED</code>.</p>\n         <p>Many failures can be resolved by updating the properties of the custom key store. To\n      update a custom key store, disconnect it (<a>DisconnectCustomKeyStore</a>), correct\n      the errors (<a>UpdateCustomKeyStore</a>), and try to connect again (<a>ConnectCustomKeyStore</a>). For additional help resolving these errors, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed\">How to Fix a\n        Connection Failure</a> in <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>All custom key stores:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>INTERNAL_ERROR</code> — KMS could not complete the request due to an\n          internal error. Retry the request. For <code>ConnectCustomKeyStore</code> requests,\n          disconnect the custom key store before trying to connect again.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NETWORK_ERRORS</code> — Network errors are preventing KMS from\n          connecting the custom key store to its backing key store.</p>\n            </li>\n         </ul>\n\n         <p>\n            <b>CloudHSM key stores:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>CLUSTER_NOT_FOUND</code> — KMS cannot find the CloudHSM cluster with the\n          specified cluster ID.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INSUFFICIENT_CLOUDHSM_HSMS</code> — The associated CloudHSM cluster does not\n          contain any active HSMs. To connect a custom key store to its CloudHSM cluster, the cluster\n          must contain at least one active HSM.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET</code> — At least one private subnet\n          associated with the CloudHSM cluster doesn't have any available IP addresses. A CloudHSM key\n          store connection requires one free IP address in each of the associated private subnets,\n          although two are preferable. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed\">How to Fix a Connection\n            Failure</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INVALID_CREDENTIALS</code> — The <code>KeyStorePassword</code> for the\n          custom key store doesn't match the current password of the <code>kmsuser</code> crypto\n          user in the CloudHSM cluster. Before you can connect your custom key store to its CloudHSM\n          cluster, you must change the <code>kmsuser</code> account password and update the\n            <code>KeyStorePassword</code> value for the custom key store.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUBNET_NOT_FOUND</code> — A subnet in the CloudHSM cluster configuration was\n          deleted. If KMS cannot find all of the subnets in the cluster configuration, attempts to\n          connect the custom key store to the CloudHSM cluster fail. To fix this error, create a\n          cluster from a recent backup and associate it with your custom key store. (This process\n          creates a new cluster configuration with a VPC and private subnets.) For details, see\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed\">How\n            to Fix a Connection Failure</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>USER_LOCKED_OUT</code> — The <code>kmsuser</code> CU account is locked\n          out of the associated CloudHSM cluster due to too many failed password attempts. Before you\n          can connect your custom key store to its CloudHSM cluster, you must change the\n            <code>kmsuser</code> account password and update the key store password value for the\n          custom key store.</p>\n            </li>\n            <li>\n               <p>\n                  <code>USER_LOGGED_IN</code> — The <code>kmsuser</code> CU account is logged\n          into the associated CloudHSM cluster. This prevents KMS from rotating the\n            <code>kmsuser</code> account password and logging into the cluster. Before you can\n          connect your custom key store to its CloudHSM cluster, you must log the <code>kmsuser</code>\n          CU out of the cluster. If you changed the <code>kmsuser</code> password to log into the\n          cluster, you must also and update the key store password value for the custom key store.\n          For help, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#login-kmsuser-2\">How to Log Out and\n            Reconnect</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>USER_NOT_FOUND</code> — KMS cannot find a <code>kmsuser</code> CU\n          account in the associated CloudHSM cluster. Before you can connect your custom key store to\n          its CloudHSM cluster, you must create a <code>kmsuser</code> CU account in the cluster, and\n          then update the key store password value for the custom key store.</p>\n            </li>\n         </ul>\n\n         <p>\n            <b>External key stores:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>INVALID_CREDENTIALS</code> — One or both of the\n            <code>XksProxyAuthenticationCredential</code> values is not valid on the specified\n          external key store proxy.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_ACCESS_DENIED</code> — KMS requests are denied access to the\n          external key store proxy. If the external key store proxy has authorization rules, verify\n          that they permit KMS to communicate with the proxy on your behalf.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_INVALID_CONFIGURATION</code> — A configuration error is\n          preventing the external key store from connecting to its proxy. Verify the value of the\n            <code>XksProxyUriPath</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_INVALID_RESPONSE</code> — KMS cannot interpret the response\n          from the external key store proxy. If you see this connection error code repeatedly,\n          notify your external key store proxy vendor.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_INVALID_TLS_CONFIGURATION</code> — KMS cannot connect to the\n          external key store proxy because the TLS configuration is invalid. Verify that the XKS\n          proxy supports TLS 1.2 or 1.3. Also, verify that the TLS certificate is not expired, and\n          that it matches the hostname in the <code>XksProxyUriEndpoint</code> value, and that it is\n          signed by a certificate authority included in the <a href=\"https://github.com/aws/aws-kms-xksproxy-api-spec/blob/main/TrustedCertificateAuthorities\">Trusted Certificate Authorities</a>\n          list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_NOT_REACHABLE</code> — KMS can't communicate with your\n          external key store proxy. Verify that the <code>XksProxyUriEndpoint</code> and\n            <code>XksProxyUriPath</code> are correct. Use the tools for your external key store\n          proxy to verify that the proxy is active and available on its network. Also, verify that\n          your external key manager instances are operating properly. Connection attempts fail with\n          this connection error code if the proxy reports that all external key manager instances\n          are unavailable.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_TIMED_OUT</code> — KMS can connect to the external key store\n          proxy, but the proxy does not respond to KMS in the time allotted. If you see this\n          connection error code repeatedly, notify your external key store proxy vendor.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_VPC_ENDPOINT_SERVICE_INVALID_CONFIGURATION</code> — The Amazon VPC\n          endpoint service configuration doesn't conform to the requirements for an KMS external\n          key store.</p>\n        \n\t \n\t              <ul>\n                  <li>\n                     <p>The VPC endpoint service must be an endpoint service for interface endpoints in the caller's Amazon Web Services account.</p>\n                  </li>\n                  <li>\n                     <p>It must have a network load balancer (NLB) connected to at least two subnets, each in a different Availability Zone.</p>\n                  </li>\n                  <li>\n                     <p>The <code>Allow principals</code> list must include \n\t         the KMS service principal for the Region, <code>cks.kms.<region>.amazonaws.com</code>,  \n\t         such as <code>cks.kms.us-east-1.amazonaws.com</code>.</p>\n                  </li>\n                  <li>\n                     <p>It must <i>not</i> require <a href=\"https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html\">acceptance</a> of connection requests.</p>\n                  </li>\n                  <li>\n                     <p>It must have a private DNS name. The private DNS name for an external key store with <code>VPC_ENDPOINT_SERVICE</code> connectivity\n\t       must be unique in its Amazon Web Services Region.</p>\n                  </li>\n                  <li>\n                     <p>The domain of the private DNS name must have a <a href=\"https://docs.aws.amazon.com/vpc/latest/privatelink/verify-domains.html\">verification status</a> of\n\t         <code>verified</code>.</p>\n                  </li>\n                  <li>\n                     <p>The <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html\">TLS certificate</a> specifies the private DNS hostname at which the endpoint is reachable.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_VPC_ENDPOINT_SERVICE_NOT_FOUND</code> — KMS can't find the VPC\n          endpoint service that it uses to communicate with the external key store proxy. Verify\n          that the <code>XksProxyVpcEndpointServiceName</code> is correct and the KMS service\n          principal has service consumer permissions on the Amazon VPC endpoint service.</p>\n            </li>\n         </ul>"
+                        "smithy.api#documentation": "<p>Describes the connection error. This field appears in the response only when the\n        <code>ConnectionState</code> is <code>FAILED</code>.</p>\n         <p>Many failures can be resolved by updating the properties of the custom key store. To\n      update a custom key store, disconnect it (<a>DisconnectCustomKeyStore</a>), correct\n      the errors (<a>UpdateCustomKeyStore</a>), and try to connect again (<a>ConnectCustomKeyStore</a>). For additional help resolving these errors, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed\">How to Fix a\n        Connection Failure</a> in <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>All custom key stores:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>INTERNAL_ERROR</code> — KMS could not complete the request due to an\n          internal error. Retry the request. For <code>ConnectCustomKeyStore</code> requests,\n          disconnect the custom key store before trying to connect again.</p>\n            </li>\n            <li>\n               <p>\n                  <code>NETWORK_ERRORS</code> — Network errors are preventing KMS from\n          connecting the custom key store to its backing key store.</p>\n            </li>\n         </ul>\n         <p>\n            <b>CloudHSM key stores:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>CLUSTER_NOT_FOUND</code> — KMS cannot find the CloudHSM cluster with the\n          specified cluster ID.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INSUFFICIENT_CLOUDHSM_HSMS</code> — The associated CloudHSM cluster does not\n          contain any active HSMs. To connect a custom key store to its CloudHSM cluster, the cluster\n          must contain at least one active HSM.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INSUFFICIENT_FREE_ADDRESSES_IN_SUBNET</code> — At least one private subnet\n          associated with the CloudHSM cluster doesn't have any available IP addresses. A CloudHSM key\n          store connection requires one free IP address in each of the associated private subnets,\n          although two are preferable. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed\">How to Fix a Connection\n            Failure</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>INVALID_CREDENTIALS</code> — The <code>KeyStorePassword</code> for the\n          custom key store doesn't match the current password of the <code>kmsuser</code> crypto\n          user in the CloudHSM cluster. Before you can connect your custom key store to its CloudHSM\n          cluster, you must change the <code>kmsuser</code> account password and update the\n            <code>KeyStorePassword</code> value for the custom key store.</p>\n            </li>\n            <li>\n               <p>\n                  <code>SUBNET_NOT_FOUND</code> — A subnet in the CloudHSM cluster configuration was\n          deleted. If KMS cannot find all of the subnets in the cluster configuration, attempts to\n          connect the custom key store to the CloudHSM cluster fail. To fix this error, create a\n          cluster from a recent backup and associate it with your custom key store. (This process\n          creates a new cluster configuration with a VPC and private subnets.) For details, see\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-failed\">How\n            to Fix a Connection Failure</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>USER_LOCKED_OUT</code> — The <code>kmsuser</code> CU account is locked\n          out of the associated CloudHSM cluster due to too many failed password attempts. Before you\n          can connect your custom key store to its CloudHSM cluster, you must change the\n            <code>kmsuser</code> account password and update the key store password value for the\n          custom key store.</p>\n            </li>\n            <li>\n               <p>\n                  <code>USER_LOGGED_IN</code> — The <code>kmsuser</code> CU account is logged\n          into the associated CloudHSM cluster. This prevents KMS from rotating the\n            <code>kmsuser</code> account password and logging into the cluster. Before you can\n          connect your custom key store to its CloudHSM cluster, you must log the <code>kmsuser</code>\n          CU out of the cluster. If you changed the <code>kmsuser</code> password to log into the\n          cluster, you must also and update the key store password value for the custom key store.\n          For help, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#login-kmsuser-2\">How to Log Out and\n            Reconnect</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>USER_NOT_FOUND</code> — KMS cannot find a <code>kmsuser</code> CU\n          account in the associated CloudHSM cluster. Before you can connect your custom key store to\n          its CloudHSM cluster, you must create a <code>kmsuser</code> CU account in the cluster, and\n          then update the key store password value for the custom key store.</p>\n            </li>\n         </ul>\n         <p>\n            <b>External key stores:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <code>INVALID_CREDENTIALS</code> — One or both of the\n            <code>XksProxyAuthenticationCredential</code> values is not valid on the specified\n          external key store proxy.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_ACCESS_DENIED</code> — KMS requests are denied access to the\n          external key store proxy. If the external key store proxy has authorization rules, verify\n          that they permit KMS to communicate with the proxy on your behalf.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_INVALID_CONFIGURATION</code> — A configuration error is\n          preventing the external key store from connecting to its proxy. Verify the value of the\n            <code>XksProxyUriPath</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_INVALID_RESPONSE</code> — KMS cannot interpret the response\n          from the external key store proxy. If you see this connection error code repeatedly,\n          notify your external key store proxy vendor.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_INVALID_TLS_CONFIGURATION</code> — KMS cannot connect to the\n          external key store proxy because the TLS configuration is invalid. Verify that the XKS\n          proxy supports TLS 1.2 or 1.3. Also, verify that the TLS certificate is not expired, and\n          that it matches the hostname in the <code>XksProxyUriEndpoint</code> value, and that it is\n          signed by a certificate authority included in the <a href=\"https://github.com/aws/aws-kms-xksproxy-api-spec/blob/main/TrustedCertificateAuthorities\">Trusted Certificate Authorities</a>\n          list.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_NOT_REACHABLE</code> — KMS can't communicate with your\n          external key store proxy. Verify that the <code>XksProxyUriEndpoint</code> and\n            <code>XksProxyUriPath</code> are correct. Use the tools for your external key store\n          proxy to verify that the proxy is active and available on its network. Also, verify that\n          your external key manager instances are operating properly. Connection attempts fail with\n          this connection error code if the proxy reports that all external key manager instances\n          are unavailable.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_PROXY_TIMED_OUT</code> — KMS can connect to the external key store\n          proxy, but the proxy does not respond to KMS in the time allotted. If you see this\n          connection error code repeatedly, notify your external key store proxy vendor.</p>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_VPC_ENDPOINT_SERVICE_INVALID_CONFIGURATION</code> — The Amazon VPC\n          endpoint service configuration doesn't conform to the requirements for an KMS external\n          key store.</p>\n               <ul>\n                  <li>\n                     <p>The VPC endpoint service must be an endpoint service for interface endpoints in the caller's Amazon Web Services account.</p>\n                  </li>\n                  <li>\n                     <p>It must have a network load balancer (NLB) connected to at least two subnets, each in a different Availability Zone.</p>\n                  </li>\n                  <li>\n                     <p>The <code>Allow principals</code> list must include \n\t         the KMS service principal for the Region, <code>cks.kms.<region>.amazonaws.com</code>,  \n\t         such as <code>cks.kms.us-east-1.amazonaws.com</code>.</p>\n                  </li>\n                  <li>\n                     <p>It must <i>not</i> require <a href=\"https://docs.aws.amazon.com/vpc/latest/privatelink/create-endpoint-service.html\">acceptance</a> of connection requests.</p>\n                  </li>\n                  <li>\n                     <p>It must have a private DNS name. The private DNS name for an external key store with <code>VPC_ENDPOINT_SERVICE</code> connectivity\n\t       must be unique in its Amazon Web Services Region.</p>\n                  </li>\n                  <li>\n                     <p>The domain of the private DNS name must have a <a href=\"https://docs.aws.amazon.com/vpc/latest/privatelink/verify-domains.html\">verification status</a> of\n\t         <code>verified</code>.</p>\n                  </li>\n                  <li>\n                     <p>The <a href=\"https://docs.aws.amazon.com/elasticloadbalancing/latest/network/create-tls-listener.html\">TLS certificate</a> specifies the private DNS hostname at which the endpoint is reachable.</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>XKS_VPC_ENDPOINT_SERVICE_NOT_FOUND</code> — KMS can't find the VPC\n          endpoint service that it uses to communicate with the external key store proxy. Verify\n          that the <code>XksProxyVpcEndpointServiceName</code> is correct and the KMS service\n          principal has service consumer permissions on the Amazon VPC endpoint service.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "CreationDate": {
@@ -1302,7 +1335,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Decrypts ciphertext that was encrypted by a KMS key using any of the following\n      operations:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>\n         <p>You can use this operation to decrypt ciphertext that was encrypted under a symmetric\n      encryption KMS key or an asymmetric encryption KMS key. When the KMS key is asymmetric, you\n      must specify the KMS key and the encryption algorithm that was used to encrypt the ciphertext.\n      For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The <code>Decrypt</code> operation also decrypts ciphertext that was encrypted outside of\n      KMS by the public key in an KMS asymmetric KMS key. However, it cannot decrypt symmetric\n      ciphertext produced by other libraries, such as the <a href=\"https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/\">Amazon Web Services Encryption SDK</a> or <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3 client-side encryption</a>.\n      These libraries return a ciphertext format that is incompatible with KMS.</p>\n         <p>If the ciphertext was encrypted under a symmetric encryption KMS key, the\n        <code>KeyId</code> parameter is optional. KMS can get this information from metadata that\n      it adds to the symmetric ciphertext blob. This feature adds durability to your implementation\n      by ensuring that authorized users can decrypt ciphertext decades after it was encrypted, even\n      if they've lost track of the key ID. However, specifying the KMS key is always recommended as\n      a best practice. When you use the <code>KeyId</code> parameter to specify a KMS key, KMS\n      only uses the KMS key you specify. If the ciphertext was encrypted under a different KMS key,\n      the <code>Decrypt</code> operation fails. This practice ensures that you use the KMS key that\n      you intend.</p>\n         <p>Whenever possible, use key policies to give users permission to call the\n        <code>Decrypt</code> operation on a particular KMS key, instead of using IAM policies.\n      Otherwise, you might create an IAM user policy that gives the user <code>Decrypt</code>\n      permission on all KMS keys. This user could decrypt ciphertext that was encrypted by KMS keys\n      in other accounts if the key policy for the cross-account KMS key permits it. If you must use\n      an IAM policy for <code>Decrypt</code> permissions, limit the user to particular KMS keys or\n      particular trusted accounts. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policies-best-practices\">Best practices for IAM\n        policies</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>Applications in Amazon Web Services Nitro Enclaves can call this operation by using the <a href=\"https://github.com/aws/aws-nitro-enclaves-sdk-c\">Amazon Web Services Nitro Enclaves Development Kit</a>. For information about the supporting parameters, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html\">How Amazon Web Services Nitro Enclaves use KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter. </p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Decrypt</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReEncrypt</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Decrypts ciphertext that was encrypted by a KMS key using any of the following\n      operations:</p>\n         <ul>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>\n         <p>You can use this operation to decrypt ciphertext that was encrypted under a symmetric\n      encryption KMS key or an asymmetric encryption KMS key. When the KMS key is asymmetric, you\n      must specify the KMS key and the encryption algorithm that was used to encrypt the ciphertext.\n      For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The <code>Decrypt</code> operation also decrypts ciphertext that was encrypted outside of\n      KMS by the public key in an KMS asymmetric KMS key. However, it cannot decrypt symmetric\n      ciphertext produced by other libraries, such as the <a href=\"https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/\">Amazon Web Services Encryption SDK</a> or <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3 client-side encryption</a>.\n      These libraries return a ciphertext format that is incompatible with KMS.</p>\n         <p>If the ciphertext was encrypted under a symmetric encryption KMS key, the\n        <code>KeyId</code> parameter is optional. KMS can get this information from metadata that\n      it adds to the symmetric ciphertext blob. This feature adds durability to your implementation\n      by ensuring that authorized users can decrypt ciphertext decades after it was encrypted, even\n      if they've lost track of the key ID. However, specifying the KMS key is always recommended as\n      a best practice. When you use the <code>KeyId</code> parameter to specify a KMS key, KMS\n      only uses the KMS key you specify. If the ciphertext was encrypted under a different KMS key,\n      the <code>Decrypt</code> operation fails. This practice ensures that you use the KMS key that\n      you intend.</p>\n         <p>Whenever possible, use key policies to give users permission to call the\n        <code>Decrypt</code> operation on a particular KMS key, instead of using &IAM; policies.\n      Otherwise, you might create an &IAM; policy that gives the user <code>Decrypt</code>\n      permission on all KMS keys. This user could decrypt ciphertext that was encrypted by KMS keys\n      in other accounts if the key policy for the cross-account KMS key permits it. If you must use\n      an IAM policy for <code>Decrypt</code> permissions, limit the user to particular KMS keys or\n      particular trusted accounts. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/iam-policies.html#iam-policies-best-practices\">Best practices for IAM\n        policies</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>Applications in Amazon Web Services Nitro Enclaves can call this operation by using the <a href=\"https://github.com/aws/aws-nitro-enclaves-sdk-c\">Amazon Web Services Nitro Enclaves Development Kit</a>. For information about the supporting parameters, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html\">How Amazon Web Services Nitro Enclaves use KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. If you use the <code>KeyId</code>\n      parameter to identify a KMS key in a different Amazon Web Services account, specify the key ARN or the alias\n      ARN of the KMS key.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Decrypt</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReEncrypt</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#DecryptRequest": {
@@ -1330,7 +1363,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the KMS key that KMS uses to decrypt the ciphertext.</p>\n\n         <p>Enter a key ID of the KMS key that was used to encrypt the ciphertext. If you identify a\n      different KMS key, the <code>Decrypt</code> operation throws an\n        <code>IncorrectKeyException</code>.</p>\n\n         <p>This parameter is required only when the ciphertext was encrypted under an asymmetric KMS\n      key. If you used a symmetric encryption KMS key, KMS can get the KMS key from metadata that\n      it adds to the symmetric ciphertext blob. However, it is always recommended as a best\n      practice. This practice ensures that you use the KMS key that you intend.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>"
+                        "smithy.api#documentation": "<p>Specifies the KMS key that KMS uses to decrypt the ciphertext.</p>\n         <p>Enter a key ID of the KMS key that was used to encrypt the ciphertext. If you identify a\n      different KMS key, the <code>Decrypt</code> operation throws an\n        <code>IncorrectKeyException</code>.</p>\n         <p>This parameter is required only when the ciphertext was encrypted under an asymmetric KMS\n      key. If you used a symmetric encryption KMS key, KMS can get the KMS key from metadata that\n      it adds to the symmetric ciphertext blob. However, it is always recommended as a best\n      practice. This practice ensures that you use the KMS key that you intend.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>"
                     }
                 },
                 "EncryptionAlgorithm": {
@@ -1339,6 +1372,9 @@
                         "smithy.api#documentation": "<p>Specifies the encryption algorithm that will be used to decrypt the ciphertext. Specify\n      the same algorithm that was used to encrypt the data. If you specify a different algorithm,\n      the <code>Decrypt</code> operation fails.</p>\n         <p>This parameter is required only when the ciphertext was encrypted under an asymmetric KMS\n      key. The default value, <code>SYMMETRIC_DEFAULT</code>, represents the only supported\n      algorithm that is valid for symmetric encryption KMS keys.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DecryptResponse": {
@@ -1362,6 +1398,9 @@
                         "smithy.api#documentation": "<p>The encryption algorithm that was used to decrypt the ciphertext.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#DeleteAlias": {
@@ -1400,6 +1439,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DeleteCustomKeyStore": {
@@ -1425,7 +1467,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. This operation does not affect any backing elements of the\n      custom key store. It does not delete the CloudHSM cluster that is associated with an CloudHSM key\n      store, or affect any users or keys in the cluster. For an external key store, it does not\n      affect the external key store proxy, external key manager, or any external keys.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>The custom key store that you delete cannot contain any <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys\">KMS keys</a>. Before deleting the key store,\n      verify that you will never need to use any of the KMS keys in the key store for any\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>. Then, use <a>ScheduleKeyDeletion</a> to delete the KMS keys from the\n      key store. After the required waiting period expires and all KMS keys are deleted from the\n      custom key store, use <a>DisconnectCustomKeyStore</a> to disconnect the key store\n      from KMS. Then, you can delete the custom key store.</p>\n         <p>For keys in an CloudHSM key store, the <code>ScheduleKeyDeletion</code> operation makes a\n      best effort to delete the key material from the associated cluster. However, you might need to\n      manually <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key\">delete the orphaned key\n        material</a> from the cluster and its backups. KMS never creates, manages, or deletes\n      cryptographic keys in the external key manager associated with an external key store. You must\n      manage them using your external key manager tools.</p>\n         <p>Instead of deleting the custom key store, consider using the <a>DisconnectCustomKeyStore</a> operation to disconnect the custom key store from its\n      backing key store. While the key store is disconnected, you cannot create or use the KMS keys\n      in the key store. But, you do not need to delete KMS keys and you can reconnect a disconnected\n      custom key store at any time.</p>\n         <p>If the operation succeeds, it returns a JSON object with no\nproperties.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DeleteCustomKeyStore</a> (IAM policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ConnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>CreateCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisconnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Deletes a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. This operation does not affect any backing elements of the\n      custom key store. It does not delete the CloudHSM cluster that is associated with an CloudHSM key\n      store, or affect any users or keys in the cluster. For an external key store, it does not\n      affect the external key store proxy, external key manager, or any external keys.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>The custom key store that you delete cannot contain any <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#kms_keys\">KMS keys</a>. Before deleting the key store,\n      verify that you will never need to use any of the KMS keys in the key store for any\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>. Then, use <a>ScheduleKeyDeletion</a> to delete the KMS keys from the\n      key store. After the required waiting period expires and all KMS keys are deleted from the\n      custom key store, use <a>DisconnectCustomKeyStore</a> to disconnect the key store\n      from KMS. Then, you can delete the custom key store.</p>\n         <p>For keys in an CloudHSM key store, the <code>ScheduleKeyDeletion</code> operation makes a\n      best effort to delete the key material from the associated cluster. However, you might need to\n      manually <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key\">delete the orphaned key\n        material</a> from the cluster and its backups. KMS never creates, manages, or deletes\n      cryptographic keys in the external key manager associated with an external key store. You must\n      manage them using your external key manager tools.</p>\n         <p>Instead of deleting the custom key store, consider using the <a>DisconnectCustomKeyStore</a> operation to disconnect the custom key store from its\n      backing key store. While the key store is disconnected, you cannot create or use the KMS keys\n      in the key store. But, you do not need to delete KMS keys and you can reconnect a disconnected\n      custom key store at any time.</p>\n         <p>If the operation succeeds, it returns a JSON object with no\nproperties.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DeleteCustomKeyStore</a> (IAM policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ConnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>CreateCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisconnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#DeleteCustomKeyStoreRequest": {
@@ -1438,11 +1480,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DeleteCustomKeyStoreResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.kms#DeleteImportedKeyMaterial": {
             "type": "operation",
@@ -1473,7 +1521,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes key material that you previously imported. This operation makes the specified KMS\n      key unusable. For more information about importing key material into KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing Key Material</a>\n      in the <i>Key Management Service Developer Guide</i>. </p>\n         <p>When the specified KMS key is in the <code>PendingDeletion</code> state, this operation\n      does not change the KMS key's state. Otherwise, it changes the KMS key's state to\n        <code>PendingImport</code>.</p>\n         <p>After you delete key material, you can use <a>ImportKeyMaterial</a> to reimport\n      the same key material into the KMS key.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DeleteImportedKeyMaterial</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetParametersForImport</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ImportKeyMaterial</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Deletes key material that you previously imported. This operation makes the specified KMS\n      key unusable. For more information about importing key material into KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing Key Material</a>\n      in the <i>Key Management Service Developer Guide</i>. </p>\n         <p>When the specified KMS key is in the <code>PendingDeletion</code> state, this operation\n      does not change the KMS key's state. Otherwise, it changes the KMS key's state to\n        <code>PendingImport</code>.</p>\n         <p>After you delete key material, you can use <a>ImportKeyMaterial</a> to reimport\n      the same key material into the KMS key.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DeleteImportedKeyMaterial</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetParametersForImport</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ImportKeyMaterial</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#DeleteImportedKeyMaterialRequest": {
@@ -1482,10 +1530,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key from which you are deleting imported key material. The\n        <code>Origin</code> of the KMS key must be <code>EXTERNAL</code>.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key from which you are deleting imported key material. The\n        <code>Origin</code> of the KMS key must be <code>EXTERNAL</code>.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DependencyTimeoutException": {
@@ -1561,6 +1612,9 @@
                         "smithy.api#documentation": "<p>Use this parameter in a subsequent request after you receive a response with\n    truncated results. Set it to the value of <code>NextMarker</code> from the truncated response\n    you just received.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DescribeCustomKeyStoresResponse": {
@@ -1585,6 +1639,9 @@
                         "smithy.api#documentation": "<p>A flag that indicates whether there are more items in the list. When this\n    value is true, the list in this response is truncated. To get more items, pass the value of\n    the <code>NextMarker</code> element in thisresponse to the <code>Marker</code> parameter in a\n    subsequent request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#DescribeKey": {
@@ -1610,7 +1667,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Provides detailed information about a KMS key. You can run <code>DescribeKey</code> on a\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed\n        key</a> or an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a>.</p>\n         <p>This detailed information includes the key ARN, creation date (and deletion date, if\n      applicable), the key state, and the origin and expiration date (if any) of the key material.\n      It includes fields, like <code>KeySpec</code>, that help you distinguish different types of\n      KMS keys. It also displays the key usage (encryption, signing, or generating and verifying\n      MACs) and the algorithms that the KMS key supports. </p>\n         <p>For <a href=\"kms/latest/developerguide/multi-region-keys-overview.html\">multi-Region keys</a>,\n        <code>DescribeKey</code> displays the primary key and all related replica keys. For KMS keys\n      in <a href=\"kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key stores</a>, it includes\n      information about the key store, such as the key store ID and the CloudHSM cluster ID. For KMS\n      keys in <a href=\"kms/latest/developerguide/keystore-external.html\">external key stores</a>, it\n      includes the custom key store ID and the ID of the external key.</p>\n         <p>\n            <code>DescribeKey</code> does not return the following information:</p>\n         <ul>\n            <li>\n               <p>Aliases associated with the KMS key. To get this information, use <a>ListAliases</a>.</p>\n            </li>\n            <li>\n               <p>Whether automatic key rotation is enabled on the KMS key. To get this information, use\n            <a>GetKeyRotationStatus</a>. Also, some key states prevent a KMS key from\n          being automatically rotated. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works\">How Automatic Key Rotation\n            Works</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>Tags on the KMS key. To get this information, use <a>ListResourceTags</a>.</p>\n            </li>\n            <li>\n               <p>Key policies and grants on the KMS key. To get this information, use <a>GetKeyPolicy</a> and <a>ListGrants</a>.</p>\n            </li>\n         </ul>\n         <p>In general, <code>DescribeKey</code> is a non-mutating operation. It returns data about\n      KMS keys, but doesn't change them. However, Amazon Web Services services use <code>DescribeKey</code> to\n      create <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services\n        managed keys</a> from a <i>predefined Amazon Web Services alias</i> with no key\n      ID.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DescribeKey</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetKeyPolicy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetKeyRotationStatus</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAliases</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListGrants</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListKeys</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListRetirableGrants</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Provides detailed information about a KMS key. You can run <code>DescribeKey</code> on a\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed\n        key</a> or an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a>.</p>\n         <p>This detailed information includes the key ARN, creation date (and deletion date, if\n      applicable), the key state, and the origin and expiration date (if any) of the key material.\n      It includes fields, like <code>KeySpec</code>, that help you distinguish different types of\n      KMS keys. It also displays the key usage (encryption, signing, or generating and verifying\n      MACs) and the algorithms that the KMS key supports. </p>\n         <p>For <a href=\"kms/latest/developerguide/multi-region-keys-overview.html\">multi-Region keys</a>,\n        <code>DescribeKey</code> displays the primary key and all related replica keys. For KMS keys\n      in <a href=\"kms/latest/developerguide/keystore-cloudhsm.html\">CloudHSM key stores</a>, it includes\n      information about the key store, such as the key store ID and the CloudHSM cluster ID. For KMS\n      keys in <a href=\"kms/latest/developerguide/keystore-external.html\">external key stores</a>, it\n      includes the custom key store ID and the ID of the external key.</p>\n         <p>\n            <code>DescribeKey</code> does not return the following information:</p>\n         <ul>\n            <li>\n               <p>Aliases associated with the KMS key. To get this information, use <a>ListAliases</a>.</p>\n            </li>\n            <li>\n               <p>Whether automatic key rotation is enabled on the KMS key. To get this information, use\n            <a>GetKeyRotationStatus</a>. Also, some key states prevent a KMS key from\n          being automatically rotated. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-how-it-works\">How Automatic Key Rotation\n            Works</a> in the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>Tags on the KMS key. To get this information, use <a>ListResourceTags</a>.</p>\n            </li>\n            <li>\n               <p>Key policies and grants on the KMS key. To get this information, use <a>GetKeyPolicy</a> and <a>ListGrants</a>.</p>\n            </li>\n         </ul>\n         <p>In general, <code>DescribeKey</code> is a non-mutating operation. It returns data about\n      KMS keys, but doesn't change them. However, Amazon Web Services services use <code>DescribeKey</code> to\n      create <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services\n        managed keys</a> from a <i>predefined Amazon Web Services alias</i> with no key\n      ID.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DescribeKey</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetKeyPolicy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetKeyRotationStatus</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAliases</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListGrants</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListKeys</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListRetirableGrants</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#DescribeKeyRequest": {
@@ -1619,7 +1676,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Describes the specified KMS key. </p>\n         <p>If you specify a predefined Amazon Web Services alias (an Amazon Web Services alias with no key ID), KMS associates\n      the alias with an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html##aws-managed-cmk\">Amazon Web Services managed key</a> and returns its\n        <code>KeyId</code> and <code>Arn</code> in the response.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Describes the specified KMS key. </p>\n         <p>If you specify a predefined Amazon Web Services alias (an Amazon Web Services alias with no key ID), KMS associates\n      the alias with an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html##aws-managed-cmk\">Amazon Web Services managed key</a> and returns its\n        <code>KeyId</code> and <code>Arn</code> in the response.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -1629,6 +1686,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DescribeKeyResponse": {
@@ -1640,6 +1700,9 @@
                         "smithy.api#documentation": "<p>Metadata associated with the key.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#DescriptionType": {
@@ -1677,7 +1740,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Sets the state of a KMS key to disabled. This change temporarily prevents use of the KMS\n      key for <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>. </p>\n         <p>For more information about how key state affects the use of a KMS key, see\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DisableKey</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>EnableKey</a>\n         </p>"
+                "smithy.api#documentation": "<p>Sets the state of a KMS key to disabled. This change temporarily prevents use of the KMS\n      key for <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>. </p>\n         <p>For more information about how key state affects the use of a KMS key, see\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DisableKey</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>EnableKey</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#DisableKeyRequest": {
@@ -1686,10 +1749,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key to disable.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key to disable.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DisableKeyRotation": {
@@ -1724,7 +1790,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Disables <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html\">automatic\n        rotation of the key material</a> of the specified symmetric encryption KMS key.</p>\n         <p>Automatic key rotation is supported only on symmetric encryption KMS keys.\n      You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key.</p>\n         <p>You can enable (<a>EnableKeyRotation</a>) and disable automatic rotation of the\n      key material in <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed KMS keys</a>. Key material rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed KMS keys</a> is not\n      configurable. KMS always rotates the key material for every year. Rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned KMS\n        keys</a> varies.</p>\n         <note>\n            <p>In May 2022, KMS changed the rotation schedule for Amazon Web Services managed keys from every three\n        years to every year. For details, see <a>EnableKeyRotation</a>.</p>\n         </note>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DisableKeyRotation</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>EnableKeyRotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetKeyRotationStatus</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Disables <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html\">automatic\n        rotation of the key material</a> of the specified symmetric encryption KMS key.</p>\n         <p>Automatic key rotation is supported only on symmetric encryption KMS keys.\n      You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key.</p>\n         <p>You can enable (<a>EnableKeyRotation</a>) and disable automatic rotation of the\n      key material in <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed KMS keys</a>. Key material rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed KMS keys</a> is not\n      configurable. KMS always rotates the key material for every year. Rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned KMS\n        keys</a> varies.</p>\n         <note>\n            <p>In May 2022, KMS changed the rotation schedule for Amazon Web Services managed keys from every three\n        years to every year. For details, see <a>EnableKeyRotation</a>.</p>\n         </note>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DisableKeyRotation</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>EnableKeyRotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetKeyRotationStatus</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#DisableKeyRotationRequest": {
@@ -1733,10 +1799,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies a symmetric encryption KMS key. You cannot enable or disable automatic rotation\n      of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC\n        KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies a symmetric encryption KMS key. You cannot enable or disable automatic rotation\n      of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html#asymmetric-cmks\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC\n        KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DisabledException": {
@@ -1776,7 +1845,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Disconnects the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> from its backing key store. This operation disconnects an\n      CloudHSM key store from its associated CloudHSM cluster or disconnects an external key store from\n      the external key store proxy that communicates with your external key manager.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>While a custom key store is disconnected, you can manage the custom key store and its KMS\n      keys, but you cannot create or use its KMS keys. You can reconnect the custom key store at any\n      time.</p>\n         <note>\n            <p>While a custom key store is disconnected, all attempts to create KMS keys in the custom key store or to use existing KMS keys in <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a> will\n        fail. This action can prevent users from storing and accessing sensitive data.</p>\n         </note>\n         <p>When you disconnect a custom key store, its <code>ConnectionState</code> changes to\n        <code>Disconnected</code>. To find the connection state of a custom key store, use the <a>DescribeCustomKeyStores</a> operation. To reconnect a custom key store, use the\n        <a>ConnectCustomKeyStore</a> operation.</p>\n         <p>If the operation succeeds, it returns a JSON object with no\nproperties.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DisconnectCustomKeyStore</a> (IAM policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ConnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>CreateCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Disconnects the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a> from its backing key store. This operation disconnects an\n      CloudHSM key store from its associated CloudHSM cluster or disconnects an external key store from\n      the external key store proxy that communicates with your external key manager.</p>\n         <p> This operation is part of the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key stores</a> feature in KMS, which\ncombines the convenience and extensive integration of KMS with the isolation and control of a\nkey store that you own and manage.</p>\n         <p>While a custom key store is disconnected, you can manage the custom key store and its KMS\n      keys, but you cannot create or use its KMS keys. You can reconnect the custom key store at any\n      time.</p>\n         <note>\n            <p>While a custom key store is disconnected, all attempts to create KMS keys in the custom key store or to use existing KMS keys in <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a> will\n        fail. This action can prevent users from storing and accessing sensitive data.</p>\n         </note>\n         <p>When you disconnect a custom key store, its <code>ConnectionState</code> changes to\n        <code>Disconnected</code>. To find the connection state of a custom key store, use the <a>DescribeCustomKeyStores</a> operation. To reconnect a custom key store, use the\n        <a>ConnectCustomKeyStore</a> operation.</p>\n         <p>If the operation succeeds, it returns a JSON object with no\nproperties.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a custom key store in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:DisconnectCustomKeyStore</a> (IAM policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ConnectCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>CreateCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteCustomKeyStore</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeCustomKeyStores</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateCustomKeyStore</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#DisconnectCustomKeyStoreRequest": {
@@ -1789,11 +1858,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#DisconnectCustomKeyStoreResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.kms#EnableKey": {
             "type": "operation",
@@ -1824,7 +1899,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Sets the key state of a KMS key to enabled. This allows you to use the KMS key for\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:EnableKey</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>DisableKey</a>\n         </p>"
+                "smithy.api#documentation": "<p>Sets the key state of a KMS key to enabled. This allows you to use the KMS key for\n      <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#cryptographic-operations\">cryptographic operations</a>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:EnableKey</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>DisableKey</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#EnableKeyRequest": {
@@ -1833,10 +1908,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key to enable.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key to enable.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#EnableKeyRotation": {
@@ -1871,7 +1949,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Enables <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html\">automatic rotation\n        of the key material</a> of the specified symmetric encryption KMS key. </p>\n         <p>When you enable automatic rotation of a<a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed KMS key</a>, KMS\n      rotates the key material of the KMS key one year (approximately 365 days) from the enable date\n      and every year thereafter. You can monitor rotation of the key material for your KMS keys in\n      CloudTrail and Amazon CloudWatch. To disable rotation of the key material in a customer\n      managed KMS key, use the <a>DisableKeyRotation</a> operation.</p>\n         <p>Automatic key rotation is supported only on <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks\">symmetric encryption KMS keys</a>.\n      You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key. </p>\n         <p>You cannot enable or disable automatic rotation <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed KMS keys</a>. KMS\n      always rotates the key material of Amazon Web Services managed keys every year. Rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned KMS\n        keys</a> varies.</p>\n         <note>\n            <p>In May 2022, KMS changed the rotation schedule for Amazon Web Services managed keys from every three\n        years (approximately 1,095 days) to every year (approximately 365 days).</p>\n            <p>New Amazon Web Services managed keys are automatically rotated one year after they are created, and\n        approximately every year thereafter. </p>\n            <p>Existing Amazon Web Services managed keys are automatically rotated one year after their most recent\n        rotation, and every year thereafter.</p>\n         </note>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:EnableKeyRotation</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DisableKeyRotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetKeyRotationStatus</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Enables <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html\">automatic rotation\n        of the key material</a> of the specified symmetric encryption KMS key. </p>\n         <p>When you enable automatic rotation of a<a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed KMS key</a>, KMS\n      rotates the key material of the KMS key one year (approximately 365 days) from the enable date\n      and every year thereafter. You can monitor rotation of the key material for your KMS keys in\n      CloudTrail and Amazon CloudWatch. To disable rotation of the key material in a customer\n      managed KMS key, use the <a>DisableKeyRotation</a> operation.</p>\n         <p>Automatic key rotation is supported only on <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks\">symmetric encryption KMS keys</a>.\n      You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key. </p>\n         <p>You cannot enable or disable automatic rotation <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed KMS keys</a>. KMS\n      always rotates the key material of Amazon Web Services managed keys every year. Rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned KMS\n        keys</a> varies.</p>\n         <note>\n            <p>In May 2022, KMS changed the rotation schedule for Amazon Web Services managed keys from every three\n        years (approximately 1,095 days) to every year (approximately 365 days).</p>\n            <p>New Amazon Web Services managed keys are automatically rotated one year after they are created, and\n        approximately every year thereafter. </p>\n            <p>Existing Amazon Web Services managed keys are automatically rotated one year after their most recent\n        rotation, and every year thereafter.</p>\n         </note>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:EnableKeyRotation</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DisableKeyRotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetKeyRotationStatus</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#EnableKeyRotationRequest": {
@@ -1880,10 +1958,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies a symmetric encryption KMS key. You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies a symmetric encryption KMS key. You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#Encrypt": {
@@ -1921,7 +2002,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Encrypts plaintext of up to 4,096 bytes using a KMS key. You can use a symmetric or\n      asymmetric KMS key with a <code>KeyUsage</code> of <code>ENCRYPT_DECRYPT</code>.</p>\n         <p>You can use this operation to encrypt small amounts of arbitrary data, such as a personal\n      identifier or database password, or other sensitive information. You don't need to use the\n        <code>Encrypt</code> operation to encrypt a data key. The <a>GenerateDataKey</a>\n      and <a>GenerateDataKeyPair</a> operations return a plaintext data key and an\n      encrypted copy of that data key.</p>\n         <p>If you use a symmetric encryption KMS key, you can use an encryption context to add\n      additional security to your encryption operation. If you specify an\n        <code>EncryptionContext</code> when encrypting data, you must specify the same encryption\n      context (a case-sensitive exact match) when decrypting the data. Otherwise, the request to\n      decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption\n        Context</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>If you specify an asymmetric KMS key, you must also specify the encryption algorithm. The\n      algorithm must be compatible with the KMS key spec.</p>\n         <important>\n            <p>When you use an asymmetric KMS key to encrypt or reencrypt data, be sure to record the KMS key and encryption algorithm that you choose. You will be required to provide the same KMS key and encryption algorithm when you decrypt the data. If the KMS key and algorithm do not match the values used to encrypt the data, the decrypt operation fails.</p>\n            <p>You are not required to supply the key ID and encryption algorithm when you decrypt with symmetric encryption KMS keys because KMS stores this information in the ciphertext blob. KMS cannot store metadata in ciphertext generated with asymmetric keys. The standard format for asymmetric key ciphertext does not include configurable fields.</p>\n         </important>\n\n\n         <p>The maximum size of the data that you can encrypt varies with the type of KMS key and the\n      encryption algorithm that you choose.</p>\n         <ul>\n            <li>\n               <p>Symmetric encryption KMS keys</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>SYMMETRIC_DEFAULT</code>: 4096 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>RSA_2048</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_1</code>: 214 bytes</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_256</code>: 190 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>RSA_3072</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_1</code>: 342 bytes</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_256</code>: 318 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>RSA_4096</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_1</code>: 470 bytes</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_256</code>: 446 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>SM2PKE</code>: 1024 bytes (China Regions only)</p>\n            </li>\n         </ul> \n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p> \n         <p>\n            <b>Cross-account use</b>: Yes.\n      To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Encrypt</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Encrypts plaintext of up to 4,096 bytes using a KMS key. You can use a symmetric or\n      asymmetric KMS key with a <code>KeyUsage</code> of <code>ENCRYPT_DECRYPT</code>.</p>\n         <p>You can use this operation to encrypt small amounts of arbitrary data, such as a personal\n      identifier or database password, or other sensitive information. You don't need to use the\n        <code>Encrypt</code> operation to encrypt a data key. The <a>GenerateDataKey</a>\n      and <a>GenerateDataKeyPair</a> operations return a plaintext data key and an\n      encrypted copy of that data key.</p>\n         <p>If you use a symmetric encryption KMS key, you can use an encryption context to add\n      additional security to your encryption operation. If you specify an\n        <code>EncryptionContext</code> when encrypting data, you must specify the same encryption\n      context (a case-sensitive exact match) when decrypting the data. Otherwise, the request to\n      decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption\n        Context</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>If you specify an asymmetric KMS key, you must also specify the encryption algorithm. The\n      algorithm must be compatible with the KMS key spec.</p>\n         <important>\n            <p>When you use an asymmetric KMS key to encrypt or reencrypt data, be sure to record the KMS key and encryption algorithm that you choose. You will be required to provide the same KMS key and encryption algorithm when you decrypt the data. If the KMS key and algorithm do not match the values used to encrypt the data, the decrypt operation fails.</p>\n            <p>You are not required to supply the key ID and encryption algorithm when you decrypt with symmetric encryption KMS keys because KMS stores this information in the ciphertext blob. KMS cannot store metadata in ciphertext generated with asymmetric keys. The standard format for asymmetric key ciphertext does not include configurable fields.</p>\n         </important>\n         <p>The maximum size of the data that you can encrypt varies with the type of KMS key and the\n      encryption algorithm that you choose.</p>\n         <ul>\n            <li>\n               <p>Symmetric encryption KMS keys</p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>SYMMETRIC_DEFAULT</code>: 4096 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>RSA_2048</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_1</code>: 214 bytes</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_256</code>: 190 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>RSA_3072</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_1</code>: 342 bytes</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_256</code>: 318 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>RSA_4096</code>\n               </p>\n               <ul>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_1</code>: 470 bytes</p>\n                  </li>\n                  <li>\n                     <p>\n                        <code>RSAES_OAEP_SHA_256</code>: 446 bytes</p>\n                  </li>\n               </ul>\n            </li>\n            <li>\n               <p>\n                  <code>SM2PKE</code>: 1024 bytes (China Regions only)</p>\n            </li>\n         </ul>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes.\n      To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Encrypt</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#EncryptRequest": {
@@ -1930,7 +2011,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key to use in the encryption operation. The KMS key must have a\n        <code>KeyUsage</code> of <code>ENCRYPT_DECRYPT</code>. To find the <code>KeyUsage</code> of\n      a KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key to use in the encryption operation. The KMS key must have a\n        <code>KeyUsage</code> of <code>ENCRYPT_DECRYPT</code>. To find the <code>KeyUsage</code> of\n      a KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -1959,6 +2040,9 @@
                         "smithy.api#documentation": "<p>Specifies the encryption algorithm that KMS will use to encrypt the plaintext message.\n      The algorithm must be compatible with the KMS key that you specify.</p>\n         <p>This parameter is required only for asymmetric KMS keys. The default value,\n        <code>SYMMETRIC_DEFAULT</code>, is the algorithm used for symmetric encryption KMS keys. If you are\n      using an asymmetric KMS key, we recommend RSAES_OAEP_SHA_256.</p>\n         <p>The SM2PKE algorithm is only available in China Regions.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#EncryptResponse": {
@@ -1982,6 +2066,9 @@
                         "smithy.api#documentation": "<p>The encryption algorithm that was used to encrypt the plaintext.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#EncryptionAlgorithmSpec": {
@@ -2106,7 +2193,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a unique symmetric data key for use outside of KMS. This operation returns a\n      plaintext copy of the data key and a copy that is encrypted under a symmetric encryption KMS\n      key that you specify. The bytes in the plaintext key are random; they are not related \n      to the caller or the KMS key. You can use the plaintext key to encrypt your data outside of KMS \n      and store the encrypted data key with the encrypted data.</p>\n\n         <p>To generate a data key, specify the symmetric encryption KMS key that will be used to\n      encrypt the data key. You cannot use an asymmetric KMS key to encrypt data keys. To get the\n      type of your KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>You must also specify the length of the data key. Use either the <code>KeySpec</code> or \n      <code>NumberOfBytes</code> parameters (but not both). For 128-bit and 256-bit data keys, use \n      the <code>KeySpec</code> parameter.</p>\n    \n         <p>To generate an SM4 data key (China Regions only), specify a <code>KeySpec</code> value of\n      <code>AES_128</code> or <code>NumberOfBytes</code> value of <code>128</code>. The symmetric \n      encryption key used in China Regions to encrypt your data key is an SM4 encryption key.</p>\n\n         <p>To get only an encrypted copy of the data key, use <a>GenerateDataKeyWithoutPlaintext</a>. To generate an asymmetric data key pair, use\n      the <a>GenerateDataKeyPair</a> or <a>GenerateDataKeyPairWithoutPlaintext</a> operation. To get a cryptographically secure\n      random byte string, use <a>GenerateRandom</a>.</p>\n\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>Applications in Amazon Web Services Nitro Enclaves can call this operation by using the <a href=\"https://github.com/aws/aws-nitro-enclaves-sdk-c\">Amazon Web Services Nitro Enclaves Development Kit</a>. For information about the supporting parameters, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html\">How Amazon Web Services Nitro Enclaves use KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>How to use your data key</b>\n         </p>\n         <p>We recommend that you use the following pattern to encrypt data locally in your\n      application. You can write your own code or use a client-side encryption library, such as the\n        <a href=\"https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/\">Amazon Web Services Encryption SDK</a>, the\n        <a href=\"https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/\">Amazon DynamoDB Encryption Client</a>,\n      or <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3\n        client-side encryption</a> to do these tasks for you.</p>\n         <p>To encrypt data outside of KMS:</p>\n         <ol>\n            <li>\n               <p>Use the <code>GenerateDataKey</code> operation to get a data key.</p>\n            </li>\n            <li>\n               <p>Use the plaintext data key (in the <code>Plaintext</code> field of the response) to\n          encrypt your data outside of KMS. Then erase the plaintext data key from memory.</p>\n            </li>\n            <li>\n               <p>Store the encrypted data key (in the <code>CiphertextBlob</code> field of the\n          response) with the encrypted data.</p>\n            </li>\n         </ol>\n         <p>To decrypt data outside of KMS:</p>\n         <ol>\n            <li>\n               <p>Use the <a>Decrypt</a> operation to decrypt the encrypted data key. The\n          operation returns a plaintext copy of the data key.</p>\n            </li>\n            <li>\n               <p>Use the plaintext data key to decrypt data outside of KMS, then erase the plaintext\n          data key from memory.</p>\n            </li>\n         </ol>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKey</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Returns a unique symmetric data key for use outside of KMS. This operation returns a\n      plaintext copy of the data key and a copy that is encrypted under a symmetric encryption KMS\n      key that you specify. The bytes in the plaintext key are random; they are not related \n      to the caller or the KMS key. You can use the plaintext key to encrypt your data outside of KMS \n      and store the encrypted data key with the encrypted data.</p>\n         <p>To generate a data key, specify the symmetric encryption KMS key that will be used to\n      encrypt the data key. You cannot use an asymmetric KMS key to encrypt data keys. To get the\n      type of your KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>You must also specify the length of the data key. Use either the <code>KeySpec</code> or \n      <code>NumberOfBytes</code> parameters (but not both). For 128-bit and 256-bit data keys, use \n      the <code>KeySpec</code> parameter.</p>\n         <p>To generate a 128-bit SM4 data key (China Regions only), specify a <code>KeySpec</code> value of\n      <code>AES_128</code> or a <code>NumberOfBytes</code> value of <code>16</code>. The symmetric \n      encryption key used in China Regions to encrypt your data key is an SM4 encryption key.</p>\n         <p>To get only an encrypted copy of the data key, use <a>GenerateDataKeyWithoutPlaintext</a>. To generate an asymmetric data key pair, use\n      the <a>GenerateDataKeyPair</a> or <a>GenerateDataKeyPairWithoutPlaintext</a> operation. To get a cryptographically secure\n      random byte string, use <a>GenerateRandom</a>.</p>\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>Applications in Amazon Web Services Nitro Enclaves can call this operation by using the <a href=\"https://github.com/aws/aws-nitro-enclaves-sdk-c\">Amazon Web Services Nitro Enclaves Development Kit</a>. For information about the supporting parameters, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html\">How Amazon Web Services Nitro Enclaves use KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>How to use your data key</b>\n         </p>\n         <p>We recommend that you use the following pattern to encrypt data locally in your\n      application. You can write your own code or use a client-side encryption library, such as the\n        <a href=\"https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/\">Amazon Web Services Encryption SDK</a>, the\n        <a href=\"https://docs.aws.amazon.com/dynamodb-encryption-client/latest/devguide/\">Amazon DynamoDB Encryption Client</a>,\n      or <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3\n        client-side encryption</a> to do these tasks for you.</p>\n         <p>To encrypt data outside of KMS:</p>\n         <ol>\n            <li>\n               <p>Use the <code>GenerateDataKey</code> operation to get a data key.</p>\n            </li>\n            <li>\n               <p>Use the plaintext data key (in the <code>Plaintext</code> field of the response) to\n          encrypt your data outside of KMS. Then erase the plaintext data key from memory.</p>\n            </li>\n            <li>\n               <p>Store the encrypted data key (in the <code>CiphertextBlob</code> field of the\n          response) with the encrypted data.</p>\n            </li>\n         </ol>\n         <p>To decrypt data outside of KMS:</p>\n         <ol>\n            <li>\n               <p>Use the <a>Decrypt</a> operation to decrypt the encrypted data key. The\n          operation returns a plaintext copy of the data key.</p>\n            </li>\n            <li>\n               <p>Use the plaintext data key to decrypt data outside of KMS, then erase the plaintext\n          data key from memory.</p>\n            </li>\n         </ol>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKey</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#GenerateDataKeyPair": {
@@ -2147,7 +2234,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a unique asymmetric data key pair for use outside of KMS. This operation returns\n      a plaintext public key, a plaintext private key, and a copy of the private key that is\n      encrypted under the symmetric encryption KMS key you specify. You can use the data key pair to\n      perform asymmetric cryptography and implement digital signatures outside of KMS. The bytes\n      in the keys are random; they not related to the caller or to the KMS key that is used to\n      encrypt the private key. </p>\n\n         <p>You can use the public key that <code>GenerateDataKeyPair</code> returns to encrypt data\n      or verify a signature outside of KMS. Then, store the encrypted private key with the data.\n      When you are ready to decrypt data or sign a message, you can use the <a>Decrypt</a> operation to decrypt the encrypted private key.</p>\n\n         <p>To generate a data key pair, you must specify a symmetric encryption KMS key to encrypt\n      the private key in a data key pair. You cannot use an asymmetric KMS key or a KMS key in a\n      custom key store. To get the type and origin of your KMS key, use the <a>DescribeKey</a> operation. </p>\n         <p>Use the <code>KeyPairSpec</code> parameter to choose an RSA or Elliptic Curve (ECC) data\n      key pair. In China Regions, you can also choose an SM2 data key pair. KMS recommends that you use\n      ECC key pairs for signing, and use RSA and SM2 key pairs for either encryption or signing, but not both.\n      However, KMS cannot enforce any restrictions on the use of data key pairs outside of KMS.</p>\n\n         <p>If you are using the data key pair to encrypt data, or for any operation where you don't\n      immediately need a private key, consider using the <a>GenerateDataKeyPairWithoutPlaintext</a> operation.\n        <code>GenerateDataKeyPairWithoutPlaintext</code> returns a plaintext public key and an\n      encrypted private key, but omits the plaintext private key that you need only to decrypt\n      ciphertext or sign a message. Later, when you need to decrypt the data or sign a message, use\n      the <a>Decrypt</a> operation to decrypt the encrypted private key in the data key\n      pair.</p>\n\n         <p>\n            <code>GenerateDataKeyPair</code> returns a unique data key pair for each request. The\n      bytes in the keys are random; they are not related to the caller or the KMS key that is used\n      to encrypt the private key. The public key is a DER-encoded X.509 SubjectPublicKeyInfo, as\n      specified in <a href=\"https://tools.ietf.org/html/rfc5280\">RFC 5280</a>. The private\n      key is a DER-encoded PKCS8 PrivateKeyInfo, as specified in <a href=\"https://tools.ietf.org/html/rfc5958\">RFC 5958</a>.</p>\n\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKeyPair</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Returns a unique asymmetric data key pair for use outside of KMS. This operation returns\n      a plaintext public key, a plaintext private key, and a copy of the private key that is\n      encrypted under the symmetric encryption KMS key you specify. You can use the data key pair to\n      perform asymmetric cryptography and implement digital signatures outside of KMS. The bytes\n      in the keys are random; they not related to the caller or to the KMS key that is used to\n      encrypt the private key. </p>\n         <p>You can use the public key that <code>GenerateDataKeyPair</code> returns to encrypt data\n      or verify a signature outside of KMS. Then, store the encrypted private key with the data.\n      When you are ready to decrypt data or sign a message, you can use the <a>Decrypt</a> operation to decrypt the encrypted private key.</p>\n         <p>To generate a data key pair, you must specify a symmetric encryption KMS key to encrypt\n      the private key in a data key pair. You cannot use an asymmetric KMS key or a KMS key in a\n      custom key store. To get the type and origin of your KMS key, use the <a>DescribeKey</a> operation. </p>\n         <p>Use the <code>KeyPairSpec</code> parameter to choose an RSA or Elliptic Curve (ECC) data\n      key pair. In China Regions, you can also choose an SM2 data key pair. KMS recommends that you use\n      ECC key pairs for signing, and use RSA and SM2 key pairs for either encryption or signing, but not both.\n      However, KMS cannot enforce any restrictions on the use of data key pairs outside of KMS.</p>\n         <p>If you are using the data key pair to encrypt data, or for any operation where you don't\n      immediately need a private key, consider using the <a>GenerateDataKeyPairWithoutPlaintext</a> operation.\n        <code>GenerateDataKeyPairWithoutPlaintext</code> returns a plaintext public key and an\n      encrypted private key, but omits the plaintext private key that you need only to decrypt\n      ciphertext or sign a message. Later, when you need to decrypt the data or sign a message, use\n      the <a>Decrypt</a> operation to decrypt the encrypted private key in the data key\n      pair.</p>\n         <p>\n            <code>GenerateDataKeyPair</code> returns a unique data key pair for each request. The\n      bytes in the keys are random; they are not related to the caller or the KMS key that is used\n      to encrypt the private key. The public key is a DER-encoded X.509 SubjectPublicKeyInfo, as\n      specified in <a href=\"https://tools.ietf.org/html/rfc5280\">RFC 5280</a>. The private\n      key is a DER-encoded PKCS8 PrivateKeyInfo, as specified in <a href=\"https://tools.ietf.org/html/rfc5958\">RFC 5958</a>.</p>\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKeyPair</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#GenerateDataKeyPairRequest": {
@@ -2162,7 +2249,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the private key in the data key\n      pair. You cannot specify an asymmetric KMS key or a KMS key in a custom key store. To get the\n      type and origin of your KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the private key in the data key\n      pair. You cannot specify an asymmetric KMS key or a KMS key in a custom key store. To get the\n      type and origin of your KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2179,6 +2266,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyPairResponse": {
@@ -2214,6 +2304,9 @@
                         "smithy.api#documentation": "<p>The type of data key pair that was generated.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyPairWithoutPlaintext": {
@@ -2254,7 +2347,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a unique asymmetric data key pair for use outside of KMS. This operation returns\n      a plaintext public key and a copy of the private key that is encrypted under the symmetric\n      encryption KMS key you specify. Unlike <a>GenerateDataKeyPair</a>, this operation\n      does not return a plaintext private key. The bytes in the keys are random; they are not\n      related to the caller or to the KMS key that is used to encrypt the private key. </p>\n         <p>You can use the public key that <code>GenerateDataKeyPairWithoutPlaintext</code> returns\n      to encrypt data or verify a signature outside of KMS. Then, store the encrypted private key\n      with the data. When you are ready to decrypt data or sign a message, you can use the <a>Decrypt</a> operation to decrypt the encrypted private key.</p>\n         <p>To generate a data key pair, you must specify a symmetric encryption KMS key to encrypt\n      the private key in a data key pair. You cannot use an asymmetric KMS key or a KMS key in a\n      custom key store. To get the type and origin of your KMS key, use the <a>DescribeKey</a> operation. </p>\n         <p>Use the <code>KeyPairSpec</code> parameter to choose an RSA or Elliptic Curve (ECC) data\n      key pair. In China Regions, you can also choose an SM2 data key pair. KMS recommends that you \n      use ECC key pairs for signing, and use RSA and SM2 key pairs for either encryption or signing, but not\n      both. However, KMS cannot enforce any restrictions on the use of data key pairs outside of KMS.</p>\n         <p>\n            <code>GenerateDataKeyPairWithoutPlaintext</code> returns a unique data key pair for each\n      request. The bytes in the key are not related to the caller or KMS key that is used to encrypt\n      the private key. The public key is a DER-encoded X.509 SubjectPublicKeyInfo, as specified in\n        <a href=\"https://tools.ietf.org/html/rfc5280\">RFC 5280</a>.</p>\n\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKeyPairWithoutPlaintext</a> (key\n      policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Returns a unique asymmetric data key pair for use outside of KMS. This operation returns\n      a plaintext public key and a copy of the private key that is encrypted under the symmetric\n      encryption KMS key you specify. Unlike <a>GenerateDataKeyPair</a>, this operation\n      does not return a plaintext private key. The bytes in the keys are random; they are not\n      related to the caller or to the KMS key that is used to encrypt the private key. </p>\n         <p>You can use the public key that <code>GenerateDataKeyPairWithoutPlaintext</code> returns\n      to encrypt data or verify a signature outside of KMS. Then, store the encrypted private key\n      with the data. When you are ready to decrypt data or sign a message, you can use the <a>Decrypt</a> operation to decrypt the encrypted private key.</p>\n         <p>To generate a data key pair, you must specify a symmetric encryption KMS key to encrypt\n      the private key in a data key pair. You cannot use an asymmetric KMS key or a KMS key in a\n      custom key store. To get the type and origin of your KMS key, use the <a>DescribeKey</a> operation. </p>\n         <p>Use the <code>KeyPairSpec</code> parameter to choose an RSA or Elliptic Curve (ECC) data\n      key pair. In China Regions, you can also choose an SM2 data key pair. KMS recommends that you \n      use ECC key pairs for signing, and use RSA and SM2 key pairs for either encryption or signing, but not\n      both. However, KMS cannot enforce any restrictions on the use of data key pairs outside of KMS.</p>\n         <p>\n            <code>GenerateDataKeyPairWithoutPlaintext</code> returns a unique data key pair for each\n      request. The bytes in the key are not related to the caller or KMS key that is used to encrypt\n      the private key. The public key is a DER-encoded X.509 SubjectPublicKeyInfo, as specified in\n        <a href=\"https://tools.ietf.org/html/rfc5280\">RFC 5280</a>.</p>\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKeyPairWithoutPlaintext</a> (key\n      policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#GenerateDataKeyPairWithoutPlaintextRequest": {
@@ -2269,7 +2362,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the private key in the data key\n      pair. You cannot specify an asymmetric KMS key or a KMS key in a custom key store. To get the\n      type and origin of your KMS key, use the <a>DescribeKey</a> operation. </p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the private key in the data key\n      pair. You cannot specify an asymmetric KMS key or a KMS key in a custom key store. To get the\n      type and origin of your KMS key, use the <a>DescribeKey</a> operation. </p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2286,6 +2379,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyPairWithoutPlaintextResponse": {
@@ -2315,6 +2411,9 @@
                         "smithy.api#documentation": "<p>The type of data key pair that was generated.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyRequest": {
@@ -2323,7 +2422,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the data key. You cannot specify\n      an asymmetric KMS key or a KMS key in a custom key store. To get the type and origin of your\n      KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the data key. You cannot specify\n      an asymmetric KMS key or a KMS key in a custom key store. To get the type and origin of your\n      KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2351,6 +2450,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyResponse": {
@@ -2374,6 +2476,9 @@
                         "smithy.api#documentation": "<p>The Amazon Resource Name (<a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">key ARN</a>) of the KMS key that encrypted the data key.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyWithoutPlaintext": {
@@ -2411,7 +2516,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a unique symmetric data key for use outside of KMS. This operation returns a\n      data key that is encrypted under a symmetric encryption KMS key that you specify. The bytes in\n      the key are random; they are not related to the caller or to the KMS key.</p>\n         <p>\n            <code>GenerateDataKeyWithoutPlaintext</code> is identical to the <a>GenerateDataKey</a> operation except that it does not return a plaintext copy of the\n      data key. </p>\n         <p>This operation is useful for systems that need to encrypt data at some point, but not\n      immediately. When you need to encrypt the data, you call the <a>Decrypt</a>\n      operation on the encrypted copy of the key.</p>\n         <p>It's also useful in distributed systems with different levels of trust. For example, you\n      might store encrypted data in containers. One component of your system creates new containers\n      and stores an encrypted data key with each container. Then, a different component puts the\n      data into the containers. That component first decrypts the data key, uses the plaintext data\n      key to encrypt data, puts the encrypted data into the container, and then destroys the\n      plaintext data key. In this system, the component that creates the containers never sees the\n      plaintext data key.</p>\n         <p>To request an asymmetric data key pair, use the <a>GenerateDataKeyPair</a> or\n        <a>GenerateDataKeyPairWithoutPlaintext</a> operations.</p>\n\n         <p>To generate a data key, you must specify the symmetric encryption KMS key that is used to\n      encrypt the data key. You cannot use an asymmetric KMS key or a key in a custom key store to generate a data key. To get the\n      type of your KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>You must also specify the length of the data key. Use either the <code>KeySpec</code> or \n      <code>NumberOfBytes</code> parameters (but not both). For 128-bit and 256-bit data keys, use \n      the <code>KeySpec</code> parameter.</p>\n    \n         <p>To generate an SM4 data key (China Regions only), specify a <code>KeySpec</code> value of\n      <code>AES_128</code> or <code>NumberOfBytes</code> value of <code>128</code>. The symmetric \n      encryption key used in China Regions to encrypt your data key is an SM4 encryption key.</p>\n\n         <p>If the operation succeeds, you will find the encrypted copy of the data key in the\n        <code>CiphertextBlob</code> field.</p>\n\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKeyWithoutPlaintext</a> (key\n      policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Returns a unique symmetric data key for use outside of KMS. This operation returns a\n      data key that is encrypted under a symmetric encryption KMS key that you specify. The bytes in\n      the key are random; they are not related to the caller or to the KMS key.</p>\n         <p>\n            <code>GenerateDataKeyWithoutPlaintext</code> is identical to the <a>GenerateDataKey</a> operation except that it does not return a plaintext copy of the\n      data key. </p>\n         <p>This operation is useful for systems that need to encrypt data at some point, but not\n      immediately. When you need to encrypt the data, you call the <a>Decrypt</a>\n      operation on the encrypted copy of the key.</p>\n         <p>It's also useful in distributed systems with different levels of trust. For example, you\n      might store encrypted data in containers. One component of your system creates new containers\n      and stores an encrypted data key with each container. Then, a different component puts the\n      data into the containers. That component first decrypts the data key, uses the plaintext data\n      key to encrypt data, puts the encrypted data into the container, and then destroys the\n      plaintext data key. In this system, the component that creates the containers never sees the\n      plaintext data key.</p>\n         <p>To request an asymmetric data key pair, use the <a>GenerateDataKeyPair</a> or\n        <a>GenerateDataKeyPairWithoutPlaintext</a> operations.</p>\n         <p>To generate a data key, you must specify the symmetric encryption KMS key that is used to\n      encrypt the data key. You cannot use an asymmetric KMS key or a key in a custom key store to generate a data key. To get the\n      type of your KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>You must also specify the length of the data key. Use either the <code>KeySpec</code> or \n      <code>NumberOfBytes</code> parameters (but not both). For 128-bit and 256-bit data keys, use \n      the <code>KeySpec</code> parameter.</p>\n         <p>To generate an SM4 data key (China Regions only), specify a <code>KeySpec</code> value of\n      <code>AES_128</code> or <code>NumberOfBytes</code> value of <code>128</code>. The symmetric \n      encryption key used in China Regions to encrypt your data key is an SM4 encryption key.</p>\n         <p>If the operation succeeds, you will find the encrypted copy of the data key in the\n        <code>CiphertextBlob</code> field.</p>\n         <p>You can use an optional encryption context to add additional security to the encryption\n      operation. If you specify an <code>EncryptionContext</code>, you must specify the same\n      encryption context (a case-sensitive exact match) when decrypting the encrypted data key.\n      Otherwise, the request to decrypt fails with an <code>InvalidCiphertextException</code>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">Encryption Context</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateDataKeyWithoutPlaintext</a> (key\n      policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPairWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#GenerateDataKeyWithoutPlaintextRequest": {
@@ -2420,7 +2525,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the data key. You cannot specify\n      an asymmetric KMS key or a KMS key in a custom key store. To get the type and origin of your\n      KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Specifies the symmetric encryption KMS key that encrypts the data key. You cannot specify\n      an asymmetric KMS key or a KMS key in a custom key store. To get the type and origin of your\n      KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2448,6 +2553,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GenerateDataKeyWithoutPlaintextResponse": {
@@ -2465,6 +2573,9 @@
                         "smithy.api#documentation": "<p>The Amazon Resource Name (<a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id-key-ARN\">key ARN</a>) of the KMS key that encrypted the data key.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GenerateMac": {
@@ -2532,6 +2643,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GenerateMacResponse": {
@@ -2540,7 +2654,7 @@
                 "Mac": {
                     "target": "com.amazonaws.kms#CiphertextType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The hash-based message authentication code (HMAC) that was generated for the\n      specified message, HMAC KMS key, and MAC algorithm.</p>    \n         <p>This is the standard, raw HMAC defined in <a href=\"https://datatracker.ietf.org/doc/html/rfc2104\">RFC 2104</a>.</p>"
+                        "smithy.api#documentation": "<p>The hash-based message authentication code (HMAC) that was generated for the\n      specified message, HMAC KMS key, and MAC algorithm.</p>\n         <p>This is the standard, raw HMAC defined in <a href=\"https://datatracker.ietf.org/doc/html/rfc2104\">RFC 2104</a>.</p>"
                     }
                 },
                 "MacAlgorithm": {
@@ -2555,6 +2669,9 @@
                         "smithy.api#documentation": "<p>The HMAC KMS key used in the operation.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GenerateRandom": {
@@ -2583,7 +2700,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns a random byte string that is cryptographically secure.</p>\n         <p>You must use the <code>NumberOfBytes</code> parameter to specify the length of the random\n      byte string. There is no default value for string length.</p>\n         <p>By default, the random byte string is generated in KMS. To generate the byte string in\n      the CloudHSM cluster associated with an CloudHSM key store, use the <code>CustomKeyStoreId</code>\n      parameter.</p>\n         <p>Applications in Amazon Web Services Nitro Enclaves can call this operation by using the <a href=\"https://github.com/aws/aws-nitro-enclaves-sdk-c\">Amazon Web Services Nitro Enclaves Development Kit</a>. For information about the supporting parameters, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html\">How Amazon Web Services Nitro Enclaves use KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>For more information about entropy and random number generation, see\n      <a href=\"https://docs.aws.amazon.com/kms/latest/cryptographic-details/\">Key Management Service Cryptographic Details</a>.</p>\n\n         <p>\n            <b>Cross-account use</b>: Not applicable.\n        <code>GenerateRandom</code> does not use any account-specific resources, such as KMS\n      keys.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateRandom</a> (IAM policy)</p>"
+                "smithy.api#documentation": "<p>Returns a random byte string that is cryptographically secure.</p>\n         <p>You must use the <code>NumberOfBytes</code> parameter to specify the length of the random\n      byte string. There is no default value for string length.</p>\n         <p>By default, the random byte string is generated in KMS. To generate the byte string in\n      the CloudHSM cluster associated with an CloudHSM key store, use the <code>CustomKeyStoreId</code>\n      parameter.</p>\n         <p>Applications in Amazon Web Services Nitro Enclaves can call this operation by using the <a href=\"https://github.com/aws/aws-nitro-enclaves-sdk-c\">Amazon Web Services Nitro Enclaves Development Kit</a>. For information about the supporting parameters, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/services-nitro-enclaves.html\">How Amazon Web Services Nitro Enclaves use KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>For more information about entropy and random number generation, see\n      <a href=\"https://docs.aws.amazon.com/kms/latest/cryptographic-details/\">Key Management Service Cryptographic Details</a>.</p>\n         <p>\n            <b>Cross-account use</b>: Not applicable.\n        <code>GenerateRandom</code> does not use any account-specific resources, such as KMS\n      keys.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GenerateRandom</a> (IAM policy)</p>"
             }
         },
         "com.amazonaws.kms#GenerateRandomRequest": {
@@ -2601,6 +2718,9 @@
                         "smithy.api#documentation": "<p>Generates the random byte string in the CloudHSM cluster that is associated with the\n      specified CloudHSM key store. To find the ID of a custom key store, use the <a>DescribeCustomKeyStores</a> operation.</p>\n         <p>External key store IDs are not valid for this parameter. If you specify the ID of an\n      external key store, <code>GenerateRandom</code> throws an\n        <code>UnsupportedOperationException</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GenerateRandomResponse": {
@@ -2612,6 +2732,9 @@
                         "smithy.api#documentation": "<p>The random byte string. When you use the HTTP API or the Amazon Web Services CLI, the value is Base64-encoded. Otherwise, it is not Base64-encoded.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GetKeyPolicy": {
@@ -2640,7 +2763,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a key policy attached to the specified KMS key.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetKeyPolicy</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>PutKeyPolicy</a>\n         </p>"
+                "smithy.api#documentation": "<p>Gets a key policy attached to the specified KMS key.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetKeyPolicy</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>PutKeyPolicy</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#GetKeyPolicyRequest": {
@@ -2649,7 +2772,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Gets the key policy for the specified KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Gets the key policy for the specified KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2660,6 +2783,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GetKeyPolicyResponse": {
@@ -2671,6 +2797,9 @@
                         "smithy.api#documentation": "<p>A key policy document in JSON format.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GetKeyRotationStatus": {
@@ -2702,7 +2831,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a Boolean value that indicates whether <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html\">automatic rotation of the key material</a> is\n      enabled for the specified KMS key.</p>\n         <p>When you enable automatic rotation for <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed KMS keys</a>, KMS\n      rotates the key material of the KMS key one year (approximately 365 days) from the enable date\n      and every year thereafter. You can monitor rotation of the key material for your KMS keys in\n      CloudTrail and Amazon CloudWatch.</p>\n         <p>Automatic key rotation is supported only on <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks\">symmetric encryption KMS keys</a>.\n      You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key..</p>\n         <p>You can enable (<a>EnableKeyRotation</a>) and disable automatic rotation (<a>DisableKeyRotation</a>) of the key material in customer managed KMS keys. Key\n      material rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed KMS keys</a> is not\n      configurable. KMS always rotates the key material in Amazon Web Services managed KMS keys every year. The\n      key rotation status for Amazon Web Services managed KMS keys is always <code>true</code>.</p>\n         <note>\n            <p>In May 2022, KMS changed the rotation schedule for Amazon Web Services managed keys from every three\n        years to every year. For details, see <a>EnableKeyRotation</a>.</p>\n         </note>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <ul>\n            <li>\n               <p>Disabled: The key rotation status does not change when you disable a KMS key. However,\n          while the KMS key is disabled, KMS does not rotate the key material. When you re-enable\n          the KMS key, rotation resumes. If the key material in the re-enabled KMS key hasn't been\n          rotated in one year, KMS rotates it immediately, and every year thereafter. If it's been\n          less than a year since the key material in the re-enabled KMS key was rotated, the KMS key\n          resumes its prior rotation schedule.</p>\n            </li>\n            <li>\n               <p>Pending deletion: While a KMS key is pending deletion, its key rotation status is\n            <code>false</code> and KMS does not rotate the key material. If you cancel the\n          deletion, the original key rotation status returns to <code>true</code>.</p>\n            </li>\n         </ul>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation on a KMS key in a different Amazon Web Services account, specify the key\n  ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetKeyRotationStatus</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DisableKeyRotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>EnableKeyRotation</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Gets a Boolean value that indicates whether <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html\">automatic rotation of the key material</a> is\n      enabled for the specified KMS key.</p>\n         <p>When you enable automatic rotation for <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed KMS keys</a>, KMS\n      rotates the key material of the KMS key one year (approximately 365 days) from the enable date\n      and every year thereafter. You can monitor rotation of the key material for your KMS keys in\n      CloudTrail and Amazon CloudWatch.</p>\n         <p>Automatic key rotation is supported only on <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks\">symmetric encryption KMS keys</a>.\n      You cannot enable automatic rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">asymmetric KMS keys</a>, <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC KMS keys</a>, KMS keys with <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">imported key material</a>, or KMS keys in a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/custom-key-store-overview.html\">custom key store</a>. To enable or disable automatic rotation of a set of related <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-manage.html#multi-region-rotate\">multi-Region keys</a>, set the property on the primary key..</p>\n         <p>You can enable (<a>EnableKeyRotation</a>) and disable automatic rotation (<a>DisableKeyRotation</a>) of the key material in customer managed KMS keys. Key\n      material rotation of <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed KMS keys</a> is not\n      configurable. KMS always rotates the key material in Amazon Web Services managed KMS keys every year. The\n      key rotation status for Amazon Web Services managed KMS keys is always <code>true</code>.</p>\n         <note>\n            <p>In May 2022, KMS changed the rotation schedule for Amazon Web Services managed keys from every three\n        years to every year. For details, see <a>EnableKeyRotation</a>.</p>\n         </note>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <ul>\n            <li>\n               <p>Disabled: The key rotation status does not change when you disable a KMS key. However,\n          while the KMS key is disabled, KMS does not rotate the key material. When you re-enable\n          the KMS key, rotation resumes. If the key material in the re-enabled KMS key hasn't been\n          rotated in one year, KMS rotates it immediately, and every year thereafter. If it's been\n          less than a year since the key material in the re-enabled KMS key was rotated, the KMS key\n          resumes its prior rotation schedule.</p>\n            </li>\n            <li>\n               <p>Pending deletion: While a KMS key is pending deletion, its key rotation status is\n            <code>false</code> and KMS does not rotate the key material. If you cancel the\n          deletion, the original key rotation status returns to <code>true</code>.</p>\n            </li>\n         </ul>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation on a KMS key in a different Amazon Web Services account, specify the key\n  ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetKeyRotationStatus</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DisableKeyRotation</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>EnableKeyRotation</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#GetKeyRotationStatusRequest": {
@@ -2711,10 +2840,13 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Gets the rotation status for the specified KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Gets the rotation status for the specified KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GetKeyRotationStatusResponse": {
@@ -2727,6 +2859,9 @@
                         "smithy.api#documentation": "<p>A Boolean value that specifies whether key rotation is enabled.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GetParametersForImport": {
@@ -2758,7 +2893,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns the items you need to import key material into a symmetric encryption KMS key. For\n      more information about importing key material into KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing key material</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>This operation returns a public key and an import token. Use the public key to encrypt the\n      symmetric key material. Store the import token to send with a subsequent <a>ImportKeyMaterial</a> request.</p>\n         <p>You must specify the key ID of the symmetric encryption KMS key into which you will import\n      key material. The KMS key <code>Origin</code> must be <code>EXTERNAL</code>. You must also\n      specify the wrapping algorithm and type of wrapping key (public key) that you will use to\n      encrypt the key material. You cannot perform this operation on an asymmetric KMS key, an HMAC KMS key, or on any KMS key in a different Amazon Web Services account.</p>\n         <p>To import key material, you must use the public key and import token from the same\n      response. These items are valid for 24 hours. The expiration date and time appear in the\n        <code>GetParametersForImport</code> response. You cannot use an expired token in an <a>ImportKeyMaterial</a> request. If your key and token expire, send another\n        <code>GetParametersForImport</code> request.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetParametersForImport</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ImportKeyMaterial</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteImportedKeyMaterial</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Returns the items you need to import key material into a symmetric encryption KMS key. For\n      more information about importing key material into KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing key material</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>This operation returns a public key and an import token. Use the public key to encrypt the\n      symmetric key material. Store the import token to send with a subsequent <a>ImportKeyMaterial</a> request.</p>\n         <p>You must specify the key ID of the symmetric encryption KMS key into which you will import\n      key material. The KMS key <code>Origin</code> must be <code>EXTERNAL</code>. You must also\n      specify the wrapping algorithm and type of wrapping key (public key) that you will use to\n      encrypt the key material. You cannot perform this operation on an asymmetric KMS key, an HMAC KMS key, or on any KMS key in a different Amazon Web Services account.</p>\n         <p>To import key material, you must use the public key and import token from the same\n      response. These items are valid for 24 hours. The expiration date and time appear in the\n        <code>GetParametersForImport</code> response. You cannot use an expired token in an <a>ImportKeyMaterial</a> request. If your key and token expire, send another\n        <code>GetParametersForImport</code> request.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetParametersForImport</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>ImportKeyMaterial</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteImportedKeyMaterial</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#GetParametersForImportRequest": {
@@ -2767,14 +2902,14 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier of the symmetric encryption KMS key into which you will import key\n      material. The <code>Origin</code> of the KMS key must be <code>EXTERNAL</code>.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>The identifier of the symmetric encryption KMS key into which you will import key\n      material. The <code>Origin</code> of the KMS key must be <code>EXTERNAL</code>.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "WrappingAlgorithm": {
                     "target": "com.amazonaws.kms#AlgorithmSpec",
                     "traits": {
-                        "smithy.api#documentation": "<p>The algorithm you will use to encrypt the key material before importing it with <a>ImportKeyMaterial</a>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-encrypt-key-material.html\">Encrypt the Key Material</a>\n      in the <i>Key Management Service Developer Guide</i>.</p>",
+                        "smithy.api#documentation": "<p>The algorithm you will use to encrypt the key material before using the <a>ImportKeyMaterial</a> operation to import it. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys-encrypt-key-material.html\">Encrypt the\n        key material</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <important>\n            <p>The <code>RSAES_PKCS1_V1_5</code> wrapping algorithm is deprecated. We recommend that\n        you begin using a different wrapping algorithm immediately. KMS will end support for\n          <code>RSAES_PKCS1_V1_5</code> by October 1, 2023 pursuant to <a href=\"https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar2.pdf\">cryptographic key management guidance</a> from the National Institute of Standards\n        and Technology (NIST).</p>\n         </important>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2785,6 +2920,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GetParametersForImportResponse": {
@@ -2814,6 +2952,9 @@
                         "smithy.api#documentation": "<p>The time at which the import token and public key are no longer valid. After this time,\n      you cannot use them to make an <a>ImportKeyMaterial</a> request and you must send\n      another <code>GetParametersForImport</code> request to get new ones.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GetPublicKey": {
@@ -2857,7 +2998,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns the public key of an asymmetric KMS key. Unlike the private key of a asymmetric\n      KMS key, which never leaves KMS unencrypted, callers with <code>kms:GetPublicKey</code>\n      permission can download the public key of an asymmetric KMS key. You can share the public key\n      to allow others to encrypt messages and verify signatures outside of KMS.\n      For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>You do not need to download the public key. Instead, you can use the public key within\n      KMS by calling the <a>Encrypt</a>, <a>ReEncrypt</a>, or <a>Verify</a> operations with the identifier of an asymmetric KMS key. When you use the\n      public key within KMS, you benefit from the authentication, authorization, and logging that\n      are part of every KMS operation. You also reduce of risk of encrypting data that cannot be\n      decrypted. These features are not effective outside of KMS.</p>\n    \n         <p>To help you use the public key safely outside of KMS, <code>GetPublicKey</code> returns\n      important information about the public key in the response, including:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeySpec\">KeySpec</a>: The type of key material in the public key, such as\n            <code>RSA_4096</code> or <code>ECC_NIST_P521</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeyUsage\">KeyUsage</a>: Whether the key is used for encryption or signing.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-EncryptionAlgorithms\">EncryptionAlgorithms</a> or <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-SigningAlgorithms\">SigningAlgorithms</a>: A list of the encryption algorithms or the signing\n          algorithms for the key.</p>\n            </li>\n         </ul>\n         <p>Although KMS cannot enforce these restrictions on external operations, it is crucial\n      that you use this information to prevent the public key from being used improperly. For\n      example, you can prevent a public signing key from being used encrypt data, or prevent a\n      public key from being used with an encryption algorithm that is not supported by KMS. You\n      can also avoid errors, such as using the wrong signing algorithm in a verification\n      operation.</p> \n         <p>To verify a signature outside of KMS with an SM2 public key (China Regions only), you must \n      specify the distinguishing ID. By default, KMS uses <code>1234567812345678</code> as the \n      distinguishing ID. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-sm-offline-verification\">Offline verification\n        with SM2 key pairs</a>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p> \n         <p>\n            <b>Cross-account use</b>:\n      Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetPublicKey</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>CreateKey</a>\n         </p>"
+                "smithy.api#documentation": "<p>Returns the public key of an asymmetric KMS key. Unlike the private key of a asymmetric\n      KMS key, which never leaves KMS unencrypted, callers with <code>kms:GetPublicKey</code>\n      permission can download the public key of an asymmetric KMS key. You can share the public key\n      to allow others to encrypt messages and verify signatures outside of KMS.\n      For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>You do not need to download the public key. Instead, you can use the public key within\n      KMS by calling the <a>Encrypt</a>, <a>ReEncrypt</a>, or <a>Verify</a> operations with the identifier of an asymmetric KMS key. When you use the\n      public key within KMS, you benefit from the authentication, authorization, and logging that\n      are part of every KMS operation. You also reduce of risk of encrypting data that cannot be\n      decrypted. These features are not effective outside of KMS.</p>\n         <p>To help you use the public key safely outside of KMS, <code>GetPublicKey</code> returns\n      important information about the public key in the response, including:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeySpec\">KeySpec</a>: The type of key material in the public key, such as\n            <code>RSA_4096</code> or <code>ECC_NIST_P521</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-KeyUsage\">KeyUsage</a>: Whether the key is used for encryption or signing.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-EncryptionAlgorithms\">EncryptionAlgorithms</a> or <a href=\"https://docs.aws.amazon.com/kms/latest/APIReference/API_GetPublicKey.html#KMS-GetPublicKey-response-SigningAlgorithms\">SigningAlgorithms</a>: A list of the encryption algorithms or the signing\n          algorithms for the key.</p>\n            </li>\n         </ul>\n         <p>Although KMS cannot enforce these restrictions on external operations, it is crucial\n      that you use this information to prevent the public key from being used improperly. For\n      example, you can prevent a public signing key from being used encrypt data, or prevent a\n      public key from being used with an encryption algorithm that is not supported by KMS. You\n      can also avoid errors, such as using the wrong signing algorithm in a verification\n      operation.</p>\n         <p>To verify a signature outside of KMS with an SM2 public key (China Regions only), you must \n      specify the distinguishing ID. By default, KMS uses <code>1234567812345678</code> as the \n      distinguishing ID. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-sm-offline-verification\">Offline verification\n        with SM2 key pairs</a>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>:\n      Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:GetPublicKey</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>CreateKey</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#GetPublicKeyRequest": {
@@ -2866,7 +3007,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the asymmetric KMS key that includes the public key.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the asymmetric KMS key that includes the public key.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -2876,6 +3017,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#GetPublicKeyResponse": {
@@ -2926,6 +3070,9 @@
                         "smithy.api#documentation": "<p>The signing algorithms that KMS supports for this key.</p>\n         <p>This field appears in the response only when the <code>KeyUsage</code> of the public key\n      is <code>SIGN_VERIFY</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#GrantConstraints": {
@@ -3204,7 +3351,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Imports key material into an existing symmetric encryption KMS key that was created\n      without key material. After you successfully import key material into a KMS key, you can\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material\">reimport the same key material</a> into that KMS key, but you cannot import different\n      key material. </p>\n         <p>You cannot perform this operation on an asymmetric KMS key, an HMAC KMS key, or on any KMS key in a different Amazon Web Services account. For more information about creating KMS keys with no key material\n      and then importing key material, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing Key Material</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>Before using this operation, call <a>GetParametersForImport</a>. Its response\n      includes a public key and an import token. Use the public key to encrypt the key material.\n      Then, submit the import token from the same <code>GetParametersForImport</code>\n      response.</p>\n         <p>When calling this operation, you must specify the following values:</p>\n         <ul>\n            <li>\n               <p>The key ID or key ARN of a KMS key with no key material. Its <code>Origin</code> must\n          be <code>EXTERNAL</code>.</p>\n               <p>To create a KMS key with no key material, call <a>CreateKey</a> and set the\n          value of its <code>Origin</code> parameter to <code>EXTERNAL</code>. To get the\n            <code>Origin</code> of a KMS key, call <a>DescribeKey</a>.)</p>\n            </li>\n            <li>\n               <p>The encrypted key material. To get the public key to encrypt the key material, call\n            <a>GetParametersForImport</a>.</p>\n            </li>\n            <li>\n               <p>The import token that <a>GetParametersForImport</a> returned. You must use\n          a public key and token from the same <code>GetParametersForImport</code> response.</p>\n            </li>\n            <li>\n               <p>Whether the key material expires (<code>ExpirationModel</code>) and, if so, when\n            (<code>ValidTo</code>). If you set an expiration date, on the specified date, KMS\n          deletes the key material from the KMS key, making the KMS key unusable. To use the KMS key\n          in cryptographic operations again, you must reimport the same key material. The only way\n          to change the expiration model or expiration date is by reimporting the same key material\n          and specifying a new expiration date. </p>\n            </li>\n         </ul>\n         <p>When this operation is successful, the key state of the KMS key changes from\n        <code>PendingImport</code> to <code>Enabled</code>, and you can use the KMS key.</p>\n         <p>If this operation fails, use the exception to help determine the problem. If the error is\n      related to the key material, the import token, or wrapping key, use <a>GetParametersForImport</a> to get a new public key and import token for the KMS key\n      and repeat the import procedure. For help, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#importing-keys-overview\">How To Import Key\n        Material</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ImportKeyMaterial</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DeleteImportedKeyMaterial</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetParametersForImport</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Imports key material into an existing symmetric encryption KMS key that was created\n      without key material. After you successfully import key material into a KMS key, you can\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#reimport-key-material\">reimport the same key material</a> into that KMS key, but you cannot import different\n      key material. </p>\n         <p>You cannot perform this operation on an asymmetric KMS key, an HMAC KMS key, or on any KMS key in a different Amazon Web Services account. For more information about creating KMS keys with no key material\n      and then importing key material, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html\">Importing Key Material</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>Before using this operation, call <a>GetParametersForImport</a>. Its response\n      includes a public key and an import token. Use the public key to encrypt the key material.\n      Then, submit the import token from the same <code>GetParametersForImport</code>\n      response.</p>\n         <p>When calling this operation, you must specify the following values:</p>\n         <ul>\n            <li>\n               <p>The key ID or key ARN of a KMS key with no key material. Its <code>Origin</code> must\n          be <code>EXTERNAL</code>.</p>\n               <p>To create a KMS key with no key material, call <a>CreateKey</a> and set the\n          value of its <code>Origin</code> parameter to <code>EXTERNAL</code>. To get the\n            <code>Origin</code> of a KMS key, call <a>DescribeKey</a>.)</p>\n            </li>\n            <li>\n               <p>The encrypted key material. To get the public key to encrypt the key material, call\n            <a>GetParametersForImport</a>.</p>\n            </li>\n            <li>\n               <p>The import token that <a>GetParametersForImport</a> returned. You must use\n          a public key and token from the same <code>GetParametersForImport</code> response.</p>\n            </li>\n            <li>\n               <p>Whether the key material expires (<code>ExpirationModel</code>) and, if so, when\n            (<code>ValidTo</code>). If you set an expiration date, on the specified date, KMS\n          deletes the key material from the KMS key, making the KMS key unusable. To use the KMS key\n          in cryptographic operations again, you must reimport the same key material. The only way\n          to change the expiration model or expiration date is by reimporting the same key material\n          and specifying a new expiration date. </p>\n            </li>\n         </ul>\n         <p>When this operation is successful, the key state of the KMS key changes from\n        <code>PendingImport</code> to <code>Enabled</code>, and you can use the KMS key.</p>\n         <p>If this operation fails, use the exception to help determine the problem. If the error is\n      related to the key material, the import token, or wrapping key, use <a>GetParametersForImport</a> to get a new public key and import token for the KMS key\n      and repeat the import procedure. For help, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/importing-keys.html#importing-keys-overview\">How To Import Key\n        Material</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ImportKeyMaterial</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>DeleteImportedKeyMaterial</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GetParametersForImport</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#ImportKeyMaterialRequest": {
@@ -3213,7 +3360,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier of the symmetric encryption KMS key that receives the imported key\n      material. This must be the same KMS key specified in the <code>KeyID</code> parameter of the\n      corresponding <a>GetParametersForImport</a> request. The <code>Origin</code> of the\n      KMS key must be <code>EXTERNAL</code>. You cannot perform this operation on an asymmetric KMS\n      key, an HMAC KMS key, a KMS key in a custom key store, or on a KMS key in a different\n      Amazon Web Services account</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>The identifier of the symmetric encryption KMS key that receives the imported key\n      material. This must be the same KMS key specified in the <code>KeyID</code> parameter of the\n      corresponding <a>GetParametersForImport</a> request. The <code>Origin</code> of the\n      KMS key must be <code>EXTERNAL</code>. You cannot perform this operation on an asymmetric KMS\n      key, an HMAC KMS key, a KMS key in a custom key store, or on a KMS key in a different\n      Amazon Web Services account</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3243,11 +3390,17 @@
                         "smithy.api#documentation": "<p>Specifies whether the key material expires. The default is\n        <code>KEY_MATERIAL_EXPIRES</code>.</p>\n         <p>When the value of <code>ExpirationModel</code> is <code>KEY_MATERIAL_EXPIRES</code>, you\n      must specify a value for the <code>ValidTo</code> parameter. When value is\n        <code>KEY_MATERIAL_DOES_NOT_EXPIRE</code>, you must omit the <code>ValidTo</code>\n      parameter.</p>\n         <p>You cannot change the <code>ExpirationModel</code> or <code>ValidTo</code> values for the\n      current import after the request completes. To change either value, you must delete (<a>DeleteImportedKeyMaterial</a>) and reimport the key material.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ImportKeyMaterialResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.kms#IncorrectKeyException": {
             "type": "structure",
@@ -3951,7 +4104,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a list of aliases in the caller's Amazon Web Services account and region. For more information\n      about aliases, see <a>CreateAlias</a>.</p>\n         <p>By default, the <code>ListAliases</code> operation returns all aliases in the account and\n      region. To get only the aliases associated with a particular KMS key, use the\n        <code>KeyId</code> parameter.</p>\n         <p>The <code>ListAliases</code> response can include aliases that you created and associated\n      with your customer managed keys, and aliases that Amazon Web Services created and associated with Amazon Web Services\n      managed keys in your account. You can recognize Amazon Web Services aliases because their names have the\n      format <code>aws/<service-name></code>, such as <code>aws/dynamodb</code>.</p>\n         <p>The response might also include aliases that have no <code>TargetKeyId</code> field. These\n      are predefined aliases that Amazon Web Services has created but has not yet associated with a KMS key.\n      Aliases that Amazon Web Services creates in your account, including predefined aliases, do not count against\n      your <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#aliases-limit\">KMS aliases\n        quota</a>.</p>\n         <p>\n            <b>Cross-account use</b>: No. <code>ListAliases</code> does not\n      return aliases in other Amazon Web Services accounts.</p>\n    \n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListAliases</a> (IAM policy)</p>\n         <p>For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access\">Controlling access to aliases</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateAlias</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteAlias</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateAlias</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Gets a list of aliases in the caller's Amazon Web Services account and region. For more information\n      about aliases, see <a>CreateAlias</a>.</p>\n         <p>By default, the <code>ListAliases</code> operation returns all aliases in the account and\n      region. To get only the aliases associated with a particular KMS key, use the\n        <code>KeyId</code> parameter.</p>\n         <p>The <code>ListAliases</code> response can include aliases that you created and associated\n      with your customer managed keys, and aliases that Amazon Web Services created and associated with Amazon Web Services\n      managed keys in your account. You can recognize Amazon Web Services aliases because their names have the\n      format <code>aws/<service-name></code>, such as <code>aws/dynamodb</code>.</p>\n         <p>The response might also include aliases that have no <code>TargetKeyId</code> field. These\n      are predefined aliases that Amazon Web Services has created but has not yet associated with a KMS key.\n      Aliases that Amazon Web Services creates in your account, including predefined aliases, do not count against\n      your <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#aliases-limit\">KMS aliases\n        quota</a>.</p>\n         <p>\n            <b>Cross-account use</b>: No. <code>ListAliases</code> does not\n      return aliases in other Amazon Web Services accounts.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListAliases</a> (IAM policy)</p>\n         <p>For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html#alias-access\">Controlling access to aliases</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateAlias</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DeleteAlias</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UpdateAlias</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "NextMarker",
@@ -3966,7 +4119,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Lists only aliases that are associated with the specified KMS key. Enter a KMS key in your\n      Amazon Web Services account. </p>\n         <p>This parameter is optional. If you omit it, <code>ListAliases</code> returns all aliases\n      in the account and Region.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>"
+                        "smithy.api#documentation": "<p>Lists only aliases that are associated with the specified KMS key. Enter a KMS key in your\n      Amazon Web Services account. </p>\n         <p>This parameter is optional. If you omit it, <code>ListAliases</code> returns all aliases\n      in the account and Region.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>"
                     }
                 },
                 "Limit": {
@@ -3981,6 +4134,9 @@
                         "smithy.api#documentation": "<p>Use this parameter in a subsequent request after you receive a response with\n    truncated results. Set it to the value of <code>NextMarker</code> from the truncated response\n    you just received.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ListAliasesResponse": {
@@ -4005,6 +4161,9 @@
                         "smithy.api#documentation": "<p>A flag that indicates whether there are more items in the list. When this\n    value is true, the list in this response is truncated. To get more items, pass the value of\n    the <code>NextMarker</code> element in thisresponse to the <code>Marker</code> parameter in a\n    subsequent request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#ListGrants": {
@@ -4039,7 +4198,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a list of all grants for the specified KMS key. </p>\n         <p>You must specify the KMS key in all requests. You can filter the grant list by grant ID or\n      grantee principal.</p>\n         <p>For detailed information about grants, including grant terminology, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html\">Grants in KMS</a> in the\n        <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>. For examples of working with grants in several\n      programming languages, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html\">Programming grants</a>. </p>\n         <note>\n            <p>The <code>GranteePrincipal</code> field in the <code>ListGrants</code> response usually contains the\n        user or role designated as the grantee principal in the grant. However, when the grantee\n        principal in the grant is an Amazon Web Services service, the <code>GranteePrincipal</code> field contains\n        the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services\">service\n          principal</a>, which might represent several different grantee principals.</p>\n         </note>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation on a KMS key in a different Amazon Web Services account, specify the key\n  ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListGrants</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListRetirableGrants</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RetireGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RevokeGrant</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Gets a list of all grants for the specified KMS key. </p>\n         <p>You must specify the KMS key in all requests. You can filter the grant list by grant ID or\n      grantee principal.</p>\n         <p>For detailed information about grants, including grant terminology, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html\">Grants in KMS</a> in the\n        <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>. For examples of working with grants in several\n      programming languages, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html\">Programming grants</a>. </p>\n         <note>\n            <p>The <code>GranteePrincipal</code> field in the <code>ListGrants</code> response usually contains the\n        user or role designated as the grantee principal in the grant. However, when the grantee\n        principal in the grant is an Amazon Web Services service, the <code>GranteePrincipal</code> field contains\n        the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-services\">service\n          principal</a>, which might represent several different grantee principals.</p>\n         </note>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation on a KMS key in a different Amazon Web Services account, specify the key\n  ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListGrants</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListRetirableGrants</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RetireGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RevokeGrant</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "NextMarker",
@@ -4066,7 +4225,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Returns only grants for the specified KMS key. This parameter is required.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Returns only grants for the specified KMS key. This parameter is required.</p>\n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4082,6 +4241,9 @@
                         "smithy.api#documentation": "<p>Returns only grants where the specified principal is the grantee principal for the\n      grant.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ListGrantsResponse": {
@@ -4134,7 +4296,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets the names of the key policies that are attached to a KMS key. This operation is\n      designed to get policy names that you can use in a <a>GetKeyPolicy</a> operation.\n      However, the only valid policy name is <code>default</code>. </p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListKeyPolicies</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetKeyPolicy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>PutKeyPolicy</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Gets the names of the key policies that are attached to a KMS key. This operation is\n      designed to get policy names that you can use in a <a>GetKeyPolicy</a> operation.\n      However, the only valid policy name is <code>default</code>. </p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListKeyPolicies</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>GetKeyPolicy</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>PutKeyPolicy</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "NextMarker",
@@ -4149,7 +4311,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Gets the names of key policies for the specified KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Gets the names of key policies for the specified KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4165,6 +4327,9 @@
                         "smithy.api#documentation": "<p>Use this parameter in a subsequent request after you receive a response with\n    truncated results. Set it to the value of <code>NextMarker</code> from the truncated response\n    you just received.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ListKeyPoliciesResponse": {
@@ -4189,6 +4354,9 @@
                         "smithy.api#documentation": "<p>A flag that indicates whether there are more items in the list. When this\n    value is true, the list in this response is truncated. To get more items, pass the value of\n    the <code>NextMarker</code> element in thisresponse to the <code>Marker</code> parameter in a\n    subsequent request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#ListKeys": {
@@ -4211,7 +4379,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Gets a list of all KMS keys in the caller's Amazon Web Services account and Region.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListKeys</a> (IAM policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAliases</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Gets a list of all KMS keys in the caller's Amazon Web Services account and Region.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListKeys</a> (IAM policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListAliases</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "NextMarker",
@@ -4235,6 +4403,9 @@
                         "smithy.api#documentation": "<p>Use this parameter in a subsequent request after you receive a response with\n    truncated results. Set it to the value of <code>NextMarker</code> from the truncated response\n    you just received.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ListKeysResponse": {
@@ -4259,6 +4430,9 @@
                         "smithy.api#documentation": "<p>A flag that indicates whether there are more items in the list. When this\n    value is true, the list in this response is truncated. To get more items, pass the value of\n    the <code>NextMarker</code> element in thisresponse to the <code>Marker</code> parameter in a\n    subsequent request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#ListResourceTags": {
@@ -4284,7 +4458,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns all tags on the specified KMS key.</p>\n         <p>For general information about tags, including the format and syntax, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in\n      the <i>Amazon Web Services General Reference</i>. For information about using\n      tags in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging\n        keys</a>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListResourceTags</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReplicateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>TagResource</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UntagResource</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Returns all tags on the specified KMS key.</p>\n         <p>For general information about tags, including the format and syntax, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in\n      the <i>Amazon Web Services General Reference</i>. For information about using\n      tags in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging\n        keys</a>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListResourceTags</a> (key policy)</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReplicateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>TagResource</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UntagResource</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "NextMarker",
@@ -4299,7 +4473,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Gets tags on the specified KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Gets tags on the specified KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4315,6 +4489,9 @@
                         "smithy.api#documentation": "<p>Use this parameter in a subsequent request after you receive a response with\n    truncated results. Set it to the value of <code>NextMarker</code> from the truncated response\n    you just received.</p>\n         <p>Do not attempt to construct this value. Use only the value of <code>NextMarker</code> from\n      the truncated response you just received.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ListResourceTagsResponse": {
@@ -4339,6 +4516,9 @@
                         "smithy.api#documentation": "<p>A flag that indicates whether there are more items in the list. When this\n    value is true, the list in this response is truncated. To get more items, pass the value of\n    the <code>NextMarker</code> element in thisresponse to the <code>Marker</code> parameter in a\n    subsequent request.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#ListRetirableGrants": {
@@ -4367,7 +4547,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns information about all grants in the Amazon Web Services account and Region that have the\n      specified retiring principal. </p>\n         <p>You can specify any principal in your Amazon Web Services account. The grants that are returned include\n      grants for KMS keys in your Amazon Web Services account and other Amazon Web Services accounts. You might use this\n      operation to determine which grants you may retire. To retire a grant, use the <a>RetireGrant</a> operation.</p>\n         <p>For detailed information about grants, including grant terminology, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html\">Grants in KMS</a> in the\n        <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>. For examples of working with grants in several\n      programming languages, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html\">Programming grants</a>. </p>\n         <p>\n            <b>Cross-account use</b>: You must specify a principal in your\n      Amazon Web Services account. However, this operation can return grants in any Amazon Web Services account. You do not need\n        <code>kms:ListRetirableGrants</code> permission (or any other additional permission) in any\n      Amazon Web Services account other than your own.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListRetirableGrants</a> (IAM policy) in your\n      Amazon Web Services account.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListGrants</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RetireGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RevokeGrant</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Returns information about all grants in the Amazon Web Services account and Region that have the\n      specified retiring principal. </p>\n         <p>You can specify any principal in your Amazon Web Services account. The grants that are returned include\n      grants for KMS keys in your Amazon Web Services account and other Amazon Web Services accounts. You might use this\n      operation to determine which grants you may retire. To retire a grant, use the <a>RetireGrant</a> operation.</p>\n         <p>For detailed information about grants, including grant terminology, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html\">Grants in KMS</a> in the\n        <i>\n               <i>Key Management Service Developer Guide</i>\n            </i>. For examples of working with grants in several\n      programming languages, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/programming-grants.html\">Programming grants</a>. </p>\n         <p>\n            <b>Cross-account use</b>: You must specify a principal in your\n      Amazon Web Services account. However, this operation can return grants in any Amazon Web Services account. You do not need\n        <code>kms:ListRetirableGrants</code> permission (or any other additional permission) in any\n      Amazon Web Services account other than your own.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ListRetirableGrants</a> (IAM policy) in your\n      Amazon Web Services account.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListGrants</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RetireGrant</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>RevokeGrant</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#paginated": {
                     "inputToken": "Marker",
                     "outputToken": "NextMarker",
@@ -4394,10 +4574,13 @@
                 "RetiringPrincipal": {
                     "target": "com.amazonaws.kms#PrincipalIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The retiring principal for which to list grants. Enter a principal in your\n      Amazon Web Services account.</p>\n         <p>To specify the retiring principal, use the <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Name (ARN)</a> of an\n      Amazon Web Services principal. Valid Amazon Web Services principals include Amazon Web Services accounts (root), IAM users, federated\n      users, and assumed role users. For examples of the ARN syntax for specifying a principal, see\n        <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam\">Amazon Web Services Identity and Access Management (IAM)</a> in the Example ARNs section of the\n        <i>Amazon Web Services General Reference</i>.</p>",
+                        "smithy.api#documentation": "<p>The retiring principal for which to list grants. Enter a principal in your\n      Amazon Web Services account.</p>\n         <p>To specify the retiring principal, use the <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html\">Amazon Resource Name (ARN)</a> of an\n      Amazon Web Services principal. Valid principals include Amazon Web Services accounts, IAM users, IAM roles,\n      federated users, and assumed role users. For help with the ARN syntax for a principal, see\n        <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-arns\">IAM ARNs</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#MacAlgorithmSpec": {
@@ -4705,7 +4888,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Attaches a key policy to the specified KMS key. </p>\n         <p>For more information about key policies, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key Policies</a> in the <i>Key Management Service Developer Guide</i>.\n      For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>. For examples of adding a key policy in multiple programming languages,\n      see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/programming-key-policies.html#put-policy\">Setting a key policy</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:PutKeyPolicy</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>GetKeyPolicy</a>\n         </p>"
+                "smithy.api#documentation": "<p>Attaches a key policy to the specified KMS key. </p>\n         <p>For more information about key policies, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key Policies</a> in the <i>Key Management Service Developer Guide</i>.\n      For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>. For examples of adding a key policy in multiple programming languages,\n      see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/programming-key-policies.html#put-policy\">Setting a key policy</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:PutKeyPolicy</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>GetKeyPolicy</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#PutKeyPolicyRequest": {
@@ -4714,7 +4897,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Sets the key policy on the specified KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Sets the key policy on the specified KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4728,7 +4911,7 @@
                 "Policy": {
                     "target": "com.amazonaws.kms#PolicyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The key policy to attach to the KMS key.</p>\n         <p>The key policy must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>If you don't set <code>BypassPolicyLockoutSafetyCheck</code> to true, the key policy\n          must allow the principal that is making the <code>PutKeyPolicy</code> request to make a\n          subsequent <code>PutKeyPolicy</code> request on the KMS key. This reduces the risk that\n          the KMS key becomes unmanageable. For more information, refer to the scenario in the\n            <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section of the <i>Key Management Service Developer Guide</i>.</p>\n            </li>\n            <li>\n               <p>Each statement in the key policy must contain one or more principals. The principals\n          in the key policy must exist and be visible to KMS. When you create a new Amazon Web Services\n          principal (for example, an IAM user or role), you might need to enforce a delay before\n          including the new principal in a key policy because the new principal might not be\n          immediately visible to KMS. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>Amazon Web Services\n            Identity and Access Management User Guide</i>.</p>\n            </li>\n         </ul>\n    \n         <p>A key policy document can include only the following characters:</p>\n         <ul>\n            <li>\n               <p>Printable ASCII characters from the space character (<code>\\u0020</code>) through the end of the ASCII character range.</p>\n            </li>\n            <li>\n               <p>Printable characters in the Basic Latin and Latin-1 Supplement character set (through <code>\\u00FF</code>).</p>\n            </li>\n            <li>\n               <p>The tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) special characters</p>\n            </li>\n         </ul>\n         <p>For information about key policies, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key policies in KMS</a> in the\n      <i>Key Management Service Developer Guide</i>.For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>",
+                        "smithy.api#documentation": "<p>The key policy to attach to the KMS key.</p>\n         <p>The key policy must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>The key policy must allow the calling principal to make a\n          subsequent <code>PutKeyPolicy</code> request on the KMS key.  This reduces the risk that\n          the KMS key becomes unmanageable. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key\">Default key policy</a> in the <i>Key Management Service Developer Guide</i>. (To omit\n          this condition, set <code>BypassPolicyLockoutSafetyCheck</code> to true.)</p>\n            </li>\n            <li>\n               <p>Each statement in the key policy must contain one or more principals. The principals\n          in the key policy must exist and be visible to KMS. When you create a new Amazon Web Services\n          principal, you might need to enforce a delay before including the new principal in a key\n          policy because the new principal might not be immediately visible to KMS. For more\n          information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>Amazon Web Services\n            Identity and Access Management User Guide</i>.</p>\n            </li>\n         </ul>\n         <p>A key policy document can include only the following characters:</p>\n         <ul>\n            <li>\n               <p>Printable ASCII characters from the space character (<code>\\u0020</code>) through the end of the ASCII character range.</p>\n            </li>\n            <li>\n               <p>Printable characters in the Basic Latin and Latin-1 Supplement character set (through <code>\\u00FF</code>).</p>\n            </li>\n            <li>\n               <p>The tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) special characters</p>\n            </li>\n         </ul>\n         <p>For information about key policies, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key policies in KMS</a> in the\n      <i>Key Management Service Developer Guide</i>.For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4736,9 +4919,12 @@
                     "target": "com.amazonaws.kms#BooleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p>\n         <important>\n            <p>Setting this value to true increases the risk that the KMS key becomes unmanageable. Do\n        not set this value to true indiscriminately.</p>\n            <p>For more information, refer to the scenario in the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>Key Management Service Developer Guide</i>.</p>\n         </important>\n         <p>Use this parameter only when you intend to prevent the principal that is making the\n      request from making a subsequent <code>PutKeyPolicy</code> request on the KMS key.</p>\n         <p>The default value is false.</p>"
+                        "smithy.api#documentation": "<p>Skips (\"bypasses\") the key policy lockout safety check. The default value is false.</p>\n         <important>\n            <p>Setting this value to true increases the risk that the KMS key becomes unmanageable. Do\n        not set this value to true indiscriminately.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key\">Default key policy</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </important>\n         <p>Use this parameter only when you intend to prevent the principal that is making the\n      request from making a subsequent <a>PutKeyPolicy</a> request on the KMS key.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ReEncrypt": {
@@ -4782,7 +4968,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Decrypts ciphertext and then reencrypts it entirely within KMS. You can use this\n      operation to change the KMS key under which data is encrypted, such as when you <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually\">manually\n        rotate</a> a KMS key or change the KMS key that protects a ciphertext. You can also use\n      it to reencrypt ciphertext under the same KMS key, such as to change the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">encryption\n        context</a> of a ciphertext.</p>\n         <p>The <code>ReEncrypt</code> operation can decrypt ciphertext that was encrypted by using a\n      KMS key in an KMS operation, such as <a>Encrypt</a> or <a>GenerateDataKey</a>. It can also decrypt ciphertext that was encrypted by using the\n      public key of an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks\">asymmetric KMS key</a>\n      outside of KMS. However, it cannot decrypt ciphertext produced by other libraries, such as\n      the <a href=\"https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/\">Amazon Web Services Encryption SDK</a> or\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3\n        client-side encryption</a>. These libraries return a ciphertext format that is\n      incompatible with KMS.</p>\n         <p>When you use the <code>ReEncrypt</code> operation, you need to provide information for the\n      decrypt operation and the subsequent encrypt operation.</p>\n         <ul>\n            <li>\n               <p>If your ciphertext was encrypted under an asymmetric KMS key, you must use the\n            <code>SourceKeyId</code> parameter to identify the KMS key that encrypted the\n          ciphertext. You must also supply the encryption algorithm that was used. This information\n          is required to decrypt the data.</p>\n            </li>\n            <li>\n               <p>If your ciphertext was encrypted under a symmetric encryption KMS key, the\n            <code>SourceKeyId</code> parameter is optional. KMS can get this information from\n          metadata that it adds to the symmetric ciphertext blob. This feature adds durability to\n          your implementation by ensuring that authorized users can decrypt ciphertext decades after\n          it was encrypted, even if they've lost track of the key ID. However, specifying the source\n          KMS key is always recommended as a best practice. When you use the\n            <code>SourceKeyId</code> parameter to specify a KMS key, KMS uses only the KMS key you\n          specify. If the ciphertext was encrypted under a different KMS key, the\n            <code>ReEncrypt</code> operation fails. This practice ensures that you use the KMS key\n          that you intend.</p>\n            </li>\n            <li>\n               <p>To reencrypt the data, you must use the <code>DestinationKeyId</code> parameter to\n          specify the KMS key that re-encrypts the data after it is decrypted. If the destination\n          KMS key is an asymmetric KMS key, you must also provide the encryption algorithm. The\n          algorithm that you choose must be compatible with the KMS key.</p>\n\n               <important>\n                  <p>When you use an asymmetric KMS key to encrypt or reencrypt data, be sure to record the KMS key and encryption algorithm that you choose. You will be required to provide the same KMS key and encryption algorithm when you decrypt the data. If the KMS key and algorithm do not match the values used to encrypt the data, the decrypt operation fails.</p>\n                  <p>You are not required to supply the key ID and encryption algorithm when you decrypt with symmetric encryption KMS keys because KMS stores this information in the ciphertext blob. KMS cannot store metadata in ciphertext generated with asymmetric keys. The standard format for asymmetric key ciphertext does not include configurable fields.</p>\n               </important>\n            </li>\n         </ul>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. The source KMS key and\n      destination KMS key can be in different Amazon Web Services accounts. Either or both KMS keys can be in a\n      different account than the caller. To specify a KMS key in a different account, you must use\n      its key ARN or alias ARN.</p>\n\n         <p>\n            <b>Required permissions</b>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ReEncryptFrom</a>\n          permission on the source KMS key (key policy)</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ReEncryptTo</a>\n          permission on the destination KMS key (key policy)</p>\n            </li>\n         </ul>\n         <p>To permit reencryption from or to a KMS key, include the <code>\"kms:ReEncrypt*\"</code>\n      permission in your <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">key policy</a>. This permission is\n      automatically included in the key policy when you use the console to create a KMS key. But you\n      must include it manually when you create a KMS key programmatically or when you use the <a>PutKeyPolicy</a> operation to set a key policy.</p>\n\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Decrypts ciphertext and then reencrypts it entirely within KMS. You can use this\n      operation to change the KMS key under which data is encrypted, such as when you <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/rotate-keys.html#rotate-keys-manually\">manually\n        rotate</a> a KMS key or change the KMS key that protects a ciphertext. You can also use\n      it to reencrypt ciphertext under the same KMS key, such as to change the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#encrypt_context\">encryption\n        context</a> of a ciphertext.</p>\n         <p>The <code>ReEncrypt</code> operation can decrypt ciphertext that was encrypted by using a\n      KMS key in an KMS operation, such as <a>Encrypt</a> or <a>GenerateDataKey</a>. It can also decrypt ciphertext that was encrypted by using the\n      public key of an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symm-asymm-concepts.html#asymmetric-cmks\">asymmetric KMS key</a>\n      outside of KMS. However, it cannot decrypt ciphertext produced by other libraries, such as\n      the <a href=\"https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/\">Amazon Web Services Encryption SDK</a> or\n        <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingClientSideEncryption.html\">Amazon S3\n        client-side encryption</a>. These libraries return a ciphertext format that is\n      incompatible with KMS.</p>\n         <p>When you use the <code>ReEncrypt</code> operation, you need to provide information for the\n      decrypt operation and the subsequent encrypt operation.</p>\n         <ul>\n            <li>\n               <p>If your ciphertext was encrypted under an asymmetric KMS key, you must use the\n            <code>SourceKeyId</code> parameter to identify the KMS key that encrypted the\n          ciphertext. You must also supply the encryption algorithm that was used. This information\n          is required to decrypt the data.</p>\n            </li>\n            <li>\n               <p>If your ciphertext was encrypted under a symmetric encryption KMS key, the\n            <code>SourceKeyId</code> parameter is optional. KMS can get this information from\n          metadata that it adds to the symmetric ciphertext blob. This feature adds durability to\n          your implementation by ensuring that authorized users can decrypt ciphertext decades after\n          it was encrypted, even if they've lost track of the key ID. However, specifying the source\n          KMS key is always recommended as a best practice. When you use the\n            <code>SourceKeyId</code> parameter to specify a KMS key, KMS uses only the KMS key you\n          specify. If the ciphertext was encrypted under a different KMS key, the\n            <code>ReEncrypt</code> operation fails. This practice ensures that you use the KMS key\n          that you intend.</p>\n            </li>\n            <li>\n               <p>To reencrypt the data, you must use the <code>DestinationKeyId</code> parameter to\n          specify the KMS key that re-encrypts the data after it is decrypted. If the destination\n          KMS key is an asymmetric KMS key, you must also provide the encryption algorithm. The\n          algorithm that you choose must be compatible with the KMS key.</p>\n               <important>\n                  <p>When you use an asymmetric KMS key to encrypt or reencrypt data, be sure to record the KMS key and encryption algorithm that you choose. You will be required to provide the same KMS key and encryption algorithm when you decrypt the data. If the KMS key and algorithm do not match the values used to encrypt the data, the decrypt operation fails.</p>\n                  <p>You are not required to supply the key ID and encryption algorithm when you decrypt with symmetric encryption KMS keys because KMS stores this information in the ciphertext blob. KMS cannot store metadata in ciphertext generated with asymmetric keys. The standard format for asymmetric key ciphertext does not include configurable fields.</p>\n               </important>\n            </li>\n         </ul>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. The source KMS key and\n      destination KMS key can be in different Amazon Web Services accounts. Either or both KMS keys can be in a\n      different account than the caller. To specify a KMS key in a different account, you must use\n      its key ARN or alias ARN.</p>\n         <p>\n            <b>Required permissions</b>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ReEncryptFrom</a>\n          permission on the source KMS key (key policy)</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:ReEncryptTo</a>\n          permission on the destination KMS key (key policy)</p>\n            </li>\n         </ul>\n         <p>To permit reencryption from or to a KMS key, include the <code>\"kms:ReEncrypt*\"</code>\n      permission in your <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">key policy</a>. This permission is\n      automatically included in the key policy when you use the console to create a KMS key. But you\n      must include it manually when you create a KMS key programmatically or when you use the <a>PutKeyPolicy</a> operation to set a key policy.</p>\n         <p>\n            <b>Related operations:</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyPair</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#ReEncryptRequest": {
@@ -4804,13 +4990,13 @@
                 "SourceKeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the KMS key that KMS will use to decrypt the ciphertext before it is\n      re-encrypted.</p>\n         <p>Enter a key ID of the KMS key that was used to encrypt the ciphertext. If you identify a\n      different KMS key, the <code>ReEncrypt</code> operation throws an\n        <code>IncorrectKeyException</code>.</p>\n         <p>This parameter is required only when the ciphertext was encrypted under an asymmetric KMS\n      key. If you used a symmetric encryption KMS key, KMS can get the KMS key from metadata that\n      it adds to the symmetric ciphertext blob. However, it is always recommended as a best\n      practice. This practice ensures that you use the KMS key that you intend.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>"
+                        "smithy.api#documentation": "<p>Specifies the KMS key that KMS will use to decrypt the ciphertext before it is\n      re-encrypted.</p>\n         <p>Enter a key ID of the KMS key that was used to encrypt the ciphertext. If you identify a\n      different KMS key, the <code>ReEncrypt</code> operation throws an\n        <code>IncorrectKeyException</code>.</p>\n         <p>This parameter is required only when the ciphertext was encrypted under an asymmetric KMS\n      key. If you used a symmetric encryption KMS key, KMS can get the KMS key from metadata that\n      it adds to the symmetric ciphertext blob. However, it is always recommended as a best\n      practice. This practice ensures that you use the KMS key that you intend.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>"
                     }
                 },
                 "DestinationKeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A unique identifier for the KMS key that is used to reencrypt the data. Specify a\n      symmetric encryption KMS key or an asymmetric KMS key with a <code>KeyUsage</code> value of\n        <code>ENCRYPT_DECRYPT</code>. To find the <code>KeyUsage</code> value of a KMS key, use the\n        <a>DescribeKey</a> operation.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>A unique identifier for the KMS key that is used to reencrypt the data. Specify a\n      symmetric encryption KMS key or an asymmetric KMS key with a <code>KeyUsage</code> value of\n        <code>ENCRYPT_DECRYPT</code>. To find the <code>KeyUsage</code> value of a KMS key, use the\n        <a>DescribeKey</a> operation.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4838,6 +5024,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ReEncryptResponse": {
@@ -4873,6 +5062,9 @@
                         "smithy.api#documentation": "<p>The encryption algorithm that was used to reencrypt the data.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#RegionType": {
@@ -4935,7 +5127,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the multi-Region primary key that is being replicated. To determine whether a\n      KMS key is a multi-Region primary key, use the <a>DescribeKey</a> operation to\n      check the value of the <code>MultiRegionKeyType</code> property.</p>\n    \n         <p>Specify the key ID or key ARN of a multi-Region primary key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the multi-Region primary key that is being replicated. To determine whether a\n      KMS key is a multi-Region primary key, use the <a>DescribeKey</a> operation to\n      check the value of the <code>MultiRegionKeyType</code> property.</p>\n         <p>Specify the key ID or key ARN of a multi-Region primary key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -4949,14 +5141,14 @@
                 "Policy": {
                     "target": "com.amazonaws.kms#PolicyType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The key policy to attach to the KMS key. This parameter is optional. If you do not provide\n      a key policy, KMS attaches the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default\">default key policy</a> to the\n      KMS key.</p>\n         <p>The key policy is not a shared property of multi-Region keys. You can specify the same key\n      policy or a different key policy for each key in a set of related multi-Region keys. KMS\n      does not synchronize this property.</p>\n         <p>If you provide a key policy, it must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>If you don't set <code>BypassPolicyLockoutSafetyCheck</code> to true, the key policy\n          must give the caller <code>kms:PutKeyPolicy</code> permission on the replica key. This\n          reduces the risk that the KMS key becomes unmanageable. For more information, refer to the\n          scenario in the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section of the <i>\n                     <i>Key Management Service Developer Guide</i>\n                  </i>.</p>\n            </li>\n            <li>\n               <p>Each statement in the key policy must contain one or more principals. The principals\n          in the key policy must exist and be visible to KMS. When you create a new Amazon Web Services\n          principal (for example, an IAM user or role), you might need to enforce a delay before\n          including the new principal in a key policy because the new principal might not be\n          immediately visible to KMS. For more information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the\n            <i>\n                     <i>Identity and Access Management User Guide</i>\n                  </i>.</p>\n            </li>\n         </ul>\n    \n         <p>A key policy document can include only the following characters:</p>\n         <ul>\n            <li>\n               <p>Printable ASCII characters from the space character (<code>\\u0020</code>) through the end of the ASCII character range.</p>\n            </li>\n            <li>\n               <p>Printable characters in the Basic Latin and Latin-1 Supplement character set (through <code>\\u00FF</code>).</p>\n            </li>\n            <li>\n               <p>The tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) special characters</p>\n            </li>\n         </ul>\n         <p>For information about key policies, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key policies in KMS</a> in the <i>Key Management Service Developer Guide</i>.\n      For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>"
+                        "smithy.api#documentation": "<p>The key policy to attach to the KMS key. This parameter is optional. If you do not provide\n      a key policy, KMS attaches the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default\">default key policy</a> to the\n      KMS key.</p>\n         <p>The key policy is not a shared property of multi-Region keys. You can specify the same key\n      policy or a different key policy for each key in a set of related multi-Region keys. KMS\n      does not synchronize this property.</p>\n         <p>If you provide a key policy, it must meet the following criteria:</p>\n         <ul>\n            <li>\n               <p>The key policy must allow the calling principal to make a\n          subsequent <code>PutKeyPolicy</code> request on the KMS key.  This reduces the risk that\n          the KMS key becomes unmanageable. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key\">Default key policy</a> in the <i>Key Management Service Developer Guide</i>. (To omit\n          this condition, set <code>BypassPolicyLockoutSafetyCheck</code> to true.)</p>\n            </li>\n            <li>\n               <p>Each statement in the key policy must contain one or more principals. The principals\n          in the key policy must exist and be visible to KMS. When you create a new Amazon Web Services\n          principal, you might need to enforce a delay before including the new principal in a key\n          policy because the new principal might not be immediately visible to KMS. For more\n          information, see <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/troubleshoot_general.html#troubleshoot_general_eventual-consistency\">Changes that I make are not always immediately visible</a> in the <i>Amazon Web Services\n            Identity and Access Management User Guide</i>.</p>\n            </li>\n         </ul>\n         <p>A key policy document can include only the following characters:</p>\n         <ul>\n            <li>\n               <p>Printable ASCII characters from the space character (<code>\\u0020</code>) through the end of the ASCII character range.</p>\n            </li>\n            <li>\n               <p>Printable characters in the Basic Latin and Latin-1 Supplement character set (through <code>\\u00FF</code>).</p>\n            </li>\n            <li>\n               <p>The tab (<code>\\u0009</code>), line feed (<code>\\u000A</code>), and carriage return (<code>\\u000D</code>) special characters</p>\n            </li>\n         </ul>\n         <p>For information about key policies, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html\">Key policies in KMS</a> in the <i>Key Management Service Developer Guide</i>.\n      For help writing and formatting a JSON policy document, see the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies.html\">IAM JSON Policy Reference</a> in the <i>\n               <i>Identity and Access Management User Guide</i>\n            </i>.</p>"
                     }
                 },
                 "BypassPolicyLockoutSafetyCheck": {
                     "target": "com.amazonaws.kms#BooleanType",
                     "traits": {
                         "smithy.api#default": false,
-                        "smithy.api#documentation": "<p>A flag to indicate whether to bypass the key policy lockout safety check.</p>\n         <important>\n            <p>Setting this value to true increases the risk that the KMS key becomes unmanageable. Do\n        not set this value to true indiscriminately.</p>\n            <p>For more information, refer to the scenario in the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-default-allow-root-enable-iam\">Default Key Policy</a> section in the <i>Key Management Service Developer Guide</i>.</p>\n         </important>\n         <p>Use this parameter only when you intend to prevent the principal that is making the\n      request from making a subsequent <code>PutKeyPolicy</code> request on the KMS key.</p>\n         <p>The default value is false.</p>"
+                        "smithy.api#documentation": "<p>Skips (\"bypasses\") the key policy lockout safety check. The default value is false.</p>\n         <important>\n            <p>Setting this value to true increases the risk that the KMS key becomes unmanageable. Do\n        not set this value to true indiscriminately.</p>\n            <p>For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#prevent-unmanageable-key\">Default key policy</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </important>\n         <p>Use this parameter only when you intend to prevent the principal that is making the\n      request from making a subsequent <a>PutKeyPolicy</a> request on the KMS key.</p>"
                     }
                 },
                 "Description": {
@@ -4971,6 +5163,9 @@
                         "smithy.api#documentation": "<p>Assigns one or more tags to the replica key. Use this parameter to tag the KMS key when it\n      is created. To tag an existing KMS key, use the <a>TagResource</a>\n      operation.</p>\n         <note>\n            <p>Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>To use this parameter, you must have <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:TagResource</a> permission in an IAM policy.</p>\n         <p>Tags are not a shared property of multi-Region keys. You can specify the same tags or\n      different tags for each key in a set of related multi-Region keys. KMS does not synchronize\n      this property.</p>\n         <p>Each tag consists of a tag key and a tag value. Both the tag key and the tag value are\n      required, but the tag value can be an empty (null) string. You cannot have more than one tag\n      on a KMS key with the same tag key. If you specify an existing tag key with a different tag\n      value, KMS replaces the current tag value with the specified one.</p>\n         <p>When you add tags to an Amazon Web Services resource, Amazon Web Services generates a cost allocation\n              report with usage and costs aggregated by tags. Tags can also be used to control access to a KMS key. For details,\n              see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging Keys</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ReplicateKeyResponse": {
@@ -4994,6 +5189,9 @@
                         "smithy.api#documentation": "<p>The tags on the new replica key. The value is a list of tag key and tag value\n      pairs.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#RetireGrant": {
@@ -5052,6 +5250,9 @@
                         "smithy.api#documentation": "<p>Identifies the grant to retire. To get the grant ID, use <a>CreateGrant</a>,\n        <a>ListGrants</a>, or <a>ListRetirableGrants</a>.</p>\n         <ul>\n            <li>\n               <p>Grant ID Example -\n          0123456789012345678901234567890123456789012345678901234567890123</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#RevokeGrant": {
@@ -5092,7 +5293,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>A unique identifier for the KMS key associated with the grant. To get the key ID and key\n      ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>A unique identifier for the KMS key associated with the grant. To get the key ID and key\n      ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>\n         <p>Specify the key ID or key ARN of the KMS key. To specify a KMS key in a\ndifferent Amazon Web Services account, you must use the key ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -5103,6 +5304,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ScheduleKeyDeletion": {
@@ -5131,7 +5335,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Schedules the deletion of a KMS key. By default, KMS applies a waiting period of 30\n      days, but you can specify a waiting period of 7-30 days. When this operation is successful,\n      the key state of the KMS key changes to <code>PendingDeletion</code> and the key can't be used\n      in any cryptographic operations. It remains in this state for the duration of the waiting\n      period. Before the waiting period ends, you can use <a>CancelKeyDeletion</a> to\n      cancel the deletion of the KMS key. After the waiting period ends, KMS deletes the KMS key,\n      its key material, and all KMS data associated with it, including all aliases that refer to\n      it.</p>\n         <important>\n            <p>Deleting a KMS key is a destructive and potentially dangerous operation. When a KMS key\n        is deleted, all data that was encrypted under the KMS key is unrecoverable. (The only\n        exception is a multi-Region replica key.) To prevent the use of a KMS key without deleting\n        it, use <a>DisableKey</a>. </p>\n         </important>\n         <p>You can schedule the deletion of a multi-Region primary key and its replica keys at any\n      time. However, KMS will not delete a multi-Region primary key with existing replica keys. If\n      you schedule the deletion of a primary key with replicas, its key state changes to\n        <code>PendingReplicaDeletion</code> and it cannot be replicated or used in cryptographic\n      operations. This status can continue indefinitely. When the last of its replicas keys is\n      deleted (not just scheduled), the key state of the primary key changes to\n        <code>PendingDeletion</code> and its waiting period (<code>PendingWindowInDays</code>)\n      begins. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html\">Deleting multi-Region keys</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>When KMS <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/delete-cmk-keystore.html\">deletes\n        a KMS key from an CloudHSM key store</a>, it makes a best effort to delete the associated\n      key material from the associated CloudHSM cluster. However, you might need to manually <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key\">delete\n        the orphaned key material</a> from the cluster and its backups. <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/delete-xks-key.html\">Deleting a KMS key from an\n        external key store</a> has no effect on the associated external key. However, for both\n      types of custom key stores, deleting a KMS key is destructive and irreversible. You cannot\n      decrypt ciphertext encrypted under the KMS key by using only its associated external key or\n      CloudHSM key. Also, you cannot recreate a KMS key in an external key store by creating a new KMS\n      key with the same key material.</p>\n         <p>For more information about scheduling a KMS key for deletion, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html\">Deleting KMS keys</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n\n         <p>\n            <b>Required permissions</b>: kms:ScheduleKeyDeletion (key\n      policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CancelKeyDeletion</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisableKey</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Schedules the deletion of a KMS key. By default, KMS applies a waiting period of 30\n      days, but you can specify a waiting period of 7-30 days. When this operation is successful,\n      the key state of the KMS key changes to <code>PendingDeletion</code> and the key can't be used\n      in any cryptographic operations. It remains in this state for the duration of the waiting\n      period. Before the waiting period ends, you can use <a>CancelKeyDeletion</a> to\n      cancel the deletion of the KMS key. After the waiting period ends, KMS deletes the KMS key,\n      its key material, and all KMS data associated with it, including all aliases that refer to\n      it.</p>\n         <important>\n            <p>Deleting a KMS key is a destructive and potentially dangerous operation. When a KMS key\n        is deleted, all data that was encrypted under the KMS key is unrecoverable. (The only\n        exception is a multi-Region replica key.) To prevent the use of a KMS key without deleting\n        it, use <a>DisableKey</a>. </p>\n         </important>\n         <p>You can schedule the deletion of a multi-Region primary key and its replica keys at any\n      time. However, KMS will not delete a multi-Region primary key with existing replica keys. If\n      you schedule the deletion of a primary key with replicas, its key state changes to\n        <code>PendingReplicaDeletion</code> and it cannot be replicated or used in cryptographic\n      operations. This status can continue indefinitely. When the last of its replicas keys is\n      deleted (not just scheduled), the key state of the primary key changes to\n        <code>PendingDeletion</code> and its waiting period (<code>PendingWindowInDays</code>)\n      begins. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/multi-region-keys-delete.html\">Deleting multi-Region keys</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>When KMS <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/delete-cmk-keystore.html\">deletes\n        a KMS key from an CloudHSM key store</a>, it makes a best effort to delete the associated\n      key material from the associated CloudHSM cluster. However, you might need to manually <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/fix-keystore.html#fix-keystore-orphaned-key\">delete\n        the orphaned key material</a> from the cluster and its backups. <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/delete-xks-key.html\">Deleting a KMS key from an\n        external key store</a> has no effect on the associated external key. However, for both\n      types of custom key stores, deleting a KMS key is destructive and irreversible. You cannot\n      decrypt ciphertext encrypted under the KMS key by using only its associated external key or\n      CloudHSM key. Also, you cannot recreate a KMS key in an external key store by creating a new KMS\n      key with the same key material.</p>\n         <p>For more information about scheduling a KMS key for deletion, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html\">Deleting KMS keys</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: kms:ScheduleKeyDeletion (key\n      policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CancelKeyDeletion</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DisableKey</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#ScheduleKeyDeletionRequest": {
@@ -5140,7 +5344,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The unique identifier of the KMS key to delete.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>The unique identifier of the KMS key to delete.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -5150,6 +5354,9 @@
                         "smithy.api#documentation": "<p>The waiting period, specified in number of days. After the waiting period ends, KMS\n      deletes the KMS key.</p>\n         <p>If the KMS key is a multi-Region primary key with replica keys, the waiting period begins\n      when the last of its replica keys is deleted. Otherwise, the waiting period begins\n      immediately.</p>\n         <p>This value is optional. If you include a value, it must be between 7 and 30, inclusive. If\n      you do not include a value, it defaults to 30.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#ScheduleKeyDeletionResponse": {
@@ -5179,6 +5386,9 @@
                         "smithy.api#documentation": "<p>The waiting period before the KMS key is deleted. </p>\n         <p>If the KMS key is a multi-Region primary key with replicas, the waiting period begins when\n      the last of its replica keys is deleted. Otherwise, the waiting period begins\n      immediately.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#Sign": {
@@ -5216,7 +5426,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Creates a <a href=\"https://en.wikipedia.org/wiki/Digital_signature\">digital\n        signature</a> for a message or message digest by using the private key in an asymmetric\n      signing KMS key. To verify the signature, use the <a>Verify</a> operation, or use\n      the public key in the same asymmetric KMS key outside of KMS. For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>Digital signatures are generated and verified by using asymmetric key pair, such as an RSA\n      or ECC pair that is represented by an asymmetric KMS key. The key owner (or an authorized\n      user) uses their private key to sign a message. Anyone with the public key can verify that the\n      message was signed with that particular private key and that the message hasn't changed since\n      it was signed. </p>\n         <p>To use the <code>Sign</code> operation, provide the following information:</p>\n         <ul>\n            <li>\n               <p>Use the <code>KeyId</code> parameter to identify an asymmetric KMS key with a\n            <code>KeyUsage</code> value of <code>SIGN_VERIFY</code>. To get the\n            <code>KeyUsage</code> value of a KMS key, use the <a>DescribeKey</a>\n          operation. The caller must have <code>kms:Sign</code> permission on the KMS key.</p>\n            </li>\n            <li>\n               <p>Use the <code>Message</code> parameter to specify the message or message digest to\n          sign. You can submit messages of up to 4096 bytes. To sign a larger message, generate a\n          hash digest of the message, and then provide the hash digest in the <code>Message</code>\n          parameter. To indicate whether the message is a full message or a digest, use the\n            <code>MessageType</code> parameter.</p>\n            </li>\n            <li>\n               <p>Choose a signing algorithm that is compatible with the KMS key. </p>\n            </li>\n         </ul>\n         <important>\n            <p>When signing a message, be sure to record the KMS key and the signing algorithm. This\n        information is required to verify the signature.</p>\n         </important>\n         <note>\n            <p>Best practices recommend that you limit the time during which any signature is\n        effective. This deters an attack where the actor uses a signed message to establish validity\n        repeatedly or long after the message is superseded. Signatures do not include a timestamp,\n        but you can include a timestamp in the signed message to help you detect when its time to\n        refresh the signature. </p>\n         </note>\n         <p>To verify the signature that this operation generates, use the <a>Verify</a>\n      operation. Or use the <a>GetPublicKey</a> operation to download the public key and\n      then use the public key to verify the signature outside of KMS. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Sign</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>Verify</a>\n         </p>"
+                "smithy.api#documentation": "<p>Creates a <a href=\"https://en.wikipedia.org/wiki/Digital_signature\">digital\n        signature</a> for a message or message digest by using the private key in an asymmetric\n      signing KMS key. To verify the signature, use the <a>Verify</a> operation, or use\n      the public key in the same asymmetric KMS key outside of KMS. For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>Digital signatures are generated and verified by using asymmetric key pair, such as an RSA\n      or ECC pair that is represented by an asymmetric KMS key. The key owner (or an authorized\n      user) uses their private key to sign a message. Anyone with the public key can verify that the\n      message was signed with that particular private key and that the message hasn't changed since\n      it was signed. </p>\n         <p>To use the <code>Sign</code> operation, provide the following information:</p>\n         <ul>\n            <li>\n               <p>Use the <code>KeyId</code> parameter to identify an asymmetric KMS key with a\n            <code>KeyUsage</code> value of <code>SIGN_VERIFY</code>. To get the\n            <code>KeyUsage</code> value of a KMS key, use the <a>DescribeKey</a>\n          operation. The caller must have <code>kms:Sign</code> permission on the KMS key.</p>\n            </li>\n            <li>\n               <p>Use the <code>Message</code> parameter to specify the message or message digest to\n          sign. You can submit messages of up to 4096 bytes. To sign a larger message, generate a\n          hash digest of the message, and then provide the hash digest in the <code>Message</code>\n          parameter. To indicate whether the message is a full message or a digest, use the\n            <code>MessageType</code> parameter.</p>\n            </li>\n            <li>\n               <p>Choose a signing algorithm that is compatible with the KMS key. </p>\n            </li>\n         </ul>\n         <important>\n            <p>When signing a message, be sure to record the KMS key and the signing algorithm. This\n        information is required to verify the signature.</p>\n         </important>\n         <note>\n            <p>Best practices recommend that you limit the time during which any signature is\n        effective. This deters an attack where the actor uses a signed message to establish validity\n        repeatedly or long after the message is superseded. Signatures do not include a timestamp,\n        but you can include a timestamp in the signed message to help you detect when its time to\n        refresh the signature. </p>\n         </note>\n         <p>To verify the signature that this operation generates, use the <a>Verify</a>\n      operation. Or use the <a>GetPublicKey</a> operation to download the public key and\n      then use the public key to verify the signature outside of KMS. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Sign</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>Verify</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#SignRequest": {
@@ -5225,21 +5435,21 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies an asymmetric KMS key. KMS uses the private key in the asymmetric KMS key to\n      sign the message. The <code>KeyUsage</code> type of the KMS key must be\n        <code>SIGN_VERIFY</code>. To find the <code>KeyUsage</code> of a KMS key, use the <a>DescribeKey</a> operation.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies an asymmetric KMS key. KMS uses the private key in the asymmetric KMS key to\n      sign the message. The <code>KeyUsage</code> type of the KMS key must be\n        <code>SIGN_VERIFY</code>. To find the <code>KeyUsage</code> of a KMS key, use the <a>DescribeKey</a> operation.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Message": {
                     "target": "com.amazonaws.kms#PlaintextType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the message or message digest to sign. Messages can be 0-4096 bytes. To sign a\n      larger message, provide the message digest.</p>\n         <p>If you provide a message, KMS generates a hash digest of the message and then signs\n      it.</p>",
+                        "smithy.api#documentation": "<p>Specifies the message or message digest to sign. Messages can be 0-4096 bytes. To sign a\n      larger message, provide a message digest.</p>\n         <p>If you provide a message digest, use the <code>DIGEST</code> value of <code>MessageType</code> to\n    prevent the digest from being hashed again while signing.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "MessageType": {
                     "target": "com.amazonaws.kms#MessageType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Tells KMS whether the value of the <code>Message</code> parameter is a message or\n      message digest. The default value, RAW, indicates a message. To indicate a message digest,\n      enter <code>DIGEST</code>.</p>"
+                        "smithy.api#documentation": "<p>Tells KMS whether the value of the <code>Message</code> parameter should be hashed\n      as part of the signing algorithm. Use <code>RAW</code> for unhashed messages; use <code>DIGEST</code>\n      for message digests, which are already hashed.</p>\n         <p>When the value of <code>MessageType</code> is <code>RAW</code>, KMS uses the standard\n      signing algorithm, which begins with a hash function. When the value is <code>DIGEST</code>, KMS skips\n      the hashing step in the signing algorithm.</p>\n         <important>\n            <p>Use the <code>DIGEST</code> value only when the value of the <code>Message</code>\n        parameter is a message digest. If you use the <code>DIGEST</code> value with an unhashed message,\n        the security of the signing operation can be compromised.</p>\n         </important>\n         <p>When the value of <code>MessageType</code>is <code>DIGEST</code>, the length\n      of the <code>Message</code> value must match the length of hashed messages for the specified signing algorithm.</p>\n         <p>You can submit a message digest and omit the <code>MessageType</code> or specify\n      <code>RAW</code> so the digest is hashed again while signing. However, this can cause verification failures when \n      verifying with a system that assumes a single hash.</p>\n         <p>The hashing algorithm in that <code>Sign</code> uses is based on the <code>SigningAlgorithm</code> value.</p>\n         <ul>\n            <li>\n               <p>Signing algorithms that end in SHA_256 use the SHA_256 hashing algorithm.</p>\n            </li>\n            <li>\n               <p>Signing algorithms that end in SHA_384 use the SHA_384 hashing algorithm.</p>\n            </li>\n            <li>\n               <p>Signing algorithms that end in SHA_512 use the SHA_512 hashing algorithm.</p>\n            </li>\n            <li>\n               <p>SM2DSA uses the SM3 hashing algorithm. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-sm-offline-verification\">Offline verification with SM2 key pairs</a>.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "GrantTokens": {
@@ -5251,10 +5461,13 @@
                 "SigningAlgorithm": {
                     "target": "com.amazonaws.kms#SigningAlgorithmSpec",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the signing algorithm to use when signing the message. </p>\n         <p>Choose an algorithm that is compatible with the type and size of the specified asymmetric\n      KMS key.</p>",
+                        "smithy.api#documentation": "<p>Specifies the signing algorithm to use when signing the message. </p>\n         <p>Choose an algorithm that is compatible with the type and size of the specified asymmetric\n      KMS key.  When signing with RSA key pairs, RSASSA-PSS algorithms are preferred. We include\n      RSASSA-PKCS1-v1_5 algorithms for compatibility with existing applications.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#SignResponse": {
@@ -5278,6 +5491,9 @@
                         "smithy.api#documentation": "<p>The signing algorithm that was used to sign the message.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#SigningAlgorithmSpec": {
@@ -5440,7 +5656,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Adds or edits tags on a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>.</p>\n         <note>\n            <p>Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>Each tag consists of a tag key and a tag value, both of which are case-sensitive strings.\n      The tag value can be an empty (null) string. To add a tag, specify a new tag key and a tag\n      value. To edit a tag, specify an existing tag key and a new tag value.</p>\n         <p>You can use this operation to tag a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>, but you cannot\n      tag an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services\n        managed key</a>, an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned key</a>, a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#keystore-concept\">custom key\n        store</a>, or an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#alias-concept\">alias</a>.</p>\n         <p>You can also add tags to a KMS key while creating it (<a>CreateKey</a>) or\n      replicating it (<a>ReplicateKey</a>).</p>\n         <p>For information about using tags in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging keys</a>. For general information about\n      tags, including the format and syntax, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in the <i>Amazon\n        Web Services General Reference</i>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account. </p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:TagResource</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReplicateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UntagResource</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Adds or edits tags on a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>.</p>\n         <note>\n            <p>Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>Each tag consists of a tag key and a tag value, both of which are case-sensitive strings.\n      The tag value can be an empty (null) string. To add a tag, specify a new tag key and a tag\n      value. To edit a tag, specify an existing tag key and a new tag value.</p>\n         <p>You can use this operation to tag a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>, but you cannot\n      tag an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services\n        managed key</a>, an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-owned-cmk\">Amazon Web Services owned key</a>, a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#keystore-concept\">custom key\n        store</a>, or an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#alias-concept\">alias</a>.</p>\n         <p>You can also add tags to a KMS key while creating it (<a>CreateKey</a>) or\n      replicating it (<a>ReplicateKey</a>).</p>\n         <p>For information about using tags in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging keys</a>. For general information about\n      tags, including the format and syntax, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in the <i>Amazon\n        Web Services General Reference</i>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account. </p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:TagResource</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReplicateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>UntagResource</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#TagResourceRequest": {
@@ -5449,7 +5665,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies a customer managed key in the account and Region.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies a customer managed key in the account and Region.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -5460,6 +5676,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#TagValueType": {
@@ -5638,7 +5857,7 @@
                     "name": "kms"
                 },
                 "aws.protocols#awsJson1_1": {},
-                "smithy.api#documentation": "<fullname>Key Management Service</fullname>\n         <p>Key Management Service (KMS) is an encryption and key management web service. This guide describes\n      the KMS operations that you can call programmatically. For general information about KMS,\n      see the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/\">\n               <i>Key Management Service Developer Guide</i>\n            </a>.</p>\n         <note>\n            <p>KMS has replaced the term <i>customer master key (CMK)</i> with <i>KMS key</i> and <i>KMS key</i>. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.</p>\n            <p>Amazon Web Services provides SDKs that consist of libraries and sample code for various programming\n        languages and platforms (Java, Ruby, .Net, macOS, Android, etc.). The SDKs provide a\n        convenient way to create programmatic access to KMS and other Amazon Web Services services. For example,\n        the SDKs take care of tasks such as signing requests (see below), managing errors, and\n        retrying requests automatically. For more information about the Amazon Web Services SDKs, including how to\n        download and install them, see <a href=\"http://aws.amazon.com/tools/\">Tools for Amazon Web\n          Services</a>.</p>\n         </note>\n         <p>We recommend that you use the Amazon Web Services SDKs to make programmatic API calls to KMS.</p>\n         <p>If you need to use FIPS 140-2 validated cryptographic modules when communicating with\n      Amazon Web Services, use the FIPS endpoint in your preferred Amazon Web Services Region. For more information about the\n      available FIPS endpoints, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region\">Service endpoints</a> in the Key Management Service topic of\n      the <i>Amazon Web Services General Reference</i>.</p>\n         <p>All KMS API calls must be signed and be transmitted using Transport Layer Security\n      (TLS). KMS recommends you always use the latest supported TLS version. Clients must also\n      support cipher suites with Perfect Forward Secrecy (PFS) such as Ephemeral Diffie-Hellman\n      (DHE) or Elliptic Curve Ephemeral Diffie-Hellman (ECDHE). Most modern systems such as Java 7\n      and later support these modes.</p>\n         <p>\n            <b>Signing Requests</b>\n         </p>\n         <p>Requests must be signed by using an access key ID and a secret access key. We strongly\n      recommend that you <i>do not</i> use your Amazon Web Services account (root) access key ID and\n      secret access key for everyday work with KMS. Instead, use the access key ID and secret\n      access key for an IAM user. You can also use the Amazon Web Services Security Token Service to generate\n      temporary security credentials that you can use to sign requests.</p>\n         <p>All KMS operations require <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         <p>\n            <b>Logging API Requests</b>\n         </p>\n         <p>KMS supports CloudTrail, a service that logs Amazon Web Services API calls and related events for your\n      Amazon Web Services account and delivers them to an Amazon S3 bucket that you specify. By using the\n      information collected by CloudTrail, you can determine what requests were made to KMS, who made\n      the request, when it was made, and so on. To learn more about CloudTrail, including how to turn it\n      on and find your log files, see the <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/\">CloudTrail User Guide</a>.</p>\n         <p>\n            <b>Additional Resources</b>\n         </p>\n         <p>For more information about credentials and request signing, see the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html\">Amazon Web Services\n            Security Credentials</a> - This topic provides general information about the types\n          of credentials used to access Amazon Web Services.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html\">Temporary\n            Security Credentials</a> - This section of the <i>IAM User Guide</i>\n          describes how to create and use temporary security credentials.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version\n            4 Signing Process</a> - This set of topics walks you through the process of signing\n          a request using an access key ID and a secret access key.</p>\n            </li>\n         </ul>\n         <p>\n            <b>Commonly Used API Operations</b>\n         </p>\n         <p>Of the API operations discussed in this guide, the following will prove the most useful\n      for most applications. You will likely perform operations other than these, such as creating\n      keys and assigning policies, by using the console.</p>\n         <ul>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<fullname>Key Management Service</fullname>\n         <p>Key Management Service (KMS) is an encryption and key management web service. This guide describes\n      the KMS operations that you can call programmatically. For general information about KMS,\n      see the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/\">\n               <i>Key Management Service Developer Guide</i>\n            </a>.</p>\n         <note>\n            <p>KMS has replaced the term <i>customer master key (CMK)</i> with <i>KMS key</i> and <i>KMS key</i>. The concept has not changed. To prevent breaking changes, KMS is keeping some variations of this term.</p>\n            <p>Amazon Web Services provides SDKs that consist of libraries and sample code for various programming\n        languages and platforms (Java, Ruby, .Net, macOS, Android, etc.). The SDKs provide a\n        convenient way to create programmatic access to KMS and other Amazon Web Services services. For example,\n        the SDKs take care of tasks such as signing requests (see below), managing errors, and\n        retrying requests automatically. For more information about the Amazon Web Services SDKs, including how to\n        download and install them, see <a href=\"http://aws.amazon.com/tools/\">Tools for Amazon Web\n          Services</a>.</p>\n         </note>\n         <p>We recommend that you use the Amazon Web Services SDKs to make programmatic API calls to KMS.</p>\n         <p>If you need to use FIPS 140-2 validated cryptographic modules when communicating with\n      Amazon Web Services, use the FIPS endpoint in your preferred Amazon Web Services Region. For more information about the\n      available FIPS endpoints, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/kms.html#kms_region\">Service endpoints</a> in the Key Management Service topic of\n      the <i>Amazon Web Services General Reference</i>.</p>\n         <p>All KMS API calls must be signed and be transmitted using Transport Layer Security\n      (TLS). KMS recommends you always use the latest supported TLS version. Clients must also\n      support cipher suites with Perfect Forward Secrecy (PFS) such as Ephemeral Diffie-Hellman\n      (DHE) or Elliptic Curve Ephemeral Diffie-Hellman (ECDHE). Most modern systems such as Java 7\n      and later support these modes.</p>\n         <p>\n            <b>Signing Requests</b>\n         </p>\n         <p>Requests must be signed using an access key ID and a secret access key. We strongly\n      recommend that you do not use your Amazon Web Services account root access key ID and secret access key for\n      everyday work. You can use the access key ID and secret access key for an IAM user or you\n      can use the Security Token Service (STS) to generate temporary security credentials and use those to sign\n      requests. </p>\n         <p>All KMS requests must be signed with <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version 4</a>.</p>\n         <p>\n            <b>Logging API Requests</b>\n         </p>\n         <p>KMS supports CloudTrail, a service that logs Amazon Web Services API calls and related events for your\n      Amazon Web Services account and delivers them to an Amazon S3 bucket that you specify. By using the\n      information collected by CloudTrail, you can determine what requests were made to KMS, who made\n      the request, when it was made, and so on. To learn more about CloudTrail, including how to turn it\n      on and find your log files, see the <a href=\"https://docs.aws.amazon.com/awscloudtrail/latest/userguide/\">CloudTrail User Guide</a>.</p>\n         <p>\n            <b>Additional Resources</b>\n         </p>\n         <p>For more information about credentials and request signing, see the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html\">Amazon Web Services\n            Security Credentials</a> - This topic provides general information about the types\n          of credentials used to access Amazon Web Services.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp.html\">Temporary\n            Security Credentials</a> - This section of the <i>IAM User Guide</i>\n          describes how to create and use temporary security credentials.</p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html\">Signature Version\n            4 Signing Process</a> - This set of topics walks you through the process of signing\n          a request using an access key ID and a secret access key.</p>\n            </li>\n         </ul>\n         <p>\n            <b>Commonly Used API Operations</b>\n         </p>\n         <p>Of the API operations discussed in this guide, the following will prove the most useful\n      for most applications. You will likely perform operations other than these, such as creating\n      keys and assigning policies, by using the console.</p>\n         <ul>\n            <li>\n               <p>\n                  <a>Encrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>Decrypt</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>GenerateDataKeyWithoutPlaintext</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#title": "AWS Key Management Service",
                 "smithy.api#xmlNamespace": {
                     "uri": "https://trent.amazonaws.com/doc/2014-11-01/"
@@ -5648,7 +5867,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -5677,15 +5896,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -5694,7 +5965,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -5704,22 +5975,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://kms-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://kms-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -5732,82 +6138,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://kms.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -5815,7 +6191,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://kms-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "url": "https://kms.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -5824,144 +6200,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://kms-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://kms.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://kms.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -5970,266 +6215,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.ap-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.ap-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
                             "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -6237,8 +6222,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "af-south-1"
                             }
                         },
@@ -6250,35 +6235,35 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "af-south-1"
                             }
                         },
                         {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.ap-south-1.amazonaws.com"
+                                    "url": "https://kms.ap-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
-                                "Region": "ap-south-1"
+                                "UseFIPS": false,
+                                "Region": "ap-east-1"
                             }
                         },
                         {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.ap-south-1.amazonaws.com"
+                                    "url": "https://kms-fips.ap-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
-                                "Region": "ap-south-1"
+                                "UseFIPS": true,
+                                "Region": "ap-east-1"
                             }
                         },
                         {
@@ -6289,8 +6274,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-northeast-1"
                             }
                         },
@@ -6302,8 +6287,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "ap-northeast-1"
                             }
                         },
@@ -6315,8 +6300,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-northeast-2"
                             }
                         },
@@ -6328,8 +6313,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "ap-northeast-2"
                             }
                         },
@@ -6341,8 +6326,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-northeast-3"
                             }
                         },
@@ -6354,139 +6339,165 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "ap-northeast-3"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.us-east-1.amazonaws.com"
+                                    "url": "https://kms.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "Region": "ap-south-1"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.us-east-1.amazonaws.com"
+                                    "url": "https://kms-fips.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "Region": "ap-south-1"
                             }
                         },
                         {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.eu-west-1.amazonaws.com"
+                                    "url": "https://kms.ap-southeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-1"
+                                "Region": "ap-southeast-1"
                             }
                         },
                         {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.eu-west-1.amazonaws.com"
+                                    "url": "https://kms-fips.ap-southeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "eu-west-1"
+                                "Region": "ap-southeast-1"
                             }
                         },
                         {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.eu-west-2.amazonaws.com"
+                                    "url": "https://kms.ap-southeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "Region": "ap-southeast-2"
                             }
                         },
                         {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.eu-west-2.amazonaws.com"
+                                    "url": "https://kms-fips.ap-southeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "Region": "ap-southeast-2"
                             }
                         },
                         {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.eu-west-3.amazonaws.com"
+                                    "url": "https://kms.ap-southeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-3"
+                                "Region": "ap-southeast-3"
                             }
                         },
                         {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-3 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.eu-west-3.amazonaws.com"
+                                    "url": "https://kms-fips.ap-southeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "eu-west-3"
+                                "Region": "ap-southeast-3"
                             }
                         },
                         {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.me-south-1.amazonaws.com"
+                                    "url": "https://kms.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "UseDualStack": false,
                                 "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "me-south-1"
+                                "Region": "ca-central-1"
                             }
                         },
                         {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.me-south-1.amazonaws.com"
+                                    "url": "https://kms-fips.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
-                                "Region": "me-south-1"
+                                "UseFIPS": true,
+                                "Region": "ca-central-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-central-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "eu-central-1"
                             }
                         },
                         {
@@ -6497,8 +6508,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "eu-north-1"
                             }
                         },
@@ -6510,9 +6521,191 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "eu-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "eu-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "eu-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "eu-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-west-3"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "eu-west-3"
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "me-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "me-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "sa-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "sa-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-east-1"
                             }
                         },
                         {
@@ -6523,8 +6716,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-2"
                             }
                         },
@@ -6536,9 +6729,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-east-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-west-2"
                             }
                         },
                         {
@@ -6549,8 +6794,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": true,
+                                "UseFIPS": true,
                                 "Region": "us-east-1"
                             }
                         },
@@ -6562,126 +6807,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://kms.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "cn-northwest-1"
                             }
                         },
                         {
@@ -6692,9 +6820,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "cn-northwest-1"
                             }
                         },
                         {
@@ -6705,8 +6846,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": true,
+                                "UseFIPS": true,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -6718,8 +6859,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "cn-north-1"
                             }
                         },
@@ -6731,35 +6872,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "cn-north-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms.us-iso-west-1.c2s.ic.gov"
+                                    "url": "https://kms.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
-                                "Region": "us-iso-west-1"
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-iso-west-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://kms-fips.us-iso-west-1.c2s.ic.gov"
+                                    "url": "https://kms-fips.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
-                                "Region": "us-iso-west-1"
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-gov-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
@@ -6770,8 +6963,8 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-iso-east-1"
                             }
                         },
@@ -6783,22 +6976,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-iso-east-1"
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-iso-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-iso-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://kms-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -6808,8 +7066,8 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
@@ -6820,8 +7078,8 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
@@ -6883,7 +7141,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Deletes tags from a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>. To delete a tag,\n      specify the tag key and the KMS key.</p>\n         <note>\n            <p>Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>When it succeeds, the <code>UntagResource</code> operation doesn't return any output.\n      Also, if the specified tag key isn't found on the KMS key, it doesn't throw an exception or\n      return a response. To confirm that the operation worked, use the <a>ListResourceTags</a> operation.</p>\n\n         <p>For information about using tags in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging keys</a>. For general information about\n      tags, including the format and syntax, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in the <i>Amazon\n        Web Services General Reference</i>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:UntagResource</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReplicateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>TagResource</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Deletes tags from a <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a>. To delete a tag,\n      specify the tag key and the KMS key.</p>\n         <note>\n            <p>Tagging or untagging a KMS key can allow or deny permission to the KMS key. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/abac.html\">ABAC for KMS</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         </note>\n         <p>When it succeeds, the <code>UntagResource</code> operation doesn't return any output.\n      Also, if the specified tag key isn't found on the KMS key, it doesn't throw an exception or\n      return a response. To confirm that the operation worked, use the <a>ListResourceTags</a> operation.</p>\n         <p>For information about using tags in KMS, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/tagging-keys.html\">Tagging keys</a>. For general information about\n      tags, including the format and syntax, see <a href=\"https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html\">Tagging Amazon Web Services resources</a> in the <i>Amazon\n        Web Services General Reference</i>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account.</p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:UntagResource</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ListResourceTags</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>ReplicateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>TagResource</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#UntagResourceRequest": {
@@ -6892,7 +7150,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the KMS key from which you are removing tags.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the KMS key from which you are removing tags.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -6903,6 +7161,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#UpdateAlias": {
@@ -6947,10 +7208,13 @@
                 "TargetKeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a> to associate with the alias. You don't have permission to\n      associate an alias with an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a>.</p>\n         <p>The KMS key must be in the same Amazon Web Services account and Region as the alias. Also, the new\n      target KMS key must be the same type as the current target KMS key (both symmetric or both\n      asymmetric or both HMAC) and they must have the same key usage. </p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>\n\n         <p>To verify that the alias is mapped to the correct KMS key, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk\">customer managed key</a> to associate with the alias. You don't have permission to\n      associate an alias with an <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed key</a>.</p>\n         <p>The KMS key must be in the same Amazon Web Services account and Region as the alias. Also, the new\n      target KMS key must be the same type as the current target KMS key (both symmetric or both\n      asymmetric or both HMAC) and they must have the same key usage. </p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>\n         <p>To verify that the alias is mapped to the correct KMS key, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#UpdateCustomKeyStore": {
@@ -7076,11 +7340,17 @@
                         "smithy.api#documentation": "<p>Changes the connectivity setting for the external key store. To indicate that the external\n      key store proxy uses a Amazon VPC endpoint service to communicate with KMS, specify\n        <code>VPC_ENDPOINT_SERVICE</code>. Otherwise, specify <code>PUBLIC_ENDPOINT</code>.</p>\n         <p>If you change the <code>XksProxyConnectivity</code> to <code>VPC_ENDPOINT_SERVICE</code>,\n      you must also change the <code>XksProxyUriEndpoint</code> and add an\n        <code>XksProxyVpcEndpointServiceName</code> value. </p>\n         <p>If you change the <code>XksProxyConnectivity</code> to <code>PUBLIC_ENDPOINT</code>, you\n      must also change the <code>XksProxyUriEndpoint</code> and specify a null or empty string for\n      the <code>XksProxyVpcEndpointServiceName</code> value.</p>\n         <p>To change this value, the external key store must be disconnected.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#UpdateCustomKeyStoreResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.kms#UpdateKeyDescription": {
             "type": "operation",
@@ -7108,7 +7378,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Updates the description of a KMS key. To see the description of a KMS key, use <a>DescribeKey</a>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account. </p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:UpdateKeyDescription</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeKey</a>\n               </p>\n            </li>\n         </ul>"
+                "smithy.api#documentation": "<p>Updates the description of a KMS key. To see the description of a KMS key, use <a>DescribeKey</a>. </p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: No. You cannot perform this operation on a KMS key in a different Amazon Web Services account. </p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:UpdateKeyDescription</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <a>CreateKey</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a>DescribeKey</a>\n               </p>\n            </li>\n         </ul>"
             }
         },
         "com.amazonaws.kms#UpdateKeyDescriptionRequest": {
@@ -7117,7 +7387,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Updates the description of the specified KMS key.</p>\n    \n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Updates the description of the specified KMS key.</p>\n         <p>Specify the key ID or key ARN of the KMS key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7128,6 +7398,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#UpdatePrimaryRegion": {
@@ -7168,7 +7441,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the current primary key. When the operation completes, this KMS key will be a\n      replica key.</p>\n    \n         <p>Specify the key ID or key ARN of a multi-Region primary key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>    \n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the current primary key. When the operation completes, this KMS key will be a\n      replica key.</p>\n         <p>Specify the key ID or key ARN of a multi-Region primary key.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/mrk-1234abcd12ab34cd56ef1234567890ab</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7179,6 +7452,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#Verify": {
@@ -7219,7 +7495,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Verifies a digital signature that was generated by the <a>Sign</a> operation. </p>\n         <p></p>\n         <p>Verification confirms that an authorized user signed the message with the specified KMS\n      key and signing algorithm, and the message hasn't changed since it was signed. If the\n      signature is verified, the value of the <code>SignatureValid</code> field in the response is\n        <code>True</code>. If the signature verification fails, the <code>Verify</code> operation\n      fails with an <code>KMSInvalidSignatureException</code> exception.</p>\n         <p>A digital signature is generated by using the private key in an asymmetric KMS key. The\n      signature is verified by using the public key in the same asymmetric KMS key.\n      For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>To verify a digital signature, you can use the <code>Verify</code> operation. Specify the\n      same asymmetric KMS key, message, and signing algorithm that were used to produce the\n      signature.</p>\n         <p>You can also verify the digital signature by using the public key of the KMS key outside\n      of KMS. Use the <a>GetPublicKey</a> operation to download the public key in the\n      asymmetric KMS key and then use the public key to verify the signature outside of KMS. The\n      advantage of using the <code>Verify</code> operation is that it is performed within KMS. As\n      a result, it's easy to call, the operation is performed within the FIPS boundary, it is logged\n      in CloudTrail, and you can use key policy and IAM policy to determine who is authorized to use\n      the KMS key to verify signatures.</p> \n         <p>To verify a signature outside of KMS with an SM2 public key (China Regions only), you must \n      specify the distinguishing ID. By default, KMS uses <code>1234567812345678</code> as the \n      distinguishing ID. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-sm-offline-verification\">Offline verification\n        with SM2 key pairs</a>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p> \n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter. </p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Verify</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>Sign</a>\n         </p>"
+                "smithy.api#documentation": "<p>Verifies a digital signature that was generated by the <a>Sign</a> operation. </p>\n         <p></p>\n         <p>Verification confirms that an authorized user signed the message with the specified KMS\n      key and signing algorithm, and the message hasn't changed since it was signed. If the\n      signature is verified, the value of the <code>SignatureValid</code> field in the response is\n        <code>True</code>. If the signature verification fails, the <code>Verify</code> operation\n      fails with an <code>KMSInvalidSignatureException</code> exception.</p>\n         <p>A digital signature is generated by using the private key in an asymmetric KMS key. The\n      signature is verified by using the public key in the same asymmetric KMS key.\n      For information about asymmetric KMS keys, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/symmetric-asymmetric.html\">Asymmetric KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>To use the <code>Verify</code> operation, specify the\n      same asymmetric KMS key, message, and signing algorithm that were used to produce the\n      signature. The message type does not need to be the same as the one used for signing, but it must \n      indicate whether the value of the <code>Message</code> parameter should be\n      hashed as part of the verification process.</p>\n         <p>You can also verify the digital signature by using the public key of the KMS key outside\n      of KMS. Use the <a>GetPublicKey</a> operation to download the public key in the\n      asymmetric KMS key and then use the public key to verify the signature outside of KMS. The\n      advantage of using the <code>Verify</code> operation is that it is performed within KMS. As\n      a result, it's easy to call, the operation is performed within the FIPS boundary, it is logged\n      in CloudTrail, and you can use key policy and IAM policy to determine who is authorized to use\n      the KMS key to verify signatures.</p>\n         <p>To verify a signature outside of KMS with an SM2 public key (China Regions only), you must \n      specify the distinguishing ID. By default, KMS uses <code>1234567812345678</code> as the \n      distinguishing ID. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-sm-offline-verification\">Offline verification\n        with SM2 key pairs</a>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter. </p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:Verify</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>Sign</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#VerifyMac": {
@@ -7257,7 +7533,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Verifies the hash-based message authentication code (HMAC) for a specified message, HMAC\n      KMS key, and MAC algorithm. To verify the HMAC, <code>VerifyMac</code> computes an HMAC using\n      the message, HMAC KMS key, and MAC algorithm that you specify, and compares the computed HMAC\n      to the HMAC that you specify. If the HMACs are identical, the verification succeeds;\n      otherwise, it fails. Verification indicates that the message hasn't changed since the HMAC was\n      calculated, and the specified key was used to generate and verify the HMAC.</p>\n         <p>HMAC KMS keys and the HMAC algorithms that KMS uses conform to industry standards\n      defined in <a href=\"https://datatracker.ietf.org/doc/html/rfc2104\">RFC 2104</a>.</p>\n         <p>This operation is part of KMS support for HMAC KMS keys. For details, see\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC keys in KMS</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter. </p>\n\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:VerifyMac</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>GenerateMac</a>\n         </p>"
+                "smithy.api#documentation": "<p>Verifies the hash-based message authentication code (HMAC) for a specified message, HMAC\n      KMS key, and MAC algorithm. To verify the HMAC, <code>VerifyMac</code> computes an HMAC using\n      the message, HMAC KMS key, and MAC algorithm that you specify, and compares the computed HMAC\n      to the HMAC that you specify. If the HMACs are identical, the verification succeeds;\n      otherwise, it fails. Verification indicates that the message hasn't changed since the HMAC was\n      calculated, and the specified key was used to generate and verify the HMAC.</p>\n         <p>HMAC KMS keys and the HMAC algorithms that KMS uses conform to industry standards\n      defined in <a href=\"https://datatracker.ietf.org/doc/html/rfc2104\">RFC 2104</a>.</p>\n         <p>This operation is part of KMS support for HMAC KMS keys. For details, see\n        <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/hmac.html\">HMAC keys in KMS</a> in the\n      <i>Key Management Service Developer Guide</i>.</p>\n         <p>The KMS key that you use for this operation must be in a compatible key state. For\ndetails, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html\">Key states of KMS keys</a> in the <i>Key Management Service Developer Guide</i>.</p>\n         <p>\n            <b>Cross-account use</b>: Yes. To perform this operation with a KMS key in a different Amazon Web Services account, specify\n  the key ARN or alias ARN in the value of the <code>KeyId</code> parameter. </p>\n         <p>\n            <b>Required permissions</b>: <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/kms-api-permissions-reference.html\">kms:VerifyMac</a> (key policy)</p>\n         <p>\n            <b>Related operations</b>: <a>GenerateMac</a>\n         </p>"
             }
         },
         "com.amazonaws.kms#VerifyMacRequest": {
@@ -7273,7 +7549,7 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The KMS key that will be used in the verification.</p>\n\n         <p>Enter a key ID of the KMS key that was used to generate the HMAC. If you identify a\n      different KMS key, the <code>VerifyMac</code> operation fails.</p>",
+                        "smithy.api#documentation": "<p>The KMS key that will be used in the verification.</p>\n         <p>Enter a key ID of the KMS key that was used to generate the HMAC. If you identify a\n      different KMS key, the <code>VerifyMac</code> operation fails.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -7297,6 +7573,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#VerifyMacResponse": {
@@ -7321,6 +7600,9 @@
                         "smithy.api#documentation": "<p>The MAC algorithm used in the verification.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#VerifyRequest": {
@@ -7329,21 +7611,21 @@
                 "KeyId": {
                     "target": "com.amazonaws.kms#KeyIdType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Identifies the asymmetric KMS key that will be used to verify the signature. This must be\n      the same KMS key that was used to generate the signature. If you specify a different KMS key,\n      the signature verification fails.</p>\n    \n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>    \n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
+                        "smithy.api#documentation": "<p>Identifies the asymmetric KMS key that will be used to verify the signature. This must be\n      the same KMS key that was used to generate the signature. If you specify a different KMS key,\n      the signature verification fails.</p>\n         <p>To specify a KMS key, use its key ID, key ARN, alias name, or alias ARN. When using an alias name, prefix it with <code>\"alias/\"</code>. To specify a KMS key in a different Amazon Web Services account, you must use the key ARN or alias ARN.</p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN: <code>arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN: <code>arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>\n         <p>To get the key ID and key ARN for a KMS key, use <a>ListKeys</a> or <a>DescribeKey</a>. To get the alias name and alias ARN, use <a>ListAliases</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "Message": {
                     "target": "com.amazonaws.kms#PlaintextType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the message that was signed. You can submit a raw message of up to 4096 bytes,\n      or a hash digest of the message. If you submit a digest, use the <code>MessageType</code>\n      parameter with a value of <code>DIGEST</code>.</p>\n         <p>If the message specified here is different from the message that was signed, the signature\n      verification fails. A message and its hash digest are considered to be the same\n      message.</p>",
+                        "smithy.api#documentation": "<p>Specifies the message that was signed. You can submit a raw message of up to 4096 bytes,\n      or a hash digest of the message. If you submit a digest, use the <code>MessageType</code> parameter\n      with a value of <code>DIGEST</code>.</p>\n         <p>If the message specified here is different from the message that was signed, the signature\n      verification fails. A message and its hash digest are considered to be the same\n      message.</p>",
                         "smithy.api#required": {}
                     }
                 },
                 "MessageType": {
                     "target": "com.amazonaws.kms#MessageType",
                     "traits": {
-                        "smithy.api#documentation": "<p>Tells KMS whether the value of the <code>Message</code> parameter is a message or\n      message digest. The default value, RAW, indicates a message. To indicate a message digest,\n      enter <code>DIGEST</code>.</p>\n         <important>\n            <p>Use the <code>DIGEST</code> value only when the value of the <code>Message</code>\n        parameter is a message digest. If you use the <code>DIGEST</code> value with a raw message,\n        the security of the verification operation can be compromised.</p>\n         </important>"
+                        "smithy.api#documentation": "<p>Tells KMS whether the value of the <code>Message</code> parameter should be hashed\n      as part of the signing algorithm. Use <code>RAW</code> for unhashed messages; use <code>DIGEST</code>\n      for message digests, which are already hashed.</p>\n         <p>When the value of <code>MessageType</code> is <code>RAW</code>, KMS uses the standard\n      signing algorithm, which begins with a hash function. When the value is <code>DIGEST</code>, KMS \n      skips the hashing step in the signing algorithm.</p>\n         <important>\n            <p>Use the <code>DIGEST</code> value only when the value of the <code>Message</code>\n        parameter is a message digest. If you use the <code>DIGEST</code> value with an unhashed message,\n        the security of the verification operation can be compromised.</p>\n         </important>\n         <p>When the value of <code>MessageType</code>is <code>DIGEST</code>, the length\n    of the <code>Message</code> value must match the length of hashed messages for the specified signing algorithm.</p>\n         <p>You can submit a message digest and omit the <code>MessageType</code> or specify\n      <code>RAW</code> so the digest is hashed again while signing. However, if the signed message is hashed once\n      while signing, but twice while verifying, verification fails, even when the message hasn't changed.</p>\n         <p>The hashing algorithm in that <code>Verify</code> uses is based on the <code>SigningAlgorithm</code> value.</p>\n         <ul>\n            <li>\n               <p>Signing algorithms that end in SHA_256 use the SHA_256 hashing algorithm.</p>\n            </li>\n            <li>\n               <p>Signing algorithms that end in SHA_384 use the SHA_384 hashing algorithm.</p>\n            </li>\n            <li>\n               <p>Signing algorithms that end in SHA_512 use the SHA_512 hashing algorithm.</p>\n            </li>\n            <li>\n               <p>SM2DSA uses the SM3 hashing algorithm. For details, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/asymmetric-key-specs.html#key-spec-sm-offline-verification\">Offline verification with SM2 key pairs</a>.</p>\n            </li>\n         </ul>"
                     }
                 },
                 "Signature": {
@@ -7366,6 +7648,9 @@
                         "smithy.api#documentation": "<p>A list of grant tokens.</p>\n         <p>Use a grant token when your permission to call this operation comes from a new grant that has not yet achieved <i>eventual consistency</i>. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grants.html#grant_token\">Grant token</a> and <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/grant-manage.html#using-grant-token\">Using a grant token</a> in the\n    <i>Key Management Service Developer Guide</i>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.kms#VerifyResponse": {
@@ -7390,6 +7675,9 @@
                         "smithy.api#documentation": "<p>The signing algorithm that was used to verify the signature.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.kms#WrappingKeySpec": {

--- a/aws/sdk/aws-models/lambda.json
+++ b/aws/sdk/aws-models/lambda.json
@@ -248,7 +248,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -277,15 +277,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -294,7 +346,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -304,22 +356,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -332,134 +519,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://lambda.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://lambda-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -467,7 +572,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://lambda-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://lambda.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -476,74 +581,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://lambda.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "endpoint": {
-                                        "url": "https://lambda.{Region}.{PartitionResult#dnsSuffix}",
-                                        "properties": {},
-                                        "headers": {}
-                                    },
-                                    "type": "endpoint"
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -552,648 +596,15 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region ap-south-2 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.ap-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-south-2.amazonaws.com"
+                                    "url": "https://lambda.af-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "ap-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-south-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.me-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "me-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.me-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "me-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.me-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "me-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.me-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "me-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ca-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ca-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-iso-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-iso-west-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-iso-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-iso-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-iso-west-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-iso-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-central-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-central-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-central-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-central-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-central-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-central-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-central-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-central-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.af-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.af-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
                                 "Region": "af-south-1"
                             }
                         },
@@ -1211,509 +622,15 @@
                             }
                         },
                         {
-                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.af-south-1.amazonaws.com"
+                                    "url": "https://lambda.ap-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-north-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-north-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-west-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-west-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-northeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-northeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-northeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-northeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-northeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-northeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-northeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-northeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.me-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.me-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.sa-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.sa-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
                                 "Region": "ap-east-1"
                             }
                         },
@@ -1731,145 +648,119 @@
                             }
                         },
                         {
-                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.ap-east-1.amazonaws.com"
+                                    "url": "https://lambda.ap-northeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "ap-east-1"
+                                "Region": "ap-northeast-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.cn-north-1.api.amazonwebservices.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "cn-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.cn-north-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "cn-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.cn-north-1.api.amazonwebservices.com.cn"
+                                    "url": "https://lambda.ap-northeast-1.api.aws"
                                 }
                             },
                             "params": {
                                 "UseDualStack": true,
                                 "UseFIPS": false,
-                                "Region": "cn-north-1"
+                                "Region": "ap-northeast-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.cn-north-1.amazonaws.com.cn"
+                                    "url": "https://lambda.ap-northeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "cn-north-1"
+                                "Region": "ap-northeast-2"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.us-gov-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-gov-west-1.api.aws"
+                                    "url": "https://lambda.ap-northeast-2.api.aws"
                                 }
                             },
                             "params": {
                                 "UseDualStack": true,
                                 "UseFIPS": false,
-                                "Region": "us-gov-west-1"
+                                "Region": "ap-northeast-2"
                             }
                         },
                         {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.us-gov-west-1.amazonaws.com"
+                                    "url": "https://lambda.ap-northeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "us-gov-west-1"
+                                "Region": "ap-northeast-3"
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-1.api.aws"
+                                    "url": "https://lambda.ap-northeast-3.api.aws"
                                 }
                             },
                             "params": {
                                 "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-1"
+                                "UseFIPS": false,
+                                "Region": "ap-northeast-3"
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-1.amazonaws.com"
+                                    "url": "https://lambda.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
-                                "UseFIPS": true,
+                                "UseFIPS": false,
+                                "Region": "ap-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.ap-south-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "ap-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.ap-southeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "ap-southeast-1"
                             }
                         },
@@ -1887,41 +778,15 @@
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.ap-southeast-1.amazonaws.com"
+                                    "url": "https://lambda.ap-southeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
                                 "Region": "ap-southeast-2"
                             }
                         },
@@ -1939,89 +804,15 @@
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.ap-southeast-2.amazonaws.com"
+                                    "url": "https://lambda.ap-southeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-iso-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-iso-east-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-iso-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-iso-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-iso-east-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-iso-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
                                 "Region": "ap-southeast-3"
                             }
                         },
@@ -2039,80 +830,249 @@
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.ap-southeast-3.amazonaws.com"
+                                    "url": "https://lambda.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-3"
+                                "Region": "ca-central-1"
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-4 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-4.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-4"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-4 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.ap-southeast-4.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-4"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-4 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.ap-southeast-4.api.aws"
+                                    "url": "https://lambda.ca-central-1.api.aws"
                                 }
                             },
                             "params": {
                                 "UseDualStack": true,
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-4"
+                                "Region": "ca-central-1"
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-4 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.ap-southeast-4.amazonaws.com"
+                                    "url": "https://lambda.eu-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-4"
+                                "Region": "eu-central-1"
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.us-east-1.api.aws"
+                                    "url": "https://lambda.eu-central-1.api.aws"
                                 }
                             },
                             "params": {
                                 "UseDualStack": true,
-                                "UseFIPS": true,
+                                "UseFIPS": false,
+                                "Region": "eu-central-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-north-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "eu-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-south-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "eu-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-west-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "eu-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-west-2.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "eu-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "eu-west-3"
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.eu-west-3.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "eu-west-3"
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "me-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.me-south-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "me-south-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "sa-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.sa-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "sa-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-east-1"
                             }
                         },
@@ -2143,28 +1103,15 @@
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.us-east-1.amazonaws.com"
+                                    "url": "https://lambda.us-east-2.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.us-east-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
                                 "Region": "us-east-2"
                             }
                         },
@@ -2195,41 +1142,132 @@
                             }
                         },
                         {
-                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.us-east-2.amazonaws.com"
+                                    "url": "https://lambda.us-west-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "us-east-2"
+                                "Region": "us-west-1"
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda-fips.cn-northwest-1.api.amazonwebservices.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "cn-northwest-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda-fips.cn-northwest-1.amazonaws.com.cn"
+                                    "url": "https://lambda-fips.us-west-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": true,
+                                "Region": "us-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-west-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-west-2.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-west-2"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "cn-northwest-1"
                             }
                         },
@@ -2247,26 +1285,158 @@
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://lambda.cn-northwest-1.amazonaws.com.cn"
+                                    "url": "https://lambda-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "cn-northwest-1"
+                                "Region": "us-gov-east-1"
                             }
                         },
                         {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-gov-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-gov-east-1.api.aws"
+                                }
                             },
                             "params": {
                                 "UseDualStack": true,
                                 "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-iso-west-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://lambda.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Region": "us-isob-east-1"
                             }
                         },
@@ -2284,31 +1454,7 @@
                             }
                         },
                         {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://lambda.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
@@ -2318,6 +1464,19 @@
                                 "UseDualStack": false,
                                 "UseFIPS": false,
                                 "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2514,6 +1673,9 @@
                         "smithy.api#httpQuery": "RevisionId"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#AddLayerVersionPermissionResponse": {
@@ -2531,6 +1693,9 @@
                         "smithy.api#documentation": "<p>A unique identifier for the current revision of the policy.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#AddPermission": {
@@ -2645,9 +1810,12 @@
                 "FunctionUrlAuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>"
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#AddPermissionResponse": {
@@ -2659,6 +1827,9 @@
                         "smithy.api#documentation": "<p>The permission statement that's added to the function policy.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#AdditionalVersion": {
@@ -3028,6 +2199,16 @@
                 "smithy.api#httpError": 400
             }
         },
+        "com.amazonaws.lambda#CollectionName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 57
+                },
+                "smithy.api#pattern": "^(^(?!(system\\x2e)))(^[_a-zA-Z0-9])([^$]*)$"
+            }
+        },
         "com.amazonaws.lambda#CompatibleArchitectures": {
             "type": "list",
             "member": {
@@ -3178,6 +2359,9 @@
                         "smithy.api#documentation": "<p>The <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-aliases.html#configuring-alias-routing\">routing\n        configuration</a> of the alias.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#CreateCodeSigningConfig": {
@@ -3227,6 +2411,9 @@
                         "smithy.api#documentation": "<p>The code signing policies define the actions to take if the validation checks fail. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#CreateCodeSigningConfigResponse": {
@@ -3239,6 +2426,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#CreateEventSourceMapping": {
@@ -3410,7 +2600,16 @@
                     "traits": {
                         "smithy.api#documentation": "<p>(Amazon SQS only) The scaling configuration for the event source. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-max-concurrency\">Configuring maximum concurrency for Amazon SQS event sources</a>.</p>"
                     }
+                },
+                "DocumentDBEventSourceConfig": {
+                    "target": "com.amazonaws.lambda#DocumentDBEventSourceConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specific configuration settings for a DocumentDB event source.</p>"
+                    }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#CreateFunction": {
@@ -3472,7 +2671,7 @@
                 "Runtime": {
                     "target": "com.amazonaws.lambda#Runtime",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier of the function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html\">runtime</a>. Runtime is required if the deployment package is a .zip file archive.\n        </p>"
+                        "smithy.api#documentation": "<p>The identifier of the function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html\">runtime</a>. Runtime is required if the deployment package is a .zip file archive.</p>\n         <p>The following list includes deprecated runtimes. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy\">Runtime deprecation policy</a>.</p>"
                     }
                 },
                 "Role": {
@@ -3547,7 +2746,7 @@
                 "KMSKeyArn": {
                     "target": "com.amazonaws.lambda#KMSKeyArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the Key Management Service (KMS) key that's used to encrypt your function's environment\n      variables. If it's not provided, Lambda uses a default service key.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the Key Management Service (KMS) customer managed key that's used to encrypt your function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-encryption\">environment variables</a>. When <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart-security.html\">Lambda SnapStart</a> is activated, this key is also used to encrypt your function's snapshot. If you don't provide a customer managed key, Lambda uses a default service key.</p>"
                     }
                 },
                 "TracingConfig": {
@@ -3604,6 +2803,9 @@
                         "smithy.api#documentation": "<p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html\">SnapStart</a> setting.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#CreateFunctionUrlConfig": {
@@ -3661,7 +2863,7 @@
                 "AuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3671,6 +2873,9 @@
                         "smithy.api#documentation": "<p>The <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS\">cross-origin resource sharing (CORS)</a> settings\n  for your function URL.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#CreateFunctionUrlConfigResponse": {
@@ -3693,7 +2898,7 @@
                 "AuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -3710,6 +2915,19 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.lambda#DatabaseName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 63
+                },
+                "smithy.api#pattern": "^[^ /\\.$\\x22]*$"
             }
         },
         "com.amazonaws.lambda#Date": {
@@ -3779,6 +2997,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteCodeSigningConfig": {
@@ -3823,11 +3044,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteCodeSigningConfigResponse": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.lambda#DeleteEventSourceMapping": {
             "type": "operation",
@@ -3874,6 +3101,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteFunction": {
@@ -3958,6 +3188,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteFunctionConcurrency": {
@@ -4005,6 +3238,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteFunctionEventInvokeConfig": {
@@ -4059,6 +3295,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteFunctionRequest": {
@@ -4079,6 +3318,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteFunctionUrlConfig": {
@@ -4130,6 +3372,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteLayerVersion": {
@@ -4177,6 +3422,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#DeleteProvisionedConcurrencyConfig": {
@@ -4232,6 +3480,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#Description": {
@@ -4271,6 +3522,32 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>A configuration object that specifies the destination of an event after Lambda processes it.</p>"
+            }
+        },
+        "com.amazonaws.lambda#DocumentDBEventSourceConfig": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.lambda#DatabaseName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The name of the database to consume within the DocumentDB cluster.\n    </p>"
+                    }
+                },
+                "CollectionName": {
+                    "target": "com.amazonaws.lambda#CollectionName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      The name of the collection to consume within the database. If you do not specify a collection, Lambda consumes all collections.\n    </p>"
+                    }
+                },
+                "FullDocument": {
+                    "target": "com.amazonaws.lambda#FullDocument",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      Determines what DocumentDB sends to your event stream during document update operations. If set to UpdateLookup, DocumentDB sends a delta describing the changes, along with a copy of the entire document. Otherwise, DocumentDB sends only a partial document that contains the changes.\n    </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      Specific configuration settings for a DocumentDB event source.\n    </p>"
             }
         },
         "com.amazonaws.lambda#EC2AccessDeniedException": {
@@ -4716,6 +3993,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>(Amazon SQS only) The scaling configuration for the event source. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-max-concurrency\">Configuring maximum concurrency for Amazon SQS event sources</a>.</p>"
                     }
+                },
+                "DocumentDBEventSourceConfig": {
+                    "target": "com.amazonaws.lambda#DocumentDBEventSourceConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specific configuration settings for a DocumentDB event source.</p>"
+                    }
                 }
             },
             "traits": {
@@ -4837,6 +4120,23 @@
             "type": "list",
             "member": {
                 "target": "com.amazonaws.lambda#Filter"
+            }
+        },
+        "com.amazonaws.lambda#FullDocument": {
+            "type": "enum",
+            "members": {
+                "UpdateLookup": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UpdateLookup"
+                    }
+                },
+                "Default": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Default"
+                    }
+                }
             }
         },
         "com.amazonaws.lambda#FunctionArn": {
@@ -5018,7 +4318,7 @@
                 "KMSKeyArn": {
                     "target": "com.amazonaws.lambda#KMSKeyArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The KMS key that's used to encrypt the function's environment variables. This key is\n      returned only if you've configured a customer managed key.</p>"
+                        "smithy.api#documentation": "<p>The KMS key that's used to encrypt the function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-encryption\">environment variables</a>. When <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart-security.html\">Lambda SnapStart</a> is activated, this key is also used to encrypt the function's snapshot. This key is\n      returned only if you've configured a customer managed key.</p>"
                     }
                 },
                 "TracingConfig": {
@@ -5286,7 +4586,7 @@
                 "AuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
                         "smithy.api#required": {}
                     }
                 }
@@ -5349,7 +4649,10 @@
         },
         "com.amazonaws.lambda#GetAccountSettingsRequest": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#input": {}
+            }
         },
         "com.amazonaws.lambda#GetAccountSettingsResponse": {
             "type": "structure",
@@ -5366,6 +4669,9 @@
                         "smithy.api#documentation": "<p>The number of functions and amount of storage in use.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetAlias": {
@@ -5418,6 +4724,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetCodeSigningConfig": {
@@ -5459,6 +4768,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetCodeSigningConfigResponse": {
@@ -5471,6 +4783,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetEventSourceMapping": {
@@ -5515,6 +4830,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunction": {
@@ -5681,6 +4999,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionCodeSigningConfigResponse": {
@@ -5700,6 +5021,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionConcurrency": {
@@ -5744,6 +5068,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionConcurrencyResponse": {
@@ -5755,6 +5082,9 @@
                         "smithy.api#documentation": "<p>The number of simultaneous executions that are reserved for the function.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionConfiguration": {
@@ -5916,6 +5246,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionEventInvokeConfig": {
@@ -5967,6 +5300,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionRequest": {
@@ -5987,6 +5323,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionResponse": {
@@ -6016,6 +5355,9 @@
                         "smithy.api#documentation": "<p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html\">reserved\n        concurrency</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionUrlConfig": {
@@ -6067,6 +5409,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetFunctionUrlConfigResponse": {
@@ -6089,7 +5434,7 @@
                 "AuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -6113,6 +5458,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetLayerVersion": {
@@ -6188,6 +5536,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetLayerVersionPolicy": {
@@ -6241,6 +5592,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetLayerVersionPolicyResponse": {
@@ -6258,6 +5612,9 @@
                         "smithy.api#documentation": "<p>A unique identifier for the current revision of the policy.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetLayerVersionRequest": {
@@ -6280,6 +5637,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetLayerVersionResponse": {
@@ -6391,6 +5751,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetPolicyResponse": {
@@ -6408,6 +5771,9 @@
                         "smithy.api#documentation": "<p>A unique identifier for the current revision of the policy.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetProvisionedConcurrencyConfig": {
@@ -6463,6 +5829,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetProvisionedConcurrencyConfigResponse": {
@@ -6504,6 +5873,9 @@
                         "smithy.api#documentation": "<p>The date and time that a user last updated the configuration, in <a href=\"https://www.iso.org/iso-8601-date-and-time-format.html\">ISO 8601 format</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#GetRuntimeManagementConfig": {
@@ -6541,7 +5913,7 @@
             "type": "structure",
             "members": {
                 "FunctionName": {
-                    "target": "com.amazonaws.lambda#FunctionName",
+                    "target": "com.amazonaws.lambda#NamespacedFunctionName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the Lambda function.</p>\n         <p class=\"title\">\n            <b>Name formats</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <b>Function name</b> – <code>my-function</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Function ARN</b> – <code>arn:aws:lambda:us-west-2:123456789012:function:my-function</code>.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Partial ARN</b> – <code>123456789012:function:my-function</code>.</p>\n            </li>\n         </ul>\n         <p>The length constraint applies only to the full ARN. If you specify only the function name, it is limited to 64\n      characters in length.</p>",
                         "smithy.api#httpLabel": {},
@@ -6555,6 +5927,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#GetRuntimeManagementConfigResponse": {
@@ -6569,9 +5944,18 @@
                 "RuntimeVersionArn": {
                     "target": "com.amazonaws.lambda#RuntimeVersionArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the runtime the function is configured to use. If the runtime update mode is <b>Manual</b>, the ARN is returned, otherwise <code>null</code> \n    is returned.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the runtime the function is configured to use. If the runtime update mode is <b>Manual</b>, the ARN is returned, otherwise <code>null</code> \n      is returned.</p>"
+                    }
+                },
+                "FunctionArn": {
+                    "target": "com.amazonaws.lambda#NameSpacedFunctionArn",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of your function.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#Handler": {
@@ -6854,6 +6238,9 @@
                         "smithy.api#httpQuery": "Qualifier"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#InvocationResponse": {
@@ -6895,6 +6282,9 @@
                         "smithy.api#httpHeader": "X-Amz-Executed-Version"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#InvocationType": {
@@ -7082,7 +6472,8 @@
                 }
             },
             "traits": {
-                "smithy.api#deprecated": {}
+                "smithy.api#deprecated": {},
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#InvokeAsyncResponse": {
@@ -7099,7 +6490,8 @@
             },
             "traits": {
                 "smithy.api#deprecated": {},
-                "smithy.api#documentation": "<p>A success response (<code>202 Accepted</code>) indicates that the request is queued for invocation.</p>"
+                "smithy.api#documentation": "<p>A success response (<code>202 Accepted</code>) indicates that the request is queued for invocation.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#KMSAccessDeniedException": {
@@ -7664,6 +7056,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListAliasesResponse": {
@@ -7681,6 +7076,9 @@
                         "smithy.api#documentation": "<p>A list of aliases.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListCodeSigningConfigs": {
@@ -7731,6 +7129,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListCodeSigningConfigsResponse": {
@@ -7748,6 +7149,9 @@
                         "smithy.api#documentation": "<p>The code signing configurations</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListEventSourceMappings": {
@@ -7818,6 +7222,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListEventSourceMappingsResponse": {
@@ -7835,6 +7242,9 @@
                         "smithy.api#documentation": "<p>A list of event source mappings.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionEventInvokeConfigs": {
@@ -7899,6 +7309,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionEventInvokeConfigsResponse": {
@@ -7916,6 +7329,9 @@
                         "smithy.api#documentation": "<p>The pagination token that's included if more results are available.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionUrlConfigs": {
@@ -7980,6 +7396,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionUrlConfigsResponse": {
@@ -7998,6 +7417,9 @@
                         "smithy.api#documentation": "<p>The pagination token that's included if more results are available.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListFunctions": {
@@ -8093,6 +7515,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionsByCodeSigningConfigResponse": {
@@ -8110,6 +7535,9 @@
                         "smithy.api#documentation": "<p>The function ARNs. </p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionsRequest": {
@@ -8143,6 +7571,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListFunctionsResponse": {
@@ -8162,7 +7593,8 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>A list of Lambda functions.</p>"
+                "smithy.api#documentation": "<p>A list of Lambda functions.</p>",
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListLayerVersions": {
@@ -8241,6 +7673,9 @@
                         "smithy.api#httpQuery": "CompatibleArchitecture"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListLayerVersionsResponse": {
@@ -8258,6 +7693,9 @@
                         "smithy.api#documentation": "<p>A list of versions.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListLayers": {
@@ -8325,6 +7763,9 @@
                         "smithy.api#httpQuery": "CompatibleArchitecture"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListLayersResponse": {
@@ -8342,6 +7783,9 @@
                         "smithy.api#documentation": "<p>A list of function layers.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListProvisionedConcurrencyConfigs": {
@@ -8406,6 +7850,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListProvisionedConcurrencyConfigsResponse": {
@@ -8423,6 +7870,9 @@
                         "smithy.api#documentation": "<p>The pagination token that's included if more results are available.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListTags": {
@@ -8467,6 +7917,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListTagsResponse": {
@@ -8478,6 +7931,9 @@
                         "smithy.api#documentation": "<p>The function's tags.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#ListVersionsByFunction": {
@@ -8542,6 +7998,9 @@
                         "smithy.api#httpQuery": "MaxItems"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#ListVersionsByFunctionResponse": {
@@ -8559,6 +8018,9 @@
                         "smithy.api#documentation": "<p>A list of Lambda function versions.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#LocalMountPath": {
@@ -9078,6 +8540,9 @@
                         "smithy.api#documentation": "<p>A list of compatible  \n<a href=\"https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html\">instruction set architectures</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PublishLayerVersionResponse": {
@@ -9138,6 +8603,9 @@
                         "smithy.api#documentation": "<p>A list of compatible  \n<a href=\"https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html\">instruction set architectures</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#PublishVersion": {
@@ -9209,6 +8677,9 @@
                         "smithy.api#documentation": "<p>Only update the function if the revision ID matches the ID that's specified. Use this option to avoid\n      publishing a version if the function configuration has changed since you last updated it.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PutFunctionCodeSigningConfig": {
@@ -9266,6 +8737,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PutFunctionCodeSigningConfigResponse": {
@@ -9285,6 +8759,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#PutFunctionConcurrency": {
@@ -9339,6 +8816,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PutFunctionEventInvokeConfig": {
@@ -9411,6 +8891,9 @@
                         "smithy.api#documentation": "<p>A destination for events after they have been sent to a function for processing.</p>\n         <p class=\"title\">\n            <b>Destinations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <b>Function</b> - The Amazon Resource Name (ARN) of a Lambda function.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Queue</b> - The ARN of an SQS queue.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Topic</b> - The ARN of an SNS topic.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Event Bus</b> - The ARN of an Amazon EventBridge event bus.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PutProvisionedConcurrencyConfig": {
@@ -9473,6 +8956,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PutProvisionedConcurrencyConfigResponse": {
@@ -9514,6 +9000,9 @@
                         "smithy.api#documentation": "<p>The date and time that a user last updated the configuration, in <a href=\"https://www.iso.org/iso-8601-date-and-time-format.html\">ISO 8601 format</a>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#PutRuntimeManagementConfig": {
@@ -9581,6 +9070,9 @@
                         "smithy.api#documentation": "<p>The ARN of the runtime version you want the function to use.</p>\n         <note>\n            <p>This is only required if you're using the <b>Manual</b> runtime update mode.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#PutRuntimeManagementConfigResponse": {
@@ -9606,6 +9098,9 @@
                         "smithy.api#documentation": "<p>The ARN of the runtime the function is configured to use. If the runtime update mode is <b>manual</b>, the ARN is returned, otherwise <code>null</code> \n      is returned.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#Qualifier": {
@@ -9709,6 +9204,9 @@
                         "smithy.api#httpQuery": "RevisionId"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#RemovePermission": {
@@ -9778,6 +9276,9 @@
                         "smithy.api#httpQuery": "RevisionId"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#RequestTooLargeException": {
@@ -10743,6 +10244,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#TagValue": {
@@ -10998,6 +10502,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateAlias": {
@@ -11080,6 +10587,9 @@
                         "smithy.api#documentation": "<p>Only update the alias if the revision ID matches the ID that's specified. Use this option to avoid modifying\n      an alias that has changed since you last read it.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateCodeSigningConfig": {
@@ -11139,6 +10649,9 @@
                         "smithy.api#documentation": "<p>The code signing policy.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateCodeSigningConfigResponse": {
@@ -11151,6 +10664,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#UpdateEventSourceMapping": {
@@ -11284,7 +10800,16 @@
                     "traits": {
                         "smithy.api#documentation": "<p>(Amazon SQS only) The scaling configuration for the event source. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-max-concurrency\">Configuring maximum concurrency for Amazon SQS event sources</a>.</p>"
                     }
+                },
+                "DocumentDBEventSourceConfig": {
+                    "target": "com.amazonaws.lambda#DocumentDBEventSourceConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specific configuration settings for a DocumentDB event source.</p>"
+                    }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateFunctionCode": {
@@ -11403,6 +10928,9 @@
                         "smithy.api#documentation": "<p>The instruction set architecture that the function supports. Enter a string array with one of the valid values (arm64 or x86_64).\n     The default value is <code>x86_64</code>.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateFunctionConfiguration": {
@@ -11507,7 +11035,7 @@
                 "Runtime": {
                     "target": "com.amazonaws.lambda#Runtime",
                     "traits": {
-                        "smithy.api#documentation": "<p>The identifier of the function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html\">runtime</a>. Runtime is required if the deployment package is a .zip file archive.\n        </p>"
+                        "smithy.api#documentation": "<p>The identifier of the function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html\">runtime</a>. Runtime is required if the deployment package is a .zip file archive.</p>\n         <p>The following list includes deprecated runtimes. For more information, see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy\">Runtime deprecation policy</a>.</p>"
                     }
                 },
                 "DeadLetterConfig": {
@@ -11519,7 +11047,7 @@
                 "KMSKeyArn": {
                     "target": "com.amazonaws.lambda#KMSKeyArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The ARN of the Key Management Service (KMS) key that's used to encrypt your function's environment\n      variables. If it's not provided, Lambda uses a default service key.</p>"
+                        "smithy.api#documentation": "<p>The ARN of the Key Management Service (KMS) customer managed key that's used to encrypt your function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html#configuration-envvars-encryption\">environment variables</a>. When <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart-security.html\">Lambda SnapStart</a> is activated, this key is also used to encrypt your function's snapshot. If you don't provide a customer managed key, Lambda uses a default service key.</p>"
                     }
                 },
                 "TracingConfig": {
@@ -11564,6 +11092,9 @@
                         "smithy.api#documentation": "<p>The function's <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html\">SnapStart</a> setting.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateFunctionEventInvokeConfig": {
@@ -11636,6 +11167,9 @@
                         "smithy.api#documentation": "<p>A destination for events after they have been sent to a function for processing.</p>\n         <p class=\"title\">\n            <b>Destinations</b>\n         </p>\n         <ul>\n            <li>\n               <p>\n                  <b>Function</b> - The Amazon Resource Name (ARN) of a Lambda function.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Queue</b> - The ARN of an SQS queue.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Topic</b> - The ARN of an SNS topic.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Event Bus</b> - The ARN of an Amazon EventBridge event bus.</p>\n            </li>\n         </ul>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateFunctionUrlConfig": {
@@ -11693,7 +11227,7 @@
                 "AuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>"
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>"
                     }
                 },
                 "Cors": {
@@ -11702,6 +11236,9 @@
                         "smithy.api#documentation": "<p>The <a href=\"https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS\">cross-origin resource sharing (CORS)</a> settings\n  for your function URL.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.lambda#UpdateFunctionUrlConfigResponse": {
@@ -11724,7 +11261,7 @@
                 "AuthType": {
                     "target": "com.amazonaws.lambda#FunctionUrlAuthType",
                     "traits": {
-                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  IAM users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
+                        "smithy.api#documentation": "<p>The type of authentication that your function URL uses. Set to <code>AWS_IAM</code> if you want to restrict access to authenticated\n  users only. Set to <code>NONE</code> if you want to bypass IAM authentication to create a public endpoint. For more information,\n  see <a href=\"https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html\">Security and auth model for Lambda function URLs</a>.</p>",
                         "smithy.api#required": {}
                     }
                 },
@@ -11748,6 +11285,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.lambda#UpdateRuntimeOn": {

--- a/aws/sdk/aws-models/polly.json
+++ b/aws/sdk/aws-models/polly.json
@@ -80,11 +80,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#DeleteLexiconOutput": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.polly#DescribeVoices": {
             "type": "operation",
@@ -143,6 +149,9 @@
                         "smithy.api#httpQuery": "NextToken"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#DescribeVoicesOutput": {
@@ -160,6 +169,9 @@
                         "smithy.api#documentation": "<p>The pagination token to use in the next request to continue the\n      listing of voices. <code>NextToken</code> is returned only if the response\n      is truncated.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#Engine": {
@@ -254,6 +266,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#GetLexiconOutput": {
@@ -271,6 +286,9 @@
                         "smithy.api#documentation": "<p>Metadata of the lexicon, including phonetic alphabetic used,\n      language code, lexicon ARN, number of lexemes defined in the lexicon, and\n      size of lexicon in bytes.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#GetSpeechSynthesisTask": {
@@ -312,6 +330,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#GetSpeechSynthesisTaskOutput": {
@@ -323,6 +344,9 @@
                         "smithy.api#documentation": "<p>SynthesisTask object that provides information from the requested\n      task, including output format, creation time, task status, and so\n      on.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#IncludeAdditionalLanguageCodes": {
@@ -867,6 +891,9 @@
                         "smithy.api#httpQuery": "NextToken"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#ListLexiconsOutput": {
@@ -884,6 +911,9 @@
                         "smithy.api#documentation": "<p>The pagination token to use in the next request to continue the\n      listing of lexicons. <code>NextToken</code> is returned only if the\n      response is truncated.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#ListSpeechSynthesisTasks": {
@@ -940,6 +970,9 @@
                         "smithy.api#httpQuery": "Status"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#ListSpeechSynthesisTasksOutput": {
@@ -957,6 +990,9 @@
                         "smithy.api#documentation": "<p>List of SynthesisTask objects that provides information from the\n      specified task in the list request, including output format, creation\n      time, task status, and so on.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#MarksNotSupportedForFormatException": {
@@ -1114,7 +1150,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -1143,15 +1179,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -1160,7 +1248,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -1170,22 +1258,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://polly-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://polly-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -1198,134 +1421,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://polly.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://polly-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -1333,7 +1474,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://polly-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://polly.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -1342,74 +1483,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://polly.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "endpoint": {
-                                        "url": "https://polly.{Region}.{PartitionResult#dnsSuffix}",
-                                        "properties": {},
-                                        "headers": {}
-                                    },
-                                    "type": "endpoint"
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -1418,305 +1498,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ca-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ca-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.us-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.us-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.af-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.af-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.af-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
                             "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1724,464 +1505,9 @@
                                 }
                             },
                             "params": {
+                                "Region": "af-south-1",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "af-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-north-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-north-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-west-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-west-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-northeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-northeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-northeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-northeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.me-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.me-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.sa-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.sa-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2192,100 +1518,48 @@
                                 }
                             },
                             "params": {
+                                "Region": "ap-east-1",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly-fips.us-gov-west-1.api.aws"
+                                    "url": "https://polly.ap-northeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-gov-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly.us-gov-west-1.api.aws"
+                                    "url": "https://polly.ap-northeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
+                                "Region": "ap-northeast-2",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-gov-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly-fips.ap-southeast-1.api.aws"
+                                    "url": "https://polly.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
+                                "Region": "ap-south-1",
                                 "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-southeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2296,48 +1570,9 @@
                                 }
                             },
                             "params": {
+                                "Region": "ap-southeast-1",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-southeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.ap-southeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2348,48 +1583,113 @@
                                 }
                             },
                             "params": {
+                                "Region": "ap-southeast-2",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-2"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly-fips.us-east-1.api.aws"
+                                    "url": "https://polly.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
+                                "Region": "ca-central-1",
                                 "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly.us-east-1.api.aws"
+                                    "url": "https://polly.eu-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-east-1"
+                                "Region": "eu-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2400,48 +1700,22 @@
                                 }
                             },
                             "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly-fips.us-east-2.api.aws"
+                                    "url": "https://polly-fips.us-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "us-east-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.us-east-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "us-east-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly.us-east-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2452,48 +1726,100 @@
                                 }
                             },
                             "params": {
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly-fips.cn-northwest-1.api.amazonwebservices.com.cn"
+                                    "url": "https://polly-fips.us-east-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseDualStack": true,
-                                "UseFIPS": true,
-                                "Region": "cn-northwest-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://polly-fips.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "UseFIPS": true,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://polly.cn-northwest-1.api.amazonwebservices.com.cn"
+                                    "url": "https://polly.us-west-1.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "UseFIPS": false,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2504,13 +1830,209 @@
                                 }
                             },
                             "params": {
+                                "Region": "cn-northwest-1",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://polly.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
@@ -2519,7 +2041,6 @@
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2529,9 +2050,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
                                 "UseFIPS": true,
-                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2541,9 +2062,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
                                 "UseFIPS": false,
-                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         }
@@ -2610,11 +2131,17 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#PutLexiconOutput": {
             "type": "structure",
-            "members": {}
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
         },
         "com.amazonaws.polly#RequestCharacters": {
             "type": "integer",
@@ -2838,6 +2365,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#StartSpeechSynthesisTaskOutput": {
@@ -2849,6 +2379,9 @@
                         "smithy.api#documentation": "<p>SynthesisTask object that provides information and attributes about a\n      newly submitted speech synthesis task.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#SynthesisTask": {
@@ -3075,6 +2608,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.polly#SynthesizeSpeechOutput": {
@@ -3103,6 +2639,9 @@
                         "smithy.api#httpHeader": "x-amzn-RequestCharacters"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.polly#TaskId": {
@@ -3757,6 +3296,30 @@
                     "target": "smithy.api#Unit",
                     "traits": {
                         "smithy.api#enumValue": "Thiago"
+                    }
+                },
+                "Ruth": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Ruth"
+                    }
+                },
+                "Stephen": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Stephen"
+                    }
+                },
+                "Kazuha": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Kazuha"
+                    }
+                },
+                "Tomoko": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Tomoko"
                     }
                 }
             }

--- a/aws/sdk/aws-models/qldb-session.json
+++ b/aws/sdk/aws-models/qldb-session.json
@@ -416,7 +416,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -445,15 +445,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -462,7 +514,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -472,22 +524,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://session.qldb-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://session.qldb-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -500,82 +687,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://session.qldb.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -583,7 +740,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://session.qldb-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "url": "https://session.qldb.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -592,144 +749,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://session.qldb-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://session.qldb.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://session.qldb.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -738,84 +764,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.us-east-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-east-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb-fips.us-east-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-east-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
                             "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -823,9 +771,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -836,74 +784,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-2",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb-fips.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -914,9 +797,152 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-southeast-1",
                                 "UseDualStack": false,
-                                "Region": "ap-southeast-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb-fips.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -927,9 +953,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -940,87 +966,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb-fips.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://session.qldb.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1031,9 +979,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1044,9 +992,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1057,9 +1005,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1070,9 +1018,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1083,9 +1083,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1096,22 +1096,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://session.qldb.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1121,9 +1160,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1133,9 +1172,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
                                 "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         }

--- a/aws/sdk/aws-models/route53.json
+++ b/aws/sdk/aws-models/route53.json
@@ -279,7 +279,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -308,15 +308,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -325,7 +377,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -335,22 +387,1066 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "route53",
+                                                                                            "signingRegion": "us-east-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53.amazonaws.com",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-cn"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.api.amazonwebservices.com.cn",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.amazonaws.com.cn",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53.{Region}.api.amazonwebservices.com.cn",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53.amazonaws.com.cn",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "cn-northwest-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-us-gov"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53.us-gov.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "route53",
+                                                                                            "signingRegion": "us-gov-west-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseDualStack"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsDualStack"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53.{Region}.api.aws",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "DualStack is enabled but this partition does not support DualStack",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53.us-gov.amazonaws.com",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-gov-west-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-iso"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.c2s.ic.gov",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53.c2s.ic.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-iso-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "stringEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "fn": "getAttr",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "PartitionResult"
+                                                                        },
+                                                                        "name"
+                                                                    ]
+                                                                },
+                                                                "aws-iso-b"
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "UseFIPS"
+                                                                        },
+                                                                        true
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [
+                                                                        {
+                                                                            "fn": "booleanEquals",
+                                                                            "argv": [
+                                                                                true,
+                                                                                {
+                                                                                    "fn": "getAttr",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "PartitionResult"
+                                                                                        },
+                                                                                        "supportsFIPS"
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.sc2s.sgov.gov",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "conditions": [],
+                                                                    "error": "FIPS is enabled but this partition does not support FIPS",
+                                                                    "type": "error"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://route53.sc2s.sgov.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-isob-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Region"
+                                                                                        },
+                                                                                        "aws-global"
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "route53",
+                                                                                            "signingRegion": "us-east-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        {
+                                                                                            "ref": "Region"
+                                                                                        },
+                                                                                        "aws-us-gov-global"
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53.us-gov.amazonaws.com",
+                                                                                "properties": {
+                                                                                    "authSchemes": [
+                                                                                        {
+                                                                                            "name": "sigv4",
+                                                                                            "signingName": "route53",
+                                                                                            "signingRegion": "us-gov-west-1"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -363,1061 +1459,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
-                                                        },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
                                                     "type": "tree",
                                                     "rules": [
                                                         {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53-fips.{Region}.api.aws",
-                                                                "properties": {
-                                                                    "authSchemes": [
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
                                                                         {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-east-1",
-                                                                            "signingName": "route53"
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
                                                                         }
                                                                     ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
                                                                 }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route53-fips.amazonaws.com",
-                                                                "properties": {
-                                                                    "authSchemes": [
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
                                                                         {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-east-1",
-                                                                            "signingName": "route53"
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://route53.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
                                                                         }
                                                                     ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
                                                                 }
                                                             ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
+                                                        },
                                                         {
                                                             "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53.{Region}.api.aws",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-east-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "DualStack is enabled but this partition does not support DualStack",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://route53.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-cn"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53-fips.{Region}.api.amazonwebservices.com.cn",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "cn-northwest-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53-fips.{Region}.amazonaws.com.cn",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "cn-northwest-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53.{Region}.api.amazonwebservices.com.cn",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "cn-northwest-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "DualStack is enabled but this partition does not support DualStack",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://route53.amazonaws.com.cn",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "cn-northwest-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-us-gov"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        },
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53-fips.{Region}.api.aws",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-gov-west-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route53.us-gov.amazonaws.com",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-gov-west-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseDualStack"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsDualStack"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53.{Region}.api.aws",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-gov-west-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "DualStack is enabled but this partition does not support DualStack",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://route53.us-gov.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-gov-west-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-iso"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53-fips.{Region}.c2s.ic.gov",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-iso-east-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://route53.c2s.ic.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-iso-east-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "stringEquals",
-                                            "argv": [
-                                                {
-                                                    "fn": "getAttr",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "PartitionResult"
-                                                        },
-                                                        "name"
-                                                    ]
-                                                },
-                                                "aws-iso-b"
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [
-                                                        {
-                                                            "fn": "booleanEquals",
-                                                            "argv": [
-                                                                true,
-                                                                {
-                                                                    "fn": "getAttr",
-                                                                    "argv": [
-                                                                        {
-                                                                            "ref": "PartitionResult"
-                                                                        },
-                                                                        "supportsFIPS"
-                                                                    ]
-                                                                }
-                                                            ]
-                                                        }
-                                                    ],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://route-53-fips.{Region}.sc2s.sgov.gov",
-                                                                "properties": {
-                                                                    "authSchemes": [
-                                                                        {
-                                                                            "name": "sigv4",
-                                                                            "signingRegion": "us-isob-east-1",
-                                                                            "signingName": "route53"
-                                                                        }
-                                                                    ]
-                                                                },
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "error": "FIPS is enabled but this partition does not support FIPS",
-                                                    "type": "error"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://route53.sc2s.sgov.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-isob-east-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://route53-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -1435,13 +1522,40 @@
                                                                 }
                                                             ],
                                                             "endpoint": {
-                                                                "url": "https://route53-fips.amazonaws.com",
+                                                                "url": "https://route53.amazonaws.com",
                                                                 "properties": {
                                                                     "authSchemes": [
                                                                         {
                                                                             "name": "sigv4",
-                                                                            "signingRegion": "us-east-1",
-                                                                            "signingName": "route53"
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-cn-global"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://route53.amazonaws.com.cn",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "cn-northwest-1"
                                                                         }
                                                                     ]
                                                                 },
@@ -1467,8 +1581,62 @@
                                                                     "authSchemes": [
                                                                         {
                                                                             "name": "sigv4",
-                                                                            "signingRegion": "us-gov-west-1",
-                                                                            "signingName": "route53"
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-gov-west-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-iso-global"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://route53.c2s.ic.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-iso-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-iso-b-global"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://route53.sc2s.sgov.gov",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "route53",
+                                                                            "signingRegion": "us-isob-east-1"
                                                                         }
                                                                     ]
                                                                 },
@@ -1479,7 +1647,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://route53-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://route53.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -1488,215 +1656,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://route53.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://route53.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-cn-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://route53.amazonaws.com.cn",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "cn-northwest-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-us-gov-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://route53.us-gov.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-gov-west-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-iso-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://route53.c2s.ic.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-iso-east-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-iso-b-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://route53.sc2s.sgov.gov",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-isob-east-1",
-                                                            "signingName": "route53"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://route53.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -1704,28 +1670,6 @@
                 },
                 "smithy.rules#endpointTests": {
                     "testCases": [
-                        {
-                            "documentation": "For region aws-cn-global with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "name": "sigv4",
-                                                "signingName": "route53",
-                                                "signingRegion": "cn-northwest-1"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://route53.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "aws-cn-global"
-                            }
-                        },
                         {
                             "documentation": "For region aws-global with FIPS disabled and DualStack disabled",
                             "expect": {
@@ -1743,13 +1687,13 @@
                                 }
                             },
                             "params": {
+                                "Region": "aws-global",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "aws-global"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region aws-iso-global with FIPS disabled and DualStack disabled",
+                            "documentation": "For region aws-global with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
                                     "properties": {
@@ -1757,21 +1701,34 @@
                                             {
                                                 "name": "sigv4",
                                                 "signingName": "route53",
-                                                "signingRegion": "us-iso-east-1"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
-                                    "url": "https://route53.c2s.ic.gov"
+                                    "url": "https://route53-fips.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "Region": "aws-global",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "aws-iso-global"
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For region aws-iso-b-global with FIPS disabled and DualStack disabled",
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
                                     "properties": {
@@ -1779,17 +1736,135 @@
                                             {
                                                 "name": "sigv4",
                                                 "signingName": "route53",
-                                                "signingRegion": "us-isob-east-1"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
-                                    "url": "https://route53.sc2s.sgov.gov"
+                                    "url": "https://route53-fips.amazonaws.com"
                                 }
                             },
                             "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "aws-iso-b-global"
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-cn-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "cn-northwest-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-cn-global",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "cn-northwest-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1809,13 +1884,233 @@
                                 }
                             },
                             "params": {
+                                "Region": "aws-us-gov-global",
                                 "UseDualStack": false,
-                                "UseFIPS": false,
-                                "Region": "aws-us-gov-global"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region aws-us-gov-global with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-us-gov-global",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-gov-west-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.us-gov.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-iso-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-iso-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-iso-global",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-iso-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region aws-iso-b-global with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-isob-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "aws-iso-b-global",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://route53-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "route53",
+                                                "signingRegion": "us-isob-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://route53.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
@@ -1824,7 +2119,6 @@
                             "params": {
                                 "UseDualStack": false,
                                 "UseFIPS": false,
-                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1834,9 +2128,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
                                 "UseFIPS": true,
-                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1846,9 +2140,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
                                 "UseFIPS": false,
-                                "Region": "us-east-1",
                                 "Endpoint": "https://example.com"
                             }
                         }

--- a/aws/sdk/aws-models/s3.json
+++ b/aws/sdk/aws-models/s3.json
@@ -816,10 +816,10 @@
                                                                                                 "properties": {
                                                                                                     "authSchemes": [
                                                                                                         {
+                                                                                                            "disableDoubleEncoding": true,
                                                                                                             "name": "sigv4",
-                                                                                                            "signingRegion": "{Region}",
                                                                                                             "signingName": "s3-outposts",
-                                                                                                            "disableDoubleEncoding": true
+                                                                                                            "signingRegion": "{Region}"
                                                                                                         }
                                                                                                     ]
                                                                                                 },
@@ -836,10 +836,10 @@
                                                                                         "properties": {
                                                                                             "authSchemes": [
                                                                                                 {
+                                                                                                    "disableDoubleEncoding": true,
                                                                                                     "name": "sigv4",
-                                                                                                    "signingRegion": "{Region}",
                                                                                                     "signingName": "s3-outposts",
-                                                                                                    "disableDoubleEncoding": true
+                                                                                                    "signingRegion": "{Region}"
                                                                                                 }
                                                                                             ]
                                                                                         },
@@ -921,10 +921,10 @@
                                                                                                 "properties": {
                                                                                                     "authSchemes": [
                                                                                                         {
+                                                                                                            "disableDoubleEncoding": true,
                                                                                                             "name": "sigv4",
-                                                                                                            "signingRegion": "{Region}",
                                                                                                             "signingName": "s3-outposts",
-                                                                                                            "disableDoubleEncoding": true
+                                                                                                            "signingRegion": "{Region}"
                                                                                                         }
                                                                                                     ]
                                                                                                 },
@@ -941,10 +941,10 @@
                                                                                         "properties": {
                                                                                             "authSchemes": [
                                                                                                 {
+                                                                                                    "disableDoubleEncoding": true,
                                                                                                     "name": "sigv4",
-                                                                                                    "signingRegion": "{Region}",
                                                                                                     "signingName": "s3-outposts",
-                                                                                                    "disableDoubleEncoding": true
+                                                                                                    "signingRegion": "{Region}"
                                                                                                 }
                                                                                             ]
                                                                                         },
@@ -1184,10 +1184,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1243,10 +1243,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1320,10 +1320,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -1395,10 +1395,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1458,10 +1458,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1521,10 +1521,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1602,10 +1602,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -1681,10 +1681,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1740,10 +1740,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1799,10 +1799,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -1876,10 +1876,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -1951,10 +1951,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2010,10 +2010,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2069,10 +2069,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2146,10 +2146,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -2221,10 +2221,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2284,10 +2284,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2347,10 +2347,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2438,10 +2438,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -2456,10 +2456,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -2535,10 +2535,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2594,10 +2594,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2653,10 +2653,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -2740,10 +2740,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -2758,10 +2758,10 @@
                                                                                                                                                 "properties": {
                                                                                                                                                     "authSchemes": [
                                                                                                                                                         {
+                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                         }
                                                                                                                                                     ]
                                                                                                                                                 },
@@ -2833,10 +2833,10 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
                                                                                                                                         },
@@ -3154,10 +3154,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3222,10 +3222,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3308,10 +3308,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -3392,10 +3392,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3460,10 +3460,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3528,10 +3528,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3614,10 +3614,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -3698,10 +3698,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3766,10 +3766,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3834,10 +3834,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -3920,10 +3920,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -4004,10 +4004,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4072,10 +4072,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4140,10 +4140,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4226,10 +4226,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -4310,10 +4310,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4397,10 +4397,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4484,10 +4484,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4571,10 +4571,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4658,10 +4658,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -4773,10 +4773,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -4791,10 +4791,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -4908,10 +4908,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -4926,10 +4926,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -5029,10 +5029,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5130,10 +5130,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5198,10 +5198,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5266,10 +5266,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5362,10 +5362,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -5380,10 +5380,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -5464,10 +5464,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5532,10 +5532,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5600,10 +5600,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "us-east-1",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "us-east-1"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5696,10 +5696,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -5714,10 +5714,10 @@
                                                                                                                                                                         "properties": {
                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                 {
+                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                                                                 }
                                                                                                                                                                             ]
                                                                                                                                                                         },
@@ -5798,10 +5798,10 @@
                                                                                                                                                                 "properties": {
                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                         {
+                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                                                         }
                                                                                                                                                                     ]
                                                                                                                                                                 },
@@ -5953,10 +5953,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -6493,10 +6493,10 @@
                                                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                    "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                     "signingName": "s3-object-lambda",
-                                                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                    "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                                                                                                                         },
@@ -6521,10 +6521,10 @@
                                                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                    "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                     "signingName": "s3-object-lambda",
-                                                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                    "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                                                                                                                         },
@@ -6539,10 +6539,10 @@
                                                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                     "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                    "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                     "signingName": "s3-object-lambda",
-                                                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                    "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                                                             ]
                                                                                                                                                                                                                                                                                                                         },
@@ -7133,10 +7133,10 @@
                                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                                 },
@@ -7170,10 +7170,10 @@
                                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                                 },
@@ -7207,10 +7207,10 @@
                                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                                 },
@@ -7261,10 +7261,10 @@
                                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                                 },
@@ -7298,10 +7298,10 @@
                                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                                             "signingName": "s3",
-                                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                                 },
@@ -7555,12 +7555,12 @@
                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                     "name": "sigv4a",
+                                                                                                                                                                                                                    "signingName": "s3",
                                                                                                                                                                                                                     "signingRegionSet": [
                                                                                                                                                                                                                         "*"
-                                                                                                                                                                                                                    ],
-                                                                                                                                                                                                                    "signingName": "s3",
-                                                                                                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                                                                                                    ]
                                                                                                                                                                                                                 }
                                                                                                                                                                                                             ]
                                                                                                                                                                                                         },
@@ -8002,10 +8002,10 @@
                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                             "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                 },
@@ -8020,10 +8020,10 @@
                                                                                                                                                                                                                                                                                                                 "properties": {
                                                                                                                                                                                                                                                                                                                     "authSchemes": [
                                                                                                                                                                                                                                                                                                                         {
+                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                                             "name": "sigv4",
-                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}",
                                                                                                                                                                                                                                                                                                                             "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                                                                                                                                                                                                            "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                                         }
                                                                                                                                                                                                                                                                                                                     ]
                                                                                                                                                                                                                                                                                                                 },
@@ -8319,10 +8319,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8378,10 +8378,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8455,10 +8455,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -8530,10 +8530,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8593,10 +8593,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8656,10 +8656,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8737,10 +8737,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -8816,10 +8816,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8875,10 +8875,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -8934,10 +8934,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9011,10 +9011,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -9086,10 +9086,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9145,10 +9145,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9204,10 +9204,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9281,10 +9281,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -9356,10 +9356,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9419,10 +9419,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9482,10 +9482,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9573,10 +9573,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -9591,10 +9591,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -9670,10 +9670,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9729,10 +9729,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9788,10 +9788,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -9875,10 +9875,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -9893,10 +9893,10 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
-                                                                                                                                            "signingRegion": "{Region}",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                                            "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
                                                                                                                                 },
@@ -9968,10 +9968,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -10160,10 +10160,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3-object-lambda",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -10188,10 +10188,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3-object-lambda",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -10206,10 +10206,10 @@
                                                                                                                         "properties": {
                                                                                                                             "authSchemes": [
                                                                                                                                 {
+                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                     "name": "sigv4",
-                                                                                                                                    "signingRegion": "{Region}",
                                                                                                                                     "signingName": "s3-object-lambda",
-                                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                                    "signingRegion": "{Region}"
                                                                                                                                 }
                                                                                                                             ]
                                                                                                                         },
@@ -10383,10 +10383,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -10446,10 +10446,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -10527,10 +10527,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -10606,10 +10606,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -10665,10 +10665,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -10724,10 +10724,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -10801,10 +10801,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -10876,10 +10876,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -10939,10 +10939,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11002,10 +11002,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11083,10 +11083,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -11162,10 +11162,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11221,10 +11221,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11280,10 +11280,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11357,10 +11357,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -11432,10 +11432,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11495,10 +11495,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11558,10 +11558,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11639,10 +11639,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -11718,10 +11718,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11777,10 +11777,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11836,10 +11836,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -11913,10 +11913,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -11988,10 +11988,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -12051,10 +12051,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -12114,10 +12114,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -12205,10 +12205,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -12223,10 +12223,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -12302,10 +12302,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -12361,10 +12361,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -12420,10 +12420,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "us-east-1",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "us-east-1"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },
@@ -12507,10 +12507,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -12525,10 +12525,10 @@
                                                                                                                 "properties": {
                                                                                                                     "authSchemes": [
                                                                                                                         {
+                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                             "name": "sigv4",
-                                                                                                                            "signingRegion": "{Region}",
                                                                                                                             "signingName": "s3",
-                                                                                                                            "disableDoubleEncoding": true
+                                                                                                                            "signingRegion": "{Region}"
                                                                                                                         }
                                                                                                                     ]
                                                                                                                 },
@@ -12600,10 +12600,10 @@
                                                                                                         "properties": {
                                                                                                             "authSchemes": [
                                                                                                                 {
+                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                     "name": "sigv4",
-                                                                                                                    "signingRegion": "{Region}",
                                                                                                                     "signingName": "s3",
-                                                                                                                    "disableDoubleEncoding": true
+                                                                                                                    "signingRegion": "{Region}"
                                                                                                                 }
                                                                                                             ]
                                                                                                         },

--- a/aws/sdk/aws-models/s3control.json
+++ b/aws/sdk/aws-models/s3control.json
@@ -70,6 +70,9 @@
                     "target": "com.amazonaws.s3control#DeleteBucketPolicy"
                 },
                 {
+                    "target": "com.amazonaws.s3control#DeleteBucketReplication"
+                },
+                {
                     "target": "com.amazonaws.s3control#DeleteBucketTagging"
                 },
                 {
@@ -122,6 +125,9 @@
                 },
                 {
                     "target": "com.amazonaws.s3control#GetBucketPolicy"
+                },
+                {
+                    "target": "com.amazonaws.s3control#GetBucketReplication"
                 },
                 {
                     "target": "com.amazonaws.s3control#GetBucketTagging"
@@ -185,6 +191,9 @@
                 },
                 {
                     "target": "com.amazonaws.s3control#PutBucketPolicy"
+                },
+                {
+                    "target": "com.amazonaws.s3control#PutBucketReplication"
                 },
                 {
                     "target": "com.amazonaws.s3control#PutBucketTagging"
@@ -546,9 +555,9 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
@@ -574,9 +583,9 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
@@ -592,9 +601,9 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
@@ -1063,9 +1072,9 @@
                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "name": "sigv4",
                                                                                                                                                                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "signingRegion": "{accessPointArn#region}"
                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                             ]
@@ -1106,9 +1115,9 @@
                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "name": "sigv4",
                                                                                                                                                                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "signingRegion": "{accessPointArn#region}"
                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                             ]
@@ -1131,9 +1140,9 @@
                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "name": "sigv4",
                                                                                                                                                                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "signingRegion": "{accessPointArn#region}"
                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                             ]
@@ -1695,9 +1704,9 @@
                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "name": "sigv4",
                                                                                                                                                                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                             ]
@@ -1738,9 +1747,9 @@
                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "name": "sigv4",
                                                                                                                                                                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                             ]
@@ -1763,9 +1772,9 @@
                                                                                                                                                                                                                                                                                         "properties": {
                                                                                                                                                                                                                                                                                             "authSchemes": [
                                                                                                                                                                                                                                                                                                 {
+                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "name": "sigv4",
                                                                                                                                                                                                                                                                                                     "signingName": "s3-outposts",
-                                                                                                                                                                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                                                                                                                                                                     "signingRegion": "{bucketArn#region}"
                                                                                                                                                                                                                                                                                                 }
                                                                                                                                                                                                                                                                                             ]
@@ -2117,9 +2126,9 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
@@ -2135,9 +2144,9 @@
                                                                                                                                         "properties": {
                                                                                                                                             "authSchemes": [
                                                                                                                                                 {
+                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "name": "sigv4",
                                                                                                                                                     "signingName": "s3",
-                                                                                                                                                    "disableDoubleEncoding": true,
                                                                                                                                                     "signingRegion": "{Region}"
                                                                                                                                                 }
                                                                                                                                             ]
@@ -2205,9 +2214,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2242,9 +2251,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2304,9 +2313,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2341,9 +2350,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2403,9 +2412,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2440,9 +2449,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2502,9 +2511,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -2539,9 +2548,9 @@
                                                                                                                                 "properties": {
                                                                                                                                     "authSchemes": [
                                                                                                                                         {
+                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "name": "sigv4",
                                                                                                                                             "signingName": "s3",
-                                                                                                                                            "disableDoubleEncoding": true,
                                                                                                                                             "signingRegion": "{Region}"
                                                                                                                                         }
                                                                                                                                     ]
@@ -6072,6 +6081,21 @@
                 "smithy.api#documentation": "<p>The container for abort incomplete multipart upload</p>"
             }
         },
+        "com.amazonaws.s3control#AccessControlTranslation": {
+            "type": "structure",
+            "members": {
+                "Owner": {
+                    "target": "com.amazonaws.s3control#OwnerOverride",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the replica ownership.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container for information about access control for replicas.</p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+            }
+        },
         "com.amazonaws.s3control#AccessPoint": {
             "type": "structure",
             "members": {
@@ -6139,7 +6163,7 @@
             "traits": {
                 "smithy.api#length": {
                     "min": 3,
-                    "max": 63
+                    "max": 255
                 }
             }
         },
@@ -6204,7 +6228,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>The container element for Amazon S3 Storage Lens activity metrics. Activity metrics show details about \n         how your storage is requested, such as requests (for example, All requests, Get requests, \n         Put requests), bytes uploaded or downloaded, and errors.</p>\n         <p>For more information about S3 Storage Lens, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens.html\">Assessing your storage activity and usage with S3 Storage Lens</a> in the <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>The container element for Amazon S3 Storage Lens activity metrics. Activity metrics show details\n         about how your storage is requested, such as requests (for example, All requests, Get\n         requests, Put requests), bytes uploaded or downloaded, and errors.</p>\n         <p>For more information about S3 Storage Lens, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens.html\">Assessing your storage activity and usage with S3 Storage Lens</a> in the <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>"
             }
         },
         "com.amazonaws.s3control#AdvancedCostOptimizationMetrics": {
@@ -6505,6 +6529,9 @@
                 }
             }
         },
+        "com.amazonaws.s3control#BucketIdentifierString": {
+            "type": "string"
+        },
         "com.amazonaws.s3control#BucketLevel": {
             "type": "structure",
             "members": {
@@ -6770,6 +6797,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#CreateAccessPointForObjectLambdaResult": {
@@ -6809,7 +6839,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the bucket that you want to associate this access point with.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>The name of the bucket that you want to associate this access point with.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
                             "name": "Bucket"
@@ -6834,6 +6864,9 @@
                         "smithy.api#documentation": "<p>The Amazon Web Services account ID associated with the S3 bucket associated with this access point.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#CreateAccessPointResult": {
@@ -6975,6 +7008,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#CreateBucketResult": {
@@ -6990,7 +7026,7 @@
                 "BucketArn": {
                     "target": "com.amazonaws.s3control#S3RegionalBucketArn",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>"
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>"
                     }
                 }
             }
@@ -7117,6 +7153,9 @@
                         "smithy.api#documentation": "<p>The attribute container for the ManifestGenerator details. Jobs must be created with\n         either a manifest file or a ManifestGenerator, but not both.</p>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#CreateJobResult": {
@@ -7211,6 +7250,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#CreateMultiRegionAccessPointResult": {
@@ -7318,6 +7360,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteAccessPointPolicy": {
@@ -7393,6 +7438,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteAccessPointPolicyRequest": {
@@ -7413,7 +7461,7 @@
                 "Name": {
                     "target": "com.amazonaws.s3control#AccessPointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the access point whose policy you want to delete.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
+                        "smithy.api#documentation": "<p>The name of the access point whose policy you want to delete.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -7421,6 +7469,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteAccessPointRequest": {
@@ -7441,7 +7492,7 @@
                 "Name": {
                     "target": "com.amazonaws.s3control#AccessPointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the access point you want to delete.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
+                        "smithy.api#documentation": "<p>The name of the access point you want to delete.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -7449,6 +7500,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteBucket": {
@@ -7519,7 +7573,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -7527,6 +7581,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteBucketPolicy": {
@@ -7572,7 +7629,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -7580,6 +7637,65 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3control#DeleteBucketReplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3control#DeleteBucketReplicationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "smithy.api#documentation": "<note>\n            <p>This operation deletes an Amazon S3 on Outposts bucket's replication configuration. To\n            delete an S3 bucket's replication configuration, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketReplication.html\">DeleteBucketReplication</a> in the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Deletes the replication configuration from the specified S3 on Outposts bucket.</p>\n         <p>To use this operation, you must have permissions to perform the\n            <code>s3-outposts:PutReplicationConfiguration</code> action. The Outposts bucket owner\n         has this permission by default and can grant it to others. For more information about\n         permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsIAM.html\">Setting up IAM with\n            S3 on Outposts</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsBucketPolicy.html\">Managing access to\n            S3 on Outposts buckets</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>It can take a while to propagate <code>PUT</code> or <code>DELETE</code> requests for\n            a replication configuration to all S3 on Outposts systems. Therefore, the replication\n            configuration that's returned by a <code>GET</code> request soon after a\n               <code>PUT</code> or <code>DELETE</code> request might return a more recent result\n            than what's on the Outpost. If an Outpost is offline, the delay in updating the\n            replication configuration on that Outpost can be significant.</p>\n         </note>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteBucketReplication.html#API_control_DeleteBucketReplication_Examples\">Examples</a> section.</p>\n         <p>For information about S3 replication on Outposts configuration, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsReplication.html\">Replicating objects for Amazon Web Services Outposts</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n         <p>The following operations are related to <code>DeleteBucketReplication</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketReplication.html\">PutBucketReplication</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketReplication.html\">GetBucketReplication</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#endpoint": {
+                    "hostPrefix": "{AccountId}."
+                },
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/v20180820/bucket/{Bucket}/replication",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "RequiresAccountId": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#DeleteBucketReplicationRequest": {
+            "type": "structure",
+            "members": {
+                "AccountId": {
+                    "target": "com.amazonaws.s3control#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID of the Outposts bucket to delete the replication configuration\n         for.</p>",
+                        "smithy.api#hostLabel": {},
+                        "smithy.api#httpHeader": "x-amz-account-id",
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "AccountId"
+                        }
+                    }
+                },
+                "Bucket": {
+                    "target": "com.amazonaws.s3control#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the S3 on Outposts bucket to delete the replication configuration for.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteBucketRequest": {
@@ -7600,7 +7716,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket being deleted.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket being deleted.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -7608,6 +7724,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteBucketTagging": {
@@ -7653,7 +7772,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The bucket ARN that has the tag set to be removed.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>The bucket ARN that has the tag set to be removed.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -7661,6 +7780,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteJobTagging": {
@@ -7683,7 +7805,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Removes the entire tag set from the specified S3 Batch Operations job. To use this operation,\n         you must have permission to perform the <code>s3:DeleteJobTagging</code> action. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-managing-jobs.html#batch-ops-job-tags\">Controlling\n            access and labeling jobs using tags</a> in the\n         <i>Amazon S3 User Guide</i>.</p>\n         <p></p>\n         <p>Related actions include:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateJob.html\">CreateJob</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html\">GetJobTagging</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutJobTagging.html\">PutJobTagging</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Removes the entire tag set from the specified S3 Batch Operations job. To use\n         the\n            <code>DeleteJobTagging</code> operation, you must have permission to\n         perform the <code>s3:DeleteJobTagging</code> action. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-managing-jobs.html#batch-ops-job-tags\">Controlling\n            access and labeling jobs using tags</a> in the\n         <i>Amazon S3 User Guide</i>.</p>\n         <p></p>\n         <p>Related actions include:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateJob.html\">CreateJob</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html\">GetJobTagging</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutJobTagging.html\">PutJobTagging</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -7722,11 +7844,46 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteJobTaggingResult": {
             "type": "structure",
             "members": {}
+        },
+        "com.amazonaws.s3control#DeleteMarkerReplication": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3control#DeleteMarkerReplicationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates whether to replicate delete markers.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies whether S3 on Outposts replicates delete markers. If you specify a\n            <code>Filter</code> element in your replication configuration, you must also include a\n            <code>DeleteMarkerReplication</code> element. If your <code>Filter</code> includes a\n            <code>Tag</code> element, the <code>DeleteMarkerReplication</code> element's\n            <code>Status</code> child element must be set to <code>Disabled</code>, because\n         S3 on Outposts does not support replicating delete markers for tag-based rules.</p>\n         <p>For more information about delete marker replication, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsReplication.html#outposts-replication-what-is-replicated\">How delete operations affect replication</a> in the <i>Amazon S3 User Guide</i>. </p>"
+            }
+        },
+        "com.amazonaws.s3control#DeleteMarkerReplicationStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
+            }
         },
         "com.amazonaws.s3control#DeleteMultiRegionAccessPoint": {
             "type": "operation",
@@ -7799,6 +7956,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteMultiRegionAccessPointResult": {
@@ -7852,6 +8012,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteStorageLensConfiguration": {
@@ -7902,6 +8065,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteStorageLensConfigurationTagging": {
@@ -7952,6 +8118,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DeleteStorageLensConfigurationTaggingResult": {
@@ -8020,6 +8189,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DescribeJobResult": {
@@ -8082,6 +8254,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#DescribeMultiRegionAccessPointOperationResult": {
@@ -8093,6 +8268,57 @@
                         "smithy.api#documentation": "<p>A container element containing the details of the asynchronous operation.</p>"
                     }
                 }
+            }
+        },
+        "com.amazonaws.s3control#Destination": {
+            "type": "structure",
+            "members": {
+                "Account": {
+                    "target": "com.amazonaws.s3control#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The destination bucket owner's account ID. </p>"
+                    }
+                },
+                "Bucket": {
+                    "target": "com.amazonaws.s3control#BucketIdentifierString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the access point for the destination bucket where you want\n         S3 on Outposts to store the replication results.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ReplicationTime": {
+                    "target": "com.amazonaws.s3control#ReplicationTime",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container that specifies S3 Replication Time Control (S3 RTC) settings, including whether S3 RTC is enabled\n         and the time when all objects and operations on objects must be replicated. Must be\n         specified together with a <code>Metrics</code> block. </p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+                    }
+                },
+                "AccessControlTranslation": {
+                    "target": "com.amazonaws.s3control#AccessControlTranslation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specify this property only in a cross-account scenario (where the source and destination\n         bucket owners are not the same), and you want to change replica ownership to the\n         Amazon Web Services account that owns the destination bucket. If this property is not specified in the\n         replication configuration, the replicas are owned by same Amazon Web Services account that owns the\n         source object.</p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+                    }
+                },
+                "EncryptionConfiguration": {
+                    "target": "com.amazonaws.s3control#EncryptionConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container that provides information about encryption. If\n            <code>SourceSelectionCriteria</code> is specified, you must specify this element.</p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+                    }
+                },
+                "Metrics": {
+                    "target": "com.amazonaws.s3control#Metrics",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A container that specifies replication metrics-related settings. </p>"
+                    }
+                },
+                "StorageClass": {
+                    "target": "com.amazonaws.s3control#ReplicationStorageClass",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The storage class to use when replicating objects. All objects stored on S3 on Outposts\n         are stored in the <code>OUTPOSTS</code> storage class. S3 on Outposts uses the\n            <code>OUTPOSTS</code> storage class to create the object replicas. </p>\n         <note>\n            <p>Values other than <code>OUTPOSTS</code> are not supported by Amazon S3 on Outposts. </p>\n         </note>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies information about the replication destination bucket and its settings for an\n         S3 on Outposts replication configuration.</p>"
             }
         },
         "com.amazonaws.s3control#DetailedStatusCodesMetrics": {
@@ -8108,6 +8334,20 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>The container element for Amazon S3 Storage Lens detailed status code metrics. Detailed status\n         code metrics generate metrics for HTTP status codes, such as <code>200 OK</code>, <code>403\n            Forbidden</code>, <code>503 Service Unavailable</code> and others. </p>\n         <p>For more information about S3 Storage Lens, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens.html\">Assessing your storage activity and usage with S3 Storage Lens</a> in the <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>"
+            }
+        },
+        "com.amazonaws.s3control#EncryptionConfiguration": {
+            "type": "structure",
+            "members": {
+                "ReplicaKmsKeyID": {
+                    "target": "com.amazonaws.s3control#ReplicaKmsKeyID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the ID of the customer managed KMS key that's stored in Key Management Service (KMS)\n         for the destination bucket. This ID is either the Amazon Resource Name (ARN) for the\n         KMS key or the alias ARN for the KMS key. Amazon S3 uses this KMS key to encrypt\n         replica objects. Amazon S3 supports only symmetric encryption KMS keys. For more information,\n         see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#symmetric-cmks\">Symmetric encryption\n            KMS keys</a> in the <i>Amazon Web Services Key Management Service Developer\n            Guide</i>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies encryption-related information for an Amazon S3 bucket that is a destination for\n         replicated objects.</p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
             }
         },
         "com.amazonaws.s3control#Endpoints": {
@@ -8160,6 +8400,38 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>A container for what Amazon S3 Storage Lens will exclude.</p>"
+            }
+        },
+        "com.amazonaws.s3control#ExistingObjectReplication": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3control#ExistingObjectReplicationStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether Amazon S3 replicates existing source bucket objects. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An optional configuration to replicate existing source bucket objects. </p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.s3control#ExistingObjectReplicationStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
             }
         },
         "com.amazonaws.s3control#ExpirationStatus": {
@@ -8318,6 +8590,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointConfigurationForObjectLambdaResult": {
@@ -8379,6 +8654,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointForObjectLambdaResult": {
@@ -8477,6 +8755,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointPolicyForObjectLambdaResult": {
@@ -8508,7 +8789,7 @@
                 "Name": {
                     "target": "com.amazonaws.s3control#AccessPointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the access point whose policy you want to retrieve.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
+                        "smithy.api#documentation": "<p>The name of the access point whose policy you want to retrieve.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -8516,6 +8797,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointPolicyResult": {
@@ -8602,6 +8886,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointPolicyStatusForObjectLambdaResult": {
@@ -8638,6 +8925,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointPolicyStatusResult": {
@@ -8669,7 +8959,7 @@
                 "Name": {
                     "target": "com.amazonaws.s3control#AccessPointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the access point whose configuration information you want to retrieve.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
+                        "smithy.api#documentation": "<p>The name of the access point whose configuration information you want to retrieve.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -8677,6 +8967,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetAccessPointResult": {
@@ -8809,7 +9102,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -8817,6 +9110,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetBucketLifecycleConfigurationResult": {
@@ -8873,7 +9169,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -8881,6 +9177,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetBucketPolicyResult": {
@@ -8890,6 +9189,73 @@
                     "target": "com.amazonaws.s3control#Policy",
                     "traits": {
                         "smithy.api#documentation": "<p>The policy of the Outposts bucket.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#GetBucketReplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3control#GetBucketReplicationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.s3control#GetBucketReplicationResult"
+            },
+            "traits": {
+                "smithy.api#documentation": "<note>\n            <p>This operation gets an Amazon S3 on Outposts bucket's replication configuration. To get an\n            S3 bucket's replication configuration, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketReplication.html\">GetBucketReplication</a>\n            in the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Returns the replication configuration of an S3 on Outposts bucket. For more information\n         about S3 on Outposts, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html\">Using Amazon S3 on Outposts</a> in the\n            <i>Amazon S3 User Guide</i>. For information about S3 replication on Outposts\n         configuration, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsReplication.html\">Replicating objects for Amazon Web Services\n            Outposts</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>It can take a while to propagate <code>PUT</code> or <code>DELETE</code> requests for\n            a replication configuration to all S3 on Outposts systems. Therefore, the replication\n            configuration that's returned by a <code>GET</code> request soon after a\n               <code>PUT</code> or <code>DELETE</code> request might return a more recent result\n            than what's on the Outpost. If an Outpost is offline, the delay in updating the\n            replication configuration on that Outpost can be significant.</p>\n         </note>\n         <p>This action requires permissions for the\n            <code>s3-outposts:GetReplicationConfiguration</code> action. The Outposts bucket owner\n         has this permission by default and can grant it to others. For more information about\n         permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsIAM.html\">Setting up IAM with\n            S3 on Outposts</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsBucketPolicy.html\">Managing access to\n            S3 on Outposts bucket</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketReplication.html#API_control_GetBucketReplication_Examples\">Examples</a> section.</p>\n         <p>If you include the <code>Filter</code> element in a replication configuration, you must\n         also include the <code>DeleteMarkerReplication</code>, <code>Status</code>, and\n            <code>Priority</code> elements. The response also returns those elements.</p>\n         <p>For information about S3 on Outposts replication failure reasons, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/outposts-replication-eventbridge.html#outposts-replication-failure-codes\">Replication failure reasons</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <p>The following operations are related to <code>GetBucketReplication</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketReplication.html\">PutBucketReplication</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteBucketReplication.html\">DeleteBucketReplication</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#endpoint": {
+                    "hostPrefix": "{AccountId}."
+                },
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/v20180820/bucket/{Bucket}/replication",
+                    "code": 200
+                },
+                "smithy.rules#staticContextParams": {
+                    "RequiresAccountId": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#GetBucketReplicationRequest": {
+            "type": "structure",
+            "members": {
+                "AccountId": {
+                    "target": "com.amazonaws.s3control#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID of the Outposts bucket.</p>",
+                        "smithy.api#hostLabel": {},
+                        "smithy.api#httpHeader": "x-amz-account-id",
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "AccountId"
+                        }
+                    }
+                },
+                "Bucket": {
+                    "target": "com.amazonaws.s3control#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the bucket to get the replication information for.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3control#GetBucketReplicationResult": {
+            "type": "structure",
+            "members": {
+                "ReplicationConfiguration": {
+                    "target": "com.amazonaws.s3control#ReplicationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container for one or more replication rules. A replication configuration must have at least one rule and you can add up to 100 rules. The maximum size of a\n         replication configuration is 128 KB.</p>"
                     }
                 }
             }
@@ -8912,7 +9278,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -8920,6 +9286,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetBucketResult": {
@@ -8989,7 +9358,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -8997,6 +9366,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetBucketTaggingResult": {
@@ -9020,7 +9392,7 @@
                 "target": "com.amazonaws.s3control#GetBucketVersioningResult"
             },
             "traits": {
-                "smithy.api#documentation": "<note>\n            <p>This operation returns the versioning state only for S3 on Outposts buckets. To return\n            the versioning state for an S3 bucket, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html\">GetBucketVersioning</a> in\n            the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Returns the versioning state for an S3 on Outposts bucket. With versioning, you can save\n         multiple distinct copies of your data and recover from unintended user actions and\n         application failures.</p>\n         <p>If you've never set versioning on your bucket, it has no versioning state. In that case,\n         the <code>GetBucketVersioning</code> request does not return a versioning state\n         value.</p>\n         <p>For more information about versioning, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html\">Versioning</a> in the <i>Amazon S3\n            User Guide</i>.</p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketVersioning.html#API_control_GetBucketVersioning_Examples\">Examples</a> section.</p>\n         <p>The following operations are related to <code>GetBucketVersioning</code> for\n         S3 on Outposts.</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketVersioning.html\">PutBucketVersioning</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketLifecycleConfiguration.html\">PutBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketLifecycleConfiguration.html\">GetBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<note>\n            <p>This operation returns the versioning state\n            for\n            S3 on Outposts\n            buckets\n            only. To return the versioning state for an S3 bucket, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketVersioning.html\">GetBucketVersioning</a> in the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Returns the versioning state for an S3 on Outposts bucket. With\n         S3\n         Versioning,\n         you can save multiple distinct copies of your\n         objects\n         and recover from unintended user actions and application failures.</p>\n         <p>If you've never set versioning on your bucket, it has no versioning state. In that case,\n         the <code>GetBucketVersioning</code> request does not return a versioning state\n         value.</p>\n         <p>For more information about versioning, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html\">Versioning</a> in the <i>Amazon S3\n            User Guide</i>.</p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketVersioning.html#API_control_GetBucketVersioning_Examples\">Examples</a> section.</p>\n         <p>The following operations are related to <code>GetBucketVersioning</code> for\n         S3 on Outposts.</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketVersioning.html\">PutBucketVersioning</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketLifecycleConfiguration.html\">PutBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketLifecycleConfiguration.html\">GetBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -9062,6 +9434,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetBucketVersioningResult": {
@@ -9102,7 +9477,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Returns the tags on an S3 Batch Operations job. To use this operation, you must have\n         permission to perform the <code>s3:GetJobTagging</code> action. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-managing-jobs.html#batch-ops-job-tags\">Controlling\n            access and labeling jobs using tags</a> in the\n         <i>Amazon S3 User Guide</i>.</p>\n         <p></p>\n         <p>Related actions include:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateJob.html\">CreateJob</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutJobTagging.html\">PutJobTagging</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteJobTagging.html\">DeleteJobTagging</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Returns the tags on an S3 Batch Operations job. To use\n         the\n            <code>GetJobTagging</code> operation, you must have permission to\n         perform the <code>s3:GetJobTagging</code> action. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-managing-jobs.html#batch-ops-job-tags\">Controlling\n            access and labeling jobs using tags</a> in the\n         <i>Amazon S3 User Guide</i>.</p>\n         <p></p>\n         <p>Related actions include:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateJob.html\">CreateJob</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutJobTagging.html\">PutJobTagging</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteJobTagging.html\">DeleteJobTagging</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -9141,6 +9516,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetJobTaggingResult": {
@@ -9229,6 +9607,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetMultiRegionAccessPointPolicyResult": {
@@ -9291,6 +9672,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetMultiRegionAccessPointPolicyStatusResult": {
@@ -9324,6 +9708,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetMultiRegionAccessPointResult": {
@@ -9386,6 +9773,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetMultiRegionAccessPointRoutesResult": {
@@ -9445,6 +9835,9 @@
                         "smithy.api#httpPayload": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#output": {}
             }
         },
         "com.amazonaws.s3control#GetPublicAccessBlockRequest": {
@@ -9462,6 +9855,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetStorageLensConfiguration": {
@@ -9473,7 +9869,7 @@
                 "target": "com.amazonaws.s3control#GetStorageLensConfigurationResult"
             },
             "traits": {
-                "smithy.api#documentation": "<p>Gets the Amazon S3 Storage Lens configuration. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens.html\">Assessing your storage\n            activity and usage with Amazon S3 Storage Lens </a> in the\n         <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>To use this action, you must have permission to perform the\n               <code>s3:GetStorageLensConfiguration</code> action. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens_iam_permissions.html\">Setting permissions to use Amazon S3 Storage Lens</a> in the\n               <i>Amazon S3 User Guide</i>.</p>\n         </note>",
+                "smithy.api#documentation": "<p>Gets the Amazon S3 Storage Lens configuration. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens.html\">Assessing your storage\n            activity and usage with Amazon S3 Storage Lens </a> in the\n            <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>To use this action, you must have permission to perform the\n               <code>s3:GetStorageLensConfiguration</code> action. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens_iam_permissions.html\">Setting permissions to use Amazon S3 Storage Lens</a> in the\n               <i>Amazon S3 User Guide</i>.</p>\n         </note>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -9512,6 +9908,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetStorageLensConfigurationResult": {
@@ -9574,6 +9973,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#GetStorageLensConfigurationTaggingResult": {
@@ -10076,7 +10478,7 @@
                 "ObjectArn": {
                     "target": "com.amazonaws.s3control#S3KeyArnString",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for a manifest object.</p>\n         <important>\n            <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using \n         XML requests. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints\">\n            XML related object key constraints</a>.</p>\n         </important>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) for a manifest object.</p>\n         <important>\n            <p>When you're using XML requests, you must \nreplace special characters (such as carriage returns) in object keys with their equivalent XML entity codes. \nFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints\">\n            XML-related object key constraints</a> in the <i>Amazon S3 User Guide</i>.</p>\n         </important>",
                         "smithy.api#required": {}
                     }
                 },
@@ -10614,7 +11016,7 @@
                 "Prefix": {
                     "target": "com.amazonaws.s3control#Prefix",
                     "traits": {
-                        "smithy.api#documentation": "<p>Prefix identifying one or more objects to which the rule applies.</p>\n         <important>\n            <p>Replacement must be made for object keys containing special characters (such as carriage returns) when using \n         XML requests. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints\">\n            XML related object key constraints</a>.</p>\n         </important>"
+                        "smithy.api#documentation": "<p>Prefix identifying one or more objects to which the rule applies.</p>\n         <important>\n            <p>When you're using XML requests, you must \nreplace special characters (such as carriage returns) in object keys with their equivalent XML entity codes. \nFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints\">\n            XML-related object key constraints</a> in the <i>Amazon S3 User Guide</i>.</p>\n         </important>"
                     }
                 },
                 "Tag": {
@@ -10663,7 +11065,7 @@
                 "target": "com.amazonaws.s3control#ListAccessPointsResult"
             },
             "traits": {
-                "smithy.api#documentation": "<p>Returns a list of the access points owned by the current account associated with the specified bucket. You can\n         retrieve up to 1000 access points per call. If the specified bucket has more than 1,000 access points (or\n         the number specified in <code>maxResults</code>, whichever is less), the response will\n         include a continuation token that you can use to list the additional access points.</p>\n         <p></p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetAccessPoint.html#API_control_GetAccessPoint_Examples\">Examples</a> section.</p>\n         <p>The following actions are related to <code>ListAccessPoints</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateAccessPoint.html\">CreateAccessPoint</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteAccessPoint.html\">DeleteAccessPoint</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetAccessPoint.html\">GetAccessPoint</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Returns a list of the access points\n         that are\n         owned by the current account\n         that's\n         associated with the specified bucket. You can retrieve up to 1000 access points\n         per call. If the specified bucket has more than 1,000 access points (or the number specified in\n            <code>maxResults</code>, whichever is less), the response will include a continuation\n         token that you can use to list the additional access points.</p>\n         <p></p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetAccessPoint.html#API_control_GetAccessPoint_Examples\">Examples</a> section.</p>\n         <p>The following actions are related to <code>ListAccessPoints</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateAccessPoint.html\">CreateAccessPoint</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteAccessPoint.html\">DeleteAccessPoint</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetAccessPoint.html\">GetAccessPoint</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -10745,6 +11147,9 @@
                         "smithy.api#httpQuery": "maxResults"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#ListAccessPointsForObjectLambdaResult": {
@@ -10782,7 +11187,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the bucket whose associated access points you want to list.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>The name of the bucket whose associated access points you want to list.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpQuery": "bucket",
                         "smithy.rules#contextParam": {
                             "name": "Bucket"
@@ -10804,6 +11209,9 @@
                         "smithy.api#httpQuery": "maxResults"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#ListAccessPointsResult": {
@@ -10901,6 +11309,9 @@
                         "smithy.api#httpQuery": "maxResults"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#ListJobsResult": {
@@ -10981,6 +11392,9 @@
                         "smithy.api#httpQuery": "maxResults"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#ListMultiRegionAccessPointsResult": {
@@ -11070,6 +11484,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#ListRegionalBucketsResult": {
@@ -11176,6 +11593,9 @@
                         "smithy.api#httpQuery": "nextToken"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#ListStorageLensConfigurationsResult": {
@@ -11264,6 +11684,44 @@
                 }
             }
         },
+        "com.amazonaws.s3control#Metrics": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3control#MetricsStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether replication metrics are enabled. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "EventThreshold": {
+                    "target": "com.amazonaws.s3control#ReplicationTimeValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container that specifies the time threshold for emitting the\n            <code>s3:Replication:OperationMissedThreshold</code> event. </p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container that specifies replication metrics-related settings.</p>"
+            }
+        },
+        "com.amazonaws.s3control#MetricsStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3control#MinStorageBytesPercentage": {
             "type": "double",
             "traits": {
@@ -11272,6 +11730,12 @@
                     "min": 0.1,
                     "max": 100
                 }
+            }
+        },
+        "com.amazonaws.s3control#Minutes": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
             }
         },
         "com.amazonaws.s3control#MultiRegionAccessPointAlias": {
@@ -11431,7 +11895,7 @@
                 "TrafficDialPercentage": {
                     "target": "com.amazonaws.s3control#TrafficDialPercentage",
                     "traits": {
-                        "smithy.api#documentation": "<p>The traffic state for the specified bucket or Amazon Web Services Region. </p>\n         <p>A value of <code>0</code> indicates a passive state, which means that no new traffic\n         will be routed to the\n         Region. </p>\n         <p>A value of <code>100</code> indicates an active state, which means that traffic will be\n         routed to the specified Region. </p>\n         <p>When\n         the routing configuration for a Region is changed from active to passive, any in-progress\n         operations (uploads, copies, deletes, and so on) to the formerly active Region will\n         continue to run to until a final success or failure status is reached.</p>\n         <p>If all Regions in the routing configuration are designated as passive, you'll receive an\n            <code>InvalidRequest</code> error. </p>",
+                        "smithy.api#documentation": "<p>The traffic state for the specified bucket or Amazon Web Services Region. </p>\n         <p>A value of <code>0</code> indicates a passive state, which means that no new traffic\n         will be routed to the Region. </p>\n         <p>A value of <code>100</code> indicates an active state, which means that traffic will be\n         routed to the specified Region. </p>\n         <p>When the routing configuration for a Region is changed from active to passive, any\n         in-progress operations (uploads, copies, deletes, and so on) to the formerly active Region\n         will continue to run to until a final success or failure status is reached.</p>\n         <p>If all Regions in the routing configuration are designated as passive, you'll receive an\n            <code>InvalidRequest</code> error.</p>",
                         "smithy.api#required": {}
                     }
                 }
@@ -11584,7 +12048,7 @@
                     "target": "com.amazonaws.s3control#NoncurrentVersionCount",
                     "traits": {
                         "smithy.api#default": null,
-                        "smithy.api#documentation": "<p>Specifies how many noncurrent versions S3 on Outposts will retain. If there are this many more\n         recent noncurrent versions, S3 on Outposts will take the associated action. For more information\n         about noncurrent versions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html\">Lifecycle configuration\n            elements</a> in the <i>Amazon S3 User Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Specifies how many noncurrent versions S3 on Outposts will retain. If there are this many\n         more recent noncurrent versions, S3 on Outposts will take the associated action. For more\n         information about noncurrent versions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html\">Lifecycle configuration\n            elements</a> in the <i>Amazon S3 User Guide</i>.</p>"
                     }
                 }
             },
@@ -11944,6 +12408,17 @@
                 }
             }
         },
+        "com.amazonaws.s3control#OwnerOverride": {
+            "type": "enum",
+            "members": {
+                "Destination": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Destination"
+                    }
+                }
+            }
+        },
         "com.amazonaws.s3control#Policy": {
             "type": "string"
         },
@@ -11997,6 +12472,12 @@
             },
             "traits": {
                 "smithy.api#documentation": "<p>A container for the prefix-level storage metrics for S3 Storage Lens.</p>"
+            }
+        },
+        "com.amazonaws.s3control#Priority": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
             }
         },
         "com.amazonaws.s3control#ProposedMultiRegionAccessPointPolicy": {
@@ -12114,6 +12595,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutAccessPointPolicy": {
@@ -12196,6 +12680,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutAccessPointPolicyRequest": {
@@ -12216,7 +12703,7 @@
                 "Name": {
                     "target": "com.amazonaws.s3control#AccessPointName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The name of the access point that you want to associate with the specified policy.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
+                        "smithy.api#documentation": "<p>The name of the access point that you want to associate with the specified policy.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the access point accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/accesspoint/<my-accesspoint-name></code>. For example, to access the access point <code>reports-ap</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/accesspoint/reports-ap</code>. The value must be URL encoded. </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -12231,6 +12718,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutBucketLifecycleConfiguration": {
@@ -12293,6 +12783,9 @@
                         "smithy.api#xmlName": "LifecycleConfiguration"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutBucketPolicy": {
@@ -12339,7 +12832,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>Specifies the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -12362,6 +12855,75 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.s3control#PutBucketReplication": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.s3control#PutBucketReplicationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "traits": {
+                "smithy.api#documentation": "<note>\n            <p>This action creates an Amazon S3 on Outposts bucket's replication configuration. To create\n            an S3 bucket's replication configuration, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketReplication.html\">PutBucketReplication</a>\n            in the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Creates a replication configuration or replaces an existing one. For information about\n         S3 replication on Outposts configuration, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/AmazonS3/latest/userguide/S3OutpostsReplication.html\">Replicating objects for Amazon Web Services Outposts</a> in the\n            <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>It can take a while to propagate <code>PUT</code> or <code>DELETE</code> requests for\n            a replication configuration to all S3 on Outposts systems. Therefore, the replication\n            configuration that's returned by a <code>GET</code> request soon after a\n               <code>PUT</code> or <code>DELETE</code> request might return a more recent result\n            than what's on the Outpost. If an Outpost is offline, the delay in updating the\n            replication configuration on that Outpost can be significant.</p>\n         </note>\n         <p>Specify the replication configuration in the request body. In the replication\n         configuration, you provide the following information:</p>\n         <ul>\n            <li>\n               <p>The name of the destination bucket or buckets where you want S3 on Outposts to\n               replicate objects</p>\n            </li>\n            <li>\n               <p>The Identity and Access Management (IAM) role that S3 on Outposts can assume to replicate objects on\n               your behalf</p>\n            </li>\n            <li>\n               <p>Other relevant information, such as replication rules</p>\n            </li>\n         </ul>\n         <p>A replication configuration must include at least one rule and can contain a maximum of\n         100. Each rule identifies a subset of objects to replicate by filtering the objects in\n         the source Outposts bucket. To choose additional subsets of objects to replicate, add a\n         rule for each subset.</p>\n         <p>To specify a subset of the objects in the source Outposts bucket to apply a replication\n         rule to, add the <code>Filter</code> element as a child of the <code>Rule</code> element.\n         You can filter objects based on an object key prefix, one or more object tags, or both.\n         When you add the <code>Filter</code> element in the configuration, you must also add the\n         following elements: <code>DeleteMarkerReplication</code>, <code>Status</code>, and\n            <code>Priority</code>.</p>\n         <p>Using <code>PutBucketReplication</code> on Outposts requires that both the source and\n         destination buckets must have versioning enabled. For information about enabling versioning\n         on a bucket, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsManagingVersioning.html\">Managing S3 Versioning\n            for your S3 on Outposts bucket</a>.</p>\n         <p>For information about S3 on Outposts replication failure reasons, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/outposts-replication-eventbridge.html#outposts-replication-failure-codes\">Replication failure reasons</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <p>\n            <b>Handling Replication of Encrypted Objects</b>\n         </p>\n         <p>Outposts buckets are encrypted at all times. All the objects in the source Outposts\n         bucket are encrypted and can be replicated. Also, all the replicas in the destination\n         Outposts bucket are encrypted with the same encryption key as the objects in the source\n         Outposts bucket.</p>\n         <p>\n            <b>Permissions</b>\n         </p>\n         <p>To create a <code>PutBucketReplication</code> request, you must have\n            <code>s3-outposts:PutReplicationConfiguration</code> permissions for the bucket. The\n         Outposts bucket owner has this permission by default and can grant it to others. For more\n         information about permissions, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsIAM.html\">Setting up IAM with\n            S3 on Outposts</a> and <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsBucketPolicy.html\">Managing access to\n            S3 on Outposts buckets</a>. </p>\n         <note>\n            <p>To perform this operation, the user or role must also have the <a href=\"https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_passrole.html\">iam:PassRole</a> permission.</p>\n         </note>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketLifecycleConfiguration.html#API_control_GetBucketLifecycleConfiguration_Examples\">Examples</a> section.</p>\n         <p>The following operations are related to <code>PutBucketReplication</code>:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketReplication.html\">GetBucketReplication</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteBucketReplication.html\">DeleteBucketReplication</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#endpoint": {
+                    "hostPrefix": "{AccountId}."
+                },
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/v20180820/bucket/{Bucket}/replication",
+                    "code": 200
+                },
+                "smithy.api#httpChecksumRequired": {},
+                "smithy.rules#staticContextParams": {
+                    "RequiresAccountId": {
+                        "value": true
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#PutBucketReplicationRequest": {
+            "type": "structure",
+            "members": {
+                "AccountId": {
+                    "target": "com.amazonaws.s3control#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID of the Outposts bucket.</p>",
+                        "smithy.api#hostLabel": {},
+                        "smithy.api#httpHeader": "x-amz-account-id",
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "AccountId"
+                        }
+                    }
+                },
+                "Bucket": {
+                    "target": "com.amazonaws.s3control#BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the S3 on Outposts bucket to set the configuration for.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {},
+                        "smithy.rules#contextParam": {
+                            "name": "Bucket"
+                        }
+                    }
+                },
+                "ReplicationConfiguration": {
+                    "target": "com.amazonaws.s3control#ReplicationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {},
+                        "smithy.api#xmlName": "ReplicationConfiguration"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutBucketTagging": {
@@ -12408,7 +12970,7 @@
                 "Bucket": {
                     "target": "com.amazonaws.s3control#BucketName",
                     "traits": {
-                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the bucket.</p>\n         <p>For using this parameter with Amazon S3 on Outposts with the REST API, you must specify the name and the x-amz-outpost-id as well.</p>\n         <p>For using this parameter with S3 on Outposts with the Amazon Web Services SDK and CLI, you must  specify the ARN of the bucket accessed in the format <code>arn:aws:s3-outposts:<Region>:<account-id>:outpost/<outpost-id>/bucket/<my-bucket-name></code>. For example, to access the bucket <code>reports</code> through Outpost <code>my-outpost</code> owned by account <code>123456789012</code> in Region <code>us-west-2</code>, use the URL encoding of <code>arn:aws:s3-outposts:us-west-2:123456789012:outpost/my-outpost/bucket/reports</code>. The value must be URL encoded.  </p>",
                         "smithy.api#httpLabel": {},
                         "smithy.api#required": {},
                         "smithy.rules#contextParam": {
@@ -12425,6 +12987,9 @@
                         "smithy.api#xmlName": "Tagging"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutBucketVersioning": {
@@ -12436,7 +13001,7 @@
                 "target": "smithy.api#Unit"
             },
             "traits": {
-                "smithy.api#documentation": "<note>\n            <p>This operation sets the versioning state only for S3 on Outposts buckets. To set the\n            versioning state for an S3 bucket, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html\">PutBucketVersioning</a> in\n            the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Sets the versioning state for an S3 on Outposts bucket. With versioning, you can save\n         multiple distinct copies of your data and recover from unintended user actions and\n         application failures.</p>\n         <p>You can set the versioning state to one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Enabled</b> - Enables versioning for the objects in\n               the bucket. All objects added to the bucket receive a unique version ID.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Suspended</b> - Suspends versioning for the objects\n               in the bucket. All objects added to the bucket receive the version ID\n                  <code>null</code>.</p>\n            </li>\n         </ul>\n         <p>If you've never set versioning on your bucket, it has no versioning state. In that case,\n         a <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketVersioning.html\">\n            GetBucketVersioning</a> request does not return a versioning state value.</p>\n         <p>When you enable S3 Versioning, for each object in your bucket, you have a current\n         version and zero or more noncurrent versions. You can configure your bucket S3 Lifecycle\n         rules to expire noncurrent versions after a specified time period. For more information,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsLifecycleManaging.html\"> Creating and managing\n            a lifecycle configuration for your S3 on Outposts bucket</a> in the <i>Amazon S3\n            User Guide</i>.</p>\n         <p>If you have an object expiration lifecycle policy in your non-versioned bucket and you\n         want to maintain the same permanent delete behavior when you enable versioning, you must\n         add a noncurrent expiration policy. The noncurrent expiration lifecycle policy will manage\n         the deletes of the noncurrent object versions in the version-enabled bucket. For more\n         information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html\">Versioning</a> in the <i>Amazon S3\n            User Guide</i>.</p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketVersioning.html#API_control_PutBucketVersioning_Examples\">Examples</a> section.</p>\n         <p>The following operations are related to <code>PutBucketVersioning</code> for\n         S3 on Outposts.</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketVersioning.html\">GetBucketVersioning</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketLifecycleConfiguration.html\">PutBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketLifecycleConfiguration.html\">GetBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<note>\n            <p>This operation sets the versioning state\n            for\n            S3 on Outposts\n            buckets\n            only. To set the versioning state for an S3 bucket, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketVersioning.html\">PutBucketVersioning</a> in the <i>Amazon S3 API Reference</i>. </p>\n         </note>\n         <p>Sets the versioning state for an S3 on Outposts bucket. With\n         S3\n         Versioning,\n         you can save multiple distinct copies of your\n         objects\n         and recover from unintended user actions and application failures.</p>\n         <p>You can set the versioning state to one of the following:</p>\n         <ul>\n            <li>\n               <p>\n                  <b>Enabled</b> - Enables versioning for the objects in\n               the bucket. All objects added to the bucket receive a unique version ID.</p>\n            </li>\n            <li>\n               <p>\n                  <b>Suspended</b> - Suspends versioning for the objects\n               in the bucket. All objects added to the bucket receive the version ID\n                  <code>null</code>.</p>\n            </li>\n         </ul>\n         <p>If you've never set versioning on your bucket, it has no versioning state. In that case,\n         a <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketVersioning.html\">\n            GetBucketVersioning</a> request does not return a versioning state value.</p>\n         <p>When you enable S3 Versioning, for each object in your bucket, you have a current\n         version and zero or more noncurrent versions. You can configure your bucket S3 Lifecycle\n         rules to expire noncurrent versions after a specified time period. For more information,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsLifecycleManaging.html\"> Creating and managing\n            a lifecycle configuration for your S3 on Outposts bucket</a> in the <i>Amazon S3\n            User Guide</i>.</p>\n         <p>If you have an object expiration lifecycle policy in your non-versioned bucket and you\n         want to maintain the same permanent delete behavior when you enable versioning, you must\n         add a noncurrent expiration policy. The noncurrent expiration lifecycle policy will manage\n         the\n         deletions\n         of the noncurrent object versions in the version-enabled bucket. For more information, see\n            <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html\">Versioning</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <p>All Amazon S3 on Outposts REST API requests for this action require an additional parameter of <code>x-amz-outpost-id</code> to be passed with the request. In addition, you must use an S3 on Outposts endpoint hostname prefix instead of <code>s3-control</code>. For an example of the request syntax for Amazon S3 on Outposts that uses the S3 on Outposts endpoint hostname prefix and the <code>x-amz-outpost-id</code> derived by using the access point ARN, see the <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketVersioning.html#API_control_PutBucketVersioning_Examples\">Examples</a> section.</p>\n         <p>The following operations are related to <code>PutBucketVersioning</code> for\n         S3 on Outposts.</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketVersioning.html\">GetBucketVersioning</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_PutBucketLifecycleConfiguration.html\">PutBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetBucketLifecycleConfiguration.html\">GetBucketLifecycleConfiguration</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -12495,6 +13060,9 @@
                         "smithy.api#xmlName": "VersioningConfiguration"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutJobTagging": {
@@ -12520,7 +13088,7 @@
                 }
             ],
             "traits": {
-                "smithy.api#documentation": "<p>Sets the supplied tag-set on an S3 Batch Operations job.</p>\n         <p>A tag is a key-value pair. You can associate S3 Batch Operations tags with any job by sending\n         a PUT request against the tagging subresource that is associated with the job. To modify\n         the existing tag set, you can either replace the existing tag set entirely, or make changes\n         within the existing tag set by retrieving the existing tag set using <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html\">GetJobTagging</a>, modify that tag set, and use this action to replace the tag set\n         with the one you modified. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-managing-jobs.html#batch-ops-job-tags\">Controlling\n            access and labeling jobs using tags</a> in the <i>Amazon S3 User Guide</i>. </p>\n         <p></p>\n         <note>\n            <ul>\n               <li>\n                  <p>If you send this request with an empty tag set, Amazon S3 deletes the existing\n                  tag set on the Batch Operations job. If you use this method, you are charged for a Tier\n                  1 Request (PUT). For more information, see <a href=\"http://aws.amazon.com/s3/pricing/\">Amazon S3 pricing</a>.</p>\n               </li>\n               <li>\n                  <p>For deleting existing tags for your Batch Operations job, a <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteJobTagging.html\">DeleteJobTagging</a> request is preferred because it achieves the same\n                  result without incurring charges.</p>\n               </li>\n               <li>\n                  <p>A few things to consider about using tags:</p>\n                  <ul>\n                     <li>\n                        <p>Amazon S3 limits the maximum number of tags to 50 tags per job.</p>\n                     </li>\n                     <li>\n                        <p>You can associate up to 50 tags with a job as long as they have unique\n                        tag keys.</p>\n                     </li>\n                     <li>\n                        <p>A tag key can be up to 128 Unicode characters in length, and tag values\n                        can be up to 256 Unicode characters in length.</p>\n                     </li>\n                     <li>\n                        <p>The key and values are case sensitive.</p>\n                     </li>\n                     <li>\n                        <p>For tagging-related restrictions related to characters and encodings, see\n                           <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html\">User-Defined Tag Restrictions</a> in the <i>Billing and Cost Management User Guide</i>.</p>\n                     </li>\n                  </ul>\n               </li>\n            </ul>\n         </note>\n         <p></p>\n         <p>To use this action, you must have permission to perform the\n            <code>s3:PutJobTagging</code> action.</p>\n         <p>Related actions include:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateJob.html\">CreateJob</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html\">GetJobTagging</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteJobTagging.html\">DeleteJobTagging</a>\n               </p>\n            </li>\n         </ul>",
+                "smithy.api#documentation": "<p>Sets the supplied tag-set on an S3 Batch Operations job.</p>\n         <p>A tag is a key-value pair. You can associate S3 Batch Operations tags with any job by sending\n         a PUT request against the tagging subresource that is associated with the job. To modify\n         the existing tag set, you can either replace the existing tag set entirely, or make changes\n         within the existing tag set by retrieving the existing tag set using <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html\">GetJobTagging</a>, modify that tag set, and use this action to replace the tag set\n         with the one you modified. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-managing-jobs.html#batch-ops-job-tags\">Controlling\n            access and labeling jobs using tags</a> in the <i>Amazon S3 User Guide</i>. </p>\n         <p></p>\n         <note>\n            <ul>\n               <li>\n                  <p>If you send this request with an empty tag set, Amazon S3 deletes the existing\n                  tag set on the Batch Operations job. If you use this method, you are charged for a Tier\n                  1 Request (PUT). For more information, see <a href=\"http://aws.amazon.com/s3/pricing/\">Amazon S3 pricing</a>.</p>\n               </li>\n               <li>\n                  <p>For deleting existing tags for your Batch Operations job, a <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteJobTagging.html\">DeleteJobTagging</a> request is preferred because it achieves the same\n                  result without incurring charges.</p>\n               </li>\n               <li>\n                  <p>A few things to consider about using tags:</p>\n                  <ul>\n                     <li>\n                        <p>Amazon S3 limits the maximum number of tags to 50 tags per job.</p>\n                     </li>\n                     <li>\n                        <p>You can associate up to 50 tags with a job as long as they have unique\n                        tag keys.</p>\n                     </li>\n                     <li>\n                        <p>A tag key can be up to 128 Unicode characters in length, and tag values\n                        can be up to 256 Unicode characters in length.</p>\n                     </li>\n                     <li>\n                        <p>The key and values are case sensitive.</p>\n                     </li>\n                     <li>\n                        <p>For tagging-related restrictions related to characters and encodings, see\n                           <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html\">User-Defined Tag Restrictions</a> in the <i>Billing and Cost Management User Guide</i>.</p>\n                     </li>\n                  </ul>\n               </li>\n            </ul>\n         </note>\n         <p></p>\n         <p>To use the\n            <code>PutJobTagging</code>\n         operation,\n         you must have permission to perform the <code>s3:PutJobTagging</code> action.</p>\n         <p>Related actions include:</p>\n         <ul>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_CreateJob.html\">CreateJob</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_GetJobTagging.html\">GetJobTagging</a>\n               </p>\n            </li>\n            <li>\n               <p>\n                  <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_DeleteJobTagging.html\">DeleteJobTagging</a>\n               </p>\n            </li>\n         </ul>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -12566,6 +13134,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutJobTaggingResult": {
@@ -12650,6 +13221,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutMultiRegionAccessPointPolicyResult": {
@@ -12712,6 +13286,9 @@
                         }
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutStorageLensConfiguration": {
@@ -12723,7 +13300,7 @@
                 "target": "smithy.api#Unit"
             },
             "traits": {
-                "smithy.api#documentation": "<p>Puts an Amazon S3 Storage Lens configuration. For more information about S3 Storage Lens, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens.html\">Working with\n         Amazon S3 Storage Lens</a> in the <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>To use this action, you must have permission to perform the\n               <code>s3:PutStorageLensConfiguration</code> action. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens_iam_permissions.html\">Setting permissions to use Amazon S3 Storage Lens</a> in the\n               <i>Amazon S3 User Guide</i>.</p>\n         </note>",
+                "smithy.api#documentation": "<p>Puts an Amazon S3 Storage Lens configuration. For more information about S3 Storage Lens, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens.html\">Working with\n            Amazon S3 Storage Lens</a> in the <i>Amazon S3 User Guide</i>. For a complete list of S3 Storage Lens metrics, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage_lens_metrics_glossary.html\">S3 Storage Lens metrics glossary</a> in the <i>Amazon S3 User Guide</i>.</p>\n         <note>\n            <p>To use this action, you must have permission to perform the\n               <code>s3:PutStorageLensConfiguration</code> action. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/storage_lens_iam_permissions.html\">Setting permissions to use Amazon S3 Storage Lens</a> in the\n               <i>Amazon S3 User Guide</i>.</p>\n         </note>",
                 "smithy.api#endpoint": {
                     "hostPrefix": "{AccountId}."
                 },
@@ -12775,6 +13352,9 @@
                         "smithy.api#documentation": "<p>The tag set of the S3 Storage Lens configuration.</p>\n         <note>\n            <p>You can set up to a maximum of 50 tags.</p>\n         </note>"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutStorageLensConfigurationTagging": {
@@ -12832,6 +13412,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#PutStorageLensConfigurationTaggingResult": {
@@ -12846,6 +13429,12 @@
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the associated bucket for the Region.</p>",
                         "smithy.api#required": {}
+                    }
+                },
+                "BucketAccountId": {
+                    "target": "com.amazonaws.s3control#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID that owns the Amazon S3 bucket that's associated with this\n         Multi-Region Access Point.</p>"
                     }
                 }
             },
@@ -12884,6 +13473,12 @@
                     "target": "com.amazonaws.s3control#RegionName",
                     "traits": {
                         "smithy.api#documentation": "<p>The name of the Region.</p>"
+                    }
+                },
+                "BucketAccountId": {
+                    "target": "com.amazonaws.s3control#AccountId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Web Services account ID that owns the Amazon S3 bucket that's associated with this\n         Multi-Region Access Point.</p>"
                     }
                 }
             },
@@ -12960,6 +13555,207 @@
                 }
             }
         },
+        "com.amazonaws.s3control#ReplicaKmsKeyID": {
+            "type": "string"
+        },
+        "com.amazonaws.s3control#ReplicaModifications": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3control#ReplicaModificationsStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether S3 on Outposts replicates modifications to object metadata on\n         replicas.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A filter that you can use to specify whether replica modification sync is enabled.\n         S3 on Outposts replica modification sync can help you keep object metadata synchronized\n         between replicas and source objects. By default, S3 on Outposts replicates metadata from the\n         source objects to the replicas only. When replica modification sync is enabled,\n         S3 on Outposts replicates metadata changes made to the replica copies back to the source\n         object, making the replication bidirectional.</p>\n         <p>To replicate object metadata modifications on replicas, you can specify this element and\n         set the <code>Status</code> of this element to <code>Enabled</code>.</p>\n         <note>\n            <p>You must enable replica modification sync on the source and destination buckets to\n            replicate replica metadata changes between the source and the replicas.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.s3control#ReplicaModificationsStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#ReplicationConfiguration": {
+            "type": "structure",
+            "members": {
+                "Role": {
+                    "target": "com.amazonaws.s3control#Role",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the Identity and Access Management (IAM) role that S3 on Outposts assumes\n         when replicating objects. For information about S3 replication on Outposts configuration,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/outposts-replication-how-setup.html\">Setting up\n            replication</a> in the <i>Amazon S3 User Guide</i>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Rules": {
+                    "target": "com.amazonaws.s3control#ReplicationRules",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container for one or more replication rules. A replication configuration must have at\n         least one rule and can contain an array of 100 rules at the most. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container for one or more replication rules. A replication configuration must have at least one rule and you can add up to 100 rules. The maximum size of a\n         replication configuration is 128 KB.</p>"
+            }
+        },
+        "com.amazonaws.s3control#ReplicationRule": {
+            "type": "structure",
+            "members": {
+                "ID": {
+                    "target": "com.amazonaws.s3control#ID",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A unique identifier for the rule. The maximum value is 255 characters.</p>"
+                    }
+                },
+                "Priority": {
+                    "target": "com.amazonaws.s3control#Priority",
+                    "traits": {
+                        "smithy.api#default": null,
+                        "smithy.api#documentation": "<p>The priority indicates which rule has precedence whenever two or more replication rules\n         conflict. S3 on Outposts attempts to replicate objects according to all replication rules.\n         However, if there are two or more rules with the same destination Outposts bucket, then objects will\n         be replicated according to the rule with the highest priority. The higher the number, the\n         higher the priority. </p>\n         <p>For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-between-outposts.html\">Creating replication rules between Outposts</a> in the\n            <i>Amazon S3 User Guide</i>.</p>"
+                    }
+                },
+                "Prefix": {
+                    "target": "com.amazonaws.s3control#Prefix",
+                    "traits": {
+                        "smithy.api#deprecated": {
+                            "message": "Prefix has been deprecated"
+                        },
+                        "smithy.api#documentation": "<p>An object key name prefix that identifies the object or objects to which the rule\n         applies. The maximum prefix length is 1,024 characters. To include all objects in an\n         Outposts bucket, specify an empty string.</p>\n         <important>\n            <p>When you're using XML requests, you must \nreplace special characters (such as carriage returns) in object keys with their equivalent XML entity codes. \nFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints\">\n            XML-related object key constraints</a> in the <i>Amazon S3 User Guide</i>.</p>\n         </important>"
+                    }
+                },
+                "Filter": {
+                    "target": "com.amazonaws.s3control#ReplicationRuleFilter",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A filter that identifies the subset of objects to which the replication rule applies. A\n            <code>Filter</code> element must specify exactly one <code>Prefix</code>,\n            <code>Tag</code>, or <code>And</code> child element.</p>"
+                    }
+                },
+                "Status": {
+                    "target": "com.amazonaws.s3control#ReplicationRuleStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether the rule is enabled.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "SourceSelectionCriteria": {
+                    "target": "com.amazonaws.s3control#SourceSelectionCriteria",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container that describes additional filters for identifying the source Outposts objects that\n         you want to replicate. You can choose to enable or disable the replication of these\n         objects.</p>"
+                    }
+                },
+                "ExistingObjectReplication": {
+                    "target": "com.amazonaws.s3control#ExistingObjectReplication",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An optional configuration to replicate existing source bucket objects. </p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+                    }
+                },
+                "Destination": {
+                    "target": "com.amazonaws.s3control#Destination",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container for information about the replication destination and its configurations.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DeleteMarkerReplication": {
+                    "target": "com.amazonaws.s3control#DeleteMarkerReplication",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether S3 on Outposts replicates delete markers. If you specify a\n            <code>Filter</code> element in your replication configuration, you must also include a\n            <code>DeleteMarkerReplication</code> element. If your <code>Filter</code> includes a\n            <code>Tag</code> element, the <code>DeleteMarkerReplication</code> element's\n            <code>Status</code> child element must be set to <code>Disabled</code>, because\n         S3 on Outposts doesn't support replicating delete markers for tag-based rules.</p>\n         <p>For more information about delete marker replication, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3OutpostsReplication.html#outposts-replication-what-is-replicated\">How delete operations affect replication</a> in the <i>Amazon S3 User Guide</i>. </p>"
+                    }
+                },
+                "Bucket": {
+                    "target": "com.amazonaws.s3control#BucketIdentifierString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the access point for the source Outposts bucket that you want\n         S3 on Outposts to replicate the objects from.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies which S3 on Outposts objects to replicate and where to store the replicas.</p>"
+            }
+        },
+        "com.amazonaws.s3control#ReplicationRuleAndOperator": {
+            "type": "structure",
+            "members": {
+                "Prefix": {
+                    "target": "com.amazonaws.s3control#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An object key name prefix that identifies the subset of objects that the rule applies\n         to.</p>"
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.s3control#S3TagSet",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of tags that contain key and value pairs.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container for specifying rule filters. The filters determine the subset of objects to\n         which the rule applies. This element is required only if you specify more than one filter. </p>\n         <p>For example:</p>\n         <ul>\n            <li>\n               <p>If you specify both a <code>Prefix</code> and a <code>Tag</code> filter, wrap\n               these filters in an <code>And</code> element. </p>\n            </li>\n            <li>\n               <p>If you specify a filter based on multiple tags, wrap the <code>Tag</code> elements\n               in an <code>And</code> element.</p>\n            </li>\n         </ul>"
+            }
+        },
+        "com.amazonaws.s3control#ReplicationRuleFilter": {
+            "type": "structure",
+            "members": {
+                "Prefix": {
+                    "target": "com.amazonaws.s3control#Prefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An object key name prefix that identifies the subset of objects that the rule applies\n         to.</p>\n         <important>\n            <p>When you're using XML requests, you must \nreplace special characters (such as carriage returns) in object keys with their equivalent XML entity codes. \nFor more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html#object-key-xml-related-constraints\">\n            XML-related object key constraints</a> in the <i>Amazon S3 User Guide</i>.</p>\n         </important>"
+                    }
+                },
+                "Tag": {
+                    "target": "com.amazonaws.s3control#S3Tag"
+                },
+                "And": {
+                    "target": "com.amazonaws.s3control#ReplicationRuleAndOperator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container for specifying rule filters. The filters determine the subset of objects\n         that the rule applies to. This element is required only if you specify more than one\n         filter. For example: </p>\n         <ul>\n            <li>\n               <p>If you specify both a <code>Prefix</code> and a <code>Tag</code> filter, wrap\n               these filters in an <code>And</code> element.</p>\n            </li>\n            <li>\n               <p>If you specify a filter based on multiple tags, wrap the <code>Tag</code> elements\n               in an <code>And</code> element.</p>\n            </li>\n         </ul>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A filter that identifies the subset of objects to which the replication rule applies. A\n            <code>Filter</code> element must specify exactly one <code>Prefix</code>,\n            <code>Tag</code>, or <code>And</code> child element.</p>"
+            }
+        },
+        "com.amazonaws.s3control#ReplicationRuleStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#ReplicationRules": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.s3control#ReplicationRule",
+                "traits": {
+                    "smithy.api#xmlName": "Rule"
+                }
+            }
+        },
         "com.amazonaws.s3control#ReplicationStatus": {
             "type": "enum",
             "members": {
@@ -12995,6 +13791,119 @@
                 "target": "com.amazonaws.s3control#ReplicationStatus"
             }
         },
+        "com.amazonaws.s3control#ReplicationStorageClass": {
+            "type": "enum",
+            "members": {
+                "STANDARD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STANDARD"
+                    }
+                },
+                "REDUCED_REDUNDANCY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REDUCED_REDUNDANCY"
+                    }
+                },
+                "STANDARD_IA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "STANDARD_IA"
+                    }
+                },
+                "ONEZONE_IA": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ONEZONE_IA"
+                    }
+                },
+                "INTELLIGENT_TIERING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTELLIGENT_TIERING"
+                    }
+                },
+                "GLACIER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GLACIER"
+                    }
+                },
+                "DEEP_ARCHIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DEEP_ARCHIVE"
+                    }
+                },
+                "OUTPOSTS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "OUTPOSTS"
+                    }
+                },
+                "GLACIER_IR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "GLACIER_IR"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#ReplicationTime": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3control#ReplicationTimeStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether S3 Replication Time Control (S3 RTC) is enabled. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Time": {
+                    "target": "com.amazonaws.s3control#ReplicationTimeValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A container that specifies the time by which replication should be complete for all\n         objects and operations on objects. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container that specifies S3 Replication Time Control (S3 RTC) related information, including whether S3 RTC\n         is enabled and the time when all objects and operations on objects must be\n         replicated.</p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.s3control#ReplicationTimeStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.s3control#ReplicationTimeValue": {
+            "type": "structure",
+            "members": {
+                "Minutes": {
+                    "target": "com.amazonaws.s3control#Minutes",
+                    "traits": {
+                        "smithy.api#default": null,
+                        "smithy.api#documentation": "<p>Contains an integer that specifies the time period in minutes. </p>\n         <p>Valid value: 15</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container that specifies the time value for S3 Replication Time Control (S3 RTC). This value is also used for\n         the replication metrics <code>EventThreshold</code> element. </p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+            }
+        },
         "com.amazonaws.s3control#ReportPrefixString": {
             "type": "string",
             "traits": {
@@ -13020,6 +13929,9 @@
                     }
                 }
             }
+        },
+        "com.amazonaws.s3control#Role": {
+            "type": "string"
         },
         "com.amazonaws.s3control#RouteList": {
             "type": "list",
@@ -13239,7 +14151,7 @@
                 "TargetResource": {
                     "target": "com.amazonaws.s3control#S3BucketArnString",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the destination bucket ARN for the batch copy operation. For example, to copy\n         objects to a bucket named <code>destinationBucket</code>, set the\n            <code>TargetResource</code> property to\n         <code>arn:aws:s3:::destinationBucket</code>.</p>"
+                        "smithy.api#documentation": "<p>Specifies the destination bucket\n         Amazon Resource Name\n         (ARN)\n         for the batch copy operation. For example, to copy objects to a bucket named\n            <code>destinationBucket</code>, set the <code>TargetResource</code> property to\n            <code>arn:aws:s3:::destinationBucket</code>.</p>"
                     }
                 },
                 "CannedAccessControlList": {
@@ -13312,7 +14224,7 @@
                 "TargetKeyPrefix": {
                     "target": "com.amazonaws.s3control#NonEmptyMaxLength1024String",
                     "traits": {
-                        "smithy.api#documentation": "<p>Specifies the folder prefix into which you would like the objects to be copied. For\n         example, to copy objects into a folder named <code>Folder1</code> in the destination\n         bucket, set the TargetKeyPrefix to <code>Folder1</code>.</p>"
+                        "smithy.api#documentation": "<p>Specifies the folder prefix\n         that\n         you\n         want\n         the objects to be\n         copied\n         into. For example, to copy objects into a folder named\n            <code>Folder1</code> in the destination bucket, set the\n            <code>TargetKeyPrefix</code>\n         property\n         to <code>Folder1</code>.</p>"
                     }
                 },
                 "ObjectLockLegalHoldStatus": {
@@ -13343,19 +14255,19 @@
                 "ChecksumAlgorithm": {
                     "target": "com.amazonaws.s3control#S3ChecksumAlgorithm",
                     "traits": {
-                        "smithy.api#documentation": "<p>Indicates the algorithm you want Amazon S3 to use to create the checksum. For more\n         information see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/CheckingObjectIntegrity.xml\"> Checking object\n            integrity</a> in the <i>Amazon S3 User Guide</i>.</p>"
+                        "smithy.api#documentation": "<p>Indicates the algorithm\n         that\n         you want Amazon S3 to use to create the checksum. For more\n         information,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/userguide/CheckingObjectIntegrity.xml\"> Checking object integrity</a> in the <i>Amazon S3 User Guide</i>.</p>"
                     }
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the configuration parameters for a PUT Copy object operation. S3 Batch Operations\n         passes every object to the underlying PUT Copy object API. For more information about the\n         parameters for this operation, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html\">PUT Object - Copy</a>.</p>"
+                "smithy.api#documentation": "<p>Contains\n         the configuration parameters for a PUT Copy object operation. S3 Batch Operations passes every\n         object to the underlying\n            <code>CopyObject</code>\n         API\n         operation. For more information about the parameters for this operation,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectCOPY.html\">CopyObject</a>.</p>"
             }
         },
         "com.amazonaws.s3control#S3DeleteObjectTaggingOperation": {
             "type": "structure",
             "members": {},
             "traits": {
-                "smithy.api#documentation": "<p>Contains no configuration parameters because the DELETE Object tagging API only accepts\n         the bucket name and key name as parameters, which are defined in the job's manifest.</p>"
+                "smithy.api#documentation": "<p>Contains no configuration parameters because the DELETE Object tagging\n            (<code>DeleteObjectTagging</code>)\n         API\n         operation\n         accepts\n         only\n         the bucket name and key name as parameters, which are defined in the\n         job's manifest.</p>"
             }
         },
         "com.amazonaws.s3control#S3ExpirationInDays": {
@@ -13494,7 +14406,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the configuration parameters for an S3 Initiate Restore Object job.\n         S3 Batch Operations passes every object to the underlying POST Object restore API. For more\n         information about the parameters for this operation, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOSTrestore.html#RESTObjectPOSTrestore-restore-request\">RestoreObject</a>.</p>"
+                "smithy.api#documentation": "<p>Contains the configuration parameters for\n         a\n         POST Object restore job. S3 Batch Operations passes every object to the\n         underlying\n            <code>RestoreObject</code>\n         API\n         operation. For more information about the parameters for this operation,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOSTrestore.html#RESTObjectPOSTrestore-restore-request\">RestoreObject</a>.</p>"
             }
         },
         "com.amazonaws.s3control#S3JobManifestGenerator": {
@@ -13875,7 +14787,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the configuration parameters for a Set Object ACL operation. S3 Batch Operations\n         passes every object to the underlying <code>PutObjectAcl</code> API. For more information\n         about the parameters for this operation, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html\">\n               <code>PutObjectAcl</code>\n            </a>.</p>"
+                "smithy.api#documentation": "<p>Contains the configuration parameters for a\n         PUT\n         Object ACL operation. S3 Batch Operations passes every object to the underlying\n            <code>PutObjectAcl</code>\n         API\n         operation. For more information about the parameters for this operation,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTacl.html\">PutObjectAcl</a>.</p>"
             }
         },
         "com.amazonaws.s3control#S3SetObjectLegalHoldOperation": {
@@ -13890,7 +14802,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the configuration for an S3 Object Lock legal hold operation that an\n         S3 Batch Operations job passes every object to the underlying <code>PutObjectLegalHold</code>\n         API. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-legal-hold.html\">Using S3 Object Lock legal hold\n            with S3 Batch Operations</a> in the <i>Amazon S3 User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Contains the configuration for an S3 Object Lock legal hold operation that an\n         S3 Batch Operations job passes\n         to\n         every object to the underlying\n            <code>PutObjectLegalHold</code>\n         API\n         operation. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-legal-hold.html\">Using S3 Object Lock legal hold\n            with S3 Batch Operations</a> in the <i>Amazon S3 User Guide</i>.</p>"
             }
         },
         "com.amazonaws.s3control#S3SetObjectRetentionOperation": {
@@ -13912,7 +14824,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the configuration parameters for the Object Lock retention action for an\n         S3 Batch Operations job. Batch Operations passes every object to the underlying\n            <code>PutObjectRetention</code> API. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-retention-date.html\">Using\n            S3 Object Lock retention with S3 Batch Operations</a> in the\n            <i>Amazon S3 User Guide</i>.</p>"
+                "smithy.api#documentation": "<p>Contains the configuration parameters for the Object Lock retention action for an\n         S3 Batch Operations job. Batch Operations passes every object to the underlying\n            <code>PutObjectRetention</code>\n         API\n         operation. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-retention-date.html\">Using S3 Object Lock retention\n            with S3 Batch Operations</a> in the <i>Amazon S3 User Guide</i>.</p>"
             }
         },
         "com.amazonaws.s3control#S3SetObjectTaggingOperation": {
@@ -13926,7 +14838,7 @@
                 }
             },
             "traits": {
-                "smithy.api#documentation": "<p>Contains the configuration parameters for a Set Object Tagging operation. S3 Batch Operations\n         passes every object to the underlying PUT Object tagging API. For more information about\n         the parameters for this operation, see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTtagging.html\">PUT Object tagging</a>.</p>"
+                "smithy.api#documentation": "<p>Contains the configuration parameters for a\n         PUT\n         Object Tagging operation. S3 Batch Operations passes every object to the underlying\n            <code>PutObjectTagging</code>\n         API\n         operation. For more information about the parameters for this operation,\n         see <a href=\"https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUTtagging.html\">PutObjectTagging</a>.</p>"
             }
         },
         "com.amazonaws.s3control#S3StorageClass": {
@@ -14102,6 +15014,58 @@
             "type": "boolean",
             "traits": {
                 "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.s3control#SourceSelectionCriteria": {
+            "type": "structure",
+            "members": {
+                "SseKmsEncryptedObjects": {
+                    "target": "com.amazonaws.s3control#SseKmsEncryptedObjects",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A filter that you can use to select Amazon S3 objects that are encrypted with server-side\n         encryption by using Key Management Service (KMS) keys. If you include\n            <code>SourceSelectionCriteria</code> in the replication configuration, this element is\n         required. </p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+                    }
+                },
+                "ReplicaModifications": {
+                    "target": "com.amazonaws.s3control#ReplicaModifications",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A filter that you can use to specify whether replica modification sync is enabled.\n         S3 on Outposts replica modification sync can help you keep object metadata synchronized\n         between replicas and source objects. By default, S3 on Outposts replicates metadata from the\n         source objects to the replicas only. When replica modification sync is enabled,\n         S3 on Outposts replicates metadata changes made to the replica copies back to the source\n         object, making the replication bidirectional.</p>\n         <p>To replicate object metadata modifications on replicas, you can specify this element and\n         set the <code>Status</code> of this element to <code>Enabled</code>.</p>\n         <note>\n            <p>You must enable replica modification sync on the source and destination buckets to\n            replicate replica metadata changes between the source and the replicas.</p>\n         </note>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container that describes additional filters for identifying the source objects that\n         you want to replicate. You can choose to enable or disable the replication of these\n         objects.</p>"
+            }
+        },
+        "com.amazonaws.s3control#SseKmsEncryptedObjects": {
+            "type": "structure",
+            "members": {
+                "Status": {
+                    "target": "com.amazonaws.s3control#SseKmsEncryptedObjectsStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether Amazon S3 replicates objects that are created with server-side encryption\n         by using an KMS key stored in Key Management Service.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A container for filter information that you can use to select S3 objects that are\n         encrypted with Key Management Service (KMS).</p>\n         <note>\n            <p>This is not supported by Amazon S3 on Outposts buckets.</p>\n         </note>"
+            }
+        },
+        "com.amazonaws.s3control#SseKmsEncryptedObjectsStatus": {
+            "type": "enum",
+            "members": {
+                "Enabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Enabled"
+                    }
+                },
+                "Disabled": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "Disabled"
+                    }
+                }
             }
         },
         "com.amazonaws.s3control#StorageLensArn": {
@@ -14356,6 +15320,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#SubmitMultiRegionAccessPointRoutesResult": {
@@ -14587,6 +15554,9 @@
                         "smithy.api#required": {}
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#UpdateJobPriorityResult": {
@@ -14689,6 +15659,9 @@
                         "smithy.api#httpQuery": "statusUpdateReason"
                     }
                 }
+            },
+            "traits": {
+                "smithy.api#input": {}
             }
         },
         "com.amazonaws.s3control#UpdateJobStatusResult": {

--- a/aws/sdk/aws-models/sso.json
+++ b/aws/sdk/aws-models/sso.json
@@ -520,7 +520,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -549,15 +549,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -566,7 +618,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -576,22 +628,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://portal.sso-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://portal.sso-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -604,90 +791,459 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://portal.sso.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
                                                     "rules": [
                                                         {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-east-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-east-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-northeast-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-northeast-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-northeast-2"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-northeast-2.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-northeast-3"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-northeast-3.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-south-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-south-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-southeast-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-southeast-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ap-southeast-2"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ap-southeast-2.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "ca-central-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.ca-central-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "eu-central-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.eu-central-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "eu-north-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.eu-north-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "eu-south-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.eu-south-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "eu-west-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.eu-west-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "eu-west-2"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.eu-west-2.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "eu-west-3"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.eu-west-3.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "me-south-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.me-south-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "sa-east-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.sa-east-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-east-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.us-east-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-east-2"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.us-east-2.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-west-2"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.us-west-2.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-gov-east-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.us-gov-east-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "stringEquals",
+                                                                    "argv": [
+                                                                        {
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "us-gov-west-1"
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "endpoint": {
+                                                                "url": "https://portal.sso.us-gov-west-1.amazonaws.com",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        },
+                                                        {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://portal.sso-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "url": "https://portal.sso.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -696,543 +1252,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://portal.sso-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://portal.sso.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-east-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-northeast-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-northeast-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-northeast-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-northeast-2.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-northeast-3"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-northeast-3.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-south-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-south-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-southeast-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-southeast-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-southeast-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ap-southeast-2.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ca-central-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.ca-central-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-central-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.eu-central-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-north-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.eu-north-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-south-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.eu-south-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-west-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.eu-west-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-west-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.eu-west-2.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-west-3"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.eu-west-3.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "me-south-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.me-south-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "sa-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.sa-east-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.us-east-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-east-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.us-east-2.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-west-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.us-west-2.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-gov-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.us-gov-east-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-gov-west-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.us-gov-west-1.amazonaws.com",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://portal.sso.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -1241,58 +1267,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "me-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
                             "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1300,165 +1274,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-east-1",
                                 "UseDualStack": false,
-                                "Region": "ap-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-south-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-north-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-east-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-east-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "eu-west-3"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-northeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.ap-northeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-northeast-3"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1469,9 +1287,87 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.ap-northeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.ap-northeast-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.ap-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.ap-southeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1482,9 +1378,139 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-central-1",
                                 "UseDualStack": false,
-                                "Region": "eu-central-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1495,9 +1521,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1508,9 +1534,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1521,100 +1547,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso-fips.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://portal.sso.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1625,9 +1560,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1638,9 +1573,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1651,9 +1586,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1664,9 +1599,74 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -1677,9 +1677,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -1690,22 +1690,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://portal.sso.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1715,9 +1754,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -1727,9 +1766,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
                                 "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         }

--- a/aws/sdk/aws-models/sts.json
+++ b/aws/sdk/aws-models/sts.json
@@ -116,6 +116,36 @@
                         {
                             "conditions": [
                                 {
+                                    "fn": "booleanEquals",
+                                    "argv": [
+                                        {
+                                            "ref": "UseGlobalEndpoint"
+                                        },
+                                        true
+                                    ]
+                                },
+                                {
+                                    "fn": "not",
+                                    "argv": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Endpoint"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Region"
+                                        }
+                                    ]
+                                },
+                                {
                                     "fn": "aws.partition",
                                     "argv": [
                                         {
@@ -123,6 +153,488 @@
                                         }
                                     ],
                                     "assign": "PartitionResult"
+                                },
+                                {
+                                    "fn": "booleanEquals",
+                                    "argv": [
+                                        {
+                                            "ref": "UseFIPS"
+                                        },
+                                        false
+                                    ]
+                                },
+                                {
+                                    "fn": "booleanEquals",
+                                    "argv": [
+                                        {
+                                            "ref": "UseDualStack"
+                                        },
+                                        false
+                                    ]
+                                }
+                            ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "ap-northeast-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "ap-south-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "ap-southeast-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "ap-southeast-2"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "aws-global"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "ca-central-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "eu-central-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "eu-north-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "eu-west-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "eu-west-2"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "eu-west-3"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "sa-east-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "us-east-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "us-east-2"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "us-west-1"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "stringEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                },
+                                                "us-west-2"
+                                            ]
+                                        }
+                                    ],
+                                    "endpoint": {
+                                        "url": "https://sts.amazonaws.com",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "us-east-1"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                },
+                                {
+                                    "conditions": [],
+                                    "endpoint": {
+                                        "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
+                                        "properties": {
+                                            "authSchemes": [
+                                                {
+                                                    "name": "sigv4",
+                                                    "signingName": "sts",
+                                                    "signingRegion": "{Region}"
+                                                }
+                                            ]
+                                        },
+                                        "headers": {}
+                                    },
+                                    "type": "endpoint"
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
                                 }
                             ],
                             "type": "tree",
@@ -133,516 +645,17 @@
                                             "fn": "booleanEquals",
                                             "argv": [
                                                 {
-                                                    "ref": "UseGlobalEndpoint"
+                                                    "ref": "UseFIPS"
                                                 },
                                                 true
                                             ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                false
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                false
-                                            ]
-                                        },
-                                        {
-                                            "fn": "not",
-                                            "argv": [
-                                                {
-                                                    "fn": "isSet",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
                                         }
                                     ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-northeast-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-south-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-southeast-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ap-southeast-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "ca-central-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-central-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-north-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-west-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-west-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "eu-west-3"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "sa-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-east-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-east-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-west-1"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "us-west-2"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "{Region}",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
                                 },
                                 {
-                                    "conditions": [
-                                        {
-                                            "fn": "isSet",
-                                            "argv": [
-                                                {
-                                                    "ref": "Endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "fn": "parseURL",
-                                            "argv": [
-                                                {
-                                                    "ref": "Endpoint"
-                                                }
-                                            ],
-                                            "assign": "url"
-                                        }
-                                    ],
+                                    "conditions": [],
                                     "type": "tree",
                                     "rules": [
                                         {
@@ -651,19 +664,226 @@
                                                     "fn": "booleanEquals",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
+                                                            "ref": "UseDualStack"
                                                         },
                                                         true
                                                     ]
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
                                             "type": "error"
                                         },
                                         {
                                             "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://sts-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [
+                                                                                {
+                                                                                    "fn": "stringEquals",
+                                                                                    "argv": [
+                                                                                        "aws-us-gov",
+                                                                                        {
+                                                                                            "fn": "getAttr",
+                                                                                            "argv": [
+                                                                                                {
+                                                                                                    "ref": "PartitionResult"
+                                                                                                },
+                                                                                                "name"
+                                                                                            ]
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ],
+                                                                            "endpoint": {
+                                                                                "url": "https://sts.{Region}.amazonaws.com",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        },
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://sts-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -676,134 +896,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://sts.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://sts-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -813,22 +951,24 @@
                                                                 {
                                                                     "fn": "stringEquals",
                                                                     "argv": [
-                                                                        "aws-us-gov",
                                                                         {
-                                                                            "fn": "getAttr",
-                                                                            "argv": [
-                                                                                {
-                                                                                    "ref": "PartitionResult"
-                                                                                },
-                                                                                "name"
-                                                                            ]
-                                                                        }
+                                                                            "ref": "Region"
+                                                                        },
+                                                                        "aws-global"
                                                                     ]
                                                                 }
                                                             ],
                                                             "endpoint": {
-                                                                "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
+                                                                "url": "https://sts.amazonaws.com",
+                                                                "properties": {
+                                                                    "authSchemes": [
+                                                                        {
+                                                                            "name": "sigv4",
+                                                                            "signingName": "sts",
+                                                                            "signingRegion": "us-east-1"
+                                                                        }
+                                                                    ]
+                                                                },
                                                                 "headers": {}
                                                             },
                                                             "type": "endpoint"
@@ -836,7 +976,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://sts-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -845,107 +985,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": "https://sts.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "stringEquals",
-                                                    "argv": [
-                                                        {
-                                                            "ref": "Region"
-                                                        },
-                                                        "aws-global"
-                                                    ]
-                                                }
-                                            ],
-                                            "endpoint": {
-                                                "url": "https://sts.amazonaws.com",
-                                                "properties": {
-                                                    "authSchemes": [
-                                                        {
-                                                            "name": "sigv4",
-                                                            "signingRegion": "us-east-1",
-                                                            "signingName": "sts"
-                                                        }
-                                                    ]
-                                                },
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://sts.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -954,687 +1000,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region ap-south-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-south-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-south-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-south-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-south-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-south-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-south-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-south-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-south-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-south-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-south-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-south-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-gov-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-gov-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-gov-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-gov-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.me-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "me-central-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.me-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "me-central-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.me-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "me-central-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region me-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.me-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "me-central-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ca-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ca-central-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ca-central-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ca-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ca-central-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ca-central-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-central-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-central-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-central-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-central-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-central-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-iso-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-iso-west-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-iso-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-iso-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-iso-west-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-iso-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-central-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-central-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-central-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-central-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-central-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-central-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-central-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-central-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-central-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-west-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-west-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-west-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-west-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region aws-global with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "properties": {
-                                        "authSchemes": [
-                                            {
-                                                "signingRegion": "us-east-1",
-                                                "signingName": "sts",
-                                                "name": "sigv4"
-                                            }
-                                        ]
-                                    },
-                                    "url": "https://sts.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "aws-global",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.af-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "af-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.af-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "af-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region af-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.af-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "af-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
                             "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -1642,516 +1007,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "af-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-north-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-north-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-north-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-north-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-north-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-north-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-north-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-west-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-west-3",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-west-3",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-west-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-west-3",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-west-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-west-3",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-west-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-west-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-west-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-west-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-west-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "eu-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.eu-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "eu-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-northeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-3",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-northeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-3",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-northeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-3",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-northeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-3",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-northeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-northeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-northeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-northeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-northeast-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-northeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-northeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-northeast-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.me-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "me-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "me-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.me-south-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "me-south-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.me-south-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "me-south-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.sa-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "sa-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "sa-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.sa-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "sa-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "sa-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-east-1",
-                                "UseDualStack": true
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2162,204 +1020,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "ap-east-1",
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                    "url": "https://sts.ap-northeast-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "cn-north-1",
-                                "UseDualStack": true
+                                "Region": "ap-northeast-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.cn-north-1.amazonaws.com.cn"
+                                    "url": "https://sts.ap-northeast-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "cn-north-1",
-                                "UseDualStack": false
+                                "Region": "ap-northeast-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.cn-north-1.api.amazonwebservices.com.cn"
+                                    "url": "https://sts.ap-northeast-3.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "cn-north-1",
-                                "UseDualStack": true
+                                "Region": "ap-northeast-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.cn-north-1.amazonaws.com.cn"
+                                    "url": "https://sts.ap-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "cn-north-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ca-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ca-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ca-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ca-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ca-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ca-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ca-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ca-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-gov-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-gov-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-gov-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-gov-west-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-gov-west-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-gov-west-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-southeast-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-1",
-                                "UseDualStack": true
+                                "Region": "ap-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2370,48 +1085,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "ap-southeast-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-southeast-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-2",
-                                "UseDualStack": true
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2422,96 +1098,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "ap-southeast-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-iso-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-iso-east-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-iso-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-iso-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-iso-east-1.c2s.ic.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-iso-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-3",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-3.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-3",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-3 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-southeast-3.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-3",
-                                "UseDualStack": true
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2522,152 +1111,148 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "ap-southeast-3",
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-4 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region aws-global with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-4.api.aws"
+                                    "properties": {
+                                        "authSchemes": [
+                                            {
+                                                "name": "sigv4",
+                                                "signingName": "sts",
+                                                "signingRegion": "us-east-1"
+                                            }
+                                        ]
+                                    },
+                                    "url": "https://sts.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-4",
-                                "UseDualStack": true
+                                "Region": "aws-global",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-4 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-4.amazonaws.com"
+                                    "url": "https://sts.ca-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-4",
-                                "UseDualStack": false
+                                "Region": "ca-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-4 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.ap-southeast-4.api.aws"
+                                    "url": "https://sts.eu-central-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-4",
-                                "UseDualStack": true
+                                "Region": "eu-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-4 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.ap-southeast-4.amazonaws.com"
+                                    "url": "https://sts.eu-north-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-4",
-                                "UseDualStack": false
+                                "Region": "eu-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-5 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-5.api.aws"
+                                    "url": "https://sts.eu-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-5",
-                                "UseDualStack": true
+                                "Region": "eu-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-5 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-5.amazonaws.com"
+                                    "url": "https://sts.eu-west-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-5",
-                                "UseDualStack": false
+                                "Region": "eu-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-5 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.ap-southeast-5.api.aws"
+                                    "url": "https://sts.eu-west-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-5",
-                                "UseDualStack": true
+                                "Region": "eu-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-5 with FIPS disabled and DualStack disabled",
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.ap-southeast-5.amazonaws.com"
+                                    "url": "https://sts.eu-west-3.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-5",
-                                "UseDualStack": false
+                                "Region": "eu-west-3",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.us-east-1.api.aws"
+                                    "url": "https://sts.me-south-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "us-east-1",
-                                "UseDualStack": true
+                                "Region": "me-south-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.us-east-1.amazonaws.com"
+                                    "url": "https://sts.sa-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "us-east-1",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-east-1",
-                                "UseDualStack": true
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2678,100 +1263,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "us-east-1",
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region ap-southeast-6 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-6.api.aws"
+                                    "url": "https://sts-fips.us-east-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-6",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-6 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.ap-southeast-6.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "ap-southeast-6",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-6 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-southeast-6.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-6",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region ap-southeast-6 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.ap-southeast-6.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "ap-southeast-6",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-east-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-east-2",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts-fips.us-east-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-east-2",
-                                "UseDualStack": false
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-2 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://sts.us-east-2.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "Region": "us-east-2",
-                                "UseDualStack": true
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2782,48 +1289,113 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "us-east-2",
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack enabled",
+                            "documentation": "For region us-east-2 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.cn-northwest-1.api.amazonwebservices.com.cn"
+                                    "url": "https://sts-fips.us-east-2.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "cn-northwest-1",
-                                "UseDualStack": true
+                                "Region": "us-east-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.cn-northwest-1.amazonaws.com.cn"
+                                    "url": "https://sts.us-west-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "cn-northwest-1",
-                                "UseDualStack": false
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region us-west-1 with FIPS enabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts.cn-northwest-1.api.amazonwebservices.com.cn"
+                                    "url": "https://sts-fips.us-west-1.amazonaws.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "cn-northwest-1",
-                                "UseDualStack": true
+                                "Region": "us-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts-fips.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2834,44 +1406,165 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "cn-northwest-1",
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "Region": "us-isob-east-1",
-                                "UseDualStack": true
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
                             "expect": {
                                 "endpoint": {
-                                    "url": "https://sts-fips.us-isob-east-1.sc2s.sgov.gov"
+                                    "url": "https://sts-fips.cn-north-1.api.amazonwebservices.com.cn"
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "Region": "us-isob-east-1",
-                                "UseDualStack": false
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
                             "expect": {
-                                "error": "DualStack is enabled but this partition does not support DualStack"
+                                "endpoint": {
+                                    "url": "https://sts-fips.cn-north-1.amazonaws.com.cn"
+                                }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "Region": "us-isob-east-1",
-                                "UseDualStack": true
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts.us-iso-west-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2882,22 +1575,48 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "us-isob-east-1",
-                                "UseDualStack": false
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://sts-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "us-east-1",
                                 "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2907,9 +1626,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
                                 "Region": "us-east-1",
                                 "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2919,9 +1638,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
                                 "Region": "us-east-1",
                                 "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -2932,9 +1651,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -2951,10 +1670,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "ap-northeast-1",
                                 "UseFIPS": false,
-                                "Region": "ap-northeast-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -2964,9 +1683,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -2983,10 +1702,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "ap-south-1",
                                 "UseFIPS": false,
-                                "Region": "ap-south-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -2996,9 +1715,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3015,10 +1734,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "ap-southeast-1",
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3028,9 +1747,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3047,10 +1766,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "ap-southeast-2",
                                 "UseFIPS": false,
-                                "Region": "ap-southeast-2"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3060,9 +1779,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3079,10 +1798,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "aws-global",
                                 "UseFIPS": false,
-                                "Region": "aws-global"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3092,9 +1811,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3111,10 +1830,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "ca-central-1",
                                 "UseFIPS": false,
-                                "Region": "ca-central-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3124,9 +1843,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3143,10 +1862,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "eu-central-1",
                                 "UseFIPS": false,
-                                "Region": "eu-central-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3156,9 +1875,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3175,10 +1894,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "eu-north-1",
                                 "UseFIPS": false,
-                                "Region": "eu-north-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3188,9 +1907,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3207,10 +1926,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "eu-west-1",
                                 "UseFIPS": false,
-                                "Region": "eu-west-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3220,9 +1939,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3239,10 +1958,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "eu-west-2",
                                 "UseFIPS": false,
-                                "Region": "eu-west-2"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3252,9 +1971,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3271,10 +1990,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "eu-west-3",
                                 "UseFIPS": false,
-                                "Region": "eu-west-3"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3284,9 +2003,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3303,10 +2022,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "sa-east-1",
                                 "UseFIPS": false,
-                                "Region": "sa-east-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3316,9 +2035,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3335,10 +2054,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "us-east-1",
                                 "UseFIPS": false,
-                                "Region": "us-east-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3348,9 +2067,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3367,10 +2086,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "us-east-2",
                                 "UseFIPS": false,
-                                "Region": "us-east-2"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3380,9 +2099,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3399,10 +2118,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "us-west-1",
                                 "UseFIPS": false,
-                                "Region": "us-west-1"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3412,9 +2131,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-1",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-1"
                                             }
                                         ]
                                     },
@@ -3431,10 +2150,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "us-west-2",
                                 "UseFIPS": false,
-                                "Region": "us-west-2"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3444,9 +2163,9 @@
                                     "properties": {
                                         "authSchemes": [
                                             {
-                                                "signingRegion": "us-east-3",
+                                                "name": "sigv4",
                                                 "signingName": "sts",
-                                                "name": "sigv4"
+                                                "signingRegion": "us-east-3"
                                             }
                                         ]
                                     },
@@ -3463,10 +2182,10 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
+                                "Region": "us-east-3",
                                 "UseFIPS": false,
-                                "Region": "us-east-3"
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true
                             }
                         },
                         {
@@ -3487,10 +2206,24 @@
                                 }
                             ],
                             "params": {
-                                "UseGlobalEndpoint": true,
-                                "UseDualStack": false,
-                                "UseFIPS": false,
                                 "Region": "us-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "UseGlobalEndpoint with unset region and custom endpoint",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "UseGlobalEndpoint": false,
                                 "Endpoint": "https://example.com"
                             }
                         }

--- a/aws/sdk/aws-models/transcribe-streaming.json
+++ b/aws/sdk/aws-models/transcribe-streaming.json
@@ -2298,7 +2298,7 @@
                     "parameters": {
                         "Region": {
                             "builtIn": "AWS::Region",
-                            "required": true,
+                            "required": false,
                             "documentation": "The AWS region used to dispatch the request.",
                             "type": "String"
                         },
@@ -2327,15 +2327,67 @@
                         {
                             "conditions": [
                                 {
-                                    "fn": "aws.partition",
+                                    "fn": "isSet",
                                     "argv": [
                                         {
-                                            "ref": "Region"
+                                            "ref": "Endpoint"
                                         }
-                                    ],
-                                    "assign": "PartitionResult"
+                                    ]
                                 }
                             ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
                             "type": "tree",
                             "rules": [
                                 {
@@ -2344,7 +2396,7 @@
                                             "fn": "isSet",
                                             "argv": [
                                                 {
-                                                    "ref": "Endpoint"
+                                                    "ref": "Region"
                                                 }
                                             ]
                                         }
@@ -2354,22 +2406,157 @@
                                         {
                                             "conditions": [
                                                 {
-                                                    "fn": "booleanEquals",
+                                                    "fn": "aws.partition",
                                                     "argv": [
                                                         {
-                                                            "ref": "UseFIPS"
-                                                        },
-                                                        true
-                                                    ]
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
                                                 }
                                             ],
-                                            "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
-                                            "type": "error"
-                                        },
-                                        {
-                                            "conditions": [],
                                             "type": "tree",
                                             "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://transcribestreaming-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://transcribestreaming-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
                                                 {
                                                     "conditions": [
                                                         {
@@ -2382,82 +2569,52 @@
                                                             ]
                                                         }
                                                     ],
-                                                    "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
-                                                    "type": "error"
-                                                },
-                                                {
-                                                    "conditions": [],
-                                                    "endpoint": {
-                                                        "url": {
-                                                            "ref": "Endpoint"
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://transcribestreaming.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
                                                         },
-                                                        "properties": {},
-                                                        "headers": {}
-                                                    },
-                                                    "type": "endpoint"
-                                                }
-                                            ]
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        },
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
                                                         {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
                                                         }
                                                     ]
                                                 },
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
                                                 {
                                                     "conditions": [],
                                                     "type": "tree",
@@ -2465,7 +2622,7 @@
                                                         {
                                                             "conditions": [],
                                                             "endpoint": {
-                                                                "url": "https://transcribestreaming-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                "url": "https://transcribestreaming.{Region}.{PartitionResult#dnsSuffix}",
                                                                 "properties": {},
                                                                 "headers": {}
                                                             },
@@ -2474,144 +2631,13 @@
                                                     ]
                                                 }
                                             ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseFIPS"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsFIPS"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://transcribestreaming-fips.{Region}.{PartitionResult#dnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "FIPS is enabled but this partition does not support FIPS",
-                                            "type": "error"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "conditions": [
-                                        {
-                                            "fn": "booleanEquals",
-                                            "argv": [
-                                                {
-                                                    "ref": "UseDualStack"
-                                                },
-                                                true
-                                            ]
-                                        }
-                                    ],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [
-                                                {
-                                                    "fn": "booleanEquals",
-                                                    "argv": [
-                                                        true,
-                                                        {
-                                                            "fn": "getAttr",
-                                                            "argv": [
-                                                                {
-                                                                    "ref": "PartitionResult"
-                                                                },
-                                                                "supportsDualStack"
-                                                            ]
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "type": "tree",
-                                            "rules": [
-                                                {
-                                                    "conditions": [],
-                                                    "type": "tree",
-                                                    "rules": [
-                                                        {
-                                                            "conditions": [],
-                                                            "endpoint": {
-                                                                "url": "https://transcribestreaming.{Region}.{PartitionResult#dualStackDnsSuffix}",
-                                                                "properties": {},
-                                                                "headers": {}
-                                                            },
-                                                            "type": "endpoint"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "conditions": [],
-                                            "error": "DualStack is enabled but this partition does not support DualStack",
-                                            "type": "error"
                                         }
                                     ]
                                 },
                                 {
                                     "conditions": [],
-                                    "type": "tree",
-                                    "rules": [
-                                        {
-                                            "conditions": [],
-                                            "endpoint": {
-                                                "url": "https://transcribestreaming.{Region}.{PartitionResult#dnsSuffix}",
-                                                "properties": {},
-                                                "headers": {}
-                                            },
-                                            "type": "endpoint"
-                                        }
-                                    ]
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
                                 }
                             ]
                         }
@@ -2620,58 +2646,6 @@
                 "smithy.rules#endpointTests": {
                     "testCases": [
                         {
-                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.ap-southeast-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ap-southeast-2"
-                            }
-                        },
-                        {
-                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.ca-central-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "ca-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.sa-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "sa-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.us-west-2.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-west-2"
-                            }
-                        },
-                        {
                             "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
                             "expect": {
                                 "endpoint": {
@@ -2679,9 +2653,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-1",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2692,9 +2666,35 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "ap-northeast-2",
                                 "UseDualStack": false,
-                                "Region": "ap-northeast-2"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2705,22 +2705,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-central-1",
                                 "UseDualStack": false,
-                                "Region": "eu-central-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.us-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2731,9 +2718,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-west-1",
                                 "UseDualStack": false,
-                                "Region": "eu-west-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2744,9 +2731,35 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "eu-west-2",
                                 "UseDualStack": false,
-                                "Region": "eu-west-2"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2757,9 +2770,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-2",
                                 "UseDualStack": false,
-                                "Region": "us-east-2"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2770,9 +2796,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2783,9 +2809,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2796,113 +2822,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-east-1",
                                 "UseDualStack": true,
-                                "Region": "us-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.us-gov-west-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-west-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming-fips.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming-fips.us-gov-east-1.amazonaws.com"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.us-gov-east-1.api.aws"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
-                                "Region": "us-gov-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming-fips.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.us-isob-east-1.sc2s.sgov.gov"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "us-isob-east-1"
-                            }
-                        },
-                        {
-                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
-                            "expect": {
-                                "endpoint": {
-                                    "url": "https://transcribestreaming.cn-northwest-1.amazonaws.com.cn"
-                                }
-                            },
-                            "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
-                                "Region": "cn-northwest-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2913,9 +2835,22 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2926,9 +2861,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2939,9 +2874,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "cn-north-1",
                                 "UseDualStack": false,
-                                "Region": "cn-north-1"
+                                "UseFIPS": true
                             }
                         },
                         {
@@ -2952,9 +2887,74 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "cn-north-1",
                                 "UseDualStack": true,
-                                "Region": "cn-north-1"
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2965,9 +2965,9 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": false
                             }
                         },
                         {
@@ -2978,22 +2978,61 @@
                                 }
                             },
                             "params": {
-                                "UseFIPS": true,
+                                "Region": "us-iso-east-1",
                                 "UseDualStack": false,
-                                "Region": "us-iso-east-1"
+                                "UseFIPS": true
                             }
                         },
                         {
-                            "documentation": "For custom endpoint with fips disabled and dualstack disabled",
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://transcribestreaming.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
                             "expect": {
                                 "endpoint": {
                                     "url": "https://example.com"
                                 }
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -3003,9 +3042,9 @@
                                 "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": true,
-                                "UseDualStack": false,
                                 "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
                                 "Endpoint": "https://example.com"
                             }
                         },
@@ -3015,9 +3054,9 @@
                                 "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
                             },
                             "params": {
-                                "UseFIPS": false,
-                                "UseDualStack": true,
                                 "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
                                 "Endpoint": "https://example.com"
                             }
                         }


### PR DESCRIPTION
## Motivation and Context
The endpoint decorator had a temporary model transform in it to fix errors in the SDK models endpoint configuration. Now that those issues have been resolved, this transform needs to be removed to successfully code generate the SDK. This PR both updates the SDK smoketest models and fixes codegen for them.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
