### PR TITLE
Fix the `HttpSigner` trait args

### DIFF
--- a/aws/rust-runtime/aws-runtime/src/auth.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth.rs
@@ -11,12 +11,12 @@ pub mod sigv4 {
         SignableRequest, SignatureLocation, SigningParams, SigningSettings,
         UriPathNormalizationMode,
     };
+    use aws_smithy_http::property_bag::PropertyBag;
     use aws_smithy_runtime_api::client::identity::Identity;
     use aws_smithy_runtime_api::client::orchestrator::{
         BoxError, HttpAuthScheme, HttpRequest, HttpRequestSigner, IdentityResolver,
         IdentityResolvers,
     };
-    use aws_smithy_runtime_api::config_bag::ConfigBag;
     use aws_types::region::SigningRegion;
     use aws_types::SigningService;
     use std::time::{Duration, SystemTime};
@@ -197,9 +197,9 @@ pub mod sigv4 {
             &self,
             request: &mut HttpRequest,
             identity: &Identity,
-            cfg: &ConfigBag,
+            signing_properties: &PropertyBag,
         ) -> Result<(), BoxError> {
-            let operation_config = cfg
+            let operation_config = signing_properties
                 .get::<SigV4OperationSigningConfig>()
                 .ok_or("missing operation signing config for SigV4")?;
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -174,7 +174,7 @@ pub trait HttpRequestSigner: Send + Sync + Debug {
         &self,
         request: &mut HttpRequest,
         identity: &Identity,
-        cfg: &ConfigBag,
+        signing_properties: &PropertyBag,
     ) -> Result<(), BoxError>;
 }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -44,7 +44,7 @@ pub(super) async fn orchestrate_auth(
                 .map_err(construction_failure)?;
             return dispatch_phase.include_mut(|ctx| {
                 let request = ctx.request_mut()?;
-                request_signer.sign_request(request, &identity, cfg)?;
+                request_signer.sign_request(request, &identity, scheme_properties)?;
                 Result::<_, BoxError>::Ok(())
             });
         }


### PR DESCRIPTION
## Motivation and Context
This trait should have been taking a `PropertyBag` that originates from `HttpAuthOption` rather than the `ConfigBag`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
