### PR TITLE
Port fix for debug bound on ResolveEndpoint

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -228,12 +228,25 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
         }
 
         writer.docs("Builder for creating a `Config`.")
-        writer.raw("#[derive(Clone, Debug, Default)]")
+        writer.raw("#[derive(Clone, Default)]")
         writer.rustBlock("pub struct Builder") {
             customizations.forEach {
                 it.section(ServiceConfig.BuilderStruct)(this)
             }
         }
+
+        // Custom implementation for Debug so we don't need to enforce Debug down the chain
+        writer.rustBlock("impl std::fmt::Debug for Builder") {
+            writer.rustTemplate(
+                """
+                fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                    let mut config = f.debug_struct("Builder");
+                    config.finish()
+                }
+                """,
+            )
+        }
+
         writer.rustBlock("impl Builder") {
             writer.docs("Constructs a config builder.")
             writer.rustTemplate("pub fn new() -> Self { Self::default() }")


### PR DESCRIPTION
## Motivation and Context
Port https://github.com/awslabs/smithy-rs/pull/2630 to the `main` branch.

## Description
Adding `Debug` bound on `ResolveEndpoint` in https://github.com/awslabs/smithy-rs/pull/2577 was a breaking change. Unfortunately, the semvar check that ran in that PR barked at a different thing (i.e. barked at moving `StaticUriEndpointResolver` and `DefaultEndpointResolver` from `aws-smithy-runtime-api` to `aws-smithy-runtime`). Eventually the breaking change got merged to the `main`  branch.

This PR reverts the change in question and implements the `Debug` trait for `ResolveEndpoint` in a semvar non-breaking way.

## Testing
- [ ] Passed tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
