### PR TITLE
split out interceptors

### DIFF
--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -73,7 +73,6 @@ mod tests {
     use crate::invocation_id::InvocationIdInterceptor;
     use aws_smithy_http::body::SdkBody;
     use aws_smithy_runtime_api::client::interceptors::{Interceptor, InterceptorContext};
-    use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse};
     use aws_smithy_runtime_api::config_bag::ConfigBag;
     use aws_smithy_runtime_api::type_erasure::TypedBox;
     use http::HeaderValue;

--- a/aws/rust-runtime/aws-runtime/src/invocation_id.rs
+++ b/aws/rust-runtime/aws-runtime/src/invocation_id.rs
@@ -5,7 +5,6 @@
 
 use aws_smithy_runtime_api::client::interceptors::error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::{Interceptor, InterceptorContext};
-use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse};
 use aws_smithy_runtime_api::config_bag::ConfigBag;
 use http::{HeaderName, HeaderValue};
 use uuid::Uuid;
@@ -35,10 +34,10 @@ impl Default for InvocationIdInterceptor {
     }
 }
 
-impl Interceptor<HttpRequest, HttpResponse> for InvocationIdInterceptor {
+impl Interceptor for InvocationIdInterceptor {
     fn modify_before_retry_loop(
         &self,
-        context: &mut InterceptorContext<HttpRequest, HttpResponse>,
+        context: &mut InterceptorContext,
         _cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         let headers = context.request_mut()?.headers_mut();
@@ -79,10 +78,7 @@ mod tests {
     use aws_smithy_runtime_api::type_erasure::TypedBox;
     use http::HeaderValue;
 
-    fn expect_header<'a>(
-        context: &'a InterceptorContext<HttpRequest, HttpResponse>,
-        header_name: &str,
-    ) -> &'a HeaderValue {
+    fn expect_header<'a>(context: &'a InterceptorContext, header_name: &str) -> &'a HeaderValue {
         context
             .request()
             .unwrap()

--- a/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-runtime/src/recursion_detection.rs
@@ -4,7 +4,6 @@
  */
 
 use aws_smithy_runtime_api::client::interceptors::{BoxError, Interceptor, InterceptorContext};
-use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse};
 use aws_smithy_runtime_api::config_bag::ConfigBag;
 use aws_types::os_shim_internal::Env;
 use http::HeaderValue;
@@ -37,10 +36,10 @@ impl RecursionDetectionInterceptor {
     }
 }
 
-impl Interceptor<HttpRequest, HttpResponse> for RecursionDetectionInterceptor {
+impl Interceptor for RecursionDetectionInterceptor {
     fn modify_before_signing(
         &self,
-        context: &mut InterceptorContext<HttpRequest, HttpResponse>,
+        context: &mut InterceptorContext,
         _cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         let request = context.request_mut()?;

--- a/aws/rust-runtime/aws-runtime/src/user_agent.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent.rs
@@ -6,7 +6,6 @@
 use aws_http::user_agent::{ApiMetadata, AwsUserAgent};
 use aws_smithy_runtime_api::client::interceptors::error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::{Interceptor, InterceptorContext};
-use aws_smithy_runtime_api::client::orchestrator::{HttpRequest, HttpResponse};
 use aws_smithy_runtime_api::config_bag::ConfigBag;
 use aws_types::app_name::AppName;
 use aws_types::os_shim_internal::Env;
@@ -70,10 +69,10 @@ fn header_values(
     ))
 }
 
-impl Interceptor<HttpRequest, HttpResponse> for UserAgentInterceptor {
+impl Interceptor for UserAgentInterceptor {
     fn modify_before_signing(
         &self,
-        context: &mut InterceptorContext<HttpRequest, HttpResponse>,
+        context: &mut InterceptorContext,
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         let api_metadata = cfg
@@ -113,10 +112,7 @@ mod tests {
     use aws_smithy_runtime_api::type_erasure::TypedBox;
     use aws_smithy_types::error::display::DisplayErrorContext;
 
-    fn expect_header<'a>(
-        context: &'a InterceptorContext<HttpRequest, HttpResponse>,
-        header_name: &str,
-    ) -> &'a str {
+    fn expect_header<'a>(context: &'a InterceptorContext, header_name: &str) -> &'a str {
         context
             .request()
             .unwrap()

--- a/aws/sra-test/integration-tests/aws-sdk-s3/benches/middleware_vs_orchestrator.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/benches/middleware_vs_orchestrator.rs
@@ -6,6 +6,7 @@
 #[macro_use]
 extern crate criterion;
 use aws_sdk_s3 as s3;
+use aws_smithy_runtime_api::client::interceptors::Interceptors;
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_runtime_api::config_bag::ConfigBag;
 use criterion::{BenchmarkId, Criterion};
@@ -94,6 +95,7 @@ async fn orchestrator(client: &s3::Client) {
         fn configure(
             &self,
             cfg: &mut ConfigBag,
+            _interceptors: &mut Interceptors,
         ) -> Result<(), aws_smithy_runtime_api::client::runtime_plugin::BoxError> {
             let params_builder = s3::endpoint::Params::builder()
                 .set_region(Some(self.region.clone()))

--- a/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
@@ -10,6 +10,7 @@ use aws_sdk_s3::Client;
 use aws_smithy_client::dvr;
 use aws_smithy_client::dvr::MediaType;
 use aws_smithy_client::erase::DynConnector;
+use aws_smithy_runtime_api::client::interceptors::Interceptors;
 use aws_smithy_runtime_api::client::orchestrator::{ConfigBagAccessors, RequestTime};
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_runtime_api::config_bag::ConfigBag;
@@ -56,6 +57,7 @@ impl RuntimePlugin for FixupPlugin {
     fn configure(
         &self,
         cfg: &mut ConfigBag,
+        _interceptors: &mut Interceptors,
     ) -> Result<(), aws_smithy_runtime_api::client::runtime_plugin::BoxError> {
         cfg.set_request_time(RequestTime::new(self.timestamp.clone()));
         cfg.put(AwsUserAgent::for_tests());

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -63,10 +63,10 @@ class EndpointParamsInterceptorGenerator(
             ##[derive(Debug)]
             struct $interceptorName;
 
-            impl #{Interceptor}<#{HttpRequest}, #{HttpResponse}> for $interceptorName {
+            impl #{Interceptor} for $interceptorName {
                 fn read_before_execution(
                     &self,
-                    context: &#{InterceptorContext}<#{HttpRequest}, #{HttpResponse}>,
+                    context: &#{InterceptorContext},
                     cfg: &mut #{ConfigBag},
                 ) -> Result<(), #{BoxError}> {
                     let _input = context.input()?;

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -32,7 +32,7 @@ sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
     /**
      * Hook for adding additional things to config inside service runtime plugins.
      */
-    data class AdditionalConfig(val configBagName: String) : ServiceRuntimePluginSection("AdditionalConfig") {
+    data class AdditionalConfig(val configBagName: String, val interceptorName: String) : ServiceRuntimePluginSection("AdditionalConfig") {
         /** Adds a value to the config bag */
         fun putConfigValue(writer: RustWriter, value: Writable) {
             writer.rust("$configBagName.put(#T);", value)
@@ -43,9 +43,7 @@ sealed class ServiceRuntimePluginSection(name: String) : Section(name) {
             val smithyRuntimeApi = RuntimeType.smithyRuntimeApi(runtimeConfig)
             writer.rustTemplate(
                 """
-                $configBagName.get::<#{Interceptors}<#{HttpRequest}, #{HttpResponse}>>()
-                    .expect("interceptors set")
-                    .register_client_interceptor(std::sync::Arc::new(#{interceptor}) as _);
+                $interceptorName.register_client_interceptor(std::sync::Arc::new(#{interceptor}) as _);
                 """,
                 "HttpRequest" to smithyRuntimeApi.resolve("client::orchestrator::HttpRequest"),
                 "HttpResponse" to smithyRuntimeApi.resolve("client::orchestrator::HttpResponse"),
@@ -83,6 +81,7 @@ class ServiceRuntimePluginGenerator(
             "Params" to endpointTypesGenerator.paramsStruct(),
             "ResolveEndpoint" to http.resolve("endpoint::ResolveEndpoint"),
             "RuntimePlugin" to runtimeApi.resolve("client::runtime_plugin::RuntimePlugin"),
+            "Interceptors" to runtimeApi.resolve("client::interceptors::Interceptors"),
             "SharedEndpointResolver" to http.resolve("endpoint::SharedEndpointResolver"),
             "StaticAuthOptionResolver" to runtimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolver"),
             "TraceProbe" to runtimeApi.resolve("client::orchestrator::TraceProbe"),
@@ -103,7 +102,7 @@ class ServiceRuntimePluginGenerator(
             }
 
             impl #{RuntimePlugin} for ServiceRuntimePlugin {
-                fn configure(&self, cfg: &mut #{ConfigBag}) -> Result<(), #{BoxError}> {
+                fn configure(&self, cfg: &mut #{ConfigBag}, _interceptors: &mut #{Interceptors}) -> Result<(), #{BoxError}> {
                     use #{ConfigBagAccessors};
 
                     // HACK: Put the handle into the config bag to work around config not being fully implemented yet
@@ -154,7 +153,7 @@ class ServiceRuntimePluginGenerator(
                 writeCustomizations(customizations, ServiceRuntimePluginSection.HttpAuthScheme("cfg"))
             },
             "additional_config" to writable {
-                writeCustomizations(customizations, ServiceRuntimePluginSection.AdditionalConfig("cfg"))
+                writeCustomizations(customizations, ServiceRuntimePluginSection.AdditionalConfig("cfg", "_interceptors"))
             },
         )
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -294,7 +294,7 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
         ) {
             rustTemplate(
                 """
-                fn configure(&self, _cfg: &mut #{ConfigBag}) -> Result<(), #{BoxError}> {
+                fn configure(&self, _cfg: &mut #{ConfigBag}, _inter: &mut #{Interceptors}) -> Result<(), #{BoxError}> {
                     // TODO(RuntimePlugins): Put into `cfg` the fields in `self.config_override` that are not `None`.
 
                     Ok(())
@@ -302,6 +302,7 @@ class ServiceConfigGenerator(private val customizations: List<ConfigCustomizatio
                 """,
                 "BoxError" to runtimeApi.resolve("client::runtime_plugin::BoxError"),
                 "ConfigBag" to runtimeApi.resolve("config_bag::ConfigBag"),
+                "Interceptors" to runtimeApi.resolve("client::interceptors::Interceptors"),
             )
         }
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors.rs
@@ -6,7 +6,6 @@
 pub mod context;
 pub mod error;
 
-use crate::client::orchestrator::{HttpRequest, HttpResponse};
 use crate::config_bag::ConfigBag;
 use aws_smithy_types::error::display::DisplayErrorContext;
 pub use context::InterceptorContext;
@@ -16,11 +15,7 @@ use std::sync::Arc;
 macro_rules! interceptor_trait_fn {
     ($name:ident, $docs:tt) => {
         #[doc = $docs]
-        fn $name(
-            &self,
-            context: &InterceptorContext<TxReq, TxRes>,
-            cfg: &mut ConfigBag,
-        ) -> Result<(), BoxError> {
+        fn $name(&self, context: &InterceptorContext, cfg: &mut ConfigBag) -> Result<(), BoxError> {
             let _ctx = context;
             let _cfg = cfg;
             Ok(())
@@ -30,7 +25,7 @@ macro_rules! interceptor_trait_fn {
         #[doc = $docs]
         fn $name(
             &self,
-            context: &mut InterceptorContext<TxReq, TxRes>,
+            context: &mut InterceptorContext,
             cfg: &mut ConfigBag,
         ) -> Result<(), BoxError> {
             let _ctx = context;
@@ -50,7 +45,7 @@ macro_rules! interceptor_trait_fn {
 ///   of the SDK ’s request execution pipeline. Hooks are either "read" hooks, which make it possible
 ///   to read in-flight request or response messages, or "read/write" hooks, which make it possible
 ///   to modify in-flight request or output messages.
-pub trait Interceptor<TxReq, TxRes>: std::fmt::Debug {
+pub trait Interceptor: std::fmt::Debug {
     interceptor_trait_fn!(
         read_before_execution,
         "
@@ -542,47 +537,12 @@ pub trait Interceptor<TxReq, TxRes>: std::fmt::Debug {
     );
 }
 
-pub type SharedInterceptor<TxReq, TxRes> = Arc<dyn Interceptor<TxReq, TxRes> + Send + Sync>;
+pub type SharedInterceptor = Arc<dyn Interceptor + Send + Sync>;
 
-#[derive(Debug)]
-struct Inner<TxReq, TxRes> {
-    client_interceptors: Vec<SharedInterceptor<TxReq, TxRes>>,
-    operation_interceptors: Vec<SharedInterceptor<TxReq, TxRes>>,
-}
-
-// The compiler isn't smart enough to realize that TxReq and TxRes don't need to implement `Clone`
-impl<TxReq, TxRes> Clone for Inner<TxReq, TxRes> {
-    fn clone(&self) -> Self {
-        Self {
-            client_interceptors: self.client_interceptors.clone(),
-            operation_interceptors: self.operation_interceptors.clone(),
-        }
-    }
-}
-
-#[derive(Debug)]
-pub struct Interceptors<TxReq = HttpRequest, TxRes = HttpResponse> {
-    inner: Inner<TxReq, TxRes>,
-}
-
-// The compiler isn't smart enough to realize that TxReq and TxRes don't need to implement `Clone`
-impl<TxReq, TxRes> Clone for Interceptors<TxReq, TxRes> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<TxReq, TxRes> Default for Interceptors<TxReq, TxRes> {
-    fn default() -> Self {
-        Self {
-            inner: Inner {
-                client_interceptors: Vec::new(),
-                operation_interceptors: Vec::new(),
-            },
-        }
-    }
+#[derive(Debug, Clone, Default)]
+pub struct Interceptors {
+    client_interceptors: Vec<SharedInterceptor>,
+    operation_interceptors: Vec<SharedInterceptor>,
 }
 
 macro_rules! interceptor_impl_fn {
@@ -593,16 +553,10 @@ macro_rules! interceptor_impl_fn {
         interceptor_impl_fn!(mut context, $name, $name);
     };
     (context, $outer_name:ident, $inner_name:ident) => {
-        interceptor_impl_fn!(
-            $outer_name,
-            $inner_name(context: &InterceptorContext<TxReq, TxRes>)
-        );
+        interceptor_impl_fn!($outer_name, $inner_name(context: &InterceptorContext));
     };
     (mut context, $outer_name:ident, $inner_name:ident) => {
-        interceptor_impl_fn!(
-            $outer_name,
-            $inner_name(context: &mut InterceptorContext<TxReq, TxRes>)
-        );
+        interceptor_impl_fn!($outer_name, $inner_name(context: &mut InterceptorContext));
     };
     ($outer_name:ident, $inner_name:ident ($context:ident : $context_ty:ty)) => {
         pub fn $outer_name(
@@ -624,33 +578,26 @@ macro_rules! interceptor_impl_fn {
     };
 }
 
-impl<TxReq, TxRes> Interceptors<TxReq, TxRes> {
+impl Interceptors {
     pub fn new() -> Self {
         Self::default()
     }
 
-    fn interceptors(&self) -> impl Iterator<Item = &SharedInterceptor<TxReq, TxRes>> {
+    fn interceptors(&self) -> impl Iterator<Item = &SharedInterceptor> {
         // Since interceptors can modify the interceptor list (since its in the config bag), copy the list ahead of time.
         // This should be cheap since the interceptors inside the list are Arcs.
-        self.inner
-            .client_interceptors
+        self.client_interceptors
             .iter()
-            .chain(self.inner.operation_interceptors.iter())
+            .chain(self.operation_interceptors.iter())
     }
 
-    pub fn register_client_interceptor(
-        &mut self,
-        interceptor: SharedInterceptor<TxReq, TxRes>,
-    ) -> &mut Self {
-        self.inner.client_interceptors.push(interceptor);
+    pub fn register_client_interceptor(&mut self, interceptor: SharedInterceptor) -> &mut Self {
+        self.client_interceptors.push(interceptor);
         self
     }
 
-    pub fn register_operation_interceptor(
-        &mut self,
-        interceptor: SharedInterceptor<TxReq, TxRes>,
-    ) -> &mut Self {
-        self.inner.operation_interceptors.push(interceptor);
+    pub fn register_operation_interceptor(&mut self, interceptor: SharedInterceptor) -> &mut Self {
+        self.operation_interceptors.push(interceptor);
         self
     }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -4,6 +4,7 @@
  */
 
 use super::InterceptorError;
+use crate::client::orchestrator::{HttpRequest, HttpResponse};
 use crate::type_erasure::TypeErasedBox;
 
 pub type Input = TypeErasedBox;
@@ -11,8 +12,11 @@ pub type Output = TypeErasedBox;
 pub type Error = TypeErasedBox;
 pub type OutputOrError = Result<Output, Error>;
 
+type Request = HttpRequest;
+type Response = HttpResponse;
+
 /// A container for the data currently available to an interceptor.
-pub struct InterceptorContext<Request, Response> {
+pub struct InterceptorContext {
     input: Option<Input>,
     output_or_error: Option<OutputOrError>,
     request: Option<Request>,
@@ -21,7 +25,7 @@ pub struct InterceptorContext<Request, Response> {
 
 // TODO(interceptors) we could use types to ensure that people calling methods on interceptor context can't access
 //     field that haven't been set yet.
-impl<Request, Response> InterceptorContext<Request, Response> {
+impl InterceptorContext {
     pub fn new(input: Input) -> Self {
         Self {
             input: Some(input),

--- a/rust-runtime/aws-smithy-runtime-api/src/client/retries.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/retries.rs
@@ -5,7 +5,7 @@
 
 use crate::client::interceptors::context::Error;
 use crate::client::interceptors::InterceptorContext;
-use crate::client::orchestrator::{BoxError, HttpRequest, HttpResponse};
+use crate::client::orchestrator::BoxError;
 use crate::config_bag::ConfigBag;
 use aws_smithy_types::retry::ErrorKind;
 use std::fmt::Debug;
@@ -23,7 +23,7 @@ pub trait RetryStrategy: Send + Sync + Debug {
 
     fn should_attempt_retry(
         &self,
-        context: &InterceptorContext<HttpRequest, HttpResponse>,
+        context: &InterceptorContext,
         cfg: &ConfigBag,
     ) -> Result<ShouldAttempt, BoxError>;
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
@@ -3,24 +3,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::client::interceptors::Interceptors;
 use crate::config_bag::ConfigBag;
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 pub trait RuntimePlugin {
-    fn configure(&self, cfg: &mut ConfigBag) -> Result<(), BoxError>;
+    fn configure(
+        &self,
+        cfg: &mut ConfigBag,
+        interceptors: &mut Interceptors,
+    ) -> Result<(), BoxError>;
 }
 
 impl RuntimePlugin for Box<dyn RuntimePlugin> {
-    fn configure(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
-        self.as_ref().configure(cfg)
+    fn configure(
+        &self,
+        cfg: &mut ConfigBag,
+        interceptors: &mut Interceptors,
+    ) -> Result<(), BoxError> {
+        self.as_ref().configure(cfg, interceptors)
     }
 }
 
-#[derive(Default)]
 pub struct RuntimePlugins {
     client_plugins: Vec<Box<dyn RuntimePlugin>>,
     operation_plugins: Vec<Box<dyn RuntimePlugin>>,
+}
+
+impl Default for RuntimePlugins {
+    fn default() -> Self {
+        Self {
+            client_plugins: vec![],
+            operation_plugins: vec![],
+        }
+    }
 }
 
 impl RuntimePlugins {
@@ -38,17 +55,25 @@ impl RuntimePlugins {
         self
     }
 
-    pub fn apply_client_configuration(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
+    pub fn apply_client_configuration(
+        &self,
+        cfg: &mut ConfigBag,
+        interceptors: &mut Interceptors,
+    ) -> Result<(), BoxError> {
         for plugin in self.client_plugins.iter() {
-            plugin.configure(cfg)?;
+            plugin.configure(cfg, interceptors)?;
         }
 
         Ok(())
     }
 
-    pub fn apply_operation_configuration(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
+    pub fn apply_operation_configuration(
+        &self,
+        cfg: &mut ConfigBag,
+        interceptors: &mut Interceptors,
+    ) -> Result<(), BoxError> {
         for plugin in self.operation_plugins.iter() {
-            plugin.configure(cfg)?;
+            plugin.configure(cfg, interceptors)?;
         }
 
         Ok(())
@@ -58,12 +83,17 @@ impl RuntimePlugins {
 #[cfg(test)]
 mod tests {
     use super::{BoxError, RuntimePlugin, RuntimePlugins};
+    use crate::client::interceptors::Interceptors;
     use crate::config_bag::ConfigBag;
 
     struct SomeStruct;
 
     impl RuntimePlugin for SomeStruct {
-        fn configure(&self, _cfg: &mut ConfigBag) -> Result<(), BoxError> {
+        fn configure(
+            &self,
+            _cfg: &mut ConfigBag,
+            _inters: &mut Interceptors,
+        ) -> Result<(), BoxError> {
             todo!()
         }
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
@@ -26,18 +26,10 @@ impl RuntimePlugin for Box<dyn RuntimePlugin> {
     }
 }
 
+#[derive(Default)]
 pub struct RuntimePlugins {
     client_plugins: Vec<Box<dyn RuntimePlugin>>,
     operation_plugins: Vec<Box<dyn RuntimePlugin>>,
-}
-
-impl Default for RuntimePlugins {
-    fn default() -> Self {
-        Self {
-            client_plugins: vec![],
-            operation_plugins: vec![],
-        }
-    }
 }
 
 impl RuntimePlugins {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -31,15 +31,14 @@ pub async fn invoke(
     let mut cfg = ConfigBag::base();
     let cfg = &mut cfg;
 
-    let interceptors = Interceptors::new();
-    cfg.put(interceptors.clone());
+    let mut interceptors = Interceptors::new();
 
     let context = Phase::construction(InterceptorContext::new(input))
         // Client configuration
-        .include(|_| runtime_plugins.apply_client_configuration(cfg))?
+        .include(|_| runtime_plugins.apply_client_configuration(cfg, &mut interceptors))?
         .include(|ctx| interceptors.client_read_before_execution(ctx, cfg))?
         // Operation configuration
-        .include(|_| runtime_plugins.apply_operation_configuration(cfg))?
+        .include(|_| runtime_plugins.apply_operation_configuration(cfg, &mut interceptors))?
         .include(|ctx| interceptors.operation_read_before_execution(ctx, cfg))?
         // Before serialization
         .include(|ctx| interceptors.read_before_serialization(ctx, cfg))?

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -10,9 +10,7 @@ use crate::client::orchestrator::phase::Phase;
 use aws_smithy_http::result::SdkError;
 use aws_smithy_runtime_api::client::interceptors::context::{Error, Input, Output};
 use aws_smithy_runtime_api::client::interceptors::{InterceptorContext, Interceptors};
-use aws_smithy_runtime_api::client::orchestrator::{
-    BoxError, ConfigBagAccessors, HttpRequest, HttpResponse,
-};
+use aws_smithy_runtime_api::client::orchestrator::{BoxError, ConfigBagAccessors, HttpResponse};
 use aws_smithy_runtime_api::client::retries::ShouldAttempt;
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugins;
 use aws_smithy_runtime_api::config_bag::ConfigBag;
@@ -116,7 +114,7 @@ pub async fn invoke(
 async fn make_an_attempt(
     dispatch_phase: Phase,
     cfg: &mut ConfigBag,
-    interceptors: &Interceptors<HttpRequest, HttpResponse>,
+    interceptors: &Interceptors,
 ) -> Result<Phase, SdkError<Error, HttpResponse>> {
     let dispatch_phase = dispatch_phase
         .include(|ctx| interceptors.read_before_attempt(ctx, cfg))?

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -10,7 +10,6 @@ use aws_smithy_http::endpoint::{
 use aws_smithy_runtime_api::client::interceptors::InterceptorContext;
 use aws_smithy_runtime_api::client::orchestrator::{
     BoxError, ConfigBagAccessors, EndpointResolver, EndpointResolverParams, HttpRequest,
-    HttpResponse,
 };
 use aws_smithy_runtime_api::config_bag::ConfigBag;
 use http::header::HeaderName;
@@ -113,7 +112,7 @@ where
 }
 
 pub(super) fn orchestrate_endpoint(
-    ctx: &mut InterceptorContext<HttpRequest, HttpResponse>,
+    ctx: &mut InterceptorContext,
     cfg: &ConfigBag,
 ) -> Result<(), BoxError> {
     let params = cfg.endpoint_resolver_params();

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/phase.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/phase.rs
@@ -6,7 +6,7 @@
 use aws_smithy_http::result::{ConnectorError, SdkError};
 use aws_smithy_runtime_api::client::interceptors::context::{Error, Output};
 use aws_smithy_runtime_api::client::interceptors::InterceptorContext;
-use aws_smithy_runtime_api::client::orchestrator::{BoxError, HttpRequest, HttpResponse};
+use aws_smithy_runtime_api::client::orchestrator::{BoxError, HttpResponse};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 enum OrchestrationPhase {
@@ -17,26 +17,21 @@ enum OrchestrationPhase {
 
 pub(super) struct Phase {
     phase: OrchestrationPhase,
-    context: InterceptorContext<HttpRequest, HttpResponse>,
+    context: InterceptorContext,
 }
 
 impl Phase {
-    pub(crate) fn construction(context: InterceptorContext<HttpRequest, HttpResponse>) -> Self {
+    pub(crate) fn construction(context: InterceptorContext) -> Self {
         Self::start(OrchestrationPhase::Construction, context)
     }
-    pub(crate) fn dispatch(context: InterceptorContext<HttpRequest, HttpResponse>) -> Self {
+    pub(crate) fn dispatch(context: InterceptorContext) -> Self {
         Self::start(OrchestrationPhase::Dispatch, context)
     }
-    pub(crate) fn response_handling(
-        context: InterceptorContext<HttpRequest, HttpResponse>,
-    ) -> Self {
+    pub(crate) fn response_handling(context: InterceptorContext) -> Self {
         Self::start(OrchestrationPhase::ResponseHandling, context)
     }
 
-    fn start(
-        phase: OrchestrationPhase,
-        context: InterceptorContext<HttpRequest, HttpResponse>,
-    ) -> Self {
+    fn start(phase: OrchestrationPhase, context: InterceptorContext) -> Self {
         match phase {
             OrchestrationPhase::Construction => {}
             OrchestrationPhase::Dispatch => {}
@@ -47,7 +42,7 @@ impl Phase {
 
     pub(crate) fn include_mut<E: Into<BoxError>>(
         mut self,
-        c: impl FnOnce(&mut InterceptorContext<HttpRequest, HttpResponse>) -> Result<(), E>,
+        c: impl FnOnce(&mut InterceptorContext) -> Result<(), E>,
     ) -> Result<Self, SdkError<Error, HttpResponse>> {
         match c(&mut self.context) {
             Ok(_) => Ok(self),
@@ -57,7 +52,7 @@ impl Phase {
 
     pub(crate) fn include<E: Into<BoxError>>(
         self,
-        c: impl FnOnce(&InterceptorContext<HttpRequest, HttpResponse>) -> Result<(), E>,
+        c: impl FnOnce(&InterceptorContext) -> Result<(), E>,
     ) -> Result<Self, SdkError<Error, HttpResponse>> {
         match c(&self.context) {
             Ok(_) => Ok(self),
@@ -113,7 +108,7 @@ impl Phase {
         }
     }
 
-    pub(crate) fn finish(self) -> InterceptorContext<HttpRequest, HttpResponse> {
+    pub(crate) fn finish(self) -> InterceptorContext {
         self.context
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/never.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/never.rs
@@ -4,7 +4,7 @@
  */
 
 use aws_smithy_runtime_api::client::interceptors::InterceptorContext;
-use aws_smithy_runtime_api::client::orchestrator::{BoxError, HttpRequest, HttpResponse};
+use aws_smithy_runtime_api::client::orchestrator::BoxError;
 use aws_smithy_runtime_api::client::retries::{RetryStrategy, ShouldAttempt};
 use aws_smithy_runtime_api::config_bag::ConfigBag;
 
@@ -24,7 +24,7 @@ impl RetryStrategy for NeverRetryStrategy {
 
     fn should_attempt_retry(
         &self,
-        _context: &InterceptorContext<HttpRequest, HttpResponse>,
+        _context: &InterceptorContext,
         _cfg: &ConfigBag,
     ) -> Result<ShouldAttempt, BoxError> {
         Ok(ShouldAttempt::No)


### PR DESCRIPTION
## Motivation and Context
- split out interceptors from config bag to simplify orchestrator

## Description
- update runtime plugin trait to split out interceptors
- remove interceptor generics 
- update interceptors struct to remove locking and indirection

## Testing
- [x] ```./gradlew :aws:sra-test:assemble && (cd aws/sra-test/integration-tests/aws-sdk-s3 && cargo test)```



----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
