### PR TITLE
Check the validity of the top-level Cargo.toml in aws-sdk-rust

### DIFF
--- a/tools/ci-scripts/check-aws-sdk-services
+++ b/tools/ci-scripts/check-aws-sdk-services
@@ -7,9 +7,8 @@
 set -eux
 cd aws-sdk
 
-# Remove examples from workspace
-sed -i '/"examples\//d' Cargo.toml
-
+# Invoking `cargo test` at the root directory implicitly checks for the validity
+# of the top-level `Cargo.toml`
 cargo test --all-features
 
 for test_dir in tests/*; do


### PR DESCRIPTION
## Motivation and Context
During the latest release of `aws-sdk-rust`, we found that the top-level `Cargo.toml` was broken. Specifically, the top-level `Cargo.toml` included examples as members in the workspace
```
[workspace]
members = [
    "examples/apigateway",
    "examples/apigatewaymanagement",
   ...
]
```
but that collided with the fact each of those example itself was also a workspace, .e.g.
```
[package]
name = "apigateway-code-examples"
version = "0.1.0"
edition = "2021"
publish = false

[workspace]
...
```
leading to `error: multiple workspace roots found in the same workspace`. The fix for this problem has been addressed in https://github.com/awslabs/smithy-rs/pull/2535. This PR is about adding to CI a check for the validity of the top-level `Cargo.toml` in `aws-rust-sdk` so we can detect problems earlier.

## Description
The way we "add" such a check is to re-purpose an existing script `tools/ci-scripts/check-aws-sdk-services`. The script previously used `sed` to remove the examples from the top-level `Cargo.toml` right before it invoked `cargo test` at the root directory of `aws-sdk-rust`. It now stops using the `sed` command and `examples` will stay in the top-level `Cargo.toml`. Invoking `cargo test` at the root directory then automatically checks for the validity of the top-level `Cargo.toml`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
