### PR TITLE
fix/format: various code that's escaped the linter

### DIFF
--- a/aws/rust-runtime/aws-http/src/user_agent.rs
+++ b/aws/rust-runtime/aws-http/src/user_agent.rs
@@ -778,7 +778,7 @@ mod test {
             .get(USER_AGENT)
             .expect("UA header should be set");
         req.headers()
-            .get(&X_AMZ_USER_AGENT)
+            .get(X_AMZ_USER_AGENT)
             .expect("UA header should be set");
     }
 }

--- a/aws/rust-runtime/aws-runtime/src/user_agent.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent.rs
@@ -183,7 +183,7 @@ mod tests {
 
         let api_metadata = ApiMetadata::new("some-service", "some-version");
         let mut config = ConfigBag::base();
-        config.put(api_metadata.clone());
+        config.put(api_metadata);
         config.put(AppName::new("my_awesome_app").unwrap());
 
         let interceptor = UserAgentInterceptor::new();

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/protocols/serialize/JsonSerializerGenerator.kt
@@ -325,7 +325,7 @@ class JsonSerializerGenerator(
                 pub fn $fnName(
                     #{AllowUnusedVariables:W} object: &mut #{JsonObjectWriter},
                     #{AllowUnusedVariables:W} input: &#{StructureSymbol},
-                ) -> Result<(), #{Error}>  
+                ) -> Result<(), #{Error}>
                 """,
                 "StructureSymbol" to symbolProvider.toSymbol(context.shape),
                 "AllowUnusedVariables" to allowUnusedVariables,

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEventStreamErrorGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEventStreamErrorGenerator.kt
@@ -61,7 +61,7 @@ class PythonServerEventStreamErrorGenerator(
                         """
                         if let Ok(it) = obj.extract::<#T>() {
                             return Ok(Self::${symbol.name}(it));
-                        }    
+                        }
                         """,
                         symbol,
                     )

--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEventStreamWrapperGenerator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/generators/PythonServerEventStreamWrapperGenerator.kt
@@ -139,8 +139,8 @@ class PythonServerEventStreamWrapperGenerator(
                     let stream = #{PyO3Asyncio}::tokio::into_stream_v1(obj)?;
                     let stream = stream.filter_map(|res| {
                         #{PyO3}::Python::with_gil(|py| {
-                            // TODO(EventStreamImprovements): Add `InternalServerError` variant to all event streaming 
-                            //                                errors and return that variant in case of errors here? 
+                            // TODO(EventStreamImprovements): Add `InternalServerError` variant to all event streaming
+                            //                                errors and return that variant in case of errors here?
                             match res {
                                 Ok(obj) => {
                                     match obj.extract::<#{Inner}>(py) {
@@ -165,11 +165,11 @@ class PythonServerEventStreamWrapperGenerator(
                             }
                         })
                     });
-            
+
                     Ok($name { inner: #{Arc}::new(#{Mutex}::new(Some(stream.into()))) })
                 }
             }
-            
+
             impl #{PyO3}::IntoPy<#{PyO3}::PyObject> for $name {
                 fn into_py(self, py: #{PyO3}::Python<'_>) -> #{PyO3}::PyObject {
                     #{PyO3}::exceptions::PyAttributeError::new_err("this is a write-only object").into_py(py)
@@ -198,7 +198,7 @@ class PythonServerEventStreamWrapperGenerator(
             writer.rustTemplate(
                 """
                 pub fn new(
-                    unmarshaller: impl #{UnmarshallMessage}<Output = #{Inner}, Error = #{Error}> + #{Send} + #{Sync} + 'static, 
+                    unmarshaller: impl #{UnmarshallMessage}<Output = #{Inner}, Error = #{Error}> + #{Send} + #{Sync} + 'static,
                     body: #{Body}
                 ) -> $name {
                     let inner = #{Wrapped}::new(unmarshaller, body);
@@ -227,7 +227,7 @@ class PythonServerEventStreamWrapperGenerator(
                         match next {
                             Ok(Some(data)) => Ok(#{PyO3}::Python::with_gil(|py| #{PyO3}::IntoPy::into_py(data, py))),
                             Ok(None) => Err(#{PyO3}::exceptions::PyStopAsyncIteration::new_err("stream exhausted")),
-                            Err(#{SmithyHttp}::result::SdkError::ServiceError(service_err)) => Err(service_err.into_err().into()), 
+                            Err(#{SmithyHttp}::result::SdkError::ServiceError(service_err)) => Err(service_err.into_err().into()),
                             Err(err) => Err(#{PyO3}::exceptions::PyRuntimeError::new_err(err.to_string())),
                         }
                     })?;

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -200,10 +200,10 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                     "application/x-www-form-urlencoded" -> "const $staticContentType: #{Mime}::Mime = #{Mime}::APPLICATION_WWW_FORM_URLENCODED;"
                     else ->
                         """
-                    static $staticContentType: #{OnceCell}::sync::Lazy<#{Mime}::Mime> = #{OnceCell}::sync::Lazy::new(|| {
-                        ${contentType.dq()}.parse::<#{Mime}::Mime>().expect("BUG: MIME parsing failed, content_type is not valid")
-                    });
-                    """
+                        static $staticContentType: #{OnceCell}::sync::Lazy<#{Mime}::Mime> = #{OnceCell}::sync::Lazy::new(|| {
+                            ${contentType.dq()}.parse::<#{Mime}::Mime>().expect("BUG: MIME parsing failed, content_type is not valid")
+                        });
+                        """
                 }
                 rustTemplate(init, *codegenScope)
             }

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationErrorGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerOperationErrorGeneratorTest.kt
@@ -21,9 +21,9 @@ import software.amazon.smithy.rust.codegen.server.smithy.testutil.serverTestSymb
 class ServerOperationErrorGeneratorTest {
     private val baseModel = """
         namespace error
-        
+
         use aws.protocols#restJson1
-        
+
         @restJson1
         service MyService {
             operations: [Greeting]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,13 @@
 # Smithy Rust Server SDK examples
 
-This folder contains some example services showcasing Smithy Rust Server SDK, 
+This folder contains some example services showcasing Smithy Rust Server SDK,
 also known as the Rust service framework, capabilities and to run benchmarks.
 
 Three server implementations are available:
 
 - `/pokemon-service`, a HTTP server demonstrating [middleware] and [extractors].
-- `/pokemon-service-tls`, a HTTPS server. This server can do 
-   its own TLS negotiation, rather than relying on a load balancer. 
+- `/pokemon-service-tls`, a HTTPS server. This server can do
+   its own TLS negotiation, rather than relying on a load balancer.
 - `/pokemon-service-lambda`, a server that can be deployed onto AWS Lambda.
 
 These servers, and their clients, are generated using smithy-rs. You're invited
@@ -23,7 +23,7 @@ a suitable choice for implementing your web service.
 You will need install Java 11 to run the smithy-rs code generator and an
 installation of Rust, including `cargo`, to compile the generated code.
 
-(Optional) The [Cargo Lambda](https://cargo-lambda.info/) sub-command for 
+(Optional) The [Cargo Lambda](https://cargo-lambda.info/) sub-command for
 `cargo` is required to support the AWS Lambda integration.
 
 
@@ -43,9 +43,9 @@ can be used directly.
 - `build`: compiles the generated client and server
 - `clean`: deletes build artifacts
 - `clippy`: lints the code
-- `distclean`: delete generated code and build artifacts 
+- `distclean`: delete generated code and build artifacts
 - `doc-open`: builds and opens the rustdoc documentation
-- `lambda_invoke`: invokes a running server 
+- `lambda_invoke`: invokes a running server
 - `lambda_watch`: runs the service on an emulated AWS Lambda environment
 - `run`: runs the Pokémon service
 - `test`: runs integration and unit tests
@@ -53,14 +53,14 @@ can be used directly.
 
 ## Running services
 
-To run one of the three server implementations locally, provide the appropriate 
+To run one of the three server implementations locally, provide the appropriate
 service name to the `--bin` flag:
 
 ```bash
 cargo run --bin pokemon-service[(-lambda|-tls)]
 ```
 
-CLI arguments can be passed to the server binaries by adding them after `--`. 
+CLI arguments can be passed to the server binaries by adding them after `--`.
 For example, to see a service's help information, use the following:
 
 ```bash
@@ -69,11 +69,11 @@ cargo run --bin <service> -- --help
 
 ## Testing
 
-The `/pokemon-test*/tests` folders provide integration tests involving the 
+The `/pokemon-test*/tests` folders provide integration tests involving the
 generated clients.
 
-They can be invoked with `cargo test`. This will spawn each service in turn 
-and run some integration tests against it. Use `-p <package>` to filter by 
+They can be invoked with `cargo test`. This will spawn each service in turn
+and run some integration tests against it. Use `-p <package>` to filter by
 package.
 
 More info can be found in the `tests` folder of each package.
@@ -81,8 +81,8 @@ More info can be found in the `tests` folder of each package.
 
 ## Benchmarking
 
-Servers running locally (see "Running services") can be benchmarked with any 
+Servers running locally (see "Running services") can be benchmarked with any
 load testing tool, such as Artillery or `wrk`.
 
-Please see [BENCHMARKS.md](/examples/BENCHMARKS.md) for benchmarking results 
+Please see [BENCHMARKS.md](/examples/BENCHMARKS.md) for benchmarking results
 produced by the smithy-rs team.

--- a/rust-runtime/aws-smithy-runtime-api/src/config_bag.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/config_bag.rs
@@ -638,9 +638,7 @@ mod test {
         }
         expected.reverse();
         assert_eq!(
-            bag.load::<TestItem>()
-                .map(|i| i.clone())
-                .collect::<Vec<_>>(),
+            bag.load::<TestItem>().cloned().collect::<Vec<_>>(),
             expected
         );
     }

--- a/rust-runtime/aws-smithy-types-convert/Cargo.toml
+++ b/rust-runtime/aws-smithy-types-convert/Cargo.toml
@@ -13,7 +13,7 @@ convert-time = ["aws-smithy-types", "time"]
 
 [dependencies]
 aws-smithy-types = { path = "../aws-smithy-types", optional = true }
-chrono = { version = "0.4.19", optional = true, default-features = false, features = ["std"] }
+chrono = { version = "0.4.23", optional = true, default-features = false, features = ["std"] }
 time = { version = "0.3.4", optional = true }
 
 [package.metadata.docs.rs]

--- a/rust-runtime/aws-smithy-types/src/number.rs
+++ b/rust-runtime/aws-smithy-types/src/number.rs
@@ -184,8 +184,8 @@ impl TryFrom<Number> for f32 {
 }
 
 #[cfg(test)]
-mod number {
-    use super::*;
+mod test {
+    use super::Number;
     use crate::error::{TryFromNumberError, TryFromNumberErrorKind};
 
     macro_rules! to_unsigned_converter_tests {


### PR DESCRIPTION
_Every once in a while I run clippy and the pre-commit checks on everything b/c stuff seems to fall through the cracks._

- fix: various code that's escaped the linter
- format: various code that's escaped the formatter
- update: `chrono` because a test was using a method only available in v0.4.23 _(I don't know why that didn't fail in CI)_


_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
