### PR TITLE
Bump `lambda_http` dependency of `aws-smithy-http-server` to 0.8.0

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -23,3 +23,9 @@ message = "Implement `Ord` and `PartialOrd` for `DateTime`."
 author = "henriiik"
 references = ["smithy-rs#2653"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
+
+[[smithy-rs]]
+message = "Bump dependency on `lambda_http` by `aws-smithy-http-server` to 0.8.0. This version of `aws-smithy-http-server` is only guaranteed to be compatible with 0.8.0, or semver-compatible versions of 0.8.0 of the `lambda_http` crate. It will not work with versions prior to 0.8.0 _at runtime_, making requests to your smithy-rs service unroutable, so please make sure you're running your service in a compatible configuration"
+author = "david-perez"
+references = ["smithy-rs#2676", "smithy-rs#2685"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }

--- a/examples/pokemon-service-lambda/Cargo.toml
+++ b/examples/pokemon-service-lambda/Cargo.toml
@@ -13,7 +13,7 @@ hyper = {version = "0.14.25", features = ["server"] }
 tokio = "1.26.0"
 tracing = "0.1"
 
-lambda_http = "0.7.3"
+lambda_http = "0.8.0"
 
 # Local paths
 aws-smithy-http-server = { path = "../../rust-runtime/aws-smithy-http-server", features = ["aws-lambda"] }

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -25,12 +25,7 @@ hyper = { version = "0.14.20", features = ["server", "http1", "http2", "tcp", "s
 tls-listener = { version = "0.7.0", features = ["rustls", "hyper-h2"] }
 rustls-pemfile = "1.0.1"
 tokio-rustls = "0.24.0"
-lambda_http = { version = "0.7.1" }
-# There is a breaking change in `lambda_runtime` between `0.7.0` and `0.7.1`,
-# and `lambda_http` depends on `0.7` which by default resolves to `0.7.1` but in our CI
-# we are running `minimal-versions` which downgrades `lambda_runtime` to `0.7.0` and fails to compile
-# because of the breaking change. Here we are forcing it to use `lambda_runtime = 0.7.1`.
-lambda_runtime = { version = "0.7.1" }
+lambda_http = { version = "0.8.0" }
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -28,7 +28,7 @@ futures-util = { version = "0.3.16", default-features = false }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = { version = "0.7.1", optional = true }
+lambda_http = { version = "0.8.0", optional = true }
 mime = "0.3"
 nom = "7"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -29,7 +29,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "tcp", "stream"] }
 lambda_http = { version = "0.8.0", optional = true }
-mime = "0.3"
+mime = "0.3.4"
 nom = "7"
 pin-project-lite = "0.2"
 once_cell = "1.13"

--- a/rust-runtime/aws-smithy-http-server/src/routing/lambda_handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/lambda_handler.rs
@@ -54,12 +54,12 @@ where
 ///
 /// [API Gateway Stage]: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-stages.html
 fn convert_event(request: Request) -> HyperRequest {
-    let raw_path = request.raw_http_path();
-    let (mut parts, body) = request.into_parts();
-    let mut path = String::from(parts.uri.path());
+    let raw_path: &str = request.extensions().raw_http_path();
+    let path: &str = request.uri().path();
 
-    if !raw_path.is_empty() && raw_path != path {
-        path = raw_path;
+    let (parts, body) = if !raw_path.is_empty() && raw_path != path {
+        let mut path = raw_path.to_owned(); // Clone only when we need to strip out the stage.
+        let (mut parts, body) = request.into_parts();
 
         let uri_parts: uri::Parts = parts.uri.into();
         let path_and_query = uri_parts
@@ -77,7 +77,11 @@ fn convert_event(request: Request) -> HyperRequest {
             .path_and_query(path)
             .build()
             .expect("unable to construct new URI");
-    }
+
+        (parts, body)
+    } else {
+        request.into_parts()
+    };
 
     let body = match body {
         lambda_http::Body::Empty => hyper::Body::empty(),


### PR DESCRIPTION
This patch also removes the unneeded dependency on `lambda_runtime` by
`aws-smithy-http-server-python`.

This patch also refactors `LambdaHandler`'s `convert_event` to avoid
cloning the URI path when not needed.

This is a breaking change. See #2676 why.

This patch also bumps `aws-smithy-http-server` dependency on `mime` to 0.3.4.

`cargo +nightly-2022-11-16 minimal-versions check --all-features` otherwise
fails when using 0.3.0, because we require `impl fmt::Display for
mime::FromStrError`, which was first introduced in 0.3.4.

As to why `minimal-versions` is now picking `mime` 0.3.0 with this patch, it's
because in `lambda_http` 0.7.3, they had [`mime =
"0.3.16"`](https://github.com/awslabs/aws-lambda-rust-runtime/blob/99dba6447253ac87cf3cefeb2ba130b50514f9df/lambda-http/Cargo.toml#L35-L35),
and in `lambda_http` 0.8.0, they've now relaxed that to [`mime =
"0.3"`](https://github.com/awslabs/aws-lambda-rust-runtime/blob/393d6447bea0502e1f939d197f4facc228e6e007/lambda-http/Cargo.toml#L36).


## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
