### PR TITLE
Call `setup_tracing` in the Lambda example

### DIFF
--- a/examples/pokemon-service-lambda/src/main.rs
+++ b/examples/pokemon-service-lambda/src/main.rs
@@ -8,13 +8,16 @@ use std::sync::Arc;
 use aws_smithy_http_server::{routing::LambdaHandler, AddExtensionLayer};
 
 use pokemon_service_common::{
-    capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics, State,
+    capture_pokemon, check_health, do_nothing, get_pokemon_species, get_server_statistics,
+    setup_tracing, State,
 };
 use pokemon_service_lambda::get_storage_lambda;
 use pokemon_service_server_sdk::PokemonService;
 
 #[tokio::main]
 pub async fn main() {
+    setup_tracing();
+
     let app = PokemonService::builder_without_plugins()
         // Build a registry containing implementations to all the operations in the service. These
         // are async functions or async closures that take as input the operation's input and


### PR DESCRIPTION
To initialize tracing. It's the only example that currently doesn't; the
rest of our binary examples (`pokemon-service`, `pokemon-service-tls`)
already do this.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
