### PR TITLE
Recalculate signing time for every retry attempt

### DIFF
--- a/aws/rust-runtime/aws-runtime/src/identity.rs
+++ b/aws/rust-runtime/aws-runtime/src/identity.rs
@@ -6,9 +6,9 @@
 /// Credentials-based identity support.
 pub mod credentials {
     use aws_credential_types::cache::SharedCredentialsCache;
-    use aws_smithy_http::property_bag::PropertyBag;
     use aws_smithy_runtime_api::client::identity::{Identity, IdentityResolver};
     use aws_smithy_runtime_api::client::orchestrator::{BoxError, Future};
+    use aws_smithy_runtime_api::config_bag::ConfigBag;
 
     /// Smithy identity resolver for AWS credentials.
     #[derive(Debug)]
@@ -24,7 +24,7 @@ pub mod credentials {
     }
 
     impl IdentityResolver for CredentialsIdentityResolver {
-        fn resolve_identity(&self, _identity_properties: &PropertyBag) -> Future<Identity> {
+        fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
             let cache = self.credentials_cache.clone();
             Future::new(Box::pin(async move {
                 let credentials = cache.as_ref().provide_cached_credentials().await?;

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -102,7 +102,7 @@ private class AuthOperationRuntimePluginCustomization(private val codegenContext
         val runtimeApi = RuntimeType.smithyRuntimeApi(runtimeConfig)
         val awsRuntime = AwsRuntimeType.awsRuntime(runtimeConfig)
         arrayOf(
-            "AuthOptionListResolver" to runtimeApi.resolve("client::auth::option_resolver::AuthOptionListResolver"),
+            "StaticAuthOptionResolver" to runtimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolver"),
             "HttpSignatureType" to awsRuntime.resolve("auth::sigv4::HttpSignatureType"),
             "SIGV4_SCHEME_ID" to awsRuntime.resolve("auth::sigv4::SCHEME_ID"),
             "SigV4OperationSigningConfig" to awsRuntime.resolve("auth::sigv4::SigV4OperationSigningConfig"),
@@ -141,7 +141,7 @@ private class AuthOperationRuntimePluginCustomization(private val codegenContext
                             signing_options,
                         });
                         // TODO(enableNewSmithyRuntime): Make auth options additive in the config bag so that multiple codegen decorators can register them
-                        let auth_option_resolver = #{AuthOptionListResolver}::new(
+                        let auth_option_resolver = #{StaticAuthOptionResolver}::new(
                             vec![#{SIGV4_SCHEME_ID}]
                         );
                         ${section.configBagName}.set_auth_option_resolver(auth_option_resolver);

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -103,9 +103,7 @@ private class AuthOperationRuntimePluginCustomization(private val codegenContext
         val awsRuntime = AwsRuntimeType.awsRuntime(runtimeConfig)
         arrayOf(
             "AuthOptionListResolver" to runtimeApi.resolve("client::auth::option_resolver::AuthOptionListResolver"),
-            "HttpAuthOption" to runtimeApi.resolve("client::orchestrator::HttpAuthOption"),
             "HttpSignatureType" to awsRuntime.resolve("auth::sigv4::HttpSignatureType"),
-            "PropertyBag" to RuntimeType.smithyHttp(runtimeConfig).resolve("property_bag::PropertyBag"),
             "SIGV4_SCHEME_ID" to awsRuntime.resolve("auth::sigv4::SCHEME_ID"),
             "SigV4OperationSigningConfig" to awsRuntime.resolve("auth::sigv4::SigV4OperationSigningConfig"),
             "SigningOptions" to awsRuntime.resolve("auth::sigv4::SigningOptions"),
@@ -136,16 +134,15 @@ private class AuthOperationRuntimePluginCustomization(private val codegenContext
                         signing_options.normalize_uri_path = $normalizeUrlPath;
                         signing_options.signing_optional = $signingOptional;
                         signing_options.payload_override = #{payload_override};
-                        signing_options.request_timestamp = cfg.request_time().unwrap_or_default().system_time();
 
-                        let mut sigv4_properties = #{PropertyBag}::new();
-                        sigv4_properties.insert(#{SigV4OperationSigningConfig} {
+                        ${section.configBagName}.put(#{SigV4OperationSigningConfig} {
                             region: signing_region,
                             service: signing_service,
                             signing_options,
                         });
+                        // TODO(enableNewSmithyRuntime): Make auth options additive in the config bag so that multiple codegen decorators can register them
                         let auth_option_resolver = #{AuthOptionListResolver}::new(
-                            vec![#{HttpAuthOption}::new(#{SIGV4_SCHEME_ID}, std::sync::Arc::new(sigv4_properties))]
+                            vec![#{SIGV4_SCHEME_ID}]
                         );
                         ${section.configBagName}.set_auth_option_resolver(auth_option_resolver);
                         """,

--- a/aws/sra-test/integration-tests/aws-sdk-s3/benches/middleware_vs_orchestrator.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/benches/middleware_vs_orchestrator.rs
@@ -5,16 +5,13 @@
 
 #[macro_use]
 extern crate criterion;
-use aws_credential_types::cache::{CredentialsCache, SharedCredentialsCache};
-use aws_credential_types::provider::SharedCredentialsProvider;
-use aws_credential_types::Credentials;
 use aws_sdk_s3 as s3;
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_client::test_connection::infallible_connection_fn;
-use aws_smithy_http::endpoint::SharedEndpointResolver;
-use aws_smithy_runtime_api::type_erasure::TypedBox;
+use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
+use aws_smithy_runtime_api::config_bag::ConfigBag;
 use criterion::Criterion;
-use s3::operation::list_objects_v2::{ListObjectsV2Error, ListObjectsV2Input, ListObjectsV2Output};
+use s3::endpoint::Params;
 
 async fn middleware(client: &s3::Client) {
     client
@@ -26,41 +23,36 @@ async fn middleware(client: &s3::Client) {
         .expect("successful execution");
 }
 
-async fn orchestrator(
-    connector: &DynConnector,
-    endpoint_resolver: SharedEndpointResolver<s3::endpoint::Params>,
-    credentials_cache: SharedCredentialsCache,
-) {
-    let service_runtime_plugin = orchestrator::ManualServiceRuntimePlugin {
-        connector: connector.clone(),
-        endpoint_resolver: endpoint_resolver.clone(),
-        credentials_cache: credentials_cache.clone(),
-    };
+async fn orchestrator(client: &s3::Client) {
+    struct FixupPlugin {
+        region: String,
+    }
+    impl RuntimePlugin for FixupPlugin {
+        fn configure(
+            &self,
+            cfg: &mut ConfigBag,
+        ) -> Result<(), aws_smithy_runtime_api::client::runtime_plugin::BoxError> {
+            let params_builder = Params::builder()
+                .set_region(Some(self.region.clone()))
+                .bucket("test-bucket");
 
-    // TODO(enableNewSmithyRuntime): benchmark with `send_v2` directly once it works
-    let runtime_plugins = aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugins::new()
-        .with_client_plugin(service_runtime_plugin)
-        .with_operation_plugin(aws_sdk_s3::operation::list_objects_v2::ListObjectsV2::new())
-        .with_operation_plugin(orchestrator::ManualOperationRuntimePlugin);
-    let input = ListObjectsV2Input::builder()
+            cfg.put(params_builder);
+            Ok(())
+        }
+    }
+    let _output = client
+        .list_objects_v2()
         .bucket("test-bucket")
         .prefix("prefix~")
-        .build()
-        .unwrap();
-    let input = TypedBox::new(input).erase();
-    let output = aws_smithy_runtime::client::orchestrator::invoke(input, &runtime_plugins)
+        .send_v2_with_plugin(Some(FixupPlugin {
+            region: client
+                .conf()
+                .region()
+                .map(|c| c.as_ref().to_string())
+                .unwrap(),
+        }))
         .await
-        .map_err(|err| {
-            err.map_service_error(|err| {
-                TypedBox::<ListObjectsV2Error>::assume_from(err)
-                    .expect("correct error type")
-                    .unwrap()
-            })
-        })
-        .unwrap();
-    TypedBox::<ListObjectsV2Output>::assume_from(output)
-        .expect("correct output type")
-        .unwrap();
+        .expect("successful execution");
 }
 
 fn test_connection() -> DynConnector {
@@ -93,14 +85,18 @@ fn test_connection() -> DynConnector {
     })
 }
 
-fn middleware_bench(c: &mut Criterion) {
+fn client() -> s3::Client {
     let conn = test_connection();
     let config = s3::Config::builder()
         .credentials_provider(s3::config::Credentials::for_tests())
         .region(s3::config::Region::new("us-east-1"))
         .http_connector(conn.clone())
         .build();
-    let client = s3::Client::from_conf(config);
+    s3::Client::from_conf(config)
+}
+
+fn middleware_bench(c: &mut Criterion) {
+    let client = client();
     c.bench_function("middleware", move |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
             .iter(|| async { middleware(&client).await })
@@ -108,189 +104,11 @@ fn middleware_bench(c: &mut Criterion) {
 }
 
 fn orchestrator_bench(c: &mut Criterion) {
-    let conn = test_connection();
-    let endpoint_resolver = SharedEndpointResolver::new(s3::endpoint::DefaultResolver::new());
-    let credentials_cache = SharedCredentialsCache::new(
-        CredentialsCache::lazy()
-            .create_cache(SharedCredentialsProvider::new(Credentials::for_tests())),
-    );
-
+    let client = client();
     c.bench_function("orchestrator", move |b| {
         b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter(|| async {
-                orchestrator(&conn, endpoint_resolver.clone(), credentials_cache.clone()).await
-            })
+            .iter(|| async { orchestrator(&client).await })
     });
-}
-
-mod orchestrator {
-    use aws_credential_types::cache::SharedCredentialsCache;
-    use aws_http::user_agent::{ApiMetadata, AwsUserAgent};
-    use aws_runtime::recursion_detection::RecursionDetectionInterceptor;
-    use aws_runtime::user_agent::UserAgentInterceptor;
-    use aws_sdk_s3::config::Region;
-    use aws_sdk_s3::endpoint::Params;
-    use aws_sdk_s3::operation::list_objects_v2::ListObjectsV2Input;
-    use aws_smithy_client::erase::DynConnector;
-    use aws_smithy_http::endpoint::SharedEndpointResolver;
-    use aws_smithy_runtime::client::connections::adapter::DynConnectorAdapter;
-    use aws_smithy_runtime::client::orchestrator::endpoints::DefaultEndpointResolver;
-    use aws_smithy_runtime_api::client::interceptors::error::ContextAttachedError;
-    use aws_smithy_runtime_api::client::interceptors::{
-        Interceptor, InterceptorContext, Interceptors,
-    };
-    use aws_smithy_runtime_api::client::orchestrator::{
-        BoxError, ConfigBagAccessors, Connection, HttpRequest, HttpResponse, TraceProbe,
-    };
-    use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
-    use aws_smithy_runtime_api::config_bag::ConfigBag;
-    use aws_types::region::SigningRegion;
-    use aws_types::SigningService;
-    use std::sync::Arc;
-
-    pub struct ManualServiceRuntimePlugin {
-        pub connector: DynConnector,
-        pub endpoint_resolver: SharedEndpointResolver<Params>,
-        pub credentials_cache: SharedCredentialsCache,
-    }
-
-    impl RuntimePlugin for ManualServiceRuntimePlugin {
-        fn configure(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
-            let identity_resolvers =
-                aws_smithy_runtime_api::client::identity::IdentityResolvers::builder()
-                    .identity_resolver(
-                        aws_runtime::auth::sigv4::SCHEME_ID,
-                        aws_runtime::identity::credentials::CredentialsIdentityResolver::new(
-                            self.credentials_cache.clone(),
-                        ),
-                    )
-                    .identity_resolver(
-                        "anonymous",
-                        aws_smithy_runtime_api::client::identity::AnonymousIdentityResolver::new(),
-                    )
-                    .build();
-            cfg.set_identity_resolvers(identity_resolvers);
-
-            let http_auth_schemes =
-                aws_smithy_runtime_api::client::orchestrator::HttpAuthSchemes::builder()
-                    .auth_scheme(
-                        aws_runtime::auth::sigv4::SCHEME_ID,
-                        aws_runtime::auth::sigv4::SigV4HttpAuthScheme::new(),
-                    )
-                    .build();
-            cfg.set_http_auth_schemes(http_auth_schemes);
-
-            cfg.set_auth_option_resolver(
-                aws_smithy_runtime_api::client::auth::option_resolver::AuthOptionListResolver::new(
-                    Vec::new(),
-                ),
-            );
-
-            cfg.set_endpoint_resolver(DefaultEndpointResolver::new(self.endpoint_resolver.clone()));
-
-            let params_builder = aws_sdk_s3::endpoint::Params::builder()
-                .set_region(Some("us-east-1".to_owned()))
-                .set_endpoint(Some("https://s3.us-east-1.amazonaws.com/".to_owned()));
-            cfg.put(params_builder);
-
-            cfg.set_retry_strategy(
-                aws_smithy_runtime_api::client::retries::NeverRetryStrategy::new(),
-            );
-
-            let connection: Box<dyn Connection> =
-                Box::new(DynConnectorAdapter::new(self.connector.clone()));
-            cfg.set_connection(connection);
-
-            cfg.set_trace_probe({
-                #[derive(Debug)]
-                struct StubTraceProbe;
-                impl TraceProbe for StubTraceProbe {
-                    fn dispatch_events(&self) {
-                        // no-op
-                    }
-                }
-                StubTraceProbe
-            });
-
-            cfg.put(SigningService::from_static("s3"));
-            cfg.put(SigningRegion::from(Region::from_static("us-east-1")));
-
-            cfg.put(ApiMetadata::new("unused", "unused"));
-            cfg.put(AwsUserAgent::for_tests()); // Override the user agent with the test UA
-            cfg.get::<Interceptors<HttpRequest, HttpResponse>>()
-                .expect("interceptors set")
-                .register_client_interceptor(Arc::new(UserAgentInterceptor::new()) as _)
-                .register_client_interceptor(Arc::new(RecursionDetectionInterceptor::new()) as _);
-            Ok(())
-        }
-    }
-
-    // This is a temporary operation runtime plugin until <Operation>EndpointParamsInterceptor and
-    // <Operation>EndpointParamsFinalizerInterceptor have been fully implemented, in which case
-    // `.with_operation_plugin(ManualOperationRuntimePlugin)` can be removed.
-    pub struct ManualOperationRuntimePlugin;
-
-    impl RuntimePlugin for ManualOperationRuntimePlugin {
-        fn configure(&self, cfg: &mut ConfigBag) -> Result<(), BoxError> {
-            #[derive(Debug)]
-            struct ListObjectsV2EndpointParamsInterceptor;
-            impl Interceptor<HttpRequest, HttpResponse> for ListObjectsV2EndpointParamsInterceptor {
-                fn read_before_execution(
-                    &self,
-                    context: &InterceptorContext<HttpRequest, HttpResponse>,
-                    cfg: &mut ConfigBag,
-                ) -> Result<(), BoxError> {
-                    let input = context.input()?;
-                    let input = input
-                        .downcast_ref::<ListObjectsV2Input>()
-                        .ok_or_else(|| "failed to downcast to ListObjectsV2Input")?;
-                    let mut params_builder = cfg
-                        .get::<aws_sdk_s3::endpoint::ParamsBuilder>()
-                        .ok_or_else(|| "missing endpoint params builder")?
-                        .clone();
-                    params_builder = params_builder.set_bucket(input.bucket.clone());
-                    cfg.put(params_builder);
-
-                    Ok(())
-                }
-            }
-
-            #[derive(Debug)]
-            struct ListObjectsV2EndpointParamsFinalizerInterceptor;
-            impl Interceptor<HttpRequest, HttpResponse> for ListObjectsV2EndpointParamsFinalizerInterceptor {
-                fn read_before_execution(
-                    &self,
-                    _context: &InterceptorContext<HttpRequest, HttpResponse>,
-                    cfg: &mut ConfigBag,
-                ) -> Result<(), BoxError> {
-                    let params_builder = cfg
-                        .get::<aws_sdk_s3::endpoint::ParamsBuilder>()
-                        .ok_or_else(|| "missing endpoint params builder")?
-                        .clone();
-                    let params = params_builder.build().map_err(|err| {
-                        ContextAttachedError::new("endpoint params could not be built", err)
-                    })?;
-                    cfg.put(
-                        aws_smithy_runtime_api::client::orchestrator::EndpointResolverParams::new(
-                            params,
-                        ),
-                    );
-
-                    Ok(())
-                }
-            }
-
-            cfg.get::<Interceptors<HttpRequest, HttpResponse>>()
-                .expect("interceptors set")
-                .register_operation_interceptor(
-                    Arc::new(ListObjectsV2EndpointParamsInterceptor) as _
-                )
-                .register_operation_interceptor(Arc::new(
-                    ListObjectsV2EndpointParamsFinalizerInterceptor,
-                ) as _);
-            Ok(())
-        }
-    }
 }
 
 criterion_group!(benches, middleware_bench, orchestrator_bench);

--- a/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/tests/sra_test.rs
@@ -7,17 +7,13 @@ use aws_http::user_agent::AwsUserAgent;
 use aws_runtime::invocation_id::InvocationId;
 use aws_sdk_s3::config::{Credentials, Region};
 use aws_sdk_s3::endpoint::Params;
-
 use aws_sdk_s3::Client;
-
 use aws_smithy_client::dvr;
 use aws_smithy_client::dvr::MediaType;
 use aws_smithy_client::erase::DynConnector;
-
 use aws_smithy_runtime_api::client::orchestrator::{ConfigBagAccessors, RequestTime};
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_runtime_api::config_bag::ConfigBag;
-
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const LIST_BUCKETS_PATH: &str = "test-data/list-objects-v2.json";

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
@@ -43,7 +43,7 @@ fun codegenScope(runtimeConfig: RuntimeConfig): Array<Pair<String, Any>> {
     return arrayOf(
         "ApiKeyAuthScheme" to authHttp.resolve("ApiKeyAuthScheme"),
         "ApiKeyLocation" to authHttp.resolve("ApiKeyLocation"),
-        "AuthOptionListResolver" to smithyRuntimeApi.resolve("client::auth::option_resolver::AuthOptionListResolver"),
+        "StaticAuthOptionResolver" to smithyRuntimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolver"),
         "BasicAuthScheme" to authHttp.resolve("BasicAuthScheme"),
         "BearerAuthScheme" to authHttp.resolve("BearerAuthScheme"),
         "DigestAuthScheme" to authHttp.resolve("DigestAuthScheme"),
@@ -207,7 +207,7 @@ private class HttpAuthOperationRuntimePluginCustomization(
         when (section) {
             is OperationRuntimePluginSection.AdditionalConfig -> {
                 withBlockTemplate(
-                    "let auth_option_resolver = #{AuthOptionListResolver}::new(vec![",
+                    "let auth_option_resolver = #{StaticAuthOptionResolver}::new(vec![",
                     "]);",
                     *codegenScope,
                 ) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
@@ -51,7 +51,6 @@ fun codegenScope(runtimeConfig: RuntimeConfig): Array<Pair<String, Any>> {
         "HTTP_BASIC_AUTH_SCHEME_ID" to authHttpApi.resolve("HTTP_BASIC_AUTH_SCHEME_ID"),
         "HTTP_BEARER_AUTH_SCHEME_ID" to authHttpApi.resolve("HTTP_BEARER_AUTH_SCHEME_ID"),
         "HTTP_DIGEST_AUTH_SCHEME_ID" to authHttpApi.resolve("HTTP_DIGEST_AUTH_SCHEME_ID"),
-        "HttpAuthOption" to smithyRuntimeApi.resolve("client::orchestrator::HttpAuthOption"),
         "IdentityResolver" to smithyRuntimeApi.resolve("client::identity::IdentityResolver"),
         "IdentityResolvers" to smithyRuntimeApi.resolve("client::identity::IdentityResolvers"),
         "Login" to smithyRuntimeApi.resolve("client::identity::http::Login"),
@@ -215,39 +214,16 @@ private class HttpAuthOperationRuntimePluginCustomization(
                     val authTrait: AuthTrait? = section.operationShape.getTrait() ?: serviceShape.getTrait()
                     for (authScheme in authTrait?.valueSet ?: emptySet()) {
                         when (authScheme) {
-                            HttpApiKeyAuthTrait.ID -> {
-                                rustTemplate(
-                                    "#{HttpAuthOption}::new(#{HTTP_API_KEY_AUTH_SCHEME_ID}, std::sync::Arc::new(#{PropertyBag}::new())),",
-                                    *codegenScope,
-                                )
-                            }
-
-                            HttpBasicAuthTrait.ID -> {
-                                rustTemplate(
-                                    "#{HttpAuthOption}::new(#{HTTP_BASIC_AUTH_SCHEME_ID}, std::sync::Arc::new(#{PropertyBag}::new())),",
-                                    *codegenScope,
-                                )
-                            }
-
-                            HttpBearerAuthTrait.ID -> {
-                                rustTemplate(
-                                    "#{HttpAuthOption}::new(#{HTTP_BEARER_AUTH_SCHEME_ID}, std::sync::Arc::new(#{PropertyBag}::new())),",
-                                    *codegenScope,
-                                )
-                            }
-
-                            HttpDigestAuthTrait.ID -> {
-                                rustTemplate(
-                                    "#{HttpAuthOption}::new(#{HTTP_DIGEST_AUTH_SCHEME_ID}, std::sync::Arc::new(#{PropertyBag}::new())),",
-                                    *codegenScope,
-                                )
-                            }
-
+                            HttpApiKeyAuthTrait.ID -> rustTemplate("#{HTTP_API_KEY_AUTH_SCHEME_ID},", *codegenScope)
+                            HttpBasicAuthTrait.ID -> rustTemplate("#{HTTP_BASIC_AUTH_SCHEME_ID},", *codegenScope)
+                            HttpBearerAuthTrait.ID -> rustTemplate("#{HTTP_BEARER_AUTH_SCHEME_ID},", *codegenScope)
+                            HttpDigestAuthTrait.ID -> rustTemplate("#{HTTP_DIGEST_AUTH_SCHEME_ID},", *codegenScope)
                             else -> {}
                         }
                     }
                 }
 
+                // TODO(enableNewSmithyRuntime): Make auth options additive in the config bag so that multiple codegen decorators can register them
                 rustTemplate("${section.configBagName}.set_auth_option_resolver(auth_option_resolver);", *codegenScope)
             }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
@@ -77,7 +77,7 @@ class OperationRuntimePluginGenerator(
         val runtimeApi = RuntimeType.smithyRuntimeApi(rc)
         arrayOf(
             "AuthOptionListResolverParams" to runtimeApi.resolve("client::auth::option_resolver::AuthOptionListResolverParams"),
-            "AuthOptionResolverParams" to runtimeApi.resolve("client::orchestrator::AuthOptionResolverParams"),
+            "AuthOptionResolverParams" to runtimeApi.resolve("client::auth::AuthOptionResolverParams"),
             "BoxError" to runtimeApi.resolve("client::runtime_plugin::BoxError"),
             "ConfigBag" to runtimeApi.resolve("config_bag::ConfigBag"),
             "ConfigBagAccessors" to runtimeApi.resolve("client::orchestrator::ConfigBagAccessors"),

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
@@ -76,7 +76,7 @@ class OperationRuntimePluginGenerator(
     private val codegenScope = codegenContext.runtimeConfig.let { rc ->
         val runtimeApi = RuntimeType.smithyRuntimeApi(rc)
         arrayOf(
-            "AuthOptionListResolverParams" to runtimeApi.resolve("client::auth::option_resolver::AuthOptionListResolverParams"),
+            "StaticAuthOptionResolverParams" to runtimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolverParams"),
             "AuthOptionResolverParams" to runtimeApi.resolve("client::auth::AuthOptionResolverParams"),
             "BoxError" to runtimeApi.resolve("client::runtime_plugin::BoxError"),
             "ConfigBag" to runtimeApi.resolve("config_bag::ConfigBag"),
@@ -101,7 +101,7 @@ class OperationRuntimePluginGenerator(
                     cfg.set_response_deserializer(${operationStructName}ResponseDeserializer);
 
                     ${"" /* TODO(IdentityAndAuth): Resolve auth parameters from input for services that need this */}
-                    cfg.set_auth_option_resolver_params(#{AuthOptionResolverParams}::new(#{AuthOptionListResolverParams}::new()));
+                    cfg.set_auth_option_resolver_params(#{AuthOptionResolverParams}::new(#{StaticAuthOptionResolverParams}::new()));
 
                     // Retry classifiers are operation-specific because they need to downcast operation-specific error types.
                     let retry_classifiers = #{RetryClassifiers}::new()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -78,7 +78,7 @@ class ServiceRuntimePluginGenerator(
             "ConnectorSettings" to RuntimeType.smithyClient(rc).resolve("http_connector::ConnectorSettings"),
             "DefaultEndpointResolver" to runtime.resolve("client::orchestrator::endpoints::DefaultEndpointResolver"),
             "DynConnectorAdapter" to runtime.resolve("client::connections::adapter::DynConnectorAdapter"),
-            "HttpAuthSchemes" to runtimeApi.resolve("client::orchestrator::HttpAuthSchemes"),
+            "HttpAuthSchemes" to runtimeApi.resolve("client::auth::HttpAuthSchemes"),
             "IdentityResolvers" to runtimeApi.resolve("client::identity::IdentityResolvers"),
             "NeverRetryStrategy" to runtime.resolve("client::retries::strategy::NeverRetryStrategy"),
             "Params" to endpointTypesGenerator.paramsStruct(),

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -70,7 +70,7 @@ class ServiceRuntimePluginGenerator(
         val runtimeApi = RuntimeType.smithyRuntimeApi(rc)
         arrayOf(
             "AnonymousIdentityResolver" to runtimeApi.resolve("client::identity::AnonymousIdentityResolver"),
-            "AuthOptionListResolver" to runtimeApi.resolve("client::auth::option_resolver::AuthOptionListResolver"),
+            "StaticAuthOptionResolver" to runtimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolver"),
             "BoxError" to runtimeApi.resolve("client::runtime_plugin::BoxError"),
             "ConfigBag" to runtimeApi.resolve("config_bag::ConfigBag"),
             "ConfigBagAccessors" to runtimeApi.resolve("client::orchestrator::ConfigBagAccessors"),
@@ -112,7 +112,7 @@ class ServiceRuntimePluginGenerator(
                     cfg.set_http_auth_schemes(http_auth_schemes);
 
                     // Set an empty auth option resolver to be overridden by operations that need auth.
-                    cfg.set_auth_option_resolver(#{AuthOptionListResolver}::new(Vec::new()));
+                    cfg.set_auth_option_resolver(#{StaticAuthOptionResolver}::new(Vec::new()));
 
                     let endpoint_resolver = #{DefaultEndpointResolver}::<#{Params}>::new(
                         #{SharedEndpointResolver}::from(self.handle.conf.endpoint_resolver()));

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth.rs
@@ -3,7 +3,141 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use crate::client::identity::{Identity, IdentityResolver, IdentityResolvers};
+use crate::client::orchestrator::{BoxError, HttpRequest};
+use crate::config_bag::ConfigBag;
+use crate::type_erasure::{TypeErasedBox, TypedBox};
+use std::any::Any;
+use std::borrow::Cow;
+use std::fmt::Debug;
+use std::sync::Arc;
+
 #[cfg(feature = "http-auth")]
 pub mod http;
 
 pub mod option_resolver;
+
+/// New type around an auth scheme ID.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct AuthSchemeId {
+    scheme_id: &'static str,
+}
+
+impl AuthSchemeId {
+    /// Creates a new auth scheme ID.
+    pub const fn new(scheme_id: &'static str) -> Self {
+        Self { scheme_id }
+    }
+
+    /// Returns the string equivalent of this auth scheme ID.
+    pub const fn as_str(&self) -> &'static str {
+        self.scheme_id
+    }
+}
+
+#[derive(Debug)]
+pub struct AuthOptionResolverParams(TypeErasedBox);
+
+impl AuthOptionResolverParams {
+    pub fn new<T: Any + Send + Sync + 'static>(params: T) -> Self {
+        Self(TypedBox::new(params).erase())
+    }
+
+    pub fn get<T: 'static>(&self) -> Option<&T> {
+        self.0.downcast_ref()
+    }
+}
+
+pub trait AuthOptionResolver: Send + Sync + Debug {
+    fn resolve_auth_options<'a>(
+        &'a self,
+        params: &AuthOptionResolverParams,
+    ) -> Result<Cow<'a, [AuthSchemeId]>, BoxError>;
+}
+
+impl AuthOptionResolver for Box<dyn AuthOptionResolver> {
+    fn resolve_auth_options<'a>(
+        &'a self,
+        params: &AuthOptionResolverParams,
+    ) -> Result<Cow<'a, [AuthSchemeId]>, BoxError> {
+        (**self).resolve_auth_options(params)
+    }
+}
+
+#[derive(Debug)]
+struct HttpAuthSchemesInner {
+    schemes: Vec<(AuthSchemeId, Box<dyn HttpAuthScheme>)>,
+}
+#[derive(Debug)]
+pub struct HttpAuthSchemes {
+    inner: Arc<HttpAuthSchemesInner>,
+}
+
+impl HttpAuthSchemes {
+    pub fn builder() -> builders::HttpAuthSchemesBuilder {
+        Default::default()
+    }
+
+    pub fn scheme(&self, scheme_id: AuthSchemeId) -> Option<&dyn HttpAuthScheme> {
+        self.inner
+            .schemes
+            .iter()
+            .find(|scheme| scheme.0 == scheme_id)
+            .map(|scheme| &*scheme.1)
+    }
+}
+
+pub trait HttpAuthScheme: Send + Sync + Debug {
+    fn scheme_id(&self) -> AuthSchemeId;
+
+    fn identity_resolver<'a>(
+        &self,
+        identity_resolvers: &'a IdentityResolvers,
+    ) -> Option<&'a dyn IdentityResolver>;
+
+    fn request_signer(&self) -> &dyn HttpRequestSigner;
+}
+
+pub trait HttpRequestSigner: Send + Sync + Debug {
+    /// Return a signed version of the given request using the given identity.
+    ///
+    /// If the provided identity is incompatible with this signer, an error must be returned.
+    fn sign_request(
+        &self,
+        request: &mut HttpRequest,
+        identity: &Identity,
+        config_bag: &ConfigBag,
+    ) -> Result<(), BoxError>;
+}
+
+pub mod builders {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    pub struct HttpAuthSchemesBuilder {
+        schemes: Vec<(AuthSchemeId, Box<dyn HttpAuthScheme>)>,
+    }
+
+    impl HttpAuthSchemesBuilder {
+        pub fn new() -> Self {
+            Default::default()
+        }
+
+        pub fn auth_scheme(
+            mut self,
+            scheme_id: AuthSchemeId,
+            auth_scheme: impl HttpAuthScheme + 'static,
+        ) -> Self {
+            self.schemes.push((scheme_id, Box::new(auth_scheme) as _));
+            self
+        }
+
+        pub fn build(self) -> HttpAuthSchemes {
+            HttpAuthSchemes {
+                inner: Arc::new(HttpAuthSchemesInner {
+                    schemes: self.schemes,
+                }),
+            }
+        }
+    }
+}

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth/http.rs
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-pub const HTTP_API_KEY_AUTH_SCHEME_ID: &str = "http-api-key-auth";
-pub const HTTP_BASIC_AUTH_SCHEME_ID: &str = "http-basic-auth";
-pub const HTTP_BEARER_AUTH_SCHEME_ID: &str = "http-bearer-auth";
-pub const HTTP_DIGEST_AUTH_SCHEME_ID: &str = "http-digest-auth";
+use crate::client::auth::AuthSchemeId;
+
+pub const HTTP_API_KEY_AUTH_SCHEME_ID: AuthSchemeId = AuthSchemeId::new("http-api-key-auth");
+pub const HTTP_BASIC_AUTH_SCHEME_ID: AuthSchemeId = AuthSchemeId::new("http-basic-auth");
+pub const HTTP_BEARER_AUTH_SCHEME_ID: AuthSchemeId = AuthSchemeId::new("http-bearer-auth");
+pub const HTTP_DIGEST_AUTH_SCHEME_ID: AuthSchemeId = AuthSchemeId::new("http-digest-auth");

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth/option_resolver.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth/option_resolver.rs
@@ -11,18 +11,18 @@ use std::borrow::Cow;
 ///
 /// This is useful for clients that don't require `AuthOptionResolverParams` to resolve auth options.
 #[derive(Debug)]
-pub struct AuthOptionListResolver {
+pub struct StaticAuthOptionResolver {
     auth_options: Vec<AuthSchemeId>,
 }
 
-impl AuthOptionListResolver {
-    /// Creates a new instance of `AuthOptionListResolver`.
+impl StaticAuthOptionResolver {
+    /// Creates a new instance of `StaticAuthOptionResolver`.
     pub fn new(auth_options: Vec<AuthSchemeId>) -> Self {
         Self { auth_options }
     }
 }
 
-impl AuthOptionResolver for AuthOptionListResolver {
+impl AuthOptionResolver for StaticAuthOptionResolver {
     fn resolve_auth_options<'a>(
         &'a self,
         _params: &AuthOptionResolverParams,
@@ -31,12 +31,12 @@ impl AuthOptionResolver for AuthOptionListResolver {
     }
 }
 
-/// Empty params to be used with [`AuthOptionListResolver`].
+/// Empty params to be used with [`StaticAuthOptionResolver`].
 #[derive(Debug)]
-pub struct AuthOptionListResolverParams;
+pub struct StaticAuthOptionResolverParams;
 
-impl AuthOptionListResolverParams {
-    /// Creates new `AuthOptionListResolverParams`.
+impl StaticAuthOptionResolverParams {
+    /// Creates new `StaticAuthOptionResolverParams`.
     pub fn new() -> Self {
         Self
     }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/auth/option_resolver.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/auth/option_resolver.rs
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use crate::client::orchestrator::{
-    AuthOptionResolver, AuthOptionResolverParams, BoxError, HttpAuthOption,
-};
+use crate::client::auth::{AuthOptionResolver, AuthOptionResolverParams, AuthSchemeId};
+use crate::client::orchestrator::BoxError;
 use std::borrow::Cow;
 
 /// New-type around a `Vec<HttpAuthOption>` that implements `AuthOptionResolver`.
@@ -13,12 +12,12 @@ use std::borrow::Cow;
 /// This is useful for clients that don't require `AuthOptionResolverParams` to resolve auth options.
 #[derive(Debug)]
 pub struct AuthOptionListResolver {
-    auth_options: Vec<HttpAuthOption>,
+    auth_options: Vec<AuthSchemeId>,
 }
 
 impl AuthOptionListResolver {
     /// Creates a new instance of `AuthOptionListResolver`.
-    pub fn new(auth_options: Vec<HttpAuthOption>) -> Self {
+    pub fn new(auth_options: Vec<AuthSchemeId>) -> Self {
         Self { auth_options }
     }
 }
@@ -27,7 +26,7 @@ impl AuthOptionResolver for AuthOptionListResolver {
     fn resolve_auth_options<'a>(
         &'a self,
         _params: &AuthOptionResolverParams,
-    ) -> Result<Cow<'a, [HttpAuthOption]>, BoxError> {
+    ) -> Result<Cow<'a, [AuthSchemeId]>, BoxError> {
         Ok(Cow::Borrowed(&self.auth_options))
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/identity/http.rs
@@ -7,7 +7,7 @@
 
 use crate::client::identity::{Identity, IdentityResolver};
 use crate::client::orchestrator::Future;
-use aws_smithy_http::property_bag::PropertyBag;
+use crate::config_bag::ConfigBag;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -65,7 +65,7 @@ impl From<String> for Token {
 }
 
 impl IdentityResolver for Token {
-    fn resolve_identity(&self, _identity_properties: &PropertyBag) -> Future<Identity> {
+    fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
         Future::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }
@@ -124,7 +124,7 @@ impl Login {
 }
 
 impl IdentityResolver for Login {
-    fn resolve_identity(&self, _identity_properties: &PropertyBag) -> Future<Identity> {
+    fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
         Future::ready(Ok(Identity::new(self.clone(), self.0.expiration)))
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -57,7 +57,7 @@ pub(super) async fn orchestrate_auth(
 mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_runtime_api::client::auth::option_resolver::AuthOptionListResolver;
+    use aws_smithy_runtime_api::client::auth::option_resolver::StaticAuthOptionResolver;
     use aws_smithy_runtime_api::client::auth::{
         AuthOptionResolverParams, AuthSchemeId, HttpAuthScheme, HttpAuthSchemes, HttpRequestSigner,
     };
@@ -122,7 +122,7 @@ mod tests {
 
         let mut cfg = ConfigBag::base();
         cfg.set_auth_option_resolver_params(AuthOptionResolverParams::new("doesntmatter"));
-        cfg.set_auth_option_resolver(AuthOptionListResolver::new(vec![TEST_SCHEME_ID]));
+        cfg.set_auth_option_resolver(StaticAuthOptionResolver::new(vec![TEST_SCHEME_ID]));
         cfg.set_identity_resolvers(
             IdentityResolvers::builder()
                 .identity_resolver(TEST_SCHEME_ID, TestIdentityResolver)
@@ -165,7 +165,7 @@ mod tests {
 
         let mut cfg = ConfigBag::base();
         cfg.set_auth_option_resolver_params(AuthOptionResolverParams::new("doesntmatter"));
-        cfg.set_auth_option_resolver(AuthOptionListResolver::new(vec![
+        cfg.set_auth_option_resolver(StaticAuthOptionResolver::new(vec![
             HTTP_BASIC_AUTH_SCHEME_ID,
             HTTP_BEARER_AUTH_SCHEME_ID,
         ]));

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/auth.rs
@@ -30,20 +30,18 @@ pub(super) async fn orchestrate_auth(
         identity_resolvers = ?identity_resolvers,
         "orchestrating auth",
     );
-    for option in auth_options.as_ref() {
-        let scheme_id = option.scheme_id();
-        let scheme_properties = option.properties();
+    for &scheme_id in auth_options.as_ref() {
         if let Some(auth_scheme) = cfg.http_auth_schemes().scheme(scheme_id) {
             if let Some(identity_resolver) = auth_scheme.identity_resolver(identity_resolvers) {
                 let request_signer = auth_scheme.request_signer();
 
                 let identity = identity_resolver
-                    .resolve_identity(scheme_properties)
+                    .resolve_identity(cfg)
                     .await
                     .map_err(construction_failure)?;
                 return dispatch_phase.include_mut(|ctx| {
                     let request = ctx.request_mut()?;
-                    request_signer.sign_request(request, &identity, scheme_properties)?;
+                    request_signer.sign_request(request, &identity, cfg)?;
                     Result::<_, BoxError>::Ok(())
                 });
             }
@@ -59,23 +57,21 @@ pub(super) async fn orchestrate_auth(
 mod tests {
     use super::*;
     use aws_smithy_http::body::SdkBody;
-    use aws_smithy_http::property_bag::PropertyBag;
     use aws_smithy_runtime_api::client::auth::option_resolver::AuthOptionListResolver;
+    use aws_smithy_runtime_api::client::auth::{
+        AuthOptionResolverParams, AuthSchemeId, HttpAuthScheme, HttpAuthSchemes, HttpRequestSigner,
+    };
     use aws_smithy_runtime_api::client::identity::{Identity, IdentityResolver, IdentityResolvers};
     use aws_smithy_runtime_api::client::interceptors::InterceptorContext;
-    use aws_smithy_runtime_api::client::orchestrator::{
-        AuthOptionResolverParams, Future, HttpAuthOption, HttpAuthScheme, HttpAuthSchemes,
-        HttpRequest, HttpRequestSigner,
-    };
+    use aws_smithy_runtime_api::client::orchestrator::{Future, HttpRequest};
     use aws_smithy_runtime_api::type_erasure::TypedBox;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn basic_case() {
         #[derive(Debug)]
         struct TestIdentityResolver;
         impl IdentityResolver for TestIdentityResolver {
-            fn resolve_identity(&self, _identity_properties: &PropertyBag) -> Future<Identity> {
+            fn resolve_identity(&self, _config_bag: &ConfigBag) -> Future<Identity> {
                 Future::ready(Ok(Identity::new("doesntmatter", None)))
             }
         }
@@ -88,7 +84,7 @@ mod tests {
                 &self,
                 request: &mut HttpRequest,
                 _identity: &Identity,
-                _signing_properties: &PropertyBag,
+                _config_bag: &ConfigBag,
             ) -> Result<(), BoxError> {
                 request
                     .headers_mut()
@@ -97,13 +93,15 @@ mod tests {
             }
         }
 
+        const TEST_SCHEME_ID: AuthSchemeId = AuthSchemeId::new("test-scheme");
+
         #[derive(Debug)]
         struct TestAuthScheme {
             signer: TestSigner,
         }
         impl HttpAuthScheme for TestAuthScheme {
-            fn scheme_id(&self) -> &'static str {
-                "test-scheme"
+            fn scheme_id(&self) -> AuthSchemeId {
+                TEST_SCHEME_ID
             }
 
             fn identity_resolver<'a>(
@@ -124,18 +122,15 @@ mod tests {
 
         let mut cfg = ConfigBag::base();
         cfg.set_auth_option_resolver_params(AuthOptionResolverParams::new("doesntmatter"));
-        cfg.set_auth_option_resolver(AuthOptionListResolver::new(vec![HttpAuthOption::new(
-            "test-scheme",
-            Arc::new(PropertyBag::new()),
-        )]));
+        cfg.set_auth_option_resolver(AuthOptionListResolver::new(vec![TEST_SCHEME_ID]));
         cfg.set_identity_resolvers(
             IdentityResolvers::builder()
-                .identity_resolver("test-scheme", TestIdentityResolver)
+                .identity_resolver(TEST_SCHEME_ID, TestIdentityResolver)
                 .build(),
         );
         cfg.set_http_auth_schemes(
             HttpAuthSchemes::builder()
-                .auth_scheme("test-scheme", TestAuthScheme { signer: TestSigner })
+                .auth_scheme(TEST_SCHEME_ID, TestAuthScheme { signer: TestSigner })
                 .build(),
         );
 
@@ -171,8 +166,8 @@ mod tests {
         let mut cfg = ConfigBag::base();
         cfg.set_auth_option_resolver_params(AuthOptionResolverParams::new("doesntmatter"));
         cfg.set_auth_option_resolver(AuthOptionListResolver::new(vec![
-            HttpAuthOption::new(HTTP_BASIC_AUTH_SCHEME_ID, Arc::new(PropertyBag::new())),
-            HttpAuthOption::new(HTTP_BEARER_AUTH_SCHEME_ID, Arc::new(PropertyBag::new())),
+            HTTP_BASIC_AUTH_SCHEME_ID,
+            HTTP_BEARER_AUTH_SCHEME_ID,
         ]));
         cfg.set_http_auth_schemes(
             HttpAuthSchemes::builder()


### PR DESCRIPTION
## Motivation and Context
When SigV4 signing was ported over to the orchestrator, the request time got calculated once before the retry loop, which was incorrect. This PR moves that request time calculation into the request signer so that it happens on every attempt (unless there is a configured request time override).

This PR also refactors auth to use the `ConfigBag` instead of a separate signing properties `PropertyBag`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
