### PR TITLE
Fix debug bound on 0.55.x

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -228,12 +228,25 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
         }
 
         writer.docs("Builder for creating a `Config`.")
-        writer.raw("#[derive(Clone, Debug, Default)]")
+        writer.raw("#[derive(Clone, Default)]")
         writer.rustBlock("pub struct Builder") {
             customizations.forEach {
                 it.section(ServiceConfig.BuilderStruct)(this)
             }
         }
+
+        // Custom implementation for Debug so we don't need to enforce Debug down the chain
+        writer.rustBlock("impl std::fmt::Debug for Builder") {
+            writer.rustTemplate(
+                """
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    let mut config = f.debug_struct("Builder");
+                    config.finish()
+                }
+                """,
+            )
+        }
+
         writer.rustBlock("impl Builder") {
             writer.docs("Constructs a config builder.")
             writer.rustTemplate("pub fn new() -> Self { Self::default() }")


### PR DESCRIPTION
## Motivation and Context
- #2577 added a `Debug` bound on `ResolveEndpoint`, but this was a semver-incompatible change

## Description
This removes that bound but re-adds a Debug implementation in areas that we need them

## Testing
- CI

- [ ] Backport this commit to main

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
