### PR TITLE
Enable paginators when code generating with the orchestrator

### DIFF
--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -458,23 +458,20 @@ class FluentClientGenerator(
                 )
             }
 
-            // TODO(enableNewSmithyRuntime): Port paginators to the orchestrator
-            if (smithyRuntimeMode.generateMiddleware) {
-                PaginatorGenerator.paginatorType(codegenContext, generics, operation, retryClassifier)
-                    ?.also { paginatorType ->
-                        rustTemplate(
-                            """
-                            /// Create a paginator for this request
-                            ///
-                            /// Paginators are used by calling [`send().await`](#{Paginator}::send) which returns a `Stream`.
-                            pub fn into_paginator(self) -> #{Paginator}${generics.inst} {
-                                #{Paginator}::new(self.handle, self.inner)
-                            }
-                            """,
-                            "Paginator" to paginatorType,
-                        )
-                    }
-            }
+            PaginatorGenerator.paginatorType(codegenContext, generics, operation, retryClassifier)
+                ?.also { paginatorType ->
+                    rustTemplate(
+                        """
+                        /// Create a paginator for this request
+                        ///
+                        /// Paginators are used by calling [`send().await`](#{Paginator}::send) which returns a `Stream`.
+                        pub fn into_paginator(self) -> #{Paginator}${generics.inst} {
+                            #{Paginator}::new(self.handle, self.inner)
+                        }
+                        """,
+                        "Paginator" to paginatorType,
+                    )
+                }
             writeCustomizations(
                 customizations,
                 FluentClientSection.FluentBuilderImpl(


### PR DESCRIPTION
## Motivation and Context
The paginators were originally turned off for the orchestrator feature flag since there were issues with them, but those issues seem to have been resolved since. This PR re-enables them.

## Testing
- [x] Generated the AWS SDK in `orchestrator` mode and verified the paginator tests pass
- [x] Added a unit test that validates the paginators compile for generic clients in `orchestrator` mode

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
