### PR TITLE
Avoid extending IMDS credentials expiry unconditionally

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -23,3 +23,9 @@ message = "Implement `Ord` and `PartialOrd` for `DateTime`."
 author = "henriiik"
 references = ["smithy-rs#2653", "smithy-rs#2656"]
 meta = { "breaking" = false, "tada" = false, "bug" = false }
+
+[[aws-sdk-rust]]
+message = "Avoid extending IMDS credentials' expiry unconditionally, which may incorrectly extend it beyond what is originally defined; If returned credentials are not stale, use them as they are."
+references = ["smithy-rs#2687", "smithy-rs#2694"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "ysaito1001"

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -306,6 +306,8 @@ mod test {
     use tracing_test::traced_test;
 
     const TOKEN_A: &str = "token_a";
+    const WARNING_FOR_EXTENDING_CREDENTIALS_EXPIRY: &str =
+        "Attempting credential expiration extension";
 
     #[tokio::test]
     async fn profile_is_not_cached() {
@@ -432,7 +434,7 @@ mod test {
         connection.assert_requests_match(&[]);
 
         // We should inform customers that expired credentials are being used for stability.
-        assert!(logs_contain("Attempting credential expiration extension"));
+        assert!(logs_contain(WARNING_FOR_EXTENDING_CREDENTIALS_EXPIRY));
     }
 
     #[tokio::test]

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -203,7 +203,10 @@ impl ImdsCredentialsProvider {
                 .expect("now should be after UNIX EPOCH")
                 .as_secs(),
         );
-        // calculate credentials' refresh offset with jitter
+        // Calculate credentials' refresh offset with jitter, which should be less than 15 minutes
+        // the smallest amount of time credentials are valid for.
+        // Setting it to something longer than that may have the risk of the credentials expiring
+        // before the next refresh.
         let refresh_offset = CREDENTIAL_EXPIRATION_INTERVAL + Duration::from_secs(rng.u64(0..=300));
         let new_expiry = now + refresh_offset;
 

--- a/aws/rust-runtime/aws-config/src/imds/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/imds/credentials.rs
@@ -384,11 +384,12 @@ mod test {
             .imds_client(client)
             .build();
         let creds = provider.provide_credentials().await.expect("valid creds");
-        assert!(creds.expiry().unwrap() > time_of_request_to_fetch_credentials);
+        // The expiry should be equal to what is originally set (==2021-09-21T04:16:53Z).
+        assert!(creds.expiry() == UNIX_EPOCH.checked_add(Duration::from_secs(1632197813)));
         connection.assert_requests_match(&[]);
 
         // There should not be logs indicating credentials are extended for stability.
-        assert!(!logs_contain("Attempting credential expiration extension"));
+        assert!(!logs_contain(WARNING_FOR_EXTENDING_CREDENTIALS_EXPIRY));
     }
     #[tokio::test]
     #[traced_test]


### PR DESCRIPTION
## Motivation and Context
Fixes https://github.com/awslabs/smithy-rs/issues/2687

## Description
The implementation for IMDS static stability support introduced a bug where returned credentials from IMDS are extended unconditionally, even though the credentials are not stale. The amount by which credentials are extended is randomized and it can incorrectly extend the expiry beyond what's originally set. IMDS produces credentials that last 6 hours, and extending them by at most 25 minutes usually won't be an issue but when other tools such as Kube2iam and AWSVault are used, the expiry can be set much shorter than that, causing the issue to occur.

This PR will conditionally extend the credentials' expiry only when the returned credentials have been expired with respect to the current wall clock time. Also, the constant values have been adjusted according to our internal spec.

## Testing
- Added a new unit test for the IMDS credentials provider

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
