### PR TITLE
Fix typo in `ErrorMetaData`

### DIFF
--- a/rust-runtime/aws-smithy-types/src/error/metadata.rs
+++ b/rust-runtime/aws-smithy-types/src/error/metadata.rs
@@ -43,7 +43,7 @@ pub const EMPTY_ERROR_METADATA: ErrorMetadata = ErrorMetadata {
 pub struct ErrorMetadata {
     code: Option<String>,
     message: Option<String>,
-    extras: Option<HashMap<&'static str, String>>,
+    extras: Option<HashMap<&'static str, String>,
 }
 
 impl ProvideErrorMetadata for ErrorMetadata {


### PR DESCRIPTION
## Motivation and Context
Fixes typo that is preventing the compilation.
this becomes,
```rust
    extras: Option<HashMap<&'static str, String>>,
```
this.
```rust
    extras: Option<HashMap<&'static str, String>,
```

## Testing
NA

## Checklist
NA
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
