### PR TITLE
runtime: add a method `into_segments` to `AggregatedBytes`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -74,3 +74,9 @@ message = "Add support for omitting session token in canonical requests for SigV
 references = ["smithy-rs#2473"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 author = "martinjlowm"
+
+[[aws-sdk-rust]]
+message = "Add `into_segments` method to `AggregatedBytes`, for zero-copy conversions."
+references = ["smithy-rs#2525"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "parker-timmerman"

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -477,6 +477,11 @@ impl AggregatedBytes {
         self.0.copy_to_bytes(self.0.remaining())
     }
 
+    /// Convert this buffer into an [`Iterator`] of underlying non-contiguous segments of [`Bytes`]
+    pub fn into_segments(self) -> impl Iterator<Item = Bytes> {
+        self.0.into_inner().into_iter()
+    }
+
     /// Convert this buffer into a `Vec<u8>`
     pub fn to_vec(self) -> Vec<u8> {
         self.0


### PR DESCRIPTION
## Motivation and Context
This change makes the `AggregatedBytes` type a bit more flexible, by allowing you to convert an `AggregatedBytes` to your own type, without needing to copy any data. This is very useful if you have your own internal non-contiguous data types that you need to convert to. But it doesn't necessarily leak implementation details of `AggregatedBytes` by using an `Iterator` for the return type.

## Description
Add a method called `into_segments(self) -> impl Iterator<Item = Bytes>` to `AggregatedBytes`.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
