### PR TITLE
Add support for omitting session token in canonical requests

### DIFF
--- a/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/mod.rs
@@ -53,7 +53,7 @@ pub(crate) mod test;
 
 pub use error::SigningError;
 pub use settings::{
-    PayloadChecksumKind, PercentEncodingMode, SignatureLocation, SigningParams, SigningSettings,
-    UriPathNormalizationMode,
+    PayloadChecksumKind, PercentEncodingMode, SessionTokenMode, SignatureLocation, SigningParams,
+    SigningSettings, UriPathNormalizationMode,
 };
 pub use sign::{sign, SignableBody, SignableRequest};

--- a/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/settings.rs
@@ -32,6 +32,11 @@ pub struct SigningSettings {
 
     /// Specifies whether the absolute path component of the URI should be normalized during signing.
     pub uri_path_normalization_mode: UriPathNormalizationMode,
+
+    /// Some services require X-Amz-Security-Token to be included in the
+    /// canonical request. Other services require only it to be added after
+    /// calculating the signature.
+    pub session_token_mode: SessionTokenMode,
 }
 
 /// HTTP payload checksum type
@@ -78,6 +83,18 @@ pub enum UriPathNormalizationMode {
     Disabled,
 }
 
+/// Config value to specify whether X-Amz-Security-Token should be part of the canonical request.
+/// <http://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html#temporary-security-credentials>
+#[non_exhaustive]
+#[derive(Debug, Eq, PartialEq)]
+pub enum SessionTokenMode {
+    /// Include in the canonical request before calculating the signature.
+    Include,
+
+    /// Exclude in the canonical request.
+    Exclude,
+}
+
 impl Default for SigningSettings {
     fn default() -> Self {
         // The user agent header should not be signed because it may be altered by proxies
@@ -90,6 +107,7 @@ impl Default for SigningSettings {
             expires_in: None,
             excluded_headers: Some(EXCLUDED_HEADERS.to_vec()),
             uri_path_normalization_mode: UriPathNormalizationMode::Enabled,
+            session_token_mode: SessionTokenMode::Include,
         }
     }
 }

--- a/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
+++ b/aws/rust-runtime/aws-sigv4/src/http_request/sign.rs
@@ -210,12 +210,14 @@ fn calculate_signing_params<'a>(
         ),
         (param::X_AMZ_SIGNATURE, Cow::Owned(signature.clone())),
     ];
+
     if let Some(security_token) = params.security_token {
         signing_params.push((
             param::X_AMZ_SECURITY_TOKEN,
             Cow::Owned(security_token.to_string()),
         ));
     }
+
     Ok((signing_params, signature))
 }
 
@@ -266,9 +268,11 @@ fn calculate_signing_headers<'a>(
             &values.content_sha256,
         );
     }
+
     if let Some(security_token) = values.security_token {
         add_header(&mut headers, header::X_AMZ_SECURITY_TOKEN, security_token);
     }
+
     Ok(SigningOutput::new(headers, signature))
 }
 


### PR DESCRIPTION
## Motivation and Context
Some services require the session token to be omitted from the canonical request when calculating the signature. 

## Description
This PR extends the signing settings with `omit_session_token` such that the security token only gets added after a signature has been calculated as is required by some services: https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html#add-signature-to-request

The security token is now added after the signature is calculated, if the new setting states so.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
