### PR TITLE
Make a minor optimization to `AuthOptionResolver`

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth/option_resolver.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth/option_resolver.rs
@@ -6,6 +6,7 @@
 use crate::client::orchestrator::{
     AuthOptionResolver, AuthOptionResolverParams, BoxError, HttpAuthOption,
 };
+use std::borrow::Cow;
 
 /// New-type around a `Vec<HttpAuthOption>` that implements `AuthOptionResolver`.
 ///
@@ -23,11 +24,11 @@ impl AuthOptionListResolver {
 }
 
 impl AuthOptionResolver for AuthOptionListResolver {
-    fn resolve_auth_options(
-        &self,
+    fn resolve_auth_options<'a>(
+        &'a self,
         _params: &AuthOptionResolverParams,
-    ) -> Result<Vec<HttpAuthOption>, BoxError> {
-        Ok(self.auth_options.clone())
+    ) -> Result<Cow<'a, [HttpAuthOption]>, BoxError> {
+        Ok(Cow::Borrowed(&self.auth_options))
     }
 }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -11,6 +11,7 @@ use crate::type_erasure::{TypeErasedBox, TypedBox};
 use aws_smithy_http::body::SdkBody;
 use aws_smithy_http::property_bag::PropertyBag;
 use std::any::Any;
+use std::borrow::Cow;
 use std::fmt::Debug;
 use std::future::Future;
 use std::pin::Pin;
@@ -72,17 +73,17 @@ impl AuthOptionResolverParams {
 }
 
 pub trait AuthOptionResolver: Send + Sync + Debug {
-    fn resolve_auth_options(
-        &self,
+    fn resolve_auth_options<'a>(
+        &'a self,
         params: &AuthOptionResolverParams,
-    ) -> Result<Vec<HttpAuthOption>, BoxError>;
+    ) -> Result<Cow<'a, [HttpAuthOption]>, BoxError>;
 }
 
 impl AuthOptionResolver for Box<dyn AuthOptionResolver> {
-    fn resolve_auth_options(
-        &self,
+    fn resolve_auth_options<'a>(
+        &'a self,
         params: &AuthOptionResolverParams,
-    ) -> Result<Vec<HttpAuthOption>, BoxError> {
+    ) -> Result<Cow<'a, [HttpAuthOption]>, BoxError> {
         (**self).resolve_auth_options(params)
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -24,7 +24,7 @@ pub(super) async fn orchestrate_auth(
         .map_err(construction_failure)?;
     let identity_resolvers = cfg.identity_resolvers();
 
-    for option in auth_options {
+    for option in auth_options.as_ref() {
         let scheme_id = option.scheme_id();
         let scheme_properties = option.properties();
         if let Some(auth_scheme) = cfg.http_auth_schemes().scheme(scheme_id) {


### PR DESCRIPTION
## Motivation and Context
Most generated clients will have a static list of auth options, so it makes sense to have this trait return a `Cow` to avoid allocating an additional `Vec` for every request.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
