### PR TITLE
Cherry-pick fix for excluding examples from the workspace

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -5,7 +5,6 @@
 
 import aws.sdk.AwsServices
 import aws.sdk.Membership
-import aws.sdk.RootTest
 import aws.sdk.discoverServices
 import aws.sdk.docsLandingPage
 import aws.sdk.parseMembership
@@ -299,9 +298,9 @@ tasks.register<Copy>("relocateChangelog") {
 fun generateCargoWorkspace(services: AwsServices): String {
     return """
     |[workspace]
-    |exclude = [${"\n"}${services.rootTests.map(RootTest::manifestName).joinToString(",\n") { "|    \"$it\"" }}
+    |exclude = [${"\n"}${services.excludedFromWorkspace().joinToString(",\n") { "|    \"$it\"" }}
     |]
-    |members = [${"\n"}${services.allModules.joinToString(",\n") { "|    \"$it\"" }}
+    |members = [${"\n"}${services.includedInWorkspace().joinToString(",\n") { "|    \"$it\"" }}
     |]
     """.trimMargin()
 }

--- a/buildSrc/src/main/kotlin/aws/sdk/ServiceLoader.kt
+++ b/buildSrc/src/main/kotlin/aws/sdk/ServiceLoader.kt
@@ -36,10 +36,10 @@ class AwsServices(
         (
             services.map(AwsService::module).map { "sdk/$it" } +
                 CrateSet.AWS_SDK_SMITHY_RUNTIME.map { "sdk/$it" } +
-                CrateSet.AWS_SDK_RUNTIME.map { "sdk/$it" } +
-                examples
+                CrateSet.AWS_SDK_RUNTIME.map { "sdk/$it" }
             // Root tests should not be included since they can't be part of the root Cargo workspace
-            // in order to test differences in Cargo features.
+            // in order to test differences in Cargo features. Examples should not be included either
+            // because each example itself is a workspace.
             ).toSortedSet()
     }
 
@@ -78,6 +78,16 @@ class AwsServices(
                 false
             }
         }
+
+    /**
+     * Returns a sorted set of members included in the workspace.
+     */
+    fun includedInWorkspace() = allModules
+
+    /**
+     * Returns a list of crates excluded from the workspace.
+     */
+    fun excludedFromWorkspace() = examples + rootTests.map(RootTest::manifestName)
 }
 
 /**


### PR DESCRIPTION
This PR cherry-picks from the main branch the [fix](https://github.com/awslabs/smithy-rs/pull/2535) for excluding examples from the top-level `Cargo.toml`. This helps keep this feature branch safe from a CI failure caused by the broken top-level `Cargo.toml`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
