### PR TITLE
Only include in versions.toml crates under the sdk directory

### DIFF
--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -360,7 +360,7 @@ tasks.register<ExecRustBuildTool>("hydrateReadme") {
     binaryName = "publisher"
     arguments = listOf(
         "hydrate-readme",
-        "--versions-manifest", sdkOutputDir.resolve("versions.toml").toString(),
+        "--versions-manifest", outputDir.resolve("versions.toml").toString(),
         "--msrv", getRustMSRV(),
         "--input", rootProject.projectDir.resolve("aws/SDK_README.md.hb").toString(),
         "--output", outputDir.resolve("README.md").absolutePath,
@@ -384,8 +384,10 @@ tasks.register<ExecRustBuildTool>("generateVersionManifest") {
     binaryName = "publisher"
     arguments = mutableListOf(
         "generate-version-manifest",
-        "--location",
+        "--input-location",
         sdkOutputDir.absolutePath,
+        "--output-location",
+        outputDir.absolutePath,
         "--smithy-build",
         buildDir.resolve("smithy-build.json").normalize().absolutePath,
         "--examples-revision",

--- a/aws/sdk/build.gradle.kts
+++ b/aws/sdk/build.gradle.kts
@@ -360,7 +360,7 @@ tasks.register<ExecRustBuildTool>("hydrateReadme") {
     binaryName = "publisher"
     arguments = listOf(
         "hydrate-readme",
-        "--versions-manifest", outputDir.resolve("versions.toml").toString(),
+        "--versions-manifest", sdkOutputDir.resolve("versions.toml").toString(),
         "--msrv", getRustMSRV(),
         "--input", rootProject.projectDir.resolve("aws/SDK_README.md.hb").toString(),
         "--output", outputDir.resolve("README.md").absolutePath,
@@ -385,7 +385,7 @@ tasks.register<ExecRustBuildTool>("generateVersionManifest") {
     arguments = mutableListOf(
         "generate-version-manifest",
         "--location",
-        outputDir.absolutePath,
+        sdkOutputDir.absolutePath,
         "--smithy-build",
         buildDir.resolve("smithy-build.json").normalize().absolutePath,
         "--examples-revision",

--- a/tools/ci-build/publisher/src/subcommand/generate_version_manifest.rs
+++ b/tools/ci-build/publisher/src/subcommand/generate_version_manifest.rs
@@ -28,7 +28,10 @@ pub struct GenerateVersionManifestArgs {
     examples_revision: String,
     /// Path containing the generated SDK to generate a version manifest for
     #[clap(long)]
-    location: PathBuf,
+    input_location: PathBuf,
+    /// Path to a directory in which a version manifest is generated
+    #[clap(long)]
+    output_location: PathBuf,
     /// Optional path to the `versions.toml` manifest from the previous SDK release
     #[clap(long)]
     previous_release_versions: Option<PathBuf>,
@@ -38,7 +41,8 @@ pub async fn subcommand_generate_version_manifest(
     GenerateVersionManifestArgs {
         smithy_build,
         examples_revision,
-        location,
+        input_location,
+        output_location,
         previous_release_versions,
         ..
     }: &GenerateVersionManifestArgs,
@@ -52,7 +56,7 @@ pub async fn subcommand_generate_version_manifest(
     info!("Resolved smithy-rs revision to {}", smithy_rs_revision);
 
     let smithy_build_root = SmithyBuildRoot::from_file(smithy_build)?;
-    let manifests = discover_package_manifests(location.into())
+    let manifests = discover_package_manifests(input_location.into())
         .await
         .context("discover package manifests")?;
     let packages = read_packages(Fs::Real, manifests)
@@ -99,7 +103,7 @@ pub async fn subcommand_generate_version_manifest(
     };
     versions_manifest.release =
         generate_release_metadata(&versions_manifest, previous_release_versions)?;
-    let manifest_file_name = location.join("versions.toml");
+    let manifest_file_name = output_location.join("versions.toml");
     info!("Writing {:?}...", manifest_file_name);
     versions_manifest.write_to_file(&manifest_file_name)?;
     Ok(())


### PR DESCRIPTION
## Motivation and Context
We have found that `aws-sdk-rust` release-2023-05-01 brought in the `aws-wasm` crate to `versions.toml`. The crate comes from an example in the `aws-doc-sdk-examples` repository. This PR fixes gradle build in `sdk` so that the `publisher` only considers crates under the `sdk` directory when generating `versions.toml`.

## Testing
Manually ran
```
./gradlew :aws:sdk:assemble
```
and confirmed that `versions.toml` got created under `smithy-rs/aws/sdk/build/aws-sdk` ~~`smithy-rs/aws/sdk/build/aws-sdk/sdk`~~ and `README` was  successfully hydrated.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
