### PR TITLE
Revert "Bump `lambda_http` dependency of `aws-smithy-http-server` to 0.8.0 (#2685)"

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -23,9 +23,3 @@ message = "Implement `Ord` and `PartialOrd` for `DateTime`."
 author = "henriiik"
 references = ["smithy-rs#2653", "smithy-rs#2656"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
-
-[[smithy-rs]]
-message = "Bump dependency on `lambda_http` by `aws-smithy-http-server` to 0.8.0. This version of `aws-smithy-http-server` is only guaranteed to be compatible with 0.8.0, or semver-compatible versions of 0.8.0 of the `lambda_http` crate. It will not work with versions prior to 0.8.0 _at runtime_, making requests to your smithy-rs service unroutable, so please make sure you're running your service in a compatible configuration"
-author = "david-perez"
-references = ["smithy-rs#2676", "smithy-rs#2685"]
-meta = { "breaking" = true, "tada" = false, "bug" = false }

--- a/examples/pokemon-service-lambda/Cargo.toml
+++ b/examples/pokemon-service-lambda/Cargo.toml
@@ -16,7 +16,7 @@ tracing = "0.1"
 # `aws-smithy-http-server` is only guaranteed to be compatible with this
 # version of `lambda_http`, or semver-compatible versions of this version.
 # Depending on other versions of `lambda_http` may not work.
-lambda_http = "0.8.0"
+lambda_http = "0.7.3"
 
 # Local paths
 aws-smithy-http-server = { path = "../../rust-runtime/aws-smithy-http-server", features = ["aws-lambda"] }

--- a/rust-runtime/aws-smithy-http-server-python/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server-python/Cargo.toml
@@ -25,7 +25,12 @@ hyper = { version = "0.14.20", features = ["server", "http1", "http2", "tcp", "s
 tls-listener = { version = "0.7.0", features = ["rustls", "hyper-h2"] }
 rustls-pemfile = "1.0.1"
 tokio-rustls = "0.24.0"
-lambda_http = { version = "0.8.0" }
+lambda_http = { version = "0.7.1" }
+# There is a breaking change in `lambda_runtime` between `0.7.0` and `0.7.1`,
+# and `lambda_http` depends on `0.7` which by default resolves to `0.7.1` but in our CI
+# we are running `minimal-versions` which downgrades `lambda_runtime` to `0.7.0` and fails to compile
+# because of the breaking change. Here we are forcing it to use `lambda_runtime = 0.7.1`.
+lambda_runtime = { version = "0.7.1" }
 num_cpus = "1.13.1"
 parking_lot = "0.12.1"
 pin-project-lite = "0.2"

--- a/rust-runtime/aws-smithy-http-server/Cargo.toml
+++ b/rust-runtime/aws-smithy-http-server/Cargo.toml
@@ -28,8 +28,8 @@ futures-util = { version = "0.3.16", default-features = false }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.12", features = ["server", "http1", "http2", "tcp", "stream"] }
-lambda_http = { version = "0.8.0", optional = true }
-mime = "0.3.4"
+lambda_http = { version = "0.7.1", optional = true }
+mime = "0.3"
 nom = "7"
 pin-project-lite = "0.2"
 once_cell = "1.13"

--- a/rust-runtime/aws-smithy-http-server/src/routing/lambda_handler.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/lambda_handler.rs
@@ -58,12 +58,12 @@ where
 ///
 /// [API Gateway Stage]: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-stages.html
 fn convert_event(request: Request) -> HyperRequest {
-    let raw_path: &str = request.extensions().raw_http_path();
-    let path: &str = request.uri().path();
+    let raw_path = request.raw_http_path();
+    let (mut parts, body) = request.into_parts();
+    let mut path = String::from(parts.uri.path());
 
-    let (parts, body) = if !raw_path.is_empty() && raw_path != path {
-        let mut path = raw_path.to_owned(); // Clone only when we need to strip out the stage.
-        let (mut parts, body) = request.into_parts();
+    if !raw_path.is_empty() && raw_path != path {
+        path = raw_path;
 
         let uri_parts: uri::Parts = parts.uri.into();
         let path_and_query = uri_parts
@@ -81,11 +81,7 @@ fn convert_event(request: Request) -> HyperRequest {
             .path_and_query(path)
             .build()
             .expect("unable to construct new URI");
-
-        (parts, body)
-    } else {
-        request.into_parts()
-    };
+    }
 
     let body = match body {
         lambda_http::Body::Empty => hyper::Body::empty(),


### PR DESCRIPTION
This reverts commit 04db5e3572448cb38e3b5f1de78ce8695567c5f3.

This is a breaking change that needs to wait to be merged in until the
next breaking release.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
