### PR TITLE
Refactor `ShapeVisitor` methods - `PythonServerOperationErrorGenerator`

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/PythonServerCodegenVisitor.kt
@@ -23,6 +23,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.generators.error.ErrorImp
 import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.isEventStream
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerEnumGenerator
+import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerOperationErrorGenerator
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerOperationHandlerGenerator
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerServiceGenerator
 import software.amazon.smithy.rust.codegen.server.python.smithy.generators.PythonServerStructureGenerator
@@ -236,8 +237,13 @@ class PythonServerCodegenVisitor(
 
     override fun operationShape(shape: OperationShape) {
         super.operationShape(shape)
+
         rustCrate.withModule(PythonServerRustModule.PythonOperationAdapter) {
             PythonServerOperationHandlerGenerator(codegenContext, shape).render(this)
+        }
+
+        rustCrate.withModule(ServerRustModule.Error) {
+            PythonServerOperationErrorGenerator(codegenContext.model, codegenContext.symbolProvider, shape).render(this)
         }
     }
 }

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerServiceGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerServiceGenerator.kt
@@ -6,7 +6,6 @@
 package software.amazon.smithy.rust.codegen.server.python.smithy.generators
 
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolSupport
 import software.amazon.smithy.rust.codegen.server.python.smithy.PythonServerRustModule
@@ -28,11 +27,6 @@ class PythonServerServiceGenerator(
     protocol: ServerProtocol,
     private val context: ServerCodegenContext,
 ) : ServerServiceGenerator(rustCrate, protocolGenerator, protocolSupport, protocol, context) {
-
-    override fun renderCombinedErrors(writer: RustWriter, operation: OperationShape) {
-        PythonServerOperationErrorGenerator(context.model, context.symbolProvider, operation).render(writer)
-    }
-
     override fun renderExtras(operations: List<OperationShape>) {
         rustCrate.withModule(PythonServerRustModule.PythonServerApplication) {
             PythonApplicationGenerator(context, protocol, operations)

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -249,14 +249,6 @@ open class ServerServiceGenerator(
             ServerProtocolTestGenerator(codegenContext, protocolSupport, protocolGenerator).render(this)
         }
 
-        for (operation in operations) {
-            if (operation.errors.isNotEmpty()) {
-                rustCrate.withModule(ErrorModule) {
-                    renderCombinedErrors(this, operation)
-                }
-            }
-        }
-
         rustCrate.withModule(RustModule.private("service")) {
             ServerServiceGeneratorV2(codegenContext, protocol).render(this)
         }
@@ -270,11 +262,6 @@ open class ServerServiceGenerator(
 
     // Render any extra section needed by subclasses of `ServerServiceGenerator`.
     open fun renderExtras(operations: List<OperationShape>) { }
-
-    // Render combined errors.
-    open fun renderCombinedErrors(writer: RustWriter, operation: OperationShape) {
-        /* Subclasses can override */
-    }
 
     // Render `server` crate, re-exporting types.
     private fun renderServerReExports(writer: RustWriter) {


### PR DESCRIPTION
## Motivation and Context

There are a variety of places where shape specific code, which is not contingent on its parent, is generated in its parent visitor method.

## Description

Move `renderCombinedErrors` logic into `ShapeVisitor::operationShape`.
