### PR TITLE
Upgrade Tokio to 1.23.1 (RUSTSEC-2023-0001)

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -353,3 +353,14 @@ references = ["smithy-rs#2471", "smithy-rs#2333", "smithy-rs#2151"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "rcoh"
 
+[[smithy-rs]] # tokio-upgrade
+message = "Increase Tokio version to 1.23.1 for all crates. This is to address [RUSTSEC-2023-0001](https://rustsec.org/advisories/RUSTSEC-2023-0001)"
+references = ["smithy-rs#2474"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, target = "all" }
+author = "rcoh"
+
+[[aws-sdk-rust]] # tokio-upgrade
+message = "Increase Tokio version to 1.23.1 for all crates. This is to address [RUSTSEC-2023-0001](https://rustsec.org/advisories/RUSTSEC-2023-0001)"
+references = ["smithy-rs#2474"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -49,7 +49,7 @@ tower = { version = "0.4.8" }
 futures-util = { version = "0.3.16", default-features = false }
 tracing-test = "0.2.1"
 
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 
 # used for fuzzing profile parsing
 arbitrary = "=1.1.3" # 1.1.4 requires Rust 1.63 to compile

--- a/aws/rust-runtime/aws-credential-types/Cargo.toml
+++ b/aws/rust-runtime/aws-credential-types/Cargo.toml
@@ -15,7 +15,7 @@ test-util = []
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 fastrand = "1.4.0"
-tokio = { version = "1.8.4", features = ["sync"] }
+tokio = { version = "1.23.1", features = ["sync"] }
 tracing = "0.1"
 zeroize = "1"
 
@@ -26,7 +26,7 @@ aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async", features =
 async-trait = "0.1.51"
 env_logger = "0.9.0"
 
-tokio = { version = "1.8.4", features = ["full", "test-util", "rt"] }
+tokio = { version = "1.23.1", features = ["full", "test-util", "rt"] }
 tracing-test = "0.2.1"
 
 [package.metadata.docs.rs]

--- a/aws/rust-runtime/aws-http/Cargo.toml
+++ b/aws/rust-runtime/aws-http/Cargo.toml
@@ -29,7 +29,7 @@ aws-smithy-protocol-test = { path = "../../../rust-runtime/aws-smithy-protocol-t
 bytes-utils = "0.1.2"
 env_logger = "0.9"
 http = "0.2.3"
-tokio = { version = "1.8.4", features = ["macros", "rt", "rt-multi-thread", "test-util", "time"] }
+tokio = { version = "1.23.1", features = ["macros", "rt", "rt-multi-thread", "test-util", "time"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 proptest = "1"
 serde = { version = "1", features = ["derive"]}

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -29,7 +29,7 @@ http = "0.2.4"
 http-body = "0.4.5"
 md-5 = "0.10.1"
 ring = "0.16"
-tokio = { version = "1.8.4", features = ["full"] }
+tokio = { version = "1.23.1", features = ["full"] }
 tokio-stream = "0.1.5"
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"

--- a/aws/sdk/integration-tests/aws-smithy-runtime-test/Cargo.toml
+++ b/aws/sdk/integration-tests/aws-smithy-runtime-test/Cargo.toml
@@ -18,7 +18,7 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-runtime = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime" }
 aws-smithy-runtime-api = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime-api" }
 aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
-tokio = { version = "1.8.4", features = ["macros", "test-util", "rt-multi-thread"] }
+tokio = { version = "1.23.1", features = ["macros", "test-util", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter", "json"] }
 http = "0.2.3"

--- a/aws/sdk/integration-tests/dynamodb/Cargo.toml
+++ b/aws/sdk/integration-tests/dynamodb/Cargo.toml
@@ -25,7 +25,7 @@ criterion = { version = "0.4.0" }
 futures-util = { version = "0.3.16", default-features = false }
 http = "0.2.0"
 serde_json = "1.0.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 tokio-stream = "0.1.5"
 

--- a/aws/sdk/integration-tests/ec2/Cargo.toml
+++ b/aws/sdk/integration-tests/ec2/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-sdk-ec2 = { path = "../../build/aws-sdk/sdk/ec2" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"]}
-tokio = { version = "1.8.4", features = ["full"]}
+tokio = { version = "1.23.1", features = ["full"]}
 http = "0.2.0"
 tokio-stream = "0.1.5"

--- a/aws/sdk/integration-tests/glacier/Cargo.toml
+++ b/aws/sdk/integration-tests/glacier/Cargo.toml
@@ -18,5 +18,5 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol-test"}
 bytes = "1.0.0"
 http = "0.2.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"]}
+tokio = { version = "1.23.1", features = ["full", "test-util"]}
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/iam/Cargo.toml
+++ b/aws/sdk/integration-tests/iam/Cargo.toml
@@ -19,5 +19,5 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 bytes = "1.0.0"
 http = "0.2.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"]}
+tokio = { version = "1.23.1", features = ["full", "test-util"]}
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -19,5 +19,5 @@ aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 bytes = "1.0.0"
 http = "0.2.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"]}
+tokio = { version = "1.23.1", features = ["full", "test-util"]}
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/lambda/Cargo.toml
+++ b/aws/sdk/integration-tests/lambda/Cargo.toml
@@ -19,5 +19,5 @@ bytes = "1.0.0"
 futures-core = "0.3.14"
 http = "0.2.0"
 serde_json = "1.0.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/no-default-features/Cargo.toml
+++ b/aws/sdk/integration-tests/no-default-features/Cargo.toml
@@ -18,5 +18,5 @@ aws-config = { path = "../../build/aws-sdk/sdk/aws-config", default-features = f
 aws-sdk-s3 = { path = "../../build/aws-sdk/sdk/s3", default-features = false }
 aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async" }
 futures = "0.3.25"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/polly/Cargo.toml
+++ b/aws/sdk/integration-tests/polly/Cargo.toml
@@ -18,5 +18,5 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 bytes = "1.0.0"
 http = "0.2.0"
-tokio = { version = "1.8.4", features = ["full"]}
+tokio = { version = "1.23.1", features = ["full"]}
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/qldbsession/Cargo.toml
+++ b/aws/sdk/integration-tests/qldbsession/Cargo.toml
@@ -18,5 +18,5 @@ aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", featur
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
 http = "0.2.0"
-tokio = { version = "1.8.4", features = ["full"]}
+tokio = { version = "1.23.1", features = ["full"]}
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/s3/Cargo.toml
+++ b/aws/sdk/integration-tests/s3/Cargo.toml
@@ -34,7 +34,7 @@ hyper = "0.14.25"
 serde_json = "1"
 smol = "1.2"
 tempfile = "3"
-tokio = { version = "1.8.4", features = ["macros", "test-util", "rt-multi-thread"] }
+tokio = { version = "1.23.1", features = ["macros", "test-util", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-subscriber = { version = "0.3.15", features = ["env-filter", "json"] }

--- a/aws/sdk/integration-tests/s3control/Cargo.toml
+++ b/aws/sdk/integration-tests/s3control/Cargo.toml
@@ -20,5 +20,5 @@ aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
 bytes = "1.0.0"
 http = "0.2.0"
 serde_json = "1.0.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/sts/Cargo.toml
+++ b/aws/sdk/integration-tests/sts/Cargo.toml
@@ -16,5 +16,5 @@ aws-sdk-sts = { path = "../../build/aws-sdk/sdk/sts" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
+++ b/aws/sdk/integration-tests/transcribestreaming/Cargo.toml
@@ -21,5 +21,5 @@ futures-core = "0.3.14"
 hound = "3.4.0"
 http = "0.2.0"
 serde_json = "1.0.0"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -235,7 +235,7 @@ data class CargoDependency(
         val Tokio: CargoDependency =
             CargoDependency(
                 "tokio",
-                CratesIo("1.8.4"),
+                CratesIo("1.23.1"),
                 DependencyScope.Dev,
                 features = setOf("macros", "test-util", "rt-multi-thread"),
             )

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ServerCargoDependency.kt
@@ -22,7 +22,7 @@ object ServerCargoDependency {
     val OnceCell: CargoDependency = CargoDependency("once_cell", CratesIo("1.13"))
     val PinProjectLite: CargoDependency = CargoDependency("pin-project-lite", CratesIo("0.2"))
     val Tower: CargoDependency = CargoDependency("tower", CratesIo("0.4"))
-    val TokioDev: CargoDependency = CargoDependency("tokio", CratesIo("1.8.4"), scope = DependencyScope.Dev)
+    val TokioDev: CargoDependency = CargoDependency("tokio", CratesIo("1.23.1"), scope = DependencyScope.Dev)
     val Regex: CargoDependency = CargoDependency("regex", CratesIo("1.5.5"))
     val HyperDev: CargoDependency = CargoDependency("hyper", CratesIo("0.14.12"), DependencyScope.Dev)
 

--- a/rust-runtime/aws-smithy-async/Cargo.toml
+++ b/rust-runtime/aws-smithy-async/Cargo.toml
@@ -12,12 +12,12 @@ rt-tokio = ["tokio/time"]
 
 [dependencies]
 pin-project-lite = "0.2"
-tokio = { version = "1.8.4", features = ["sync"] }
+tokio = { version = "1.23.1", features = ["sync"] }
 tokio-stream = "0.1.5"
 futures-util = { version = "0.3.16", default-features = false }
 
 [dev-dependencies]
-tokio = { version = "1.8.4", features = ["rt", "macros", "test-util"] }
+tokio = { version = "1.23.1", features = ["rt", "macros", "test-util"] }
 tokio-test = "0.4.2"
 
 [package.metadata.docs.rs]

--- a/rust-runtime/aws-smithy-checksums/Cargo.toml
+++ b/rust-runtime/aws-smithy-checksums/Cargo.toml
@@ -30,7 +30,7 @@ tracing = "0.1"
 [dev-dependencies]
 bytes-utils = "0.1.2"
 pretty_assertions = "1.3"
-tokio = { version = "1.8.4", features = ["macros", "rt"] }
+tokio = { version = "1.23.1", features = ["macros", "rt"] }
 tracing-test = "0.2.1"
 
 [package.metadata.docs.rs]

--- a/rust-runtime/aws-smithy-client/Cargo.toml
+++ b/rust-runtime/aws-smithy-client/Cargo.toml
@@ -43,7 +43,7 @@ tracing = "0.1"
 aws-smithy-async = { path = "../aws-smithy-async", features = ["rt-tokio"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1.8.4", features = ["full", "test-util"] }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
 tower-test = "0.4.0"
 tracing-subscriber = "0.3.16"
 tracing-test = "0.2.4"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -38,7 +38,7 @@ serde_urlencoded = "0.7"
 strum_macros = "0.24"
 thiserror = "1.0.0"
 tracing = "0.1.35"
-tokio = { version = "1.8.4", features = ["full"] }
+tokio = { version = "1.23.1", features = ["full"] }
 tower = { version = "0.4.11", features = ["util", "make"], default-features = false }
 tower-http = { version = "0.3", features = ["add-extension", "map-response-body"] }
 uuid = { version = "1", features = ["v4", "fast-rng"], optional = true }

--- a/rust-runtime/aws-smithy-http-tower/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-tower/Cargo.toml
@@ -19,7 +19,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 tower = { version = "0.4.4", features = ["util"] }
-tokio = { version = "1.8.4", features = ["full"]}
+tokio = { version = "1.23.1", features = ["full"]}
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rust-runtime/aws-smithy-http/Cargo.toml
+++ b/rust-runtime/aws-smithy-http/Cargo.toml
@@ -32,7 +32,7 @@ hyper = "0.14.25"
 
 # ByteStream internals
 futures-core = "0.3.14"
-tokio = { version = "1.8.4", optional = true }
+tokio = { version = "1.23.1", optional = true }
 tokio-util = { version = "0.7", optional = true }
 
 [dev-dependencies]
@@ -41,7 +41,7 @@ futures-util = { version = "0.3.16", default-features = false }
 hyper = { version = "0.14.25", features = ["stream"] }
 pretty_assertions = "1.3"
 proptest = "1"
-tokio = { version = "1.8.4", features = [
+tokio = { version = "1.23.1", features = [
   "macros",
   "rt",
   "rt-multi-thread",


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Bump Tokio version to 1.23.1 across the board (RUSTSEC-2023-0001)

## Description
<!--- Describe your changes in detail -->

## Testing
- CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
