### PR TITLE
Switch to rust-toolchain@master in "Update GitHub Pages"

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,6 +7,9 @@ on:
 
 name: Update GitHub Pages
 
+env:
+  rust_version: 1.66.1
+
 # Allow only one doc pages build to run at a time for the entire smithy-rs repo
 concurrency:
   group: github-pages-yml
@@ -20,7 +23,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         persist-credentials: false
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.rust_version }}
     - name: Generate docs
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,11 +1,5 @@
 on:
   workflow_dispatch:
-    inputs:
-      opt-in-to-sparse-registry:
-        description: Enable/disable CARGO_UNSTABLE_SPARSE_REGISTRY (https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html)
-        required: true
-        type: boolean
-        default: false
   push:
     branches: [main]
     paths:
@@ -30,7 +24,6 @@ jobs:
     - name: Generate docs
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        CARGO_UNSTABLE_SPARSE_REGISTRY: ${{ inputs.opt-in-to-sparse-registry }}
       run: |
         git config --local user.name "AWS SDK Rust Bot"
         git config --local user.email "aws-sdk-rust-primary@amazon.com"


### PR DESCRIPTION
## Motivation and Context
The previous attempt https://github.com/awslabs/smithy-rs/pull/2610 did not work for properly running the workflow for `Update GitHub Pages`. This PR reverts it and uses a different fix to address the issue.

## Description
Possibly with [this](https://users.rust-lang.org/t/sparse-registry-breaking-my-ci-and-i-dont-understand-why/89976) and `dtolnaly/rust-toolchain` having fixed a couple of issues [related to the sparse registry](https://github.com/dtolnay/rust-toolchain/issues?q=is%3Aissue+is%3Aclosed+sparse) recently, this PR will use `dtolnaly/rust-toolchain@master` rather than `stable` (most CIs in this repository have been using `master`).

## Testing
The workflow in question has been verified to run successfully with this change ([link](https://github.com/awslabs/smithy-rs/actions/runs/4758820036)).

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
