### PR TITLE
RFC30 update for codegen code

### DIFF
--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -16,6 +16,7 @@ import java.nio.file.Path
 sealed class DependencyScope {
     object Dev : DependencyScope()
     object Compile : DependencyScope()
+    object CfgUnstable : DependencyScope()
     object Build : DependencyScope()
 }
 
@@ -277,5 +278,8 @@ data class CargoDependency(
         fun smithyRuntimeApi(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-runtime-api")
         fun smithyTypes(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-types")
         fun smithyXml(runtimeConfig: RuntimeConfig) = runtimeConfig.smithyRuntimeCrate("smithy-xml")
+
+        // behind feature-gate
+        val Serde = CargoDependency("serde", CratesIo("1.0"), features = setOf("derive"), scope = DependencyScope.CfgUnstable)
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustType.kt
@@ -473,6 +473,23 @@ class Attribute(val inner: Writable) {
         }
     }
 
+    // These were supposed to be a part of companion object but we decided to move it out to here to avoid NPE
+    // You can find the discussion here.
+    // https://github.com/awslabs/smithy-rs/discussions/2248
+    public fun SerdeSerialize(): Attribute {
+        return Attribute(cfgAttr(all(writable("aws_sdk_unstable"), feature("serde-serialize")), derive(RuntimeType.SerdeSerialize)))
+    }
+    public fun SerdeDeserialize(): Attribute {
+        return Attribute(cfgAttr(all(writable("aws_sdk_unstable"), feature("serde-deserialize")), derive(RuntimeType.SerdeDeserialize)))
+    }
+    public fun SerdeSkip(): Attribute {
+        return Attribute(cfgAttr(all(writable("aws_sdk_unstable"), any(feature("serde-serialize"), feature("serde-deserialize"))), serde("skip")))
+    }
+
+    public fun SerdeSerializeOrDeserialize(): Attribute {
+        return Attribute(cfg(all(writable("aws_sdk_unstable"), any(feature("serde-serialize"), feature("serde-deserialize")))))
+    }
+
     companion object {
         val AllowClippyBoxedLocal = Attribute(allow("clippy::boxed_local"))
         val AllowClippyLetAndReturn = Attribute(allow("clippy::let_and_return"))
@@ -501,6 +518,7 @@ class Attribute(val inner: Writable) {
 
         val Test = Attribute("test")
         val TokioTest = Attribute(RuntimeType.Tokio.resolve("test").writable)
+        val AwsSdkUnstableAttribute = Attribute(cfg("aws_sdk_unstable"))
 
         /**
          * [non_exhaustive](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute)
@@ -529,10 +547,12 @@ class Attribute(val inner: Writable) {
         }
 
         fun all(vararg attrMacros: Writable): Writable = macroWithArgs("all", *attrMacros)
+        fun cfgAttr(vararg attrMacros: Writable): Writable = macroWithArgs("cfg_attr", *attrMacros)
 
         fun allow(lints: Collection<String>): Writable = macroWithArgs("allow", *lints.toTypedArray())
         fun allow(vararg lints: String): Writable = macroWithArgs("allow", *lints)
         fun deny(vararg lints: String): Writable = macroWithArgs("deny", *lints)
+        fun serde(vararg lints: String): Writable = macroWithArgs("serde", *lints)
         fun any(vararg attrMacros: Writable): Writable = macroWithArgs("any", *attrMacros)
         fun cfg(vararg attrMacros: Writable): Writable = macroWithArgs("cfg", *attrMacros)
         fun cfg(vararg attrMacros: String): Writable = macroWithArgs("cfg", *attrMacros)

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/RuntimeType.kt
@@ -247,6 +247,11 @@ data class RuntimeType(val path: String, val dependency: RustDependency? = null)
         val ConstrainedTrait = RuntimeType("crate::constrained::Constrained", InlineDependency.constrained())
         val MaybeConstrained = RuntimeType("crate::constrained::MaybeConstrained", InlineDependency.constrained())
 
+        // serde types. Gated behind `CfgUnstable`.
+        val Serde = CargoDependency.Serde.toType()
+        val SerdeSerialize = Serde.resolve("Serialize")
+        val SerdeDeserialize = Serde.resolve("Deserialize")
+
         // smithy runtime types
         fun smithyAsync(runtimeConfig: RuntimeConfig) = CargoDependency.smithyAsync(runtimeConfig).toType()
         fun smithyChecksums(runtimeConfig: RuntimeConfig) = CargoDependency.smithyChecksums(runtimeConfig).toType()

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/CargoTomlGenerator.kt
@@ -76,9 +76,18 @@ class CargoTomlGenerator(
                 .associate { it.name to it.toMap() },
             "dev-dependencies" to dependencies.filter { it.scope == DependencyScope.Dev }
                 .associate { it.name to it.toMap() },
+            "target.'cfg(aws_sdk_unstable)'.dependencies" to dependencies.filter {
+                it.scope == DependencyScope.CfgUnstable
+            }
+                .associate { it.name to it.toMap() },
             "features" to cargoFeatures.toMap(),
         ).deepMergeWith(manifestCustomizations)
 
-        writer.writeWithNoFormatting(TomlWriter().write(cargoToml))
+        // NOTE: without this it will produce ["target.'cfg(aws_sdk_unstable)'.dependencies"]
+        // In JSON, this is an equivalent of: {"target.'cfg(aws_sdk_unstable)'.dependencies" : ...}
+        // To make it work, it has to be: {"target": {'cfg(aws_sdk_unstable)': {"dependencies": ...}}}
+        // This piece of code fixes it.
+        var tomlString = TomlWriter().write(cargoToml).replace("\"target.'cfg(aws_sdk_unstable)'.dependencies\"", "target.'cfg(aws_sdk_unstable)'.dependencies")
+        writer.writeWithNoFormatting(tomlString)
     }
 }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/EnumGenerator.kt
@@ -4,7 +4,6 @@
  */
 
 package software.amazon.smithy.rust.codegen.core.smithy.generators
-
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
@@ -222,6 +221,8 @@ open class EnumGenerator(
     private fun RustWriter.renderUnnamedEnum() {
         documentShape(shape, model)
         deprecatedShape(shape)
+        RenderSerdeAttribute.writeAttributes(this)
+        SensitiveWarning.addDoc(this, shape)
         context.enumMeta.render(this)
         rust("struct ${context.enumName}(String);")
         implBlock(
@@ -257,6 +258,8 @@ open class EnumGenerator(
         )
         deprecatedShape(shape)
 
+        RenderSerdeAttribute.writeAttributes(this)
+        SensitiveWarning.addDoc(this, shape)
         context.enumMeta.render(this)
         rustBlock("enum ${context.enumName}") {
             context.sortedMembers.forEach { member -> member.render(this) }

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/RenderSerdeAttribute.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/RenderSerdeAttribute.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy.generators
+
+import software.amazon.smithy.model.Model
+import software.amazon.smithy.model.shapes.MemberShape
+import software.amazon.smithy.model.shapes.StructureShape
+import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.rustlang.raw
+import software.amazon.smithy.rust.codegen.core.util.isEventStream
+import software.amazon.smithy.rust.codegen.core.util.isStreaming
+
+// Part of RFC30
+public object RenderSerdeAttribute {
+    public fun forStructureShape(writer: RustWriter, shape: StructureShape, model: Model) {
+        if (shape.members().none { it.isEventStream(model) }) {
+            writeAttributes(writer)
+        }
+    }
+
+    public fun forBuilders(writer: RustWriter, shape: StructureShape, model: Model) {
+        if (shape.members().none { it.isEventStream(model) }) {
+            writeAttributes(writer)
+        }
+    }
+
+    public fun skipIfStream(writer: RustWriter, member: MemberShape, model: Model) {
+        if (member.isEventStream(model)) {
+            return
+        }
+        if (member.isStreaming(model)) {
+            Attribute("").SerdeSkip().render(writer)
+        }
+    }
+
+    public fun importSerde(writer: RustWriter) {
+        // we need this for skip serde to work
+        Attribute.AllowUnusedImports.render(writer)
+        Attribute("").SerdeSerializeOrDeserialize().render(writer)
+        writer.raw("use serde;")
+    }
+
+    public fun writeAttributes(writer: RustWriter) {
+        Attribute("").SerdeSerialize().render(writer)
+        Attribute("").SerdeDeserialize().render(writer)
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/SensitiveWarning.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/SensitiveWarning.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rust.codegen.core.smithy.generators
+
+import software.amazon.smithy.model.shapes.Shape
+import software.amazon.smithy.model.traits.SensitiveTrait
+import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
+import software.amazon.smithy.rust.codegen.core.util.hasTrait
+
+object SensitiveWarning {
+    private const val warningMessage = "/// This data may contain sensitive information; It will not be obscured when serialized.\n"
+    fun<T : Shape> addDoc(writer: RustWriter, shape: T) {
+        if (shape.hasTrait<SensitiveTrait>()) {
+            writer.writeInline(warningMessage)
+        }
+    }
+}

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/StructureGenerator.kt
@@ -4,7 +4,6 @@
  */
 
 package software.amazon.smithy.rust.codegen.core.smithy.generators
-
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.model.Model
 import software.amazon.smithy.model.shapes.MemberShape
@@ -161,14 +160,19 @@ open class StructureGenerator(
     }
 
     open fun renderStructure() {
+        RenderSerdeAttribute.importSerde(writer)
         val symbol = symbolProvider.toSymbol(shape)
         val containerMeta = symbol.expectRustMetadata()
         writer.documentShape(shape, model)
         writer.deprecatedShape(shape)
+        RenderSerdeAttribute.forStructureShape(writer, shape, model)
+        SensitiveWarning.addDoc(writer, shape)
         containerMeta.render(writer)
 
         writer.rustBlock("struct $name ${lifetimeDeclaration()}") {
             writer.forEachMember(members) { member, memberName, memberSymbol ->
+                SensitiveWarning.addDoc(writer, shape)
+                RenderSerdeAttribute.skipIfStream(writer, member, model)
                 renderStructureMember(writer, member, memberName, memberSymbol)
             }
             writeCustomizations(customizations, StructureSection.AdditionalFields(shape))

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/UnionGenerator.kt
@@ -4,7 +4,6 @@
  */
 
 package software.amazon.smithy.rust.codegen.core.smithy.generators
-
 import software.amazon.smithy.codegen.core.Symbol
 import software.amazon.smithy.codegen.core.SymbolProvider
 import software.amazon.smithy.model.Model
@@ -63,7 +62,7 @@ open class UnionGenerator(
     open fun render() {
         writer.documentShape(shape, model)
         writer.deprecatedShape(shape)
-
+        RenderSerdeAttribute.writeAttributes(writer)
         val containerMeta = unionSymbol.expectRustMetadata()
         containerMeta.render(writer)
 


### PR DESCRIPTION
## Motivation and Context
Part of RFC30.

## Description
This PR implements changes to client/core codegen.
List of changes:

- Add sensitive warning
- Add `serde` attributes 
- Import `serde` crate to enable `serde(skip)` on some namespaces
- Add `serde` crate behind unstable feature gate on Cargo.toml

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
