### PR TITLE
Make AppName configurable from within ConfigLoader

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -52,3 +52,9 @@ message = "The `enableNewCrateOrganizationScheme` codegen flag has been removed.
 references = ["smithy-rs#2507"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Make AppName configurable from within `ConfigLoader`."
+references = ["smithy-rs#2513"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "ysaito1001"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -54,7 +54,7 @@ meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" 
 author = "jdisanti"
 
 [[aws-sdk-rust]]
-message = "Make AppName configurable from within `ConfigLoader`."
+message = "`AppName` is now configurable from within `ConfigLoader`."
 references = ["smithy-rs#2513"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "ysaito1001"

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -56,5 +56,5 @@ author = "jdisanti"
 [[aws-sdk-rust]]
 message = "`AppName` is now configurable from within `ConfigLoader`."
 references = ["smithy-rs#2513"]
-meta = { "breaking" = false, "tada" = false, "bug" = false }
+meta = { "breaking" = false, "tada" = false, "bug" = true }
 author = "ysaito1001"

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -345,6 +345,7 @@ mod loader {
         }
 
         /// Override the name of the app used to build [`SdkConfig`](aws_types::SdkConfig).
+        ///
         /// This _optional_ name is used to identify the application in the user agent that
         /// gets sent along with requests.
         ///

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -344,6 +344,24 @@ mod loader {
             self
         }
 
+        /// Override the name of the app used to build [`SdkConfig`](aws_types::SdkConfig).
+        /// This _optional_ name is used to identify the application in the user agent that
+        /// gets sent along with requests.
+        ///
+        /// # Examples
+        /// ```no_run
+        /// # async fn create_config() {
+        /// use aws_config::AppName;
+        /// let config = aws_config::from_env()
+        ///     .app_name(AppName::new("my-app-name").expect("valid app name"))
+        ///     .load().await;
+        /// # }
+        /// ```
+        pub fn app_name(mut self, app_name: AppName) -> Self {
+            self.app_name = Some(app_name);
+            self
+        }
+
         /// Provides the ability to programmatically override the profile files that get loaded by the SDK.
         ///
         /// The [`Default`] for `ProfileFiles` includes the default SDK config and credential files located in
@@ -628,9 +646,10 @@ mod loader {
                 )
                 .load()
                 .await;
-            assert_eq!(loader.retry_config().unwrap().max_attempts(), 10);
-            assert_eq!(loader.region().unwrap().as_ref(), "us-west-4");
+            assert_eq!(10, loader.retry_config().unwrap().max_attempts());
+            assert_eq!("us-west-4", loader.region().unwrap().as_ref());
             assert_eq!(
+                "akid",
                 loader
                     .credentials_provider()
                     .unwrap()
@@ -638,9 +657,8 @@ mod loader {
                     .await
                     .unwrap()
                     .access_key_id(),
-                "akid"
             );
-            assert_eq!(loader.app_name(), Some(&AppName::new("correct").unwrap()));
+            assert_eq!(Some(&AppName::new("correct").unwrap()), loader.app_name());
             logs_assert(|lines| {
                 let num_config_loader_logs = lines
                     .iter()
@@ -669,16 +687,23 @@ mod loader {
         #[tokio::test]
         async fn load_fips() {
             let conf = base_conf().use_fips(true).load().await;
-            assert_eq!(conf.use_fips(), Some(true));
+            assert_eq!(Some(true), conf.use_fips());
         }
 
         #[tokio::test]
         async fn load_dual_stack() {
             let conf = base_conf().use_dual_stack(false).load().await;
-            assert_eq!(conf.use_dual_stack(), Some(false));
+            assert_eq!(Some(false), conf.use_dual_stack());
 
             let conf = base_conf().load().await;
-            assert_eq!(conf.use_dual_stack(), None);
+            assert_eq!(None, conf.use_dual_stack());
+        }
+
+        #[tokio::test]
+        async fn app_name() {
+            let app_name = AppName::new("my-app-name").unwrap();
+            let conf = base_conf().app_name(app_name.clone()).load().await;
+            assert_eq!(Some(&app_name), conf.app_name());
         }
     }
 }

--- a/aws/rust-runtime/aws-types/src/app_name.rs
+++ b/aws/rust-runtime/aws-types/src/app_name.rs
@@ -46,6 +46,9 @@ impl AppName {
     pub fn new(app_name: impl Into<Cow<'static, str>>) -> Result<Self, InvalidAppName> {
         let app_name = app_name.into();
 
+        if app_name.is_empty() {
+            return Err(InvalidAppName);
+        }
         fn valid_character(c: char) -> bool {
             match c {
                 _ if c.is_ascii_alphanumeric() => true,
@@ -105,6 +108,7 @@ mod tests {
         assert!(AppName::new("asdf1234ASDF!#$%&'*+-.^_`|~").is_ok());
         assert!(AppName::new("foo bar").is_err());
         assert!(AppName::new("🚀").is_err());
+        assert!(AppName::new("").is_err());
     }
 
     #[tracing_test::traced_test]


### PR DESCRIPTION
## Motivation and Context
Fixes https://github.com/awslabs/smithy-rs/issues/2511

## Description
This small PR adds a setter for `app_name` in `ConfigLoader`. Prior to the commit, in a typical config chain of `ConfigLoader` -> `SdkConfig` -> service config, the field was only settable from `SdkConfig` onward.

## Testing
- [x] Added unit test
- [x] Passed tests in CI  

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
