### PR TITLE
Document compatibility of `aws-smithy-http-server` with `lambda_http`

### DIFF
--- a/examples/pokemon-service-lambda/Cargo.toml
+++ b/examples/pokemon-service-lambda/Cargo.toml
@@ -13,6 +13,9 @@ hyper = {version = "0.14.25", features = ["server"] }
 tokio = "1.26.0"
 tracing = "0.1"
 
+# `aws-smithy-http-server` is only guaranteed to be compatible with this
+# version of `lambda_http`, or semver-compatible versions of this version.
+# Depending on other versions of `lambda_http` may not work.
 lambda_http = "0.7.3"
 
 # Local paths

--- a/rust-runtime/aws-smithy-http-server/src/routing/lambda_handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/lambda_handler.rs
@@ -16,6 +16,10 @@ type HyperRequest = http::Request<hyper::Body>;
 /// A [`Service`] that takes a `lambda_http::Request` and converts
 /// it to `http::Request<hyper::Body>`.
 ///
+/// **This version is only guaranteed to be compatible with
+/// [`lambda_http`](https://docs.rs/lambda_http) ^0.7.0.** Please ensure that your service crate's
+/// `Cargo.toml` depends on a compatible version.
+///
 /// [`Service`]: tower::Service
 #[derive(Debug, Clone)]
 pub struct LambdaHandler<S> {


### PR DESCRIPTION
See #2676.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
