### PR TITLE
Add examples folder to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,6 +4,7 @@
 /codegen-server-test/                               @awslabs/smithy-rs-server
 /codegen-server/                                    @awslabs/smithy-rs-server
 /rust-runtime/aws-smithy-http-server/               @awslabs/smithy-rs-server
+/examples/                                          @awslabs/smithy-rs-server
 
 # Python Server
 /codegen-server-test/python/                        @awslabs/smithy-rs-python-server @awslabs/smithy-rs-server


### PR DESCRIPTION
## Motivation and Context

This was missing from the https://github.com/awslabs/smithy-rs/pull/2481 change.