### PR TITLE
implement `Ord` and `PartialOrd` for `DateTime`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -17,3 +17,9 @@ author = "rcoh"
 references = ["smithy-rs#2612"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
 
+
+[[smithy-rs]]
+message = "Implement `Ord` and `PartialOrd` for `DateTime`."
+author = "henriiik"
+references = ["smithy-rs#2653"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }


### PR DESCRIPTION
## Motivation and Context

This change will allow easy sorting or comparing anything that contains a DateTime. My example is wanting to sort a list of S3 objects by last modified.

This PR fixes #2406

## Description
It's a pretty small PR, it implements the `Ord` trait for `DateTime` by comparing the `seconds` property of `self` and `other`, if they are equal it compares the `subsec_nanos` properties instead.

The `PartialOrd` trait is implemented by calling the `Ord` trait.

## Testing
I added a unit test that compares a number of `DateTime` values with different combinations of positive/zero/negative `seconds`/`subsec_nanos`.

## Checklist
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
