### PR TITLE
Fix docs for generic clients (`call()` -> `send()`)

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDocs.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDocs.kt
@@ -202,13 +202,13 @@ object FluentClientDocs {
                     A client has a function for every operation that can be performed by the service.
                     For example, the [`${operationSymbol.name}`](${operationSymbol.namespace}) operation has
                     a [`Client::$operationFnName`], function which returns a builder for that operation.
-                    The fluent builder ultimately has a `call()` function that returns an async future that
+                    The fluent builder ultimately has a `send()` function that returns an async future that
                     returns a result, as illustrated below:
 
                     ```rust,ignore
                     let result = client.$operationFnName()
                         .${memberSymbol.name}("example")
-                        .call()
+                        .send()
                         .await;
                     ```
 


### PR DESCRIPTION
## Description

Docs were wrong, the function is called `send()`, not `call()`.

-----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
