### PR TITLE
remove: non-existent retry strategy from SRA test

### DIFF
--- a/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
@@ -106,7 +106,7 @@ async fn sra_manual_test() {
             cfg.put(params_builder);
 
             cfg.set_retry_strategy(
-                aws_smithy_runtime::client::retries::strategy::StandardRetryStrategy::default(),
+                aws_smithy_runtime::client::retries::strategy::NeverRetryStrategy::default(),
             );
 
             let connection: Box<dyn Connection> = Box::new(DynConnectorAdapter::new(


### PR DESCRIPTION
I made a mistake when I split the classifier work from the retry strategy work. Russell pointed that out to me, and this PR fixes it.
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
