### PR TITLE
Add credentials exposure test & fix STS + SSO

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -128,3 +128,19 @@ message = "Fix server code generation bug affecting constrained shapes bound wit
 references = ["smithy-rs#2583", "smithy-rs#2584"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "server" }
 author = "david-perez"
+
+[[aws-sdk-rust]]
+message = """Reduce several instances of credential exposure in the SDK logs:
+- IMDS now suppresses the body of the response from logs
+- `aws-sigv4` marks the `x-amz-session-token` header as sensitive
+- STS & SSO credentials have been manually marked as sensitive which suppresses logging of response bodies for relevant operations
+"""
+author = "rcoh"
+references = ["smithy-rs#2603"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+
+[[smithy-rs]]
+message = "Add a sensitive method to `ParseHttpResponse`. When this returns true, logging of the HTTP response body will be suppressed."
+author = "rcoh"
+references = ["smithy-rs#2603"]
+meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }

--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -49,6 +49,7 @@ zeroize = { version = "1", optional = true }
 [dev-dependencies]
 futures-util = { version = "0.3.16", default-features = false }
 tracing-test = "0.2.1"
+tracing-subscriber = { version = "0.3.16", features = ["fmt", "json"] }
 
 tokio = { version = "1.23.1", features = ["full", "test-util"] }
 

--- a/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/default_provider/credentials.rs
@@ -198,8 +198,6 @@ impl Builder {
 
 #[cfg(test)]
 mod test {
-    use tracing_test::traced_test;
-
     use aws_credential_types::provider::ProvideCredentials;
 
     use crate::default_provider::credentials::DefaultCredentialsChain;
@@ -242,7 +240,6 @@ mod test {
             make_test!($name, execute, $provider_config_builder);
         };
         ($name: ident, $func: ident, $provider_config_builder: expr) => {
-            #[traced_test]
             #[tokio::test]
             async fn $name() {
                 crate::test_case::TestEnvironment::from_dir(concat!(
@@ -324,7 +321,6 @@ mod test {
     }
 
     #[tokio::test]
-    #[traced_test]
     #[cfg(feature = "client-hyper")]
     async fn no_providers_configured_err() {
         use crate::provider_config::ProviderConfig;

--- a/aws/rust-runtime/aws-config/src/http_credential_provider.rs
+++ b/aws/rust-runtime/aws-config/src/http_credential_provider.rs
@@ -149,6 +149,10 @@ impl ParseStrictResponse for CredentialsResponseParser {
             )),
         }
     }
+
+    fn sensitive(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/aws/rust-runtime/aws-config/src/imds/client.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client.rs
@@ -280,6 +280,10 @@ impl ParseStrictResponse for ImdsGetResponseHandler {
             Err(InnerImdsError::BadStatus)
         }
     }
+
+    fn sensitive(&self) -> bool {
+        true
+    }
 }
 
 /// IMDSv2 Endpoint Mode

--- a/aws/rust-runtime/aws-config/src/imds/client/token.rs
+++ b/aws/rust-runtime/aws-config/src/imds/client/token.rs
@@ -197,4 +197,8 @@ impl ParseStrictResponse for GetTokenResponseHandler {
             expiry: self.time.now() + Duration::from_secs(ttl),
         })
     }
+
+    fn sensitive(&self) -> bool {
+        true
+    }
 }

--- a/aws/rust-runtime/aws-config/src/lib.rs
+++ b/aws/rust-runtime/aws-config/src/lib.rs
@@ -374,7 +374,7 @@ mod loader {
         ///
         /// # Example: Using a custom profile file path
         ///
-        /// ```
+        /// ```no_run
         /// use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
         /// use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
         ///
@@ -417,7 +417,7 @@ mod loader {
         ///
         /// # Example: Using a custom profile name
         ///
-        /// ```
+        /// ```no_run
         /// use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
         /// use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
         ///

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -455,14 +455,12 @@ async fn build_provider_chain(
 
 #[cfg(test)]
 mod test {
-    use tracing_test::traced_test;
 
     use crate::profile::credentials::Builder;
     use crate::test_case::TestEnvironment;
 
     macro_rules! make_test {
         ($name: ident) => {
-            #[traced_test]
             #[tokio::test]
             async fn $name() {
                 TestEnvironment::from_dir(concat!(

--- a/aws/rust-runtime/aws-config/src/profile/profile_file.rs
+++ b/aws/rust-runtime/aws-config/src/profile/profile_file.rs
@@ -20,7 +20,7 @@ use std::path::PathBuf;
 ///
 /// # Example: Using a custom profile file path
 ///
-/// ```
+/// ```no_run
 /// use aws_config::profile::{ProfileFileCredentialsProvider, ProfileFileRegionProvider};
 /// use aws_config::profile::profile_file::{ProfileFiles, ProfileFileKind};
 /// use std::sync::Arc;

--- a/aws/rust-runtime/aws-config/test-data/profile-provider/credential_process/fs/home/.aws/config
+++ b/aws/rust-runtime/aws-config/test-data/profile-provider/credential_process/fs/home/.aws/config
@@ -1,6 +1,6 @@
 [default]
 source_profile = base
-# base64 encoded to prevent triggering the secret scanner
+# these fake credentials are base64 encoded to prevent triggering the unit test that scans logs for secrets
 credential_process = echo eyAiVmVyc2lvbiI6IDEsICJBY2Nlc3NLZXlJZCI6ICJBU0lBUlRFU1RJRCIsICJTZWNyZXRBY2Nlc3NLZXkiOiAiVEVTVFNFQ1JFVEtFWSIsICJTZXNzaW9uVG9rZW4iOiAiVEVTVFNFU1NJT05UT0tFTiIsICJFeHBpcmF0aW9uIjogIjIwMjItMDUtMDJUMTg6MzY6MDArMDA6MDAiIH0K | base64 --decode
 
 [profile base]

--- a/aws/rust-runtime/aws-config/test-data/profile-provider/credential_process/fs/home/.aws/config
+++ b/aws/rust-runtime/aws-config/test-data/profile-provider/credential_process/fs/home/.aws/config
@@ -1,6 +1,7 @@
 [default]
 source_profile = base
-credential_process = echo '{ "Version": 1, "AccessKeyId": "ASIARTESTID", "SecretAccessKey": "TESTSECRETKEY", "SessionToken": "TESTSESSIONTOKEN", "Expiration": "2022-05-02T18:36:00+00:00" }'
+# base64 encoded to prevent triggering the secret scanner
+credential_process = echo eyAiVmVyc2lvbiI6IDEsICJBY2Nlc3NLZXlJZCI6ICJBU0lBUlRFU1RJRCIsICJTZWNyZXRBY2Nlc3NLZXkiOiAiVEVTVFNFQ1JFVEtFWSIsICJTZXNzaW9uVG9rZW4iOiAiVEVTVFNFU1NJT05UT0tFTiIsICJFeHBpcmF0aW9uIjogIjIwMjItMDUtMDJUMTg6MzY6MDArMDA6MDAiIH0K | base64 --decode
 
 [profile base]
 region = us-east-1

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -19,6 +19,7 @@ import software.amazon.smithy.rustsdk.customize.route53.Route53Decorator
 import software.amazon.smithy.rustsdk.customize.s3.S3Decorator
 import software.amazon.smithy.rustsdk.customize.s3.S3ExtendedRequestIdDecorator
 import software.amazon.smithy.rustsdk.customize.s3control.S3ControlDecorator
+import software.amazon.smithy.rustsdk.customize.sso.SSODecorator
 import software.amazon.smithy.rustsdk.customize.sts.STSDecorator
 import software.amazon.smithy.rustsdk.endpoints.AwsEndpointsStdLib
 import software.amazon.smithy.rustsdk.endpoints.OperationInputTestDecorator
@@ -65,6 +66,7 @@ val DECORATORS: List<ClientCodegenDecorator> = listOf(
     ),
     S3ControlDecorator().onlyApplyTo("com.amazonaws.s3control#AWSS3ControlServiceV20180820"),
     STSDecorator().onlyApplyTo("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
+    SSODecorator().onlyApplyTo("com.amazonaws.sso#SWBPortalService"),
 
     // Only build docs-rs for linux to reduce load on docs.rs
     listOf(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/sso/SSODecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/sso/SSODecorator.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk.customize.sso
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.ServiceShape
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.model.traits.SensitiveTrait
+import software.amazon.smithy.model.transform.ModelTransformer
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.core.util.letIf
+import java.util.logging.Logger
+
+class SSODecorator : ClientCodegenDecorator {
+    override val name: String = "SSO"
+    override val order: Byte = 0
+    private val logger: Logger = Logger.getLogger(javaClass.name)
+
+    private fun isAwsCredentials(shape: Shape): Boolean = shape.id == ShapeId.from("com.amazonaws.sso#RoleCredentials")
+
+    override fun transformModel(service: ServiceShape, model: Model): Model =
+        ModelTransformer.create().mapShapes(model) { shape ->
+            shape.letIf(isAwsCredentials(shape)) {
+                (shape as StructureShape).toBuilder().addTrait(SensitiveTrait()).build()
+            }
+        }
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/sts/STSDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/sts/STSDecorator.kt
@@ -7,9 +7,11 @@ package software.amazon.smithy.rustsdk.customize.sts
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.ServiceShape
 import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.model.traits.ErrorTrait
 import software.amazon.smithy.model.traits.RetryableTrait
+import software.amazon.smithy.model.traits.SensitiveTrait
 import software.amazon.smithy.model.transform.ModelTransformer
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
@@ -25,6 +27,8 @@ class STSDecorator : ClientCodegenDecorator {
         shape is StructureShape && shape.hasTrait<ErrorTrait>() &&
             shape.id.namespace == "com.amazonaws.sts" && shape.id.name == "IDPCommunicationErrorException"
 
+    private fun isAwsCredentials(shape: Shape): Boolean = shape.id == ShapeId.from("com.amazonaws.sts#Credentials")
+
     override fun transformModel(service: ServiceShape, model: Model): Model =
         ModelTransformer.create().mapShapes(model) { shape ->
             shape.letIf(isIdpCommunicationError(shape)) {
@@ -33,6 +37,8 @@ class STSDecorator : ClientCodegenDecorator {
                     .removeTrait(ErrorTrait.ID)
                     .addTrait(ErrorTrait("server"))
                     .addTrait(RetryableTrait.builder().build()).build()
+            }.letIf(isAwsCredentials(shape)) {
+                (shape as StructureShape).toBuilder().addTrait(SensitiveTrait()).build()
             }
         }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/SensitiveIndex.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/SensitiveIndex.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.knowledge.KnowledgeIndex
+import software.amazon.smithy.model.selector.Selector
+import software.amazon.smithy.model.shapes.OperationShape
+
+class SensitiveIndex(model: Model) : KnowledgeIndex {
+    private val sensitiveInputSelector = Selector.parse("operation:test(-[input]-> ~> [trait|sensitive])")
+    private val sensitiveOutputSelector = Selector.parse("operation:test(-[output]-> ~> [trait|sensitive])")
+    private val sensitiveInputs = sensitiveInputSelector.select(model).map { it.id }.toSet()
+    private val sensitiveOutputs = sensitiveOutputSelector.select(model).map { it.id }.toSet()
+
+    fun hasSensitiveInput(operationShape: OperationShape): Boolean = sensitiveInputs.contains(operationShape.id)
+    fun hasSensitiveOutput(operationShape: OperationShape): Boolean = sensitiveOutputs.contains(operationShape.id)
+
+    companion object {
+        fun of(model: Model): SensitiveIndex {
+            return model.getKnowledge(SensitiveIndex::class.java) {
+                SensitiveIndex(it)
+            }
+        }
+    }
+}

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/SensitiveIndexTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/SensitiveIndexTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.client.smithy.generators
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
+import software.amazon.smithy.rust.codegen.core.util.lookup
+
+class SensitiveIndexTest {
+    val model = """
+        namespace com.example
+        service TestService {
+            operations: [
+                NotSensitive,
+                SensitiveInput,
+                SensitiveOutput,
+                NestedSensitiveInput,
+                NestedSensitiveOutput
+            ]
+        }
+
+        @sensitive
+        structure Credentials {
+           username: String,
+           password: String
+        }
+
+        operation NotSensitive {
+            input := { userId: String }
+
+            output := { response: String }
+        }
+
+        operation SensitiveInput {
+            input := { credentials: Credentials }
+        }
+
+        operation SensitiveOutput {
+            output := { credentials: Credentials }
+        }
+
+        operation NestedSensitiveInput {
+            input := { nested: Nested }
+        }
+
+        operation NestedSensitiveOutput {
+            output := { nested: Nested }
+        }
+
+        structure Nested {
+            inner: Inner
+        }
+
+        structure Inner {
+            credentials: Credentials
+        }
+    """.asSmithyModel(smithyVersion = "2.0")
+
+    @Test
+    fun `correctly identify operations`() {
+        val index = SensitiveIndex.of(model)
+
+        data class TestCase(val shape: String, val sensitiveInput: Boolean, val sensitiveOutput: Boolean)
+
+        val testCases = listOf(
+            TestCase("NotSensitive", sensitiveInput = false, sensitiveOutput = false),
+            TestCase("SensitiveInput", sensitiveInput = true, sensitiveOutput = false),
+            TestCase("SensitiveOutput", sensitiveInput = false, sensitiveOutput = true),
+            TestCase("NestedSensitiveInput", sensitiveInput = true, sensitiveOutput = false),
+            TestCase("NestedSensitiveOutput", sensitiveInput = false, sensitiveOutput = true),
+        )
+        testCases.forEach { tc ->
+            assertEquals(tc.sensitiveInput, index.hasSensitiveInput(model.lookup("com.example#${tc.shape}")), "input: $tc")
+            assertEquals(tc.sensitiveOutput, index.hasSensitiveOutput(model.lookup("com.example#${tc.shape}")), "output: $tc ")
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-http/src/middleware.rs
+++ b/rust-runtime/aws-smithy-http/src/middleware.rs
@@ -132,7 +132,9 @@ where
     };
 
     let http_response = http::Response::from_parts(parts, Bytes::from(body));
-    trace!(http_response = ?http_response, "read HTTP response body");
+    if !handler.sensitive() {
+        trace!(http_response = ?http_response, "read HTTP response body");
+    }
     debug_span!("parse_loaded").in_scope(move || {
         let parsed = handler.parse_loaded(&http_response);
         sdk_result(

--- a/rust-runtime/aws-smithy-http/src/middleware.rs
+++ b/rust-runtime/aws-smithy-http/src/middleware.rs
@@ -21,6 +21,8 @@ use tracing::{debug_span, trace, Instrument};
 
 type BoxError = Box<dyn Error + Send + Sync>;
 
+const LOG_SENSITIVE_BODIES: &str = "LOG_SENSITIVE_BODIES";
+
 /// [`AsyncMapRequest`] defines an asynchronous middleware that transforms an [`operation::Request`].
 ///
 /// Typically, these middleware will read configuration from the `PropertyBag` and use it to
@@ -132,8 +134,14 @@ where
     };
 
     let http_response = http::Response::from_parts(parts, Bytes::from(body));
-    if !handler.sensitive() {
+    if !handler.sensitive()
+        || std::env::var(LOG_SENSITIVE_BODIES)
+            .map(|v| v.eq_ignore_ascii_case("true"))
+            .unwrap_or_default()
+    {
         trace!(http_response = ?http_response, "read HTTP response body");
+    } else {
+        trace!(http_response = "** REDACTED **. To print, set LOG_SENSITIVE_BODIES=true")
     }
     debug_span!("parse_loaded").in_scope(move || {
         let parsed = handler.parse_loaded(&http_response);

--- a/rust-runtime/aws-smithy-http/src/response.rs
+++ b/rust-runtime/aws-smithy-http/src/response.rs
@@ -60,6 +60,13 @@ pub trait ParseHttpResponse {
     /// if `parse_unloaded` will never return `None`, however, it may make your code easier to test if an
     /// implementation is provided.
     fn parse_loaded(&self, response: &http::Response<Bytes>) -> Self::Output;
+
+    /// Returns whether the contents of this response are sensitive
+    ///
+    /// When this is set to true, wire logging will be disabled
+    fn sensitive(&self) -> bool {
+        false
+    }
 }
 
 /// Convenience Trait for non-streaming APIs
@@ -72,6 +79,13 @@ pub trait ParseStrictResponse {
 
     /// Parse an [`http::Response<Bytes>`] into `Self::Output`.
     fn parse(&self, response: &http::Response<Bytes>) -> Self::Output;
+
+    /// Returns whether the contents of this response are sensitive
+    ///
+    /// When this is set to true, wire logging will be disabled
+    fn sensitive(&self) -> bool {
+        false
+    }
 }
 
 impl<T: ParseStrictResponse> ParseHttpResponse for T {
@@ -83,6 +97,10 @@ impl<T: ParseStrictResponse> ParseHttpResponse for T {
 
     fn parse_loaded(&self, response: &http::Response<Bytes>) -> Self::Output {
         self.parse(response)
+    }
+
+    fn sensitive(&self) -> bool {
+        ParseStrictResponse::sensitive(self)
     }
 }
 


### PR DESCRIPTION

## Motivation and Context
- credentials providers may leak credentials in the HTTP body at the debug level

## Description
This adds a test to aws-config that looks for leaked credentials in all of our provider integration tests—since these test use AWS APIs under the hood, this also serves to test AWS services in general.

To support this, `sensitive` was added to the ParseHttpResponse trait and code was generated to take action based on this change.

- [x] Add environment variable to force logging of the body
- [x] consider if we want to suppress request body logging as well

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
