### PR TITLE
Update the base image for ci-build's Dockerfile

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -5,7 +5,7 @@
 
 # This is the base Docker build image used by CI
 
-ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2
+ARG base_image=public.ecr.aws/amazonlinux/amazonlinux:2023
 ARG rust_stable_version=1.66.1
 ARG rust_nightly_version=nightly-2022-11-16
 
@@ -30,7 +30,7 @@ ENV RUSTUP_HOME=/opt/rustup \
     PATH=/opt/cargo/bin/:${PATH} \
     CARGO_INCREMENTAL=0
 WORKDIR /root
-RUN yum -y install \
+RUN yum -y install --allowerasing \
         autoconf \
         automake \
         binutils \
@@ -41,6 +41,7 @@ RUN yum -y install \
         git \
         make \
         openssl-devel \
+        perl \
         pkgconfig && \
     yum clean all
 RUN set -eux; \


### PR DESCRIPTION
## Description
This PR updates the base image for ci-build's Dockerfile as a latest image for [amazonlinux](https://gallery.ecr.aws/amazonlinux/amazonlinux) has been updated to 2023.

As part of it, the changes to Dockerfile include
- fixing conflicting curl's libraries by specifying `--allowerasing`
Without it, we'd get an error as follows:
```
package curl-minimal-7.88.1-1.amzn2023.0.1.x86_64 conflicts with curl provided by curl-7.87.0-2.amzn2023.0.2.x86_64
```
- adding perl explicitly as a new version of openssl now requires it
Without `perl`, we'd get an error as follows:
```
Step 24/48 : RUN cargo +${rust_nightly_version} -Z sparse-registry install cargo-deny --locked --version ${cargo_deny_version}
 ---> Running in 3c3431881cfa
...
error: failed to run custom build command for `openssl-sys v0.9.76`
...
  --- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC contains: /usr/local/lib64/perl5/5.32 /usr/local/share/perl5/5.32 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.
  thread 'main' panicked at '
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
