### PR TITLE
Python: Link `stubgen.{py,sh}` to `resources/` and read them using `getResource()`

### DIFF
--- a/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/customizations/PythonServerCodegenDecorator.kt
+++ b/codegen-server/python/src/main/kotlin/software/amazon/smithy/rust/codegen/server/python/smithy/customizations/PythonServerCodegenDecorator.kt
@@ -23,7 +23,6 @@ import software.amazon.smithy.rust.codegen.server.python.smithy.generators.Pytho
 import software.amazon.smithy.rust.codegen.server.smithy.ServerCodegenContext
 import software.amazon.smithy.rust.codegen.server.smithy.customizations.AddInternalServerErrorToAllOperationsDecorator
 import software.amazon.smithy.rust.codegen.server.smithy.customize.ServerCodegenDecorator
-import java.io.File
 
 /**
  * Configure the [lib] section of `Cargo.toml`.
@@ -206,14 +205,11 @@ class AddStubgenScriptDecorator : ServerCodegenDecorator {
     override val order: Byte = 0
 
     override fun extras(codegenContext: ServerCodegenContext, rustCrate: RustCrate) {
-        val runtimeCratesPath = codegenContext.runtimeConfig.runtimeCratesPath()
-        val stubgenPythonLocation = "$runtimeCratesPath/aws-smithy-http-server-python/stubgen.py"
-        val stubgenPythonContent = File(stubgenPythonLocation).readText(Charsets.UTF_8)
+        val stubgenPythonContent = this::class.java.getResource("/stubgen.py").readText()
         rustCrate.withFile("stubgen.py") {
             writeWithNoFormatting("$stubgenPythonContent")
         }
-        val stubgenShellLocation = "$runtimeCratesPath/aws-smithy-http-server-python/stubgen.sh"
-        val stubgenShellContent = File(stubgenShellLocation).readText(Charsets.UTF_8)
+        val stubgenShellContent = this::class.java.getResource("/stubgen.sh").readText()
         rustCrate.withFile("stubgen.sh") {
             writeWithNoFormatting("$stubgenShellContent")
         }

--- a/codegen-server/python/src/main/resources/stubgen.py
+++ b/codegen-server/python/src/main/resources/stubgen.py
@@ -1,0 +1,1 @@
+../../../../../rust-runtime/aws-smithy-http-server-python/stubgen.py

--- a/codegen-server/python/src/main/resources/stubgen.sh
+++ b/codegen-server/python/src/main/resources/stubgen.sh
@@ -1,0 +1,1 @@
+../../../../../rust-runtime/aws-smithy-http-server-python/stubgen.sh


### PR DESCRIPTION
## Motivation and Context
Currently, we're relying on `runtimeConfig.runtimeCratesPath()` to read `stubgen.{py,sh}` files, but that function only returns a path if we're using `relativePath` for our runtime crates:
```
"runtimeConfig": {
      "relativePath": "../rust-runtime"
},
```
otherwise it returns `null` and in that case our code generator fails with:
```
Projection pokemon-service failed: java.io.FileNotFoundException: null/aws-smithy-http-server-python/stubgen.py (No such file or directory)
java.io.FileNotFoundException: null/aws-smithy-http-server-python/stubgen.py (No such file or directory)
```

With this PR we're linking `stubgen.{py,sh}` to `resources/` folder and reading them using `getResource()` function. 

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
