### PR TITLE
Allow for customizing runtime plugins at different config levels

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -26,6 +26,7 @@ aws-smithy-client = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-client", de
 aws-smithy-http = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-http-tower = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-http-tower" }
 aws-smithy-json = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-json" }
+aws-smithy-runtime-api = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-runtime-api" }
 aws-smithy-types = { path = "../../sdk/build/aws-sdk/sdk/aws-smithy-types" }
 aws-types = { path = "../../sdk/build/aws-sdk/sdk/aws-types" }
 hyper = { version = "0.14.25", default-features = false }

--- a/aws/rust-runtime/aws-types/Cargo.toml
+++ b/aws/rust-runtime/aws-types/Cargo.toml
@@ -14,6 +14,7 @@ examples = ["aws-smithy-client/client-hyper", "aws-smithy-client/rustls", "hyper
 [dependencies]
 aws-credential-types = { path = "../aws-credential-types" }
 aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
+aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-smithy-client = { path = "../../../rust-runtime/aws-smithy-client" }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SdkConfigDecorator.kt
@@ -78,6 +78,7 @@ class GenericSmithySdkConfigSettings : ClientCodegenDecorator {
 
                     ${section.serviceConfigBuilder}.set_http_connector(${section.sdkConfig}.http_connector().cloned());
 
+                    ${section.serviceConfigBuilder}.set_runtime_plugins(${section.sdkConfig}.runtime_plugins().cloned());
                     """,
                 )
             },

--- a/aws/sdk/integration-tests/aws-smithy-runtime-test/tests/runtime_plugin.rs
+++ b/aws/sdk/integration-tests/aws-smithy-runtime-test/tests/runtime_plugin.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_smithy_runtime::BoxError;
+use aws_smithy_runtime_api::config_bag::ConfigBag;
+use aws_smithy_runtime_api::runtime_plugin::RuntimePlugin;
+
+#[derive(Debug)]
+struct ClientPlugin;
+
+impl RuntimePlugin for ClientPlugin {
+    fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+        todo!()
+    }
+}
+
+#[derive(Debug)]
+struct OperationPlugin;
+
+impl RuntimePlugin for OperationPlugin {
+    fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+        todo!()
+    }
+}
+
+#[tokio::test]
+async fn plugins_can_be_configured_at_various_levels() {
+    // The AWS config level
+    let sdk_config = aws_config::from_env()
+        .runtime_plugin(ClientPlugin {})
+        .load()
+        .await;
+
+    // The service config level
+    let s3_config = aws_sdk_s3::config::Builder::from(&sdk_config)
+        .runtime_plugin(ClientPlugin {})
+        .build();
+
+    // The operation config level
+    let s3_client = aws_sdk_s3::Client::from_conf(s3_config);
+    let _ = s3_client
+        .create_bucket()
+        .bucket("mybucket")
+        .runtime_plugin(OperationPlugin {})
+        .send()
+        .await;
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/RuntimePluginConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/RuntimePluginConfigCustomization.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.customizations
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+
+class RuntimePluginConfigCustomization(codegenContext: CodegenContext) : ConfigCustomization() {
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val runtimePluginModule = RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("runtime_plugin")
+    private val codegenScope = arrayOf(
+        "RuntimePlugin" to runtimePluginModule.resolve("RuntimePlugin"),
+        "SharedRuntimePlugin" to runtimePluginModule.resolve("SharedRuntimePlugin"),
+    )
+
+    override fun section(section: ServiceConfig) =
+        writable {
+            when (section) {
+                is ServiceConfig.ConfigStruct -> rustTemplate(
+                    """
+                    // TODO(RuntimePlugins): Unused until integrated with [`invoke`](aws_smithy_runtime::invoke).
+                    ##[allow(dead_code)]
+                    pub(crate) client_plugins: Vec<#{SharedRuntimePlugin}>,
+                    """,
+                    *codegenScope,
+                )
+
+                is ServiceConfig.ConfigImpl -> {}
+
+                is ServiceConfig.BuilderStruct ->
+                    rustTemplate(
+                        """
+                        client_plugins: Vec<#{SharedRuntimePlugin}>,
+                        """,
+                        *codegenScope,
+                    )
+
+                ServiceConfig.BuilderImpl ->
+                    rustTemplate(
+                        """
+                        /// Set the `runtime_plugin` for the builder
+                        ///
+                        /// `runtime_plugin` is applied to the service configuration level.
+                        ///
+                        /// ## Examples
+                        /// ```no_run
+                        /// use aws_smithy_runtime_api::config_bag::ConfigBag;
+                        /// use aws_smithy_runtime_api::runtime_plugin::{BoxError, RuntimePlugin};
+                        /// use aws_types::sdk_config::{SdkConfig, Builder};
+                        ///
+                        /// ##[derive(Debug)]
+                        /// struct APlugin;
+                        ///
+                        /// impl RuntimePlugin for APlugin {
+                        ///     fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+                        ///         // ..
+                        ///         ## todo!()
+                        ///     }
+                        /// }
+                        ///
+                        /// SdkConfig::builder().runtime_plugin(APlugin{}).build();
+                        /// ```
+                        pub fn runtime_plugin(mut self, runtime_plugin: impl #{RuntimePlugin} + 'static) -> Self {
+                            self.set_runtime_plugin(runtime_plugin);
+                            self
+                        }
+
+                        /// Set the `runtime_plugin` for the builder
+                        ///
+                        /// `runtime_plugin` is applied to the service configuration level.
+                        ///
+                        /// ## Examples
+                        /// ```no_run
+                        /// use aws_smithy_runtime_api::config_bag::ConfigBag;
+                        /// use aws_smithy_runtime_api::runtime_plugin::{BoxError, RuntimePlugin};
+                        /// use aws_types::sdk_config::{SdkConfig, Builder};
+                        ///
+                        /// ##[derive(Debug)]
+                        /// struct APlugin;
+                        ///
+                        /// impl RuntimePlugin for APlugin {
+                        ///     fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+                        ///         // ..
+                        ///         ## todo!()
+                        ///     }
+                        /// }
+                        ///
+                        /// fn set_runtime_plugin(builder: &mut Builder) {
+                        ///     builder.set_runtime_plugin(APlugin{});
+                        /// }
+                        ///
+                        /// let mut builder = SdkConfig::builder();
+                        /// set_runtime_plugin(&mut builder);
+                        /// builder.build();
+                        /// ```
+                        pub fn set_runtime_plugin(
+                            &mut self,
+                            runtime_plugin: impl #{RuntimePlugin} + 'static,
+                        ) -> &mut Self {
+                            self.client_plugins
+                                .push(#{SharedRuntimePlugin}::new(runtime_plugin));
+                            self
+                        }
+
+                        /// Bulk set [`SharedRuntimePlugin`](aws_smithy_runtime_api::runtime_plugin::SharedRuntimePlugin)s
+                        /// for the builder
+                        ///
+                        /// `runtime_plugins` are applied to the service configuration level.
+                        ///
+                        /// ## Examples
+                        /// ```no_run
+                        /// use aws_smithy_runtime_api::config_bag::ConfigBag;
+                        /// use aws_smithy_runtime_api::runtime_plugin::{BoxError, RuntimePlugin, SharedRuntimePlugin};
+                        /// use aws_types::sdk_config::{SdkConfig, Builder};
+                        ///
+                        /// ##[derive(Debug)]
+                        /// struct APlugin;
+                        ///
+                        /// impl RuntimePlugin for APlugin {
+                        ///     fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+                        ///         // ..
+                        ///         ## todo!()
+                        ///     }
+                        /// }
+                        ///
+                        /// let plugins = vec![
+                        ///     SharedRuntimePlugin::new(APlugin{}),
+                        ///     SharedRuntimePlugin::new(APlugin{}),
+                        ///     SharedRuntimePlugin::new(APlugin{}),
+                        /// ];
+                        /// SdkConfig::builder().runtime_plugins(plugins).build();
+                        /// ```
+                        pub fn runtime_plugins(
+                            mut self,
+                            runtime_plugins: impl IntoIterator<Item = #{SharedRuntimePlugin}>,
+                        ) -> Self {
+                            self.set_runtime_plugins(runtime_plugins);
+                            self
+                        }
+
+                        /// Bulk set [`SharedRuntimePlugin`](aws_smithy_runtime_api::runtime_plugin::SharedRuntimePlugin)s
+                        /// for the builder
+                        ///
+                        /// `runtime_plugins` are applied to the service configuration level.
+                        ///
+                        /// ## Examples
+                        /// ```no_run
+                        /// use aws_smithy_runtime_api::config_bag::ConfigBag;
+                        /// use aws_smithy_runtime_api::runtime_plugin::{BoxError, RuntimePlugin, SharedRuntimePlugin};
+                        /// use aws_types::sdk_config::{SdkConfig, Builder};
+                        ///
+                        /// ##[derive(Debug)]
+                        /// struct APlugin;
+                        ///
+                        /// impl RuntimePlugin for APlugin {
+                        ///     fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+                        ///         // ..
+                        ///         ## todo!()
+                        ///     }
+                        /// }
+                        ///
+                        /// fn set_runtime_plugins(builder: &mut Builder) {
+                        ///     let plugins = vec![
+                        ///         SharedRuntimePlugin::new(APlugin{}),
+                        ///         SharedRuntimePlugin::new(APlugin{}),
+                        ///         SharedRuntimePlugin::new(APlugin{}),
+                        ///     ];
+                        ///     builder.set_runtime_plugins(plugins);
+                        /// }
+                        ///
+                        /// let mut builder = SdkConfig::builder();
+                        /// set_runtime_plugins(&mut builder);
+                        /// builder.build();
+                        /// ```
+                        pub fn set_runtime_plugins(
+                            &mut self,
+                            runtime_plugins: impl IntoIterator<Item = #{SharedRuntimePlugin}>,
+                        ) -> &mut Self {
+                            self.client_plugins.extend(runtime_plugins.into_iter());
+                            self
+                        }
+                        """,
+                        *codegenScope,
+                    )
+
+                ServiceConfig.BuilderBuild -> rust(
+                    """
+                    client_plugins: self.client_plugins,
+                    """,
+                )
+
+                else -> emptySection
+            }
+        }
+}
+
+class RuntimePluginReExportCustomization(private val runtimeConfig: RuntimeConfig) {
+    fun extras(rustCrate: RustCrate) {
+        rustCrate.withModule(ClientRustModule.Config) {
+            rustTemplate(
+                """
+                /// Runtime plugin configuration
+                ///
+                /// These are re-exported from `aws-smithy-runtime-api` for convenience.
+                pub mod runtime_plugin {
+                    pub use #{runtime_plugin}::{RuntimePlugins, SharedRuntimePlugin};
+                }
+                """,
+                "runtime_plugin" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("runtime_plugin"),
+            )
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -14,6 +14,8 @@ import software.amazon.smithy.rust.codegen.client.smithy.customizations.HttpVers
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.IdempotencyTokenGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyReExportCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.customizations.RuntimePluginConfigCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.customizations.RuntimePluginReExportCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.featureGatedMetaModule
 import software.amazon.smithy.rust.codegen.client.smithy.featureGatedPrimitivesModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
@@ -52,7 +54,7 @@ class RequiredCustomizations : ClientCodegenDecorator {
         codegenContext: ClientCodegenContext,
         baseCustomizations: List<ConfigCustomization>,
     ): List<ConfigCustomization> =
-        baseCustomizations + ResiliencyConfigCustomization(codegenContext)
+        baseCustomizations + ResiliencyConfigCustomization(codegenContext) + RuntimePluginConfigCustomization(codegenContext)
 
     override fun libRsCustomizations(
         codegenContext: ClientCodegenContext,
@@ -68,6 +70,8 @@ class RequiredCustomizations : ClientCodegenDecorator {
 
         // Re-export resiliency types
         ResiliencyReExportCustomization(codegenContext.runtimeConfig).extras(rustCrate)
+
+        RuntimePluginReExportCustomization(codegenContext.runtimeConfig).extras(rustCrate)
 
         rustCrate.withModule(codegenContext.featureGatedPrimitivesModule()) {
             pubUseSmithyPrimitives(codegenContext, codegenContext.model)(this)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -261,6 +261,7 @@ data class CargoDependency(
         fun smithyProtocolTestHelpers(runtimeConfig: RuntimeConfig) =
             runtimeConfig.smithyRuntimeCrate("smithy-protocol-test", scope = DependencyScope.Dev)
 
+        fun smithyRuntimeApi(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-runtime-api")
         fun smithyQuery(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-query")
         fun smithyTypes(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-types")
         fun smithyXml(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-xml")

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -254,6 +254,7 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         fun smithyHttpTower(runtimeConfig: RuntimeConfig) = CargoDependency.smithyHttpTower(runtimeConfig).toType()
         fun smithyJson(runtimeConfig: RuntimeConfig) = CargoDependency.smithyJson(runtimeConfig).toType()
         fun smithyQuery(runtimeConfig: RuntimeConfig) = CargoDependency.smithyQuery(runtimeConfig).toType()
+        fun smithyRuntimeApi(runtimeConfig: RuntimeConfig) = CargoDependency.smithyRuntimeApi(runtimeConfig).toType()
         fun smithyTypes(runtimeConfig: RuntimeConfig) = CargoDependency.smithyTypes(runtimeConfig).toType()
         fun smithyXml(runtimeConfig: RuntimeConfig) = CargoDependency.smithyXml(runtimeConfig).toType()
         private fun smithyProtocolTest(runtimeConfig: RuntimeConfig) =

--- a/rust-runtime/aws-smithy-runtime-api/src/runtime_plugin.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/runtime_plugin.rs
@@ -4,60 +4,86 @@
  */
 
 use crate::config_bag::ConfigBag;
+use std::sync::Arc;
 
-type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
+pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-pub trait RuntimePlugin {
+pub trait RuntimePlugin: Send + Sync + std::fmt::Debug {
     fn configure(&self, cfg: &mut ConfigBag) -> Result<(), BoxError>;
 }
 
-impl<T> From<T> for Box<dyn RuntimePlugin>
+/// Sharable runtime plugin that implements `Clone` using an internal
+#[derive(Clone, Debug)]
+pub struct SharedRuntimePlugin(Arc<dyn RuntimePlugin>);
+
+impl SharedRuntimePlugin {
+    /// Create a new `SharedRuntimePlugin` from `RuntimePlugin`
+    pub fn new(plugin: impl RuntimePlugin + 'static) -> Self {
+        Self(Arc::new(plugin))
+    }
+}
+
+impl<T> From<T> for SharedRuntimePlugin
 where
     T: RuntimePlugin + 'static,
 {
     fn from(t: T) -> Self {
-        Box::new(t) as _
+        SharedRuntimePlugin::new(t) as _
     }
 }
 
-#[derive(Default)]
+/// `RuntiemPlugins` stores collections of runtime plugins of different scope
+///
+/// Plugins have different scope. Plugins for an operation take precedence over those for its
+/// service client as the former is more specific. `RuntimePlugins` does not enforce the specificity
+/// as it is meant to be simple collections of plugins. It is up to the user of `RuntimePlugins` to
+/// ensure that specificity by first calling `apply_client_configuration` and then
+/// `apply_operation_configuration`.
+#[derive(Clone, Debug, Default)]
 pub struct RuntimePlugins {
-    client_plugins: Vec<Box<dyn RuntimePlugin>>,
-    operation_plugins: Vec<Box<dyn RuntimePlugin>>,
+    // In each collection, a plugin that appears later overwrites that appearing earlier in it
+    // because `apply_client_configuration` (or `apply_operation_configuration`) builds
+    // configuration layers into the bag as it traverses the collection from the beginning to the
+    // end.
+    // Furthermore, each collection stores `Arc`ed plugins as opposed to `Box`ed plugins to make
+    // cloning `RuntimePlugins` more efficient.
+    client_plugins: Vec<SharedRuntimePlugin>,
+    operation_plugins: Vec<SharedRuntimePlugin>,
 }
 
 impl RuntimePlugins {
+    /// Create a default constructed `RuntimePlugins`
     pub fn new() -> Self {
         Default::default()
     }
 
-    pub fn with_client_plugin(
-        &mut self,
-        plugin: impl Into<Box<dyn RuntimePlugin + 'static>>,
-    ) -> &mut Self {
+    /// Modify `self` by appending `plugin` to the end of client plugins
+    pub fn with_client_plugin(&mut self, plugin: impl Into<SharedRuntimePlugin>) -> &mut Self {
         self.client_plugins.push(plugin.into());
         self
     }
 
-    pub fn with_operation_plugin(
-        &mut self,
-        plugin: impl Into<Box<dyn RuntimePlugin + 'static>>,
-    ) -> &mut Self {
+    /// Modify `self` by appending `plugin` to the end of operation plugins
+    pub fn with_operation_plugin(&mut self, plugin: impl Into<SharedRuntimePlugin>) -> &mut Self {
         self.operation_plugins.push(plugin.into());
         self
     }
 
+    /// Apply to `cfg` each plugin in client plugins from the beginning, with the last plugin
+    /// resulting in the top layer of [`ConfigBag`](crate::config_bag::ConfigBag).
     pub fn apply_client_configuration(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
         for plugin in self.client_plugins.iter() {
-            plugin.configure(cfg)?;
+            plugin.0.configure(cfg)?;
         }
 
         Ok(())
     }
 
+    /// Apply to `cfg` each plugin in operation plugins from the beginning, with the last plugin
+    /// resulting in the top layer of [`ConfigBag`](crate::config_bag::ConfigBag).
     pub fn apply_operation_configuration(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
         for plugin in self.operation_plugins.iter() {
-            plugin.configure(cfg)?;
+            plugin.0.configure(cfg)?;
         }
 
         Ok(())
@@ -69,6 +95,7 @@ mod tests {
     use super::{BoxError, RuntimePlugin, RuntimePlugins};
     use crate::config_bag::ConfigBag;
 
+    #[derive(Debug)]
     struct SomeStruct;
 
     impl RuntimePlugin for SomeStruct {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

## Description
This is a draft until an accompanying RFC is published (feel free to review feedback, though).

## Testing
[x] Added a compile-only test to `integration-tests/aws-smithy-runtime-test`

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
