### PR TITLE
Fix compilation when generating both the middleware and orchestrator implementations

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -42,9 +42,9 @@ class HttpRequestChecksumDecorator : ClientCodegenDecorator {
     override val name: String = "HttpRequestChecksum"
     override val order: Byte = 0
 
-    // TODO(enableNewSmithyRuntime): Implement checksumming via interceptor and delete this decorator
+    // TODO(enableNewSmithyRuntime): Implement checksumming via interceptor and delete this decorator upon launching the orchestrator
     private fun applies(codegenContext: ClientCodegenContext): Boolean =
-        codegenContext.smithyRuntimeMode.exclusivelyGenerateMiddleware
+        codegenContext.smithyRuntimeMode.generateMiddleware
 
     override fun operationCustomizations(
         codegenContext: ClientCodegenContext,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
@@ -83,6 +83,10 @@ class HttpResponseChecksumCustomization(
                 }
             }
             is OperationSection.MutateOutput -> {
+                if (!section.propertyBagAvailable) {
+                    return emptySection
+                }
+
                 // CRC32, CRC32C, SHA256, SHA1 -> "crc32", "crc32c", "sha256", "sha1"
                 val responseAlgorithms = checksumTrait.responseAlgorithms
                     .map { algorithm -> algorithm.lowercase() }.joinToString(", ") { algorithm -> "\"$algorithm\"" }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
@@ -59,11 +59,17 @@ class ProtocolParserGenerator(
         "PropertyBag" to RuntimeType.smithyHttp(codegenContext.runtimeConfig).resolve("property_bag::PropertyBag"),
     )
 
-    fun parseResponseFn(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
+    fun parseResponseFn(
+        operationShape: OperationShape,
+        // TODO(enableNewSmithyRuntime): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
+        propertyBagAvailable: Boolean,
+        customizations: List<OperationCustomization>,
+    ): RuntimeType {
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = "http_response") { fnName ->
+        val fnNameSuffix = if (propertyBagAvailable) "http_response_with_props" else "http_response"
+        return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = fnNameSuffix) { fnName ->
             Attribute.AllowClippyUnnecessaryWraps.render(this)
             rustBlockTemplate(
                 "pub fn $fnName(_response_status: u16, _response_headers: &#{http}::header::HeaderMap, _response_body: &[u8]) -> std::result::Result<#{O}, #{E}>",
@@ -77,6 +83,7 @@ class ProtocolParserGenerator(
                         outputShape,
                         httpBindingResolver.responseBindings(operationShape),
                         errorSymbol,
+                        propertyBagAvailable,
                         customizations,
                     )
                 }
@@ -84,7 +91,10 @@ class ProtocolParserGenerator(
         }
     }
 
-    fun parseErrorFn(operationShape: OperationShape, customizations: List<OperationCustomization>): RuntimeType {
+    fun parseErrorFn(
+        operationShape: OperationShape,
+        customizations: List<OperationCustomization>,
+    ): RuntimeType {
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
@@ -143,6 +153,7 @@ class ProtocolParserGenerator(
                                             errorShape,
                                             httpBindingResolver.errorResponseBindings(errorShape),
                                             errorSymbol,
+                                            false,
                                             listOf(
                                                 object : OperationCustomization() {
                                                     override fun section(section: OperationSection): Writable = {
@@ -178,17 +189,17 @@ class ProtocolParserGenerator(
 
     fun parseStreamingResponseFn(
         operationShape: OperationShape,
-        // TODO(enableNewSmithyRuntime): Remove the `includeProperties` flag as if it were always set to `false`
-        includeProperties: Boolean,
+        // TODO(enableNewSmithyRuntime): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
+        propertyBagAvailable: Boolean,
         customizations: List<OperationCustomization>,
     ): RuntimeType {
         val outputShape = operationShape.outputShape(model)
         val outputSymbol = symbolProvider.toSymbol(outputShape)
         val errorSymbol = symbolProvider.symbolForOperationError(operationShape)
-        val fnNameSuffix = if (includeProperties) "http_response_with_props" else "http_response"
+        val fnNameSuffix = if (propertyBagAvailable) "http_response_with_props" else "http_response"
         return protocolFunctions.deserializeFn(operationShape, fnNameSuffix = fnNameSuffix) { fnName ->
             Attribute.AllowClippyUnnecessaryWraps.render(this)
-            val propertiesArg = if (includeProperties) {
+            val propertiesArg = if (propertyBagAvailable) {
                 Attribute.AllowUnusedVariables.render(this)
                 ", properties: &#{PropertyBag}"
             } else {
@@ -217,6 +228,7 @@ class ProtocolParserGenerator(
                         outputShape,
                         httpBindingResolver.responseBindings(operationShape),
                         errorSymbol,
+                        propertyBagAvailable,
                         customizations,
                     )
                 }
@@ -229,6 +241,8 @@ class ProtocolParserGenerator(
         outputShape: StructureShape,
         bindings: List<HttpBindingDescriptor>,
         errorSymbol: Symbol,
+        // TODO(enableNewSmithyRuntime): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
+        propertyBagAvailable: Boolean,
         customizations: List<OperationCustomization>,
     ) {
         val httpBindingGenerator = ResponseBindingGenerator(protocol, codegenContext, operationShape)
@@ -270,7 +284,7 @@ class ProtocolParserGenerator(
 
         writeCustomizations(
             customizations,
-            OperationSection.MutateOutput(customizations, operationShape, "_response_headers"),
+            OperationSection.MutateOutput(customizations, operationShape, "_response_headers", propertyBagAvailable),
         )
 
         rust("output.build()$err")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
@@ -144,7 +144,7 @@ class ResponseDeserializerGenerator(
             """,
             *codegenScope,
             "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
-            "parse_response" to parserGenerator.parseResponseFn(operationShape, customizations),
+            "parse_response" to parserGenerator.parseResponseFn(operationShape, false, customizations),
             "BeforeParseResponse" to writable {
                 writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
             },

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -101,7 +101,7 @@ open class HttpBoundProtocolTraitImplGenerator(
             "O" to outputSymbol,
             "E" to symbolProvider.symbolForOperationError(operationShape),
             "parse_error" to parserGenerator.parseErrorFn(operationShape, customizations),
-            "parse_response" to parserGenerator.parseResponseFn(operationShape, customizations),
+            "parse_response" to parserGenerator.parseResponseFn(operationShape, true, customizations),
             "BeforeParseResponse" to writable {
                 writeCustomizations(customizations, OperationSection.BeforeParseResponse(customizations, "response"))
             },

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/OperationCustomization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/OperationCustomization.kt
@@ -54,6 +54,10 @@ sealed class OperationSection(name: String) : Section(name) {
         val operationShape: OperationShape,
         /** Name of the response headers map (for referring to it in Rust code) */
         val responseHeadersName: String,
+
+        // TODO(enableNewSmithyRuntime): Remove this flag when switching to the orchestrator
+        /** Whether the property bag exists in this context */
+        val propertyBagAvailable: Boolean,
     ) : OperationSection("MutateOutput")
 
     /**


### PR DESCRIPTION
## Motivation and Context
When setting the `enableNewSmithyRuntime` feature gate to `both_default_middleware` or `both_default_orchestrator`, the generated code would fail to compile due to the a checksum response decorator assuming the property bag always existed. This PR makes that decorator aware of the conditional existence of the property bag so that it can elect to not customize the code for the orchestrator use case (which will ultimately replace the decorator with an interceptor).

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
