### PR TITLE
Generate `RequestSerializer` traits for client operations

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/http/RequestBindingGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/http/RequestBindingGenerator.kt
@@ -125,11 +125,11 @@ class RequestBindingGenerator(
             "${label.content} = ${local(member)}"
         }
         val combinedArgs = listOf(formatString, *args.toTypedArray())
-        writer.addImport(RuntimeType.stdFmt.resolve("Write").toSymbol(), null)
         writer.rustBlockTemplate(
             "fn uri_base(_input: &#{Input}, output: &mut String) -> std::result::Result<(), #{BuildError}>",
             *codegenScope,
         ) {
+            rust("use #T as _;", RuntimeType.stdFmt.resolve("Write"))
             httpTrait.uri.labels.map { label ->
                 val member = inputShape.expectMember(label.content)
                 serializeLabel(member, label, local(member))
@@ -168,7 +168,7 @@ class RequestBindingGenerator(
             "fn uri_query(_input: &#{Input}, mut output: &mut String) -> Result<(), #{BuildError}>",
             *codegenScope,
         ) {
-            write("let mut query = #T::new(&mut output);", RuntimeType.queryFormat(runtimeConfig, "Writer"))
+            write("let mut query = #T::new(output);", RuntimeType.queryFormat(runtimeConfig, "Writer"))
             literalParams.forEach { (k, v) ->
                 // When `v` is an empty string, no value should be set.
                 // this generates a query string like `?k=v&xyz`

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ClientProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ClientProtocolGenerator.kt
@@ -23,7 +23,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 
 open class ClientProtocolGenerator(
-    codegenContext: ClientCodegenContext,
+    private val codegenContext: ClientCodegenContext,
     private val protocol: Protocol,
     /**
      * Operations generate a `make_operation(&config)` method to build a `aws_smithy_http::Operation` that can be dispatched
@@ -85,6 +85,10 @@ open class ClientProtocolGenerator(
 
             writeCustomizations(customizations, OperationSection.OperationImplBlock(customizations))
         }
-        traitGenerator.generateTraitImpls(operationWriter, operationShape, customizations)
+        when (codegenContext.settings.codegenConfig.enableNewSmithyRuntime) {
+            true -> ResponseDeserializerGenerator(codegenContext, protocol)
+                .render(operationWriter, operationShape, customizations)
+            else -> traitGenerator.generateTraitImpls(operationWriter, operationShape, customizations)
+        }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -33,6 +33,7 @@ import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.letIf
 
+// TODO(enableNewSmithyRuntime): Delete this class when cleaning up `enableNewSmithyRuntime`
 /** Generates the `make_operation` function on input structs */
 open class MakeOperationGenerator(
     protected val codegenContext: CodegenContext,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
@@ -1,0 +1,330 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators.protocol
+
+import software.amazon.smithy.codegen.core.Symbol
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.ErrorTrait
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.generators.http.ResponseBindingGenerator
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.assignment
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
+import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
+import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBindingDescriptor
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctions
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.StructuredDataParserGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.transformers.operationErrors
+import software.amazon.smithy.rust.codegen.core.util.UNREACHABLE
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.errorMessageMember
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+import software.amazon.smithy.rust.codegen.core.util.isStreaming
+import software.amazon.smithy.rust.codegen.core.util.outputShape
+
+class ProtocolParserGenerator(
+    private val codegenContext: ClientCodegenContext,
+    private val protocol: Protocol,
+) {
+    private val model = codegenContext.model
+    private val httpBindingResolver = protocol.httpBindingResolver
+    private val protocolFunctions = ProtocolFunctions(codegenContext)
+    private val symbolProvider: RustSymbolProvider = codegenContext.symbolProvider
+
+    private val codegenScope = arrayOf(
+        "http" to RuntimeType.Http,
+        "operation" to RuntimeType.operationModule(codegenContext.runtimeConfig),
+        "Bytes" to RuntimeType.Bytes,
+        "SdkBody" to RuntimeType.sdkBody(codegenContext.runtimeConfig),
+    )
+
+    fun parseResponseFn(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
+        val outputShape = operationShape.outputShape(model)
+        val outputSymbol = symbolProvider.toSymbol(outputShape)
+        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
+        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_response") { fnName ->
+            Attribute.AllowClippyUnnecessaryWraps.render(this)
+            rustBlockTemplate(
+                "pub fn $fnName(_response_status: u16, _response_headers: &#{http}::header::HeaderMap, _response_body: &[u8]) -> std::result::Result<#{O}, #{E}>",
+                *codegenScope,
+                "O" to outputSymbol,
+                "E" to errorSymbol,
+            ) {
+                withBlock("Ok({", "})") {
+                    renderShapeParser(
+                        operationShape,
+                        outputShape,
+                        httpBindingResolver.responseBindings(operationShape),
+                        errorSymbol,
+                        customizations,
+                    )
+                }
+            }
+        }
+    }
+
+    fun parseErrorFn(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
+        val outputShape = operationShape.outputShape(model)
+        val outputSymbol = symbolProvider.toSymbol(outputShape)
+        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
+        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_error") { fnName ->
+            Attribute.AllowClippyUnnecessaryWraps.render(this)
+            rustBlockTemplate(
+                "pub fn $fnName(_response_status: u16, _response_headers: &#{http}::header::HeaderMap, _response_body: &[u8]) -> std::result::Result<#{O}, #{E}>",
+                *codegenScope,
+                "O" to outputSymbol,
+                "E" to errorSymbol,
+            ) {
+                Attribute.AllowUnusedMut.render(this)
+                rust(
+                    "let mut generic_builder = #T(_response_status, _response_headers, _response_body).map_err(#T::unhandled)?;",
+                    protocol.parseHttpErrorMetadata(operationShape),
+                    errorSymbol,
+                )
+                writeCustomizations(
+                    customizations,
+                    OperationSection.PopulateErrorMetadataExtras(
+                        customizations,
+                        "generic_builder",
+                        "_response_status",
+                        "_response_headers",
+                    ),
+                )
+                rust("let generic = generic_builder.build();")
+                if (operationShape.operationErrors(model).isNotEmpty()) {
+                    rustTemplate(
+                        """
+                        let error_code = match generic.code() {
+                            Some(code) => code,
+                            None => return Err(#{error_symbol}::unhandled(generic))
+                        };
+
+                        let _error_message = generic.message().map(|msg|msg.to_owned());
+                        """,
+                        "error_symbol" to errorSymbol,
+                    )
+                    withBlock("Err(match error_code {", "})") {
+                        val errors = operationShape.operationErrors(model)
+                        errors.forEach { error ->
+                            val errorShape = model.expectShape(error.id, software.amazon.smithy.model.shapes.StructureShape::class.java)
+                            val variantName = symbolProvider.toSymbol(model.expectShape(error.id)).name
+                            val errorCode = httpBindingResolver.errorCode(errorShape).dq()
+                            withBlock(
+                                "$errorCode => #1T::$variantName({",
+                                "}),",
+                                errorSymbol,
+                            ) {
+                                software.amazon.smithy.rust.codegen.core.rustlang.Attribute.AllowUnusedMut.render(this)
+                                assignment("mut tmp") {
+                                    rustBlock("") {
+                                        renderShapeParser(
+                                            operationShape,
+                                            errorShape,
+                                            httpBindingResolver.errorResponseBindings(errorShape),
+                                            errorSymbol,
+                                            listOf(object : software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization() {
+                                                override fun section(section: software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection): Writable =
+                                                    software.amazon.smithy.rust.codegen.core.rustlang.writable {
+                                                        if (section is software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection.MutateOutput) {
+                                                            rust("let output = output.meta(generic);")
+                                                        }
+                                                    }
+                                            },
+                                            ),
+                                        )
+                                    }
+                                }
+                                if (errorShape.errorMessageMember() != null) {
+                                    rust(
+                                        """
+                                        if tmp.message.is_none() {
+                                            tmp.message = _error_message;
+                                        }
+                                        """,
+                                    )
+                                }
+                                rust("tmp")
+                            }
+                        }
+                        rust("_ => #T::generic(generic)", errorSymbol)
+                    }
+                } else {
+                    rust("Err(#T::generic(generic))", errorSymbol)
+                }
+            }
+        }
+    }
+
+    fun parseStreamingResponseFn(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
+        val outputShape = operationShape.outputShape(model)
+        val outputSymbol = symbolProvider.toSymbol(outputShape)
+        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
+        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_response") { fnName ->
+            Attribute.AllowClippyUnnecessaryWraps.render(this)
+            rustBlockTemplate(
+                "pub fn $fnName(response: &mut #{http}::Response<#{SdkBody}>) -> std::result::Result<#{O}, #{E}>",
+                *codegenScope,
+                "O" to outputSymbol,
+                "E" to errorSymbol,
+            ) {
+                rustTemplate(
+                    """
+                    let mut _response_body = #{SdkBody}::taken();
+                    std::mem::swap(&mut _response_body, response.body_mut());
+                    let _response_body = &mut _response_body;
+
+                    let _response_status = response.status().as_u16();
+                    let _response_headers = response.headers();
+                    """,
+                    *codegenScope,
+                )
+                withBlock("Ok({", "})") {
+                    renderShapeParser(
+                        operationShape,
+                        outputShape,
+                        httpBindingResolver.responseBindings(operationShape),
+                        errorSymbol,
+                        customizations,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun RustWriter.renderShapeParser(
+        operationShape: OperationShape,
+        outputShape: StructureShape,
+        bindings: List<HttpBindingDescriptor>,
+        errorSymbol: Symbol,
+        customizations: List<OperationCustomization>,
+    ) {
+        val httpBindingGenerator = ResponseBindingGenerator(protocol, codegenContext, operationShape)
+        val structuredDataParser = protocol.structuredDataParser(operationShape)
+        Attribute.AllowUnusedMut.render(this)
+        rust("let mut output = #T::default();", symbolProvider.symbolForBuilder(outputShape))
+        if (outputShape.id == operationShape.output.get()) {
+            structuredDataParser.operationParser(operationShape)?.also { parser ->
+                rust(
+                    "output = #T(_response_body, output).map_err(#T::unhandled)?;",
+                    parser,
+                    errorSymbol,
+                )
+            }
+        } else {
+            check(outputShape.hasTrait<ErrorTrait>()) { "should only be called on outputs or errors $outputShape" }
+            structuredDataParser.errorParser(outputShape)?.also { parser ->
+                rust(
+                    "output = #T(_response_body, output).map_err(#T::unhandled)?;",
+                    parser, errorSymbol,
+                )
+            }
+        }
+        for (binding in bindings) {
+            val member = binding.member
+            val parsedValue = renderBindingParser(binding, operationShape, httpBindingGenerator, structuredDataParser)
+            if (parsedValue != null) {
+                withBlock("output = output.${member.setterName()}(", ");") {
+                    parsedValue(this)
+                }
+            }
+        }
+
+        val err = if (BuilderGenerator.hasFallibleBuilder(outputShape, symbolProvider)) {
+            ".map_err(${format(errorSymbol)}::unhandled)?"
+        } else {
+            ""
+        }
+
+        writeCustomizations(
+            customizations,
+            OperationSection.MutateOutput(customizations, operationShape, "_response_headers"),
+        )
+
+        rust("output.build()$err")
+    }
+
+    /**
+     * Generate a parser & a parsed value converter for each output member of `operationShape`
+     *
+     * Returns a map with key = memberName, value = parsedValue
+     */
+    private fun renderBindingParser(
+        binding: HttpBindingDescriptor,
+        operationShape: OperationShape,
+        httpBindingGenerator: ResponseBindingGenerator,
+        structuredDataParser: StructuredDataParserGenerator,
+    ): Writable? {
+        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
+        val member = binding.member
+        return when (binding.location) {
+            HttpLocation.HEADER -> writable {
+                val fnName = httpBindingGenerator.generateDeserializeHeaderFn(binding)
+                rust(
+                    """
+                    #T(_response_headers)
+                        .map_err(|_|#T::unhandled("Failed to parse ${member.memberName} from header `${binding.locationName}"))?
+                    """,
+                    fnName, errorSymbol,
+                )
+            }
+            HttpLocation.DOCUMENT -> {
+                // document is handled separately
+                null
+            }
+            HttpLocation.PAYLOAD -> {
+                val payloadParser: RustWriter.(String) -> Unit = { body ->
+                    rust("#T($body).map_err(#T::unhandled)", structuredDataParser.payloadParser(member), errorSymbol)
+                }
+                val deserializer = httpBindingGenerator.generateDeserializePayloadFn(
+                    binding,
+                    errorSymbol,
+                    payloadParser = payloadParser,
+                )
+                return if (binding.member.isStreaming(model)) {
+                    writable { rust("Some(#T(_response_body)?)", deserializer) }
+                } else {
+                    writable { rust("#T(_response_body)?", deserializer) }
+                }
+            }
+            HttpLocation.RESPONSE_CODE -> writable {
+                rust("Some(_response_status as _)")
+            }
+            HttpLocation.PREFIX_HEADERS -> {
+                val sym = httpBindingGenerator.generateDeserializePrefixHeaderFn(binding)
+                writable {
+                    rustTemplate(
+                        """
+                        #{deser}(_response_headers)
+                             .map_err(|_|
+                                #{err}::unhandled("Failed to parse ${member.memberName} from prefix header `${binding.locationName}")
+                             )?
+                        """,
+                        "deser" to sym, "err" to errorSymbol,
+                    )
+                }
+            }
+            else -> {
+                UNREACHABLE("Unexpected binding location: ${binding.location}")
+            }
+        }
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators.protocol
+
+import software.amazon.smithy.model.shapes.BlobShape
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
+import software.amazon.smithy.rust.codegen.client.smithy.generators.http.RequestBindingGenerator
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.Writable
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolPayloadGenerator
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
+import software.amazon.smithy.rust.codegen.core.util.dq
+import software.amazon.smithy.rust.codegen.core.util.findStreamingMember
+import software.amazon.smithy.rust.codegen.core.util.inputShape
+
+class RequestSerializerGenerator(
+    private val codegenContext: ClientCodegenContext,
+    private val protocol: Protocol,
+    private val bodyGenerator: ProtocolPayloadGenerator,
+) {
+    private val httpBindingResolver = protocol.httpBindingResolver
+    private val symbolProvider = codegenContext.symbolProvider
+    private val codegenScope by lazy {
+        CargoDependency.smithyRuntimeApi(codegenContext.runtimeConfig).toType().let { runtimeApi ->
+            val interceptorContext = runtimeApi.resolve("client::interceptors::context")
+            val orchestrator = runtimeApi.resolve("client::orchestrator")
+            arrayOf(
+                "BoxError" to orchestrator.resolve("BoxError"),
+                "HttpRequest" to orchestrator.resolve("HttpRequest"),
+                "HttpRequestBuilder" to RuntimeType.HttpRequestBuilder,
+                "Input" to interceptorContext.resolve("Input"),
+                "RequestSerializer" to orchestrator.resolve("RequestSerializer"),
+                "SdkBody" to RuntimeType.sdkBody(codegenContext.runtimeConfig),
+                "TypedBox" to runtimeApi.resolve("type_erasure::TypedBox"),
+                "config" to ClientRustModule.Config,
+                "header_util" to RuntimeType.smithyHttp(codegenContext.runtimeConfig).resolve("header"),
+                "http" to RuntimeType.Http,
+                "operation" to RuntimeType.operationModule(codegenContext.runtimeConfig),
+            )
+        }
+    }
+
+    fun render(writer: RustWriter, operationShape: OperationShape, customizations: List<OperationCustomization>) {
+        val inputShape = operationShape.inputShape(codegenContext.model)
+        val operationName = symbolProvider.toSymbol(operationShape).name
+        val inputSymbol = symbolProvider.toSymbol(inputShape)
+        writer.rustTemplate(
+            """
+            impl #{RequestSerializer} for $operationName {
+                ##[allow(unused_mut, clippy::let_and_return, clippy::needless_borrow, clippy::useless_conversion)]
+                fn serialize_input(&self, input: #{Input}) -> Result<#{HttpRequest}, #{BoxError}> {
+                    let input = #{TypedBox}::<#{ConcreteInput}>::assume_from(input).expect("correct type").unwrap();
+                    let mut request_builder = {
+                        #{create_http_request}
+                    };
+                    let body = #{generate_body};
+                    #{add_content_length}
+                    Ok(request_builder.body(body).expect("valid request"))
+                }
+            }
+            """,
+            *codegenScope,
+            "ConcreteInput" to inputSymbol,
+            "create_http_request" to createHttpRequest(operationShape),
+            "generate_body" to writable {
+                val body = writable { bodyGenerator.generatePayload(this, "input", operationShape) }
+                val streamingMember = inputShape.findStreamingMember(codegenContext.model)
+                val isBlobStreaming =
+                    streamingMember != null && codegenContext.model.expectShape(streamingMember.target) is BlobShape
+                if (isBlobStreaming) {
+                    // Consume the `ByteStream` into its inner `SdkBody`.
+                    rust("#T.into_inner()", body)
+                } else {
+                    rustTemplate("#{SdkBody}::from(#{body})", *codegenScope, "body" to body)
+                }
+            },
+            "add_content_length" to if (needsContentLength(operationShape)) {
+                writable {
+                    rustTemplate(
+                        """
+                        if let Some(content_length) = body.content_length() {
+                            request_builder = #{header_util}::set_request_header_if_absent(request_builder, #{http}::header::CONTENT_LENGTH, content_length);
+                        }
+                        """,
+                        *codegenScope,
+                    )
+                }
+            } else {
+                writable { }
+            },
+        )
+    }
+
+    private fun needsContentLength(operationShape: OperationShape): Boolean {
+        return protocol.httpBindingResolver.requestBindings(operationShape)
+            .any { it.location == HttpLocation.DOCUMENT || it.location == HttpLocation.PAYLOAD }
+    }
+
+    private fun createHttpRequest(operationShape: OperationShape): Writable = writable {
+        val httpBindingGenerator = RequestBindingGenerator(
+            codegenContext,
+            protocol,
+            operationShape,
+        )
+        httpBindingGenerator.renderUpdateHttpBuilder(this)
+        val contentType = httpBindingResolver.requestContentType(operationShape)
+
+        rust("let mut builder = update_http_builder(&input, #T::new())?;", RuntimeType.HttpRequestBuilder)
+        if (contentType != null) {
+            rustTemplate(
+                "builder = #{header_util}::set_request_header_if_absent(builder, #{http}::header::CONTENT_TYPE, ${contentType.dq()});",
+                *codegenScope,
+            )
+        }
+        for (header in protocol.additionalRequestHeaders(operationShape)) {
+            rustTemplate(
+                """
+                builder = #{header_util}::set_request_header_if_absent(
+                    builder,
+                    #{http}::header::HeaderName::from_static(${header.first.dq()}),
+                    ${header.second.dq()}
+                );
+                """,
+                *codegenScope,
+            )
+        }
+        rust("builder")
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators.protocol
+
+import software.amazon.smithy.model.shapes.OperationShape
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
+import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctions
+import software.amazon.smithy.rust.codegen.core.util.hasStreamingMember
+import software.amazon.smithy.rust.codegen.core.util.outputShape
+
+class ResponseDeserializerGenerator(
+    codegenContext: ClientCodegenContext,
+    protocol: Protocol,
+) {
+    private val symbolProvider = codegenContext.symbolProvider
+    private val model = codegenContext.model
+    private val runtimeConfig = codegenContext.runtimeConfig
+    private val httpBindingResolver = protocol.httpBindingResolver
+    private val parserGenerator = ProtocolParserGenerator(codegenContext, protocol)
+
+    private val codegenScope by lazy {
+        val interceptorContext =
+            CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("client::interceptors::context")
+        val orchestrator =
+            CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("client::orchestrator")
+        arrayOf(
+            "Error" to interceptorContext.resolve("Error"),
+            "HttpResponse" to orchestrator.resolve("HttpResponse"),
+            "Instrument" to CargoDependency.Tracing.toType().resolve("Instrument"),
+            "Output" to interceptorContext.resolve("Output"),
+            "OutputOrError" to interceptorContext.resolve("OutputOrError"),
+            "ResponseDeserializer" to orchestrator.resolve("ResponseDeserializer"),
+            "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
+            "SdkError" to RuntimeType.sdkError(runtimeConfig),
+            "TypedBox" to CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("type_erasure::TypedBox"),
+            "debug_span" to RuntimeType.Tracing.resolve("debug_span"),
+            "type_erase_result" to typeEraseResult(),
+        )
+    }
+
+    fun render(writer: RustWriter, operationShape: OperationShape, customizations: List<OperationCustomization>) {
+        val outputSymbol = symbolProvider.toSymbol(operationShape.outputShape(model))
+        val operationName = symbolProvider.toSymbol(operationShape).name
+        val streaming = operationShape.outputShape(model).hasStreamingMember(model)
+
+        writer.rustTemplate(
+            """
+            impl #{ResponseDeserializer} for $operationName {
+                #{deserialize_streaming}
+
+                fn deserialize_nonstreaming(&self, response: &#{HttpResponse}) -> #{OutputOrError} {
+                    #{deserialize_nonstreaming}
+                }
+            }
+            """,
+            *codegenScope,
+            "O" to outputSymbol,
+            "E" to symbolProvider.symbolForOperationError(operationShape),
+            "deserialize_streaming" to writable {
+                if (streaming) {
+                    deserializeStreaming(operationShape, customizations)
+                }
+            },
+            "deserialize_nonstreaming" to writable {
+                when (streaming) {
+                    true -> deserializeStreamingError(operationShape, customizations)
+                    else -> deserializeNonStreaming(operationShape, customizations)
+                }
+            },
+        )
+    }
+
+    private fun RustWriter.deserializeStreaming(
+        operationShape: OperationShape,
+        customizations: List<OperationCustomization>,
+    ) {
+        val successCode = httpBindingResolver.httpTrait(operationShape).code
+        rustTemplate(
+            """
+            fn deserialize_streaming(&self, response: &mut #{HttpResponse}) -> Option<#{OutputOrError}> {
+                #{BeforeParseResponse}
+
+                // If this is an error, defer to the non-streaming parser
+                if !response.status().is_success() && response.status().as_u16() != $successCode {
+                    return None;
+                }
+                Some(#{type_erase_result}(#{parse_streaming_response}(response)))
+            }
+            """,
+            *codegenScope,
+            "parse_streaming_response" to parserGenerator.parseStreamingResponseFn(operationShape, customizations),
+            "BeforeParseResponse" to writable {
+                writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
+            },
+        )
+    }
+
+    private fun RustWriter.deserializeStreamingError(
+        operationShape: OperationShape,
+        customizations: List<OperationCustomization>,
+    ) {
+        rustTemplate(
+            """
+            // For streaming operations, we only hit this case if its an error
+            let body = response.body().bytes().expect("body loaded");
+            #{type_erase_result}(#{parse_error}(response.status().as_u16(), response.headers(), body))
+            """,
+            *codegenScope,
+            "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
+        )
+    }
+
+    private fun RustWriter.deserializeNonStreaming(
+        operationShape: OperationShape,
+        customizations: List<OperationCustomization>,
+    ) {
+        val successCode = httpBindingResolver.httpTrait(operationShape).code
+        rustTemplate(
+            """
+            let (success, status) = (response.status().is_success(), response.status().as_u16());
+            let headers = response.headers();
+            let body = response.body().bytes().expect("body loaded");
+             #{BeforeParseResponse}
+            let parse_result = if !success && status != $successCode {
+                #{parse_error}(status, headers, body)
+            } else {
+                #{parse_response}(status, headers, body)
+            };
+            #{type_erase_result}(parse_result)
+            """,
+            *codegenScope,
+            "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
+            "parse_response" to parserGenerator.parseResponseFn(operationShape, customizations),
+            "BeforeParseResponse" to writable {
+                writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
+            },
+        )
+    }
+
+    private fun typeEraseResult(): RuntimeType = ProtocolFunctions.crossOperationFn("type_erase_result") { fnName ->
+        rustTemplate(
+            """
+            pub(crate) fn $fnName<O, E>(result: Result<O, E>) -> Result<#{Output}, #{Error}>
+            where
+                O: Send + Sync + 'static,
+                E: Send + Sync + 'static,
+            {
+                result.map(|output| #{TypedBox}::new(output).erase())
+                    .map_err(|error| #{TypedBox}::new(error).erase())
+            }
+            """,
+            *codegenScope,
+        )
+    }
+}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -7,44 +7,27 @@ package software.amazon.smithy.rust.codegen.client.smithy.protocols
 
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.shapes.OperationShape
-import software.amazon.smithy.model.shapes.StructureShape
-import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
-import software.amazon.smithy.rust.codegen.client.smithy.generators.http.ResponseBindingGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ClientProtocolGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.MakeOperationGenerator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ProtocolParserGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
-import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
-import software.amazon.smithy.rust.codegen.core.rustlang.Writable
-import software.amazon.smithy.rust.codegen.core.rustlang.assignment
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
-import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.core.rustlang.withBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
-import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
-import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBindingDescriptor
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBoundProtocolPayloadGenerator
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctions
-import software.amazon.smithy.rust.codegen.core.smithy.protocols.parse.StructuredDataParserGenerator
-import software.amazon.smithy.rust.codegen.core.smithy.transformers.operationErrors
-import software.amazon.smithy.rust.codegen.core.util.UNREACHABLE
-import software.amazon.smithy.rust.codegen.core.util.dq
-import software.amazon.smithy.rust.codegen.core.util.errorMessageMember
 import software.amazon.smithy.rust.codegen.core.util.hasStreamingMember
-import software.amazon.smithy.rust.codegen.core.util.hasTrait
-import software.amazon.smithy.rust.codegen.core.util.isStreaming
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 
+// TODO(enableNewSmithyRuntime): Delete this class when cleaning up `enableNewSmithyRuntime`
 class HttpBoundProtocolGenerator(
     codegenContext: ClientCodegenContext,
     protocol: Protocol,
@@ -61,15 +44,17 @@ class HttpBoundProtocolGenerator(
     HttpBoundProtocolTraitImplGenerator(codegenContext, protocol),
 )
 
+// TODO(enableNewSmithyRuntime): Delete this class when cleaning up `enableNewSmithyRuntime`
 open class HttpBoundProtocolTraitImplGenerator(
-    private val codegenContext: ClientCodegenContext,
-    private val protocol: Protocol,
+    codegenContext: ClientCodegenContext,
+    protocol: Protocol,
 ) {
     private val symbolProvider = codegenContext.symbolProvider
     private val model = codegenContext.model
     private val runtimeConfig = codegenContext.runtimeConfig
     private val httpBindingResolver = protocol.httpBindingResolver
     private val protocolFunctions = ProtocolFunctions(codegenContext)
+    private val parserGenerator = ProtocolParserGenerator(codegenContext, protocol)
 
     private val codegenScope = arrayOf(
         "ParseStrict" to RuntimeType.parseStrictResponse(runtimeConfig),
@@ -79,25 +64,6 @@ open class HttpBoundProtocolTraitImplGenerator(
         "Bytes" to RuntimeType.Bytes,
         "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
     )
-    private val orchestratorCodegenScope by lazy {
-        val interceptorContext =
-            CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("client::interceptors::context")
-        val orchestrator =
-            CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("client::orchestrator")
-        arrayOf(
-            "Error" to interceptorContext.resolve("Error"),
-            "HttpResponse" to orchestrator.resolve("HttpResponse"),
-            "Instrument" to CargoDependency.Tracing.toType().resolve("Instrument"),
-            "Output" to interceptorContext.resolve("Output"),
-            "OutputOrError" to interceptorContext.resolve("OutputOrError"),
-            "ResponseDeserializer" to orchestrator.resolve("ResponseDeserializer"),
-            "SdkBody" to RuntimeType.sdkBody(runtimeConfig),
-            "SdkError" to RuntimeType.sdkError(runtimeConfig),
-            "TypedBox" to CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("type_erasure::TypedBox"),
-            "debug_span" to RuntimeType.Tracing.resolve("debug_span"),
-            "type_erase_result" to typeEraseResult(),
-        )
-    }
 
     open fun generateTraitImpls(
         operationWriter: RustWriter,
@@ -116,130 +82,8 @@ open class HttpBoundProtocolTraitImplGenerator(
         } else {
             operationWriter.renderNonStreamingTraits(operationName, outputSymbol, operationShape, customizations)
         }
-
-        if (codegenContext.settings.codegenConfig.enableNewSmithyRuntime) {
-            operationWriter.renderRuntimeTraits(operationName, outputSymbol, operationShape, customizations, streaming)
-        }
     }
 
-    private fun typeEraseResult(): RuntimeType = ProtocolFunctions.crossOperationFn("type_erase_result") { fnName ->
-        rustTemplate(
-            """
-            pub(crate) fn $fnName<O, E>(result: Result<O, E>) -> Result<#{Output}, #{Error}>
-            where
-                O: Send + Sync + 'static,
-                E: Send + Sync + 'static,
-            {
-                result.map(|output| #{TypedBox}::new(output).erase())
-                    .map_err(|error| #{TypedBox}::new(error).erase())
-            }
-            """,
-            *orchestratorCodegenScope,
-        )
-    }
-
-    private fun RustWriter.renderRuntimeTraits(
-        operationName: String?,
-        outputSymbol: Symbol,
-        operationShape: OperationShape,
-        customizations: List<OperationCustomization>,
-        streaming: Boolean,
-    ) {
-        rustTemplate(
-            """
-            impl #{ResponseDeserializer} for $operationName {
-                #{deserialize_streaming}
-
-                fn deserialize_nonstreaming(&self, response: &#{HttpResponse}) -> #{OutputOrError} {
-                    #{deserialize_nonstreaming}
-                }
-            }
-            """,
-            *orchestratorCodegenScope,
-            "O" to outputSymbol,
-            "E" to symbolProvider.symbolForOperationError(operationShape),
-            "deserialize_streaming" to writable {
-                if (streaming) {
-                    deserializeStreaming(operationShape, customizations)
-                }
-            },
-            "deserialize_nonstreaming" to writable {
-                when (streaming) {
-                    true -> deserializeStreamingError(operationShape, customizations)
-                    else -> deserializeNonStreaming(operationShape, customizations)
-                }
-            },
-        )
-    }
-
-    private fun RustWriter.deserializeStreaming(
-        operationShape: OperationShape,
-        customizations: List<OperationCustomization>,
-    ) {
-        val successCode = httpBindingResolver.httpTrait(operationShape).code
-        rustTemplate(
-            """
-            fn deserialize_streaming(&self, response: &mut #{HttpResponse}) -> Option<#{OutputOrError}> {
-                #{BeforeParseResponse}
-
-                // If this is an error, defer to the non-streaming parser
-                if !response.status().is_success() && response.status().as_u16() != $successCode {
-                    return None;
-                }
-                Some(#{type_erase_result}(#{parse_streaming_response}(response)))
-            }
-            """,
-            *orchestratorCodegenScope,
-            "parse_streaming_response" to parseStreamingResponse(operationShape, customizations),
-            "BeforeParseResponse" to writable {
-                writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
-            },
-        )
-    }
-
-    private fun RustWriter.deserializeStreamingError(
-        operationShape: OperationShape,
-        customizations: List<OperationCustomization>,
-    ) {
-        rustTemplate(
-            """
-            // For streaming operations, we only hit this case if its an error
-            let body = response.body().bytes().expect("body loaded");
-            #{type_erase_result}(#{parse_error}(response.status().as_u16(), response.headers(), body))
-            """,
-            *orchestratorCodegenScope,
-            "parse_error" to parseError(operationShape, customizations),
-        )
-    }
-
-    private fun RustWriter.deserializeNonStreaming(
-        operationShape: OperationShape,
-        customizations: List<OperationCustomization>,
-    ) {
-        val successCode = httpBindingResolver.httpTrait(operationShape).code
-        rustTemplate(
-            """
-            let (success, status) = (response.status().is_success(), response.status().as_u16());
-            let headers = response.headers();
-            let body = response.body().bytes().expect("body loaded");
-             #{BeforeParseResponse}
-            let parse_result = if !success && status != $successCode {
-                #{parse_error}(status, headers, body)
-            } else {
-                #{parse_response}(status, headers, body)
-            };
-            #{type_erase_result}(parse_result)
-            """,
-            *orchestratorCodegenScope,
-            "parse_error" to parseError(operationShape, customizations),
-            "parse_response" to parseResponse(operationShape, customizations),
-            "BeforeParseResponse" to writable {
-                writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
-            },
-        )
-    }
-
-    // TODO(enableNewSmithyRuntime): Delete this when cleaning up `enableNewSmithyRuntime`
     private fun RustWriter.renderNonStreamingTraits(
         operationName: String?,
         outputSymbol: Symbol,
@@ -250,8 +94,8 @@ open class HttpBoundProtocolTraitImplGenerator(
         val localScope = arrayOf(
             "O" to outputSymbol,
             "E" to symbolProvider.symbolForOperationError(operationShape),
-            "parse_error" to parseError(operationShape, customizations),
-            "parse_response" to parseResponse(operationShape, customizations),
+            "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
+            "parse_response" to parserGenerator.parseResponseFn(operationShape, customizations),
             "BeforeParseResponse" to writable {
                 writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
             },
@@ -277,7 +121,6 @@ open class HttpBoundProtocolTraitImplGenerator(
         )
     }
 
-    // TODO(enableNewSmithyRuntime): Delete this when cleaning up `enableNewSmithyRuntime`
     private fun RustWriter.renderStreamingTraits(
         operationName: String,
         outputSymbol: Symbol,
@@ -305,8 +148,8 @@ open class HttpBoundProtocolTraitImplGenerator(
             """,
             "O" to outputSymbol,
             "E" to symbolProvider.symbolForOperationError(operationShape),
-            "parse_streaming_response" to parseStreamingResponseNoRt(operationShape, customizations),
-            "parse_error" to parseError(operationShape, customizations),
+            "parse_streaming_response" to parseStreamingResponse(operationShape, customizations),
+            "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
             "BeforeParseResponse" to writable {
                 writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
             },
@@ -314,139 +157,11 @@ open class HttpBoundProtocolTraitImplGenerator(
         )
     }
 
-    private fun parseError(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
-        val outputShape = operationShape.outputShape(model)
-        val outputSymbol = symbolProvider.toSymbol(outputShape)
-        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_error") { fnName ->
-            Attribute.AllowClippyUnnecessaryWraps.render(this)
-            rustBlockTemplate(
-                "pub fn $fnName(_response_status: u16, _response_headers: &#{http}::header::HeaderMap, _response_body: &[u8]) -> std::result::Result<#{O}, #{E}>",
-                *codegenScope,
-                "O" to outputSymbol,
-                "E" to errorSymbol,
-            ) {
-                Attribute.AllowUnusedMut.render(this)
-                rust(
-                    "let mut generic_builder = #T(_response_status, _response_headers, _response_body).map_err(#T::unhandled)?;",
-                    protocol.parseHttpErrorMetadata(operationShape),
-                    errorSymbol,
-                )
-                writeCustomizations(
-                    customizations,
-                    OperationSection.PopulateErrorMetadataExtras(
-                        customizations,
-                        "generic_builder",
-                        "_response_status",
-                        "_response_headers",
-                    ),
-                )
-                rust("let generic = generic_builder.build();")
-                if (operationShape.operationErrors(model).isNotEmpty()) {
-                    rustTemplate(
-                        """
-                        let error_code = match generic.code() {
-                            Some(code) => code,
-                            None => return Err(#{error_symbol}::unhandled(generic))
-                        };
-
-                        let _error_message = generic.message().map(|msg|msg.to_owned());
-                        """,
-                        "error_symbol" to errorSymbol,
-                    )
-                    withBlock("Err(match error_code {", "})") {
-                        val errors = operationShape.operationErrors(model)
-                        errors.forEach { error ->
-                            val errorShape = model.expectShape(error.id, StructureShape::class.java)
-                            val variantName = symbolProvider.toSymbol(model.expectShape(error.id)).name
-                            val errorCode = httpBindingResolver.errorCode(errorShape).dq()
-                            withBlock(
-                                "$errorCode => #1T::$variantName({",
-                                "}),",
-                                errorSymbol,
-                            ) {
-                                Attribute.AllowUnusedMut.render(this)
-                                assignment("mut tmp") {
-                                    rustBlock("") {
-                                        renderShapeParser(
-                                            operationShape,
-                                            errorShape,
-                                            httpBindingResolver.errorResponseBindings(errorShape),
-                                            errorSymbol,
-                                            listOf(object : OperationCustomization() {
-                                                override fun section(section: OperationSection): Writable = writable {
-                                                    if (section is OperationSection.MutateOutput) {
-                                                        rust("let output = output.meta(generic);")
-                                                    }
-                                                }
-                                            },
-                                            ),
-                                        )
-                                    }
-                                }
-                                if (errorShape.errorMessageMember() != null) {
-                                    rust(
-                                        """
-                                        if tmp.message.is_none() {
-                                            tmp.message = _error_message;
-                                        }
-                                        """,
-                                    )
-                                }
-                                rust("tmp")
-                            }
-                        }
-                        rust("_ => #T::generic(generic)", errorSymbol)
-                    }
-                } else {
-                    rust("Err(#T::generic(generic))", errorSymbol)
-                }
-            }
-        }
-    }
-
     private fun parseStreamingResponse(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_response") { fnName ->
-            Attribute.AllowClippyUnnecessaryWraps.render(this)
-            rustBlockTemplate(
-                "pub fn $fnName(response: &mut #{http}::Response<#{SdkBody}>) -> std::result::Result<#{O}, #{E}>",
-                *codegenScope,
-                "O" to outputSymbol,
-                "E" to errorSymbol,
-            ) {
-                rustTemplate(
-                    """
-                    let mut _response_body = #{SdkBody}::taken();
-                    std::mem::swap(&mut _response_body, response.body_mut());
-                    let _response_body = &mut _response_body;
-
-                    let _response_status = response.status().as_u16();
-                    let _response_headers = response.headers();
-                    """,
-                    *codegenScope,
-                )
-                withBlock("Ok({", "})") {
-                    renderShapeParser(
-                        operationShape,
-                        outputShape,
-                        httpBindingResolver.responseBindings(operationShape),
-                        errorSymbol,
-                        customizations,
-                    )
-                }
-            }
-        }
-    }
-
-    // TODO(enableNewSmithyRuntime): Delete this when cleaning up `enableNewSmithyRuntime`
-    private fun parseStreamingResponseNoRt(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
-        val outputShape = operationShape.outputShape(model)
-        val outputSymbol = symbolProvider.toSymbol(outputShape)
-        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_response_") { fnName ->
+        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "op_response") { fnName ->
             Attribute.AllowClippyUnnecessaryWraps.render(this)
             rustBlockTemplate(
                 "pub fn $fnName(op_response: &mut #{operation}::Response) -> std::result::Result<#{O}, #{E}>",
@@ -459,167 +174,10 @@ open class HttpBoundProtocolTraitImplGenerator(
                 rust("let (response, properties) = op_response.parts_mut();")
                 rustTemplate(
                     """
-                    let mut _response_body = #{SdkBody}::taken();
-                    std::mem::swap(&mut _response_body, response.body_mut());
-                    let _response_body = &mut _response_body;
-
-                    let _response_status = response.status().as_u16();
-                    let _response_headers = response.headers();
+                    #{parse_streaming_response}(response)
                     """,
-                    *codegenScope,
+                    "parse_streaming_response" to parserGenerator.parseStreamingResponseFn(operationShape, customizations),
                 )
-                withBlock("Ok({", "})") {
-                    renderShapeParser(
-                        operationShape,
-                        outputShape,
-                        httpBindingResolver.responseBindings(operationShape),
-                        errorSymbol,
-                        customizations,
-                    )
-                }
-            }
-        }
-    }
-
-    private fun parseResponse(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
-        val outputShape = operationShape.outputShape(model)
-        val outputSymbol = symbolProvider.toSymbol(outputShape)
-        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_response") { fnName ->
-            Attribute.AllowClippyUnnecessaryWraps.render(this)
-            rustBlockTemplate(
-                "pub fn $fnName(_response_status: u16, _response_headers: &#{http}::header::HeaderMap, _response_body: &[u8]) -> std::result::Result<#{O}, #{E}>",
-                *codegenScope,
-                "O" to outputSymbol,
-                "E" to errorSymbol,
-            ) {
-                withBlock("Ok({", "})") {
-                    renderShapeParser(
-                        operationShape,
-                        outputShape,
-                        httpBindingResolver.responseBindings(operationShape),
-                        errorSymbol,
-                        customizations,
-                    )
-                }
-            }
-        }
-    }
-
-    private fun RustWriter.renderShapeParser(
-        operationShape: OperationShape,
-        outputShape: StructureShape,
-        bindings: List<HttpBindingDescriptor>,
-        errorSymbol: Symbol,
-        customizations: List<OperationCustomization>,
-    ) {
-        val httpBindingGenerator = ResponseBindingGenerator(protocol, codegenContext, operationShape)
-        val structuredDataParser = protocol.structuredDataParser(operationShape)
-        Attribute.AllowUnusedMut.render(this)
-        rust("let mut output = #T::default();", symbolProvider.symbolForBuilder(outputShape))
-        if (outputShape.id == operationShape.output.get()) {
-            structuredDataParser.operationParser(operationShape)?.also { parser ->
-                rust(
-                    "output = #T(_response_body, output).map_err(#T::unhandled)?;",
-                    parser,
-                    errorSymbol,
-                )
-            }
-        } else {
-            check(outputShape.hasTrait<ErrorTrait>()) { "should only be called on outputs or errors $outputShape" }
-            structuredDataParser.errorParser(outputShape)?.also { parser ->
-                rust(
-                    "output = #T(_response_body, output).map_err(#T::unhandled)?;",
-                    parser, errorSymbol,
-                )
-            }
-        }
-        for (binding in bindings) {
-            val member = binding.member
-            val parsedValue = renderBindingParser(binding, operationShape, httpBindingGenerator, structuredDataParser)
-            if (parsedValue != null) {
-                withBlock("output = output.${member.setterName()}(", ");") {
-                    parsedValue(this)
-                }
-            }
-        }
-
-        val err = if (BuilderGenerator.hasFallibleBuilder(outputShape, symbolProvider)) {
-            ".map_err(${format(errorSymbol)}::unhandled)?"
-        } else {
-            ""
-        }
-
-        writeCustomizations(
-            customizations,
-            OperationSection.MutateOutput(customizations, operationShape, "_response_headers"),
-        )
-
-        rust("output.build()$err")
-    }
-
-    /**
-     * Generate a parser & a parsed value converter for each output member of `operationShape`
-     *
-     * Returns a map with key = memberName, value = parsedValue
-     */
-    private fun renderBindingParser(
-        binding: HttpBindingDescriptor,
-        operationShape: OperationShape,
-        httpBindingGenerator: ResponseBindingGenerator,
-        structuredDataParser: StructuredDataParserGenerator,
-    ): Writable? {
-        val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        val member = binding.member
-        return when (binding.location) {
-            HttpLocation.HEADER -> writable {
-                val fnName = httpBindingGenerator.generateDeserializeHeaderFn(binding)
-                rust(
-                    """
-                    #T(_response_headers)
-                        .map_err(|_|#T::unhandled("Failed to parse ${member.memberName} from header `${binding.locationName}"))?
-                    """,
-                    fnName, errorSymbol,
-                )
-            }
-            HttpLocation.DOCUMENT -> {
-                // document is handled separately
-                null
-            }
-            HttpLocation.PAYLOAD -> {
-                val payloadParser: RustWriter.(String) -> Unit = { body ->
-                    rust("#T($body).map_err(#T::unhandled)", structuredDataParser.payloadParser(member), errorSymbol)
-                }
-                val deserializer = httpBindingGenerator.generateDeserializePayloadFn(
-                    binding,
-                    errorSymbol,
-                    payloadParser = payloadParser,
-                )
-                return if (binding.member.isStreaming(model)) {
-                    writable { rust("Some(#T(_response_body)?)", deserializer) }
-                } else {
-                    writable { rust("#T(_response_body)?", deserializer) }
-                }
-            }
-            HttpLocation.RESPONSE_CODE -> writable {
-                rust("Some(_response_status as _)")
-            }
-            HttpLocation.PREFIX_HEADERS -> {
-                val sym = httpBindingGenerator.generateDeserializePrefixHeaderFn(binding)
-                writable {
-                    rustTemplate(
-                        """
-                        #{deser}(_response_headers)
-                             .map_err(|_|
-                                #{err}::unhandled("Failed to parse ${member.memberName} from prefix header `${binding.locationName}")
-                             )?
-                        """,
-                        "deser" to sym, "err" to errorSymbol,
-                    )
-                }
-            }
-            else -> {
-                UNREACHABLE("Unexpected binding location: ${binding.location}")
             }
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
+import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolPayloadGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBoundProtocolPayloadGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctions
@@ -31,16 +32,18 @@ import software.amazon.smithy.rust.codegen.core.util.outputShape
 class HttpBoundProtocolGenerator(
     codegenContext: ClientCodegenContext,
     protocol: Protocol,
+    bodyGenerator: ProtocolPayloadGenerator = HttpBoundProtocolPayloadGenerator(codegenContext, protocol),
 ) : ClientProtocolGenerator(
     codegenContext,
     protocol,
     MakeOperationGenerator(
         codegenContext,
         protocol,
-        HttpBoundProtocolPayloadGenerator(codegenContext, protocol),
+        bodyGenerator,
         public = true,
         includeDefaultPayloadHeaders = true,
     ),
+    bodyGenerator,
     HttpBoundProtocolTraitImplGenerator(codegenContext, protocol),
 )
 

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolTestGeneratorTest.kt
@@ -101,6 +101,7 @@ private class TestProtocolGenerator(
     codegenContext,
     protocol,
     TestProtocolMakeOperationGenerator(codegenContext, protocol, body, httpRequestBuilder),
+    TestProtocolPayloadGenerator(body),
     TestProtocolTraitImplGenerator(codegenContext, correctResponse),
 )
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/error.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/error.rs
@@ -189,24 +189,31 @@ impl InterceptorError {
             source: Some(source.into()),
         }
     }
-    /// Create a new error indicating that an interceptor tried to access the tx_request out of turn
+    /// Create a new error indicating that an interceptor tried to access the request out of turn
     pub fn invalid_request_access() -> Self {
         Self {
             kind: ErrorKind::InvalidRequestAccess,
             source: None,
         }
     }
-    /// Create a new error indicating that an interceptor tried to access the tx_response out of turn
+    /// Create a new error indicating that an interceptor tried to access the response out of turn
     pub fn invalid_response_access() -> Self {
         Self {
             kind: ErrorKind::InvalidResponseAccess,
             source: None,
         }
     }
-    /// Create a new error indicating that an interceptor tried to access the modeled_response out of turn
-    pub fn invalid_modeled_response_access() -> Self {
+    /// Create a new error indicating that an interceptor tried to access the input out of turn
+    pub fn invalid_input_access() -> Self {
         Self {
-            kind: ErrorKind::InvalidModeledResponseAccess,
+            kind: ErrorKind::InvalidInputAccess,
+            source: None,
+        }
+    }
+    /// Create a new error indicating that an interceptor tried to access the output out of turn
+    pub fn invalid_output_access() -> Self {
+        Self {
+            kind: ErrorKind::InvalidOutputAccess,
             source: None,
         }
     }
@@ -257,8 +264,10 @@ enum ErrorKind {
     InvalidRequestAccess,
     /// An interceptor tried to access the response out of turn
     InvalidResponseAccess,
-    /// An interceptor tried to access the modeled_response out of turn
-    InvalidModeledResponseAccess,
+    /// An interceptor tried to access the input out of turn
+    InvalidInputAccess,
+    /// An interceptor tried to access the output out of turn
+    InvalidOutputAccess,
 }
 
 impl fmt::Display for InterceptorError {
@@ -327,9 +336,13 @@ impl fmt::Display for InterceptorError {
             InvalidResponseAccess => {
                 write!(f, "tried to access response before transmitting a request")
             }
-            InvalidModeledResponseAccess => write!(
+            InvalidInputAccess => write!(
                 f,
-                "tried to access modeled_response before response deserialization"
+                "tried to access the input before response deserialization"
+            ),
+            InvalidOutputAccess => write!(
+                f,
+                "tried to access the output before response deserialization"
             ),
         }
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -22,11 +22,11 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 pub type BoxFallibleFut<T> = Pin<Box<dyn Future<Output = Result<T, BoxError>>>>;
 
 pub trait TraceProbe: Send + Sync + Debug {
-    fn dispatch_events(&self, cfg: &ConfigBag) -> BoxFallibleFut<()>;
+    fn dispatch_events(&self) -> BoxFallibleFut<()>;
 }
 
 pub trait RequestSerializer: Send + Sync + Debug {
-    fn serialize_input(&self, input: &Input, cfg: &ConfigBag) -> Result<HttpRequest, BoxError>;
+    fn serialize_input(&self, input: Input) -> Result<HttpRequest, BoxError>;
 }
 
 pub trait ResponseDeserializer: Send + Sync + Debug {
@@ -161,11 +161,7 @@ pub trait HttpRequestSigner: Send + Sync + Debug {
 }
 
 pub trait EndpointResolver: Send + Sync + Debug {
-    fn resolve_and_apply_endpoint(
-        &self,
-        request: &mut HttpRequest,
-        cfg: &ConfigBag,
-    ) -> Result<(), BoxError>;
+    fn resolve_and_apply_endpoint(&self, request: &mut HttpRequest) -> Result<(), BoxError>;
 }
 
 pub trait ConfigBagAccessors {

--- a/rust-runtime/aws-smithy-runtime-api/src/type_erasure.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/type_erasure.rs
@@ -76,6 +76,33 @@ impl<T: 'static> DerefMut for TypedBox<T> {
     }
 }
 
+#[derive(Debug)]
+pub struct TypedRef<'a, T> {
+    inner: &'a TypeErasedBox,
+    _phantom: PhantomData<T>,
+}
+
+impl<'a, T: 'static> TypedRef<'a, T> {
+    pub fn assume_from(type_erased: &'a TypeErasedBox) -> Option<TypedRef<'a, T>> {
+        if type_erased.downcast_ref::<T>().is_some() {
+            Some(TypedRef {
+                inner: type_erased,
+                _phantom: Default::default(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T: 'static> Deref for TypedRef<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner.downcast_ref().expect("type checked")
+    }
+}
+
 /// A new-type around `Box<dyn Any + Send + Sync>`
 #[derive(Debug)]
 pub struct TypeErasedBox {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -39,7 +39,8 @@ pub async fn invoke(
         // Serialization
         .include_mut(|ctx| {
             let request_serializer = cfg.request_serializer();
-            let request = request_serializer.serialize_input(ctx.input(), cfg)?;
+            let request = request_serializer
+                .serialize_input(ctx.take_input().expect("input set at this point"))?;
             ctx.set_request(request);
             Result::<(), BoxError>::Ok(())
         })?
@@ -83,7 +84,7 @@ pub async fn invoke(
         let handling_phase = Phase::response_handling(context)
             .include_mut(|ctx| interceptors.modify_before_completion(ctx, cfg))?;
         let trace_probe = cfg.trace_probe();
-        trace_probe.dispatch_events(cfg);
+        trace_probe.dispatch_events();
 
         break handling_phase.include(|ctx| interceptors.read_after_execution(ctx, cfg))?;
     };
@@ -105,7 +106,7 @@ async fn make_an_attempt(
             let request = ctx.request_mut().expect("request has been set");
 
             let endpoint_resolver = cfg.endpoint_resolver();
-            endpoint_resolver.resolve_and_apply_endpoint(request, cfg)
+            endpoint_resolver.resolve_and_apply_endpoint(request)
         })?
         .include_mut(|ctx| interceptors.modify_before_signing(ctx, cfg))?
         .include(|ctx| interceptors.read_before_signing(ctx, cfg))?;


### PR DESCRIPTION
## Motivation and Context
This PR adds `RequestSerializer` codegen behind the `enableSmithyRuntime` feature flag, and also cleans up the `RequestDeserializer` codegen logic.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
