### PR TITLE
Exclude examples from the workspace in `aws-sdk-rust`

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -5,7 +5,6 @@
 
 import aws.sdk.AwsServices
 import aws.sdk.Membership
-import aws.sdk.RootTest
 import aws.sdk.discoverServices
 import aws.sdk.docsLandingPage
 import aws.sdk.parseMembership
@@ -302,9 +301,9 @@ tasks.register<Copy>("relocateChangelog") {
 fun generateCargoWorkspace(services: AwsServices): String {
     return """
     |[workspace]
-    |exclude = [${"\n"}${services.rootTests.map(RootTest::manifestName).joinToString(",\n") { "|    \"$it\"" }}
+    |exclude = [${"\n"}${services.excludedFromWorkspace().joinToString(",\n") { "|    \"$it\"" }}
     |]
-    |members = [${"\n"}${services.allModules.joinToString(",\n") { "|    \"$it\"" }}
+    |members = [${"\n"}${services.includedInWorkspace().joinToString(",\n") { "|    \"$it\"" }}
     |]
     """.trimMargin()
 }

--- a/buildSrc/src/main/kotlin/aws/sdk/ServiceLoader.kt
+++ b/buildSrc/src/main/kotlin/aws/sdk/ServiceLoader.kt
@@ -36,10 +36,10 @@ class AwsServices(
         (
             services.map(AwsService::module).map { "sdk/$it" } +
                 CrateSet.AWS_SDK_SMITHY_RUNTIME.map { "sdk/$it" } +
-                CrateSet.AWS_SDK_RUNTIME.map { "sdk/$it" } +
-                examples
+                CrateSet.AWS_SDK_RUNTIME.map { "sdk/$it" }
             // Root tests should not be included since they can't be part of the root Cargo workspace
-            // in order to test differences in Cargo features.
+            // in order to test differences in Cargo features. Examples should not be included either
+            // because each example itself is a workspace.
             ).toSortedSet()
     }
 
@@ -78,6 +78,16 @@ class AwsServices(
                 false
             }
         }
+
+    /**
+     * Returns a sorted set of members included in the workspace.
+     */
+    fun includedInWorkspace() = allModules
+
+    /**
+     * Returns a list of crates excluded from the workspace.
+     */
+    fun excludedFromWorkspace() = examples + rootTests.map(RootTest::manifestName)
 }
 
 /**


### PR DESCRIPTION
## Motivation and Context
This commit automates the fix made in https://github.com/awslabs/aws-sdk-rust/pull/767.

## Description
In `aws-sdk-rust/examples`, each example is now its own workspace ([example](https://github.com/awslabs/aws-sdk-rust/blob/main/examples/apigateway/Cargo.toml#L8)). We therefore need to exclude them from the workspace specified in the top-level `Cargo.toml`. 

## Testing
Manually generated `aws/sdk/examples/s3` (with empty `Cargo.toml` and `src/main.rs` there) and triggered `./gradlew :aws:sdk:assemble` from the root of `smithy-rs`. Confirmed that `examples/s3` only appears in the `exclude` section in `aws/sdk/build/aws-sdk/Cargo.toml`:
```
[workspace]
exclude = [
    "examples/s3",
    "tests/no-default-features",
    "tests/using-native-tls-instead-of-rustls",
    "tests/webassembly"
]
```

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
