### PR TITLE
Use `aws_smithy_types::primitive::Parse` in the server

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -1124,17 +1124,13 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                         check(target is NumberShape || target is BooleanShape)
                         rustTemplate(
                             """
-                            let value = std::str::FromStr::from_str(value)?;
+                            let value = <_ as #{PrimitiveParse}>::parse_smithy_primitive(value)?;
                             """,
-                            *codegenScope,
+                            "PrimitiveParse" to RuntimeType.smithyTypes(runtimeConfig).resolve("primitive::Parse"),
                         )
                     }
                 }
-                rust(
-                    """
-                    Ok(${symbolProvider.wrapOptional(binding.member, "value")})
-                    """,
-                )
+                rust("Ok(${symbolProvider.wrapOptional(binding.member, "value")})")
             }
         }
     }

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_json_1/rejection.rs
@@ -141,14 +141,6 @@ pub enum RequestRejection {
     /// into "primitive" types.
     PrimitiveParse(crate::Error),
 
-    // The following three variants are used when failing to deserialize strings from a URL query
-    // string and URI path labels into "primitive" types.
-    // TODO(https://github.com/awslabs/smithy-rs/issues/1232): They should be removed and
-    // conflated into the `PrimitiveParse` variant above after this issue is resolved.
-    IntParse(crate::Error),
-    FloatParse(crate::Error),
-    BoolParse(crate::Error),
-
     /// Used when consuming the input struct builder, and constraint violations occur.
     // Unlike the rejections above, this does not take in `crate::Error`, since it is constructed
     // directly in the code-generated SDK instead of in this crate.
@@ -192,9 +184,6 @@ convert_to_request_rejection!(aws_smithy_json::deserialize::error::DeserializeEr
 convert_to_request_rejection!(aws_smithy_http::header::ParseError, HeaderParse);
 convert_to_request_rejection!(aws_smithy_types::date_time::DateTimeParseError, DateTimeParse);
 convert_to_request_rejection!(aws_smithy_types::primitive::PrimitiveParseError, PrimitiveParse);
-convert_to_request_rejection!(std::str::ParseBoolError, BoolParse);
-convert_to_request_rejection!(std::num::ParseFloatError, FloatParse);
-convert_to_request_rejection!(std::num::ParseIntError, IntParse);
 convert_to_request_rejection!(serde_urlencoded::de::Error, InvalidUtf8);
 
 impl From<nom::Err<nom::error::Error<&str>>> for RequestRejection {

--- a/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/rejection.rs
+++ b/rust-runtime/aws-smithy-http-server/src/proto/rest_xml/rejection.rs
@@ -44,10 +44,6 @@ pub enum RequestRejection {
 
     PrimitiveParse(crate::Error),
 
-    IntParse(crate::Error),
-    FloatParse(crate::Error),
-    BoolParse(crate::Error),
-
     ConstraintViolation(String),
 }
 
@@ -81,9 +77,6 @@ convert_to_request_rejection!(aws_smithy_xml::decode::XmlDecodeError, XmlDeseria
 convert_to_request_rejection!(aws_smithy_http::header::ParseError, HeaderParse);
 convert_to_request_rejection!(aws_smithy_types::date_time::DateTimeParseError, DateTimeParse);
 convert_to_request_rejection!(aws_smithy_types::primitive::PrimitiveParseError, PrimitiveParse);
-convert_to_request_rejection!(std::str::ParseBoolError, BoolParse);
-convert_to_request_rejection!(std::num::ParseFloatError, FloatParse);
-convert_to_request_rejection!(std::num::ParseIntError, IntParse);
 convert_to_request_rejection!(serde_urlencoded::de::Error, InvalidUtf8);
 
 impl From<nom::Err<nom::error::Error<&str>>> for RequestRejection {


### PR DESCRIPTION
This further reduces the number of request rejection variants.
https://docs.rs/aws-smithy-types/latest/aws_smithy_types/primitive/trait.Parse.html

Closes #1232.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
