### PR TITLE
Add skeleton for supporting operation level config

### DIFF
--- a/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
@@ -59,6 +59,7 @@ async fn sra_test() {
     let _ = dbg!(
         client
             .list_objects_v2()
+            .config_override(aws_sdk_s3::Config::builder().force_path_style(false))
             .bucket("test-bucket")
             .prefix("prefix~")
             .send_v2()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceGenerator.kt
@@ -40,14 +40,17 @@ class ServiceGenerator(
         ).render(rustCrate)
 
         rustCrate.withModule(ClientRustModule.Config) {
-            ServiceConfigGenerator.withBaseBehavior(
+            val serviceConfigGenerator = ServiceConfigGenerator.withBaseBehavior(
                 codegenContext,
                 extraCustomizations = decorator.configCustomizations(codegenContext, listOf()),
-            ).render(this)
+            )
+            serviceConfigGenerator.render(this)
 
             if (codegenContext.settings.codegenConfig.enableNewSmithyRuntime) {
                 ServiceRuntimePluginGenerator(codegenContext)
                     .render(this, decorator.serviceRuntimePluginCustomizations(codegenContext, emptyList()))
+
+                serviceConfigGenerator.renderRuntimePluginImplForBuilder(this, codegenContext)
             }
         }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -400,7 +400,7 @@ class FluentClientGenerator(
                     /// Sets the `config_override` for the builder.
                     ///
                     /// `config_override` is applied to the operation configuration level.
-                    /// For the fields in the builder that are not `None, they override those applied to the service
+                    /// The fields in the builder that are `Some` override those applied to the service
                     /// configuration level.
                     pub fn set_config_override(
                         &mut self,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -388,7 +388,7 @@ class FluentClientGenerator(
                     ///
                     /// `config_override` is applied to the operation configuration level.
                     /// The fields in the builder that are `Some` override those applied to the service
-                    /// configuration level or the AWS configuration level.
+                    /// configuration level.
                     pub fn config_override(
                         mut self,
                         config_override: impl Into<crate::config::Builder>,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -33,10 +33,12 @@ import software.amazon.smithy.rust.codegen.core.rustlang.escape
 import software.amazon.smithy.rust.codegen.core.rustlang.normalizeHtml
 import software.amazon.smithy.rust.codegen.core.rustlang.qualifiedName
 import software.amazon.smithy.rust.codegen.core.rustlang.render
+import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTypeParameters
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
@@ -60,11 +62,13 @@ class FluentClientGenerator(
         client = RuntimeType.smithyClient(codegenContext.runtimeConfig),
     ),
     private val customizations: List<FluentClientCustomization> = emptyList(),
-    private val retryClassifier: RuntimeType = RuntimeType.smithyHttp(codegenContext.runtimeConfig).resolve("retry::DefaultResponseRetryClassifier"),
+    private val retryClassifier: RuntimeType = RuntimeType.smithyHttp(codegenContext.runtimeConfig)
+        .resolve("retry::DefaultResponseRetryClassifier"),
 ) {
     companion object {
         fun clientOperationFnName(operationShape: OperationShape, symbolProvider: RustSymbolProvider): String =
             RustReservedWords.escapeIfNeeded(symbolProvider.toSymbol(operationShape).name.toSnakeCase())
+
         fun clientOperationModuleName(operationShape: OperationShape, symbolProvider: RustSymbolProvider): String =
             RustReservedWords.escapeIfNeeded(
                 symbolProvider.toSymbol(operationShape).name.toSnakeCase(),
@@ -79,6 +83,7 @@ class FluentClientGenerator(
     private val model = codegenContext.model
     private val runtimeConfig = codegenContext.runtimeConfig
     private val core = FluentClientCore(model)
+    private val enableNewSmithyRuntime = codegenContext.settings.codegenConfig.enableNewSmithyRuntime
 
     fun render(crate: RustCrate) {
         renderFluentClient(crate)
@@ -242,18 +247,23 @@ class FluentClientGenerator(
         documentShape(operation, model, autoSuppressMissingDocs = false)
         deprecatedShape(operation)
         Attribute(derive(derives.toSet())).render(this)
-        rustTemplate(
-            """
-            pub struct $builderName#{generics:W} {
-                handle: std::sync::Arc<crate::client::Handle${generics.inst}>,
-                inner: #{Inner}
-            }
-            """,
-            "Inner" to symbolProvider.symbolForBuilder(input),
-            "client" to RuntimeType.smithyClient(runtimeConfig),
+        withBlockTemplate(
+            "pub struct $builderName#{generics:W} {",
+            "}",
             "generics" to generics.decl,
-            "operation" to operationSymbol,
-        )
+        ) {
+            rustTemplate(
+                """
+                handle: std::sync::Arc<crate::client::Handle${generics.inst}>,
+                inner: #{Inner},
+                """,
+                "Inner" to symbolProvider.symbolForBuilder(input),
+                "generics" to generics.decl,
+            )
+            if (enableNewSmithyRuntime) {
+                rust("config_override: std::option::Option<crate::config::Builder>,")
+            }
+        }
 
         rustBlockTemplate(
             "impl${generics.inst} $builderName${generics.inst} #{bounds:W}",
@@ -264,13 +274,24 @@ class FluentClientGenerator(
             val errorType = symbolProvider.symbolForOperationError(operation)
 
             // Have to use fully-qualified result here or else it could conflict with an op named Result
+            rust("/// Creates a new `${operationSymbol.name}`.")
+            withBlockTemplate(
+                "pub(crate) fn new(handle: std::sync::Arc<crate::client::Handle${generics.inst}>) -> Self {",
+                "}",
+                "generics" to generics.decl,
+            ) {
+                withBlockTemplate(
+                    "Self {",
+                    "}",
+                ) {
+                    rust("handle, inner: Default::default(),")
+                    if (enableNewSmithyRuntime) {
+                        rust("config_override: None,")
+                    }
+                }
+            }
             rustTemplate(
                 """
-                /// Creates a new `${operationSymbol.name}`.
-                pub(crate) fn new(handle: std::sync::Arc<crate::client::Handle${generics.inst}>) -> Self {
-                    Self { handle, inner: Default::default() }
-                }
-
                 /// Consume this builder, creating a customizable operation that can be modified before being
                 /// sent. The operation's inner [http::Request] can be modified as well.
                 pub async fn customize(self) -> std::result::Result<
@@ -316,7 +337,7 @@ class FluentClientGenerator(
                     generics.toRustGenerics(),
                 ),
             )
-            if (codegenContext.settings.codegenConfig.enableNewSmithyRuntime) {
+            if (enableNewSmithyRuntime) {
                 rustTemplate(
                     """
                     // TODO(enableNewSmithyRuntime): Replace `send` with `send_v2`
@@ -329,9 +350,12 @@ class FluentClientGenerator(
                     /// is configurable with the [RetryConfig](aws_smithy_types::retry::RetryConfig), which can be
                     /// set when configuring the client.
                     pub async fn send_v2(self) -> std::result::Result<#{OperationOutput}, #{SdkError}<#{OperationError}, #{HttpResponse}>> {
-                        let runtime_plugins = #{RuntimePlugins}::new()
-                            .with_client_plugin(crate::config::ServiceRuntimePlugin::new(self.handle.clone()))
-                            .with_operation_plugin(#{Operation}::new());
+                        let mut runtime_plugins = #{RuntimePlugins}::new()
+                            .with_client_plugin(crate::config::ServiceRuntimePlugin::new(self.handle.clone()));
+                        if let Some(config_override) = self.config_override {
+                            runtime_plugins = runtime_plugins.with_operation_plugin(config_override);
+                        }
+                        runtime_plugins = runtime_plugins.with_operation_plugin(#{Operation}::new());
                         let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
                         let input = #{TypedBox}::new(input).erase();
                         let output = #{invoke}(input, &runtime_plugins)
@@ -346,29 +370,62 @@ class FluentClientGenerator(
                         Ok(#{TypedBox}::<#{OperationOutput}>::assume_from(output).expect("correct output type").unwrap())
                     }
                     """,
-                    "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::orchestrator::HttpResponse"),
+                    "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig)
+                        .resolve("client::orchestrator::HttpResponse"),
                     "OperationError" to errorType,
                     "Operation" to symbolProvider.toSymbol(operation),
                     "OperationOutput" to outputType,
-                    "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::runtime_plugin::RuntimePlugins"),
+                    "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig)
+                        .resolve("client::runtime_plugin::RuntimePlugins"),
                     "SdkError" to RuntimeType.sdkError(runtimeConfig),
                     "TypedBox" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("type_erasure::TypedBox"),
                     "invoke" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::orchestrator::invoke"),
                 )
-            }
-            PaginatorGenerator.paginatorType(codegenContext, generics, operation, retryClassifier)?.also { paginatorType ->
+
                 rustTemplate(
                     """
-                    /// Create a paginator for this request
+                    /// Sets the `config_override` for the builder.
                     ///
-                    /// Paginators are used by calling [`send().await`](#{Paginator}::send) which returns a `Stream`.
-                    pub fn into_paginator(self) -> #{Paginator}${generics.inst} {
-                        #{Paginator}::new(self.handle, self.inner)
+                    /// `config_override` is applied to the operation configuration level.
+                    /// For the fields in the builder that are not `None, they override those applied to the service
+                    /// configuration level or the AWS configuration level.
+                    pub fn config_override(
+                        mut self,
+                        config_override: impl Into<crate::config::Builder>,
+                    ) -> Self {
+                        self.set_config_override(Some(config_override.into()));
+                        self
+                    }
+
+                    /// Sets the `config_override` for the builder.
+                    ///
+                    /// `config_override` is applied to the operation configuration level.
+                    /// For the fields in the builder that are not `None, they override those applied to the service
+                    /// configuration level or the AWS configuration level.
+                    pub fn set_config_override(
+                        &mut self,
+                        config_override: Option<crate::config::Builder>,
+                    ) -> &mut Self {
+                        self.config_override = config_override;
+                        self
                     }
                     """,
-                    "Paginator" to paginatorType,
                 )
             }
+            PaginatorGenerator.paginatorType(codegenContext, generics, operation, retryClassifier)
+                ?.also { paginatorType ->
+                    rustTemplate(
+                        """
+                        /// Create a paginator for this request
+                        ///
+                        /// Paginators are used by calling [`send().await`](#{Paginator}::send) which returns a `Stream`.
+                        pub fn into_paginator(self) -> #{Paginator}${generics.inst} {
+                            #{Paginator}::new(self.handle, self.inner)
+                        }
+                        """,
+                        "Paginator" to paginatorType,
+                    )
+                }
             writeCustomizations(
                 customizations,
                 FluentClientSection.FluentBuilderImpl(

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -387,7 +387,12 @@ class FluentClientGenerator(
                     ///
                     /// `config_override` is applied to the operation configuration level.
                     /// The fields in the builder that are `Some` override those applied to the service
-                    /// configuration level.
+                    /// configuration level. For instance,
+                    ///
+                    /// Config A     overridden by    Config B          ==        Config C
+                    /// field_1: None,                field_1: Some(v2),          field_1: Some(v2),
+                    /// field_2: Some(v1),            field_2: Some(v2),          field_2: Some(v2),
+                    /// field_3: Some(v1),            field_3: None,              field_3: Some(v1),
                     pub fn config_override(
                         mut self,
                         config_override: impl Into<crate::config::Builder>,
@@ -400,7 +405,12 @@ class FluentClientGenerator(
                     ///
                     /// `config_override` is applied to the operation configuration level.
                     /// The fields in the builder that are `Some` override those applied to the service
-                    /// configuration level.
+                    /// configuration level. For instance,
+                    ///
+                    /// Config A     overridden by    Config B          ==        Config C
+                    /// field_1: None,                field_1: Some(v2),          field_1: Some(v2),
+                    /// field_2: Some(v1),            field_2: Some(v2),          field_2: Some(v2),
+                    /// field_3: Some(v1),            field_3: None,              field_3: Some(v1),
                     pub fn set_config_override(
                         &mut self,
                         config_override: Option<crate::config::Builder>,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -401,7 +401,7 @@ class FluentClientGenerator(
                     ///
                     /// `config_override` is applied to the operation configuration level.
                     /// For the fields in the builder that are not `None, they override those applied to the service
-                    /// configuration level or the AWS configuration level.
+                    /// configuration level.
                     pub fn set_config_override(
                         &mut self,
                         config_override: Option<crate::config::Builder>,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -273,7 +273,6 @@ class FluentClientGenerator(
             val outputType = symbolProvider.toSymbol(operation.outputShape(model))
             val errorType = symbolProvider.symbolForOperationError(operation)
 
-            // Have to use fully-qualified result here or else it could conflict with an op named Result
             rust("/// Creates a new `${operationSymbol.name}`.")
             withBlockTemplate(
                 "pub(crate) fn new(handle: std::sync::Arc<crate::client::Handle${generics.inst}>) -> Self {",

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -387,7 +387,7 @@ class FluentClientGenerator(
                     /// Sets the `config_override` for the builder.
                     ///
                     /// `config_override` is applied to the operation configuration level.
-                    /// For the fields in the builder that are not `None, they override those applied to the service
+                    /// The fields in the builder that are `Some` override those applied to the service
                     /// configuration level or the AWS configuration level.
                     pub fn config_override(
                         mut self,

--- a/rust-runtime/inlineable/src/idempotency_token.rs
+++ b/rust-runtime/inlineable/src/idempotency_token.rs
@@ -94,3 +94,11 @@ impl Clone for IdempotencyTokenProvider {
         }
     }
 }
+
+impl std::fmt::Debug for IdempotencyTokenProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdempotencyTokenProvider")
+            .field("inner", &"** redacted **")
+            .finish()
+    }
+}

--- a/rust-runtime/inlineable/src/idempotency_token.rs
+++ b/rust-runtime/inlineable/src/idempotency_token.rs
@@ -42,6 +42,7 @@ pub struct IdempotencyTokenProvider {
     inner: Inner,
 }
 
+#[derive(Debug)]
 enum Inner {
     Static(&'static str),
     Random(Mutex<fastrand::Rng>),

--- a/rust-runtime/inlineable/src/idempotency_token.rs
+++ b/rust-runtime/inlineable/src/idempotency_token.rs
@@ -37,6 +37,7 @@ pub(crate) fn uuid_v4(input: u128) -> String {
 /// for testing, two options are available:
 /// 1. Utilize the From<&'static str>` implementation to hard code an idempotency token
 /// 2. Seed the token provider with [`IdempotencyTokenProvider::with_seed`](IdempotencyTokenProvider::with_seed)
+#[derive(Debug)]
 pub struct IdempotencyTokenProvider {
     inner: Inner,
 }
@@ -92,13 +93,5 @@ impl Clone for IdempotencyTokenProvider {
             Inner::Static(token) => IdempotencyTokenProvider::fixed(token),
             Inner::Random(_) => IdempotencyTokenProvider::random(),
         }
-    }
-}
-
-impl std::fmt::Debug for IdempotencyTokenProvider {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IdempotencyTokenProvider")
-            .field("inner", &"** redacted **")
-            .finish()
     }
 }


### PR DESCRIPTION
## Motivation and Context
This PR adds skeleton code for supporting operation level config behind `enableNewSmithyRuntime`.

## Description
The approach is described in https://github.com/awslabs/smithy-rs/pull/2527, where fluent builders now have a new method, `config_override`, that takes a service config builder.  The builder implements the `RuntimePlugin` trait and once `TODO(RuntimePlugins)` is implemented, allows itself to put field values into a config bag within `send_v2`.

## Testing
Added a line of code to an ignored test in `sra_test`, which, however, does check compilation.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
