### PR TITLE
Implement `StdError::source()` for Error enum

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -12,6 +12,18 @@
 # author = "rcoh"
 
 [[aws-sdk-rust]]
+message = "Implement std::error::Error#source() properly for the service meta Error enum"
+references = ["aws-sdk-rust#784"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "abusch"
+
+[[smithy-rs]]
+message = "Implement std::error::Error#source() properly for the service meta Error enum"
+references = ["aws-sdk-rust#784"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+author = "abusch"
+
+[[aws-sdk-rust]]
 message = "The outputs for event stream operations (for example, S3's SelectObjectContent) now implement the `Sync` auto-trait."
 references = ["smithy-rs#2496"]
 meta = { "breaking" = false, "tada" = false, "bug" = true }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/error/ServiceErrorGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/error/ServiceErrorGeneratorTest.kt
@@ -16,39 +16,38 @@ import software.amazon.smithy.rust.codegen.core.util.lookup
 
 internal class ServiceErrorGeneratorTest {
     private val model = """
-            namespace com.example
+        namespace com.example
 
-            use aws.protocols#restJson1
+        use aws.protocols#restJson1
 
-            @restJson1
-            service HelloService {
-                operations: [SayHello],
-                version: "1"
-            }
+        @restJson1
+        service HelloService {
+            operations: [SayHello],
+            version: "1"
+        }
 
-            @http(uri: "/", method: "POST")
-            operation SayHello {
-                input: EmptyStruct,
-                output: EmptyStruct,
-                errors: [SorryBusy, CanYouRepeatThat, MeDeprecated]
-            }
+        @http(uri: "/", method: "POST")
+        operation SayHello {
+            input: EmptyStruct,
+            output: EmptyStruct,
+            errors: [SorryBusy, CanYouRepeatThat, MeDeprecated]
+        }
 
-            structure EmptyStruct { }
+        structure EmptyStruct { }
 
-            @error("server")
-            structure SorryBusy { }
+        @error("server")
+        structure SorryBusy { }
 
-            @error("client")
-            structure CanYouRepeatThat { }
+        @error("client")
+        structure CanYouRepeatThat { }
 
-            @error("client")
-            @deprecated
-            structure MeDeprecated { }
-        """.asSmithyModel()
+        @error("client")
+        @deprecated
+        structure MeDeprecated { }
+    """.asSmithyModel()
 
     @Test
     fun `top level errors are send + sync`() {
-
         clientIntegrationTest(model) { codegenContext, rustCrate ->
             rustCrate.integrationTest("validate_errors") {
                 rust(


### PR DESCRIPTION
## Motivation and Context
This is an attempt at fixing https://github.com/awslabs/aws-sdk-rust/issues/784.

The service-level `Error` enum implements `std::error::Error` but does not implement its `source()` method. This means that an error library like `anyhow` or `eyre` won't be able to display the root cause of an error, which is especially problematic for the `Unhandled` variant.

## Description
I modified `ServiceErrorGenerator` in the `codegen-client` crate and replaced the line that output `impl std::error::Error for Error {}` with an impl block that implements the `source()` method by delegating to the inner error structure.

## Testing
I've added a simple unit test to `ServiceErrorGeneratorTest`.

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
