### PR TITLE
Fix `rewrite_base_url`: don't discard query params

### DIFF
--- a/examples/pokemon-service-common/src/lib.rs
+++ b/examples/pokemon-service-common/src/lib.rs
@@ -46,7 +46,7 @@ pub fn rewrite_base_url(
         let mut uri_parts = http_req.uri().clone().into_parts();
         uri_parts.authority = Some(authority.clone());
         uri_parts.scheme = Some(scheme.clone());
-        *http_req.uri_mut() = Uri::from_parts(uri_parts).expect("valid uri");
+        *http_req.uri_mut() = Uri::from_parts(uri_parts).expect("failed to create uri from parts");
         req
     }
 }

--- a/examples/pokemon-service-common/src/lib.rs
+++ b/examples/pokemon-service-common/src/lib.rs
@@ -17,6 +17,10 @@ use std::{
 use async_stream::stream;
 use aws_smithy_http::operation::Request;
 use aws_smithy_http_server::Extension;
+use http::{
+    uri::{Authority, Scheme},
+    Uri,
+};
 use pokemon_service_server_sdk::{
     error, input, model, model::CapturingPayload, output, types::Blob,
 };
@@ -33,11 +37,16 @@ const PIKACHU_JAPANESE_FLAVOR_TEXT: &str =
     "ほっぺたの りょうがわに ちいさい でんきぶくろを もつ。ピンチのときに ほうでんする。";
 
 /// Rewrites the base URL of a request
-pub fn rewrite_base_url(base_url: String) -> impl Fn(Request) -> Request + Clone {
+pub fn rewrite_base_url(
+    scheme: Scheme,
+    authority: Authority,
+) -> impl Fn(Request) -> Request + Clone {
     move |mut req| {
         let http_req = req.http_mut();
-        let uri = format!("{base_url}{}", http_req.uri().path());
-        *http_req.uri_mut() = uri.parse().unwrap();
+        let mut uri_parts = http_req.uri().clone().into_parts();
+        uri_parts.authority = Some(authority.clone());
+        uri_parts.scheme = Some(scheme.clone());
+        *http_req.uri_mut() = Uri::from_parts(uri_parts).expect("valid uri");
         req
     }
 }

--- a/examples/pokemon-service-common/tests/plugins_execution_order.rs
+++ b/examples/pokemon-service-common/tests/plugins_execution_order.rs
@@ -64,10 +64,7 @@ struct SentinelPlugin {
 
 impl SentinelPlugin {
     pub fn new(name: &'static str, output: Arc<Mutex<Vec<&'static str>>>) -> Self {
-        Self {
-            name,
-            output: output,
-        }
+        Self { name, output }
     }
 }
 

--- a/examples/pokemon-service-tls/tests/common/mod.rs
+++ b/examples/pokemon-service-tls/tests/common/mod.rs
@@ -49,8 +49,8 @@ pub fn client_http2_only() -> Client<DynConnector, DynMiddleware<DynConnector>> 
         .enable_http2()
         .build();
 
-    let authority =
-        Authority::from_str(&format!("{DEFAULT_DOMAIN}:{DEFAULT_PORT}")).expect("valid authority");
+    let authority = Authority::from_str(&format!("{DEFAULT_DOMAIN}:{DEFAULT_PORT}"))
+        .expect("could not parse authority");
     let raw_client = Builder::new()
         .connector(DynConnector::new(Adapter::builder().build(connector)))
         .middleware_fn(rewrite_base_url(Scheme::HTTPS, authority))

--- a/examples/pokemon-service-tls/tests/common/mod.rs
+++ b/examples/pokemon-service-tls/tests/common/mod.rs
@@ -3,13 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{fs::File, io::BufReader, process::Command, time::Duration};
+use std::{fs::File, io::BufReader, process::Command, str::FromStr, time::Duration};
 
 use assert_cmd::prelude::*;
 use aws_smithy_client::{
     erase::{DynConnector, DynMiddleware},
     hyper_ext::Adapter,
 };
+use hyper::http::uri::{Authority, Scheme};
 use tokio::time::sleep;
 
 use pokemon_service_client::{Builder, Client, Config};
@@ -48,10 +49,11 @@ pub fn client_http2_only() -> Client<DynConnector, DynMiddleware<DynConnector>> 
         .enable_http2()
         .build();
 
-    let base_url = format!("https://{DEFAULT_DOMAIN}:{DEFAULT_PORT}");
+    let authority =
+        Authority::from_str(&format!("{DEFAULT_DOMAIN}:{DEFAULT_PORT}")).expect("valid authority");
     let raw_client = Builder::new()
         .connector(DynConnector::new(Adapter::builder().build(connector)))
-        .middleware_fn(rewrite_base_url(base_url))
+        .middleware_fn(rewrite_base_url(Scheme::HTTPS, authority))
         .build_dyn();
     let config = Config::builder().build();
     Client::with_config(raw_client, config)

--- a/examples/pokemon-service/tests/common/mod.rs
+++ b/examples/pokemon-service/tests/common/mod.rs
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use std::{process::Command, time::Duration};
+use std::{process::Command, str::FromStr, time::Duration};
 
 use assert_cmd::prelude::*;
 use aws_smithy_client::erase::{DynConnector, DynMiddleware};
+use hyper::http::uri::{Authority, Scheme};
 use tokio::time::sleep;
 
 use pokemon_service::{DEFAULT_ADDRESS, DEFAULT_PORT};
@@ -25,10 +26,11 @@ pub async fn run_server() -> ChildDrop {
 }
 
 pub fn client() -> Client<DynConnector, DynMiddleware<DynConnector>> {
-    let base_url = format!("http://{DEFAULT_ADDRESS}:{DEFAULT_PORT}");
+    let authority =
+        Authority::from_str(&format!("{DEFAULT_ADDRESS}:{DEFAULT_PORT}")).expect("valid authority");
     let raw_client = Builder::new()
         .rustls_connector(Default::default())
-        .middleware_fn(rewrite_base_url(base_url))
+        .middleware_fn(rewrite_base_url(Scheme::HTTP, authority))
         .build_dyn();
     let config = Config::builder().build();
     Client::with_config(raw_client, config)

--- a/examples/pokemon-service/tests/common/mod.rs
+++ b/examples/pokemon-service/tests/common/mod.rs
@@ -26,8 +26,8 @@ pub async fn run_server() -> ChildDrop {
 }
 
 pub fn client() -> Client<DynConnector, DynMiddleware<DynConnector>> {
-    let authority =
-        Authority::from_str(&format!("{DEFAULT_ADDRESS}:{DEFAULT_PORT}")).expect("valid authority");
+    let authority = Authority::from_str(&format!("{DEFAULT_ADDRESS}:{DEFAULT_PORT}"))
+        .expect("could not parse authority");
     let raw_client = Builder::new()
         .rustls_connector(Default::default())
         .middleware_fn(rewrite_base_url(Scheme::HTTP, authority))


### PR DESCRIPTION
## Description
The previous version of this function discarded query params, which meant that if our model had a `@httpQuery` bound input, those would not be sent to the server and the requests would fail.

## Testing
Ran existing tests

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
