### PR TITLE
Upgrade cargo semver checks to 0.20.0

### DIFF
--- a/tools/ci-build/Dockerfile
+++ b/tools/ci-build/Dockerfile
@@ -139,7 +139,7 @@ ARG rust_nightly_version
 RUN cargo +${rust_nightly_version} -Z sparse-registry install cargo-wasi --locked --version ${cargo_wasi_version}
 
 FROM install_rust AS cargo_semver_checks
-ARG cargo_semver_checks_version=0.19.0
+ARG cargo_semver_checks_version=0.20.0
 ARG rust_nightly_version
 RUN cargo +${rust_nightly_version} -Z sparse-registry install cargo-semver-checks --locked --version ${cargo_semver_checks_version}
 #


### PR DESCRIPTION
## Motivation and Context
cargo semver-checks 0.20.0 is something like 100x faster


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
