### PR TITLE
Allow "Update GitHub Pages" to opt-in to cargo sparse registry

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,5 +1,11 @@
 on:
   workflow_dispatch:
+    inputs:
+      opt-in-to-sparse-registry:
+        description: Whether the environment variable CARGO_UNSTABLE_SPARSE_REGISTRY is set
+        required: true
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths:
@@ -24,6 +30,7 @@ jobs:
     - name: Generate docs
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        CARGO_UNSTABLE_SPARSE_REGISTRY: ${{ inputs.opt-in-to-sparse-registry }}
       run: |
         git config --local user.name "AWS SDK Rust Bot"
         git config --local user.email "aws-sdk-rust-primary@amazon.com"

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,7 +2,7 @@ on:
   workflow_dispatch:
     inputs:
       opt-in-to-sparse-registry:
-        description: Whether the environment variable CARGO_UNSTABLE_SPARSE_REGISTRY is set
+        description: Enable/disable CARGO_UNSTABLE_SPARSE_REGISTRY (https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html)
         required: true
         type: boolean
         default: false


### PR DESCRIPTION
## Motivation and Context
Addresses a CI failure within `Update GitHub Pages` due to the use of the cargo sparse registry ([example](https://github.com/awslabs/smithy-rs/actions/runs/4746548497/jobs/8430328515)).

## Description
The PR allows the action to configure whether the cargo sparse registry is used via the environment variable [CARGO_UNSTABLE_SPARSE_REGISTRY](https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html#overview):

<img width="800" alt="Screenshot 2023-04-20 at 11 55 06 AM" src="https://user-images.githubusercontent.com/15333866/233435686-d24ceb2f-facf-45c9-b6cb-490b8ea2b085.png">

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
