### PR TITLE
Execute Python's diff commands inside correct directory

### DIFF
--- a/tools/ci-scripts/codegen-diff/codegen-diff-revisions.py
+++ b/tools/ci-scripts/codegen-diff/codegen-diff-revisions.py
@@ -20,7 +20,7 @@ from diff_lib import eprint, run, get_cmd_status, get_cmd_output, generate_and_c
 #
 # ```
 # $ cd test/smithy-rs
-# $ ../../smithy-rs/tools/ci-scripts/codegen-diff-revisions.py . <some commit hash to diff against>
+# $ ../../smithy-rs/tools/ci-scripts/codegen-diff/codegen-diff-revisions.py . <some commit hash to diff against>
 # ```
 #
 # It will diff the generated code from HEAD against any commit hash you feed it. If you want to test

--- a/tools/ci-scripts/codegen-diff/diff_lib.py
+++ b/tools/ci-scripts/codegen-diff/diff_lib.py
@@ -15,6 +15,8 @@ COMMIT_AUTHOR_EMAIL = "generated-code-action@github.com"
 
 CDN_URL = "https://d2luzm2xt3nokh.cloudfront.net"
 
+PYTHON_EXAMPLES_PATH = "rust-runtime/aws-smithy-http-server-python/examples"
+
 target_codegen_client = 'codegen-client-test'
 target_codegen_server = 'codegen-server-test'
 target_aws_sdk = 'aws:sdk'
@@ -40,14 +42,14 @@ def generate_and_commit_generated_code(revision_sha, targets=None):
     # Clean the build artifacts before continuing
     get_cmd_output("rm -rf aws/sdk/build")
     if target_codegen_server in targets:
-        get_cmd_output("cd rust-runtime/aws-smithy-http-server-python/examples && make distclean", shell=True)
+        get_cmd_output("make distclean", shell=True, cwd=PYTHON_EXAMPLES_PATH)
     get_cmd_output("./gradlew codegen-core:clean codegen-client:clean codegen-server:clean aws:sdk-codegen:clean")
 
     # Generate code
     tasks = ' '.join([f'{t}:assemble' for t in targets])
     get_cmd_output(f"./gradlew --rerun-tasks {tasks}")
     if target_codegen_server in targets:
-        get_cmd_output("cd rust-runtime/aws-smithy-http-server-python/examples && make build", shell=True, check=False)
+        get_cmd_output("make build", shell=True, check=False, cwd=PYTHON_EXAMPLES_PATH)
         get_cmd_output(f"./gradlew --rerun-tasks codegen-server-test:typescript:assemble")
 
     # Move generated code into codegen-diff/ directory
@@ -60,7 +62,7 @@ def generate_and_commit_generated_code(revision_sha, targets=None):
             get_cmd_output(f"mv {target}/build/smithyprojections/{target} {OUTPUT_PATH}/")
             if target == target_codegen_server:
                 get_cmd_output(
-                    f"mv rust-runtime/aws-smithy-http-server-python/examples/pokemon-service-server-sdk/ {OUTPUT_PATH}/codegen-server-test-python/",
+                    f"mv {PYTHON_EXAMPLES_PATH}/pokemon-service-server-sdk/ {OUTPUT_PATH}/codegen-server-test-python/",
                     check=False)
                 get_cmd_output(
                     f"mv codegen-server-test/typescript/build/smithyprojections/codegen-server-test-typescript {OUTPUT_PATH}/",


### PR DESCRIPTION
## Motivation and Context
Fixes codegen diff for Python

## Testing
I've tested the change locally and I was able to see correct diff generated.
```bash
# A commit before Event Streaming for Python PR is merged
$ ../smithy-rs/tools/ci-scripts/codegen-diff/codegen-diff-revisions.py . 33b24bb7f31d269ee9256f867bd66c01b3f2b347 
# I was able to see correct diff related to Event Streaming changes
$ ls tmp-codegen-diff/33b24bb7f31d269ee9256f867bd66c01b3f2b347/1e27efe05fe7b991c9f9bbf3d63a297b2dded334/server-test-python/
index.html  index_page_1.html  index_page_2.html
```

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
