### PR TITLE
Undeprecate `{content_type,accept}_header_classifier` from `aws-smithy-http-server`

### DIFF
--- a/rust-runtime/aws-smithy-http-server/src/protocols.rs
+++ b/rust-runtime/aws-smithy-http-server/src/protocols.rs
@@ -34,7 +34,7 @@ fn parse_content_type(headers: &HeaderMap) -> Result<mime::Mime, MissingContentT
 }
 
 /// Checks that the `content-type` header is valid.
-#[allow(deprecated, clippy::result_large_err)]
+#[allow(clippy::result_large_err)]
 pub fn content_type_header_classifier(
     headers: &HeaderMap,
     expected_content_type: Option<&'static str>,
@@ -66,7 +66,6 @@ pub fn content_type_header_classifier(
     Ok(())
 }
 
-#[allow(deprecated)]
 pub fn accept_header_classifier(headers: &HeaderMap, content_type: &'static str) -> bool {
     if !headers.contains_key(http::header::ACCEPT) {
         return true;
@@ -105,7 +104,6 @@ pub fn accept_header_classifier(headers: &HeaderMap, content_type: &'static str)
         })
 }
 
-#[allow(deprecated)]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
These functions were mistakenly deprecated when deprecating the old
service builder API in #1886.

However, they're fine, and they're internally used by the generated
server SDKs.
The module they reside in is `#[doc(hidden)]`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
