### PR TITLE
Port API Gateway customizations to the orchestrator

### DIFF
--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -20,6 +20,7 @@ aws-smithy-checksums = { path = "../../../rust-runtime/aws-smithy-checksums" }
 aws-smithy-client = { path = "../../../rust-runtime/aws-smithy-client" }
 aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
 aws-smithy-http-tower= { path = "../../../rust-runtime/aws-smithy-http-tower" }
+aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
 aws-types = { path = "../aws-types" }
 bytes = "1"

--- a/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/apigateway_interceptors.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#![allow(dead_code)]
+
+use aws_smithy_runtime_api::client::interceptors::context::phase::BeforeTransmit;
+use aws_smithy_runtime_api::client::interceptors::{BoxError, Interceptor, InterceptorContext};
+use aws_smithy_runtime_api::config_bag::ConfigBag;
+use http::header::ACCEPT;
+use http::HeaderValue;
+
+/// Interceptor that adds an Accept header to API Gateway requests.
+#[derive(Debug, Default)]
+pub(crate) struct AcceptHeaderInterceptor;
+
+impl Interceptor for AcceptHeaderInterceptor {
+    fn modify_before_signing(
+        &self,
+        context: &mut InterceptorContext<BeforeTransmit>,
+        _cfg: &mut ConfigBag,
+    ) -> Result<(), BoxError> {
+        context
+            .request_mut()
+            .headers_mut()
+            .insert(ACCEPT, HeaderValue::from_static("application/json"));
+        Ok(())
+    }
+}

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -19,6 +19,9 @@
     unreachable_pub
 )]
 
+/// Interceptors for API Gateway
+pub mod apigateway_interceptors;
+
 /// Stub credentials provider for use when no credentials provider is used.
 pub mod no_credentials;
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/ServiceSpecificDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/ServiceSpecificDecorator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientProtocolMap
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.error.ErrorCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
@@ -130,4 +131,11 @@ class ServiceSpecificDecorator(
         model.maybeApply(service) {
             delegateTo.transformModel(service, model)
         }
+
+    override fun serviceRuntimePluginCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ServiceRuntimePluginCustomization>,
+    ): List<ServiceRuntimePluginCustomization> = baseCustomizations.maybeApply(codegenContext.serviceShape) {
+        delegateTo.serviceRuntimePluginCustomizations(codegenContext, baseCustomizations)
+    }
 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/apigateway/ApiGatewayDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/apigateway/ApiGatewayDecorator.kt
@@ -8,25 +8,44 @@ package software.amazon.smithy.rustsdk.customize.apigateway
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
+import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginSection
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationSection
+import software.amazon.smithy.rust.codegen.core.util.letIf
+import software.amazon.smithy.rustsdk.InlineAwsDependency
 
 class ApiGatewayDecorator : ClientCodegenDecorator {
     override val name: String = "ApiGateway"
     override val order: Byte = 0
 
+    // TODO(enableNewSmithyRuntime): Delete when cleaning up middleware
     override fun operationCustomizations(
         codegenContext: ClientCodegenContext,
         operation: OperationShape,
         baseCustomizations: List<OperationCustomization>,
-    ): List<OperationCustomization> = baseCustomizations + ApiGatewayAddAcceptHeader()
+    ): List<OperationCustomization> =
+        baseCustomizations.letIf(codegenContext.smithyRuntimeMode.generateMiddleware) {
+            it + ApiGatewayAddAcceptHeader()
+        }
+
+    override fun serviceRuntimePluginCustomizations(
+        codegenContext: ClientCodegenContext,
+        baseCustomizations: List<ServiceRuntimePluginCustomization>,
+    ): List<ServiceRuntimePluginCustomization> =
+        baseCustomizations.letIf(codegenContext.smithyRuntimeMode.generateOrchestrator) {
+            it + ApiGatewayAcceptHeaderInterceptorCustomization(codegenContext)
+        }
 }
 
-class ApiGatewayAddAcceptHeader : OperationCustomization() {
+// TODO(enableNewSmithyRuntime): Delete when cleaning up middleware
+private class ApiGatewayAddAcceptHeader : OperationCustomization() {
     override fun section(section: OperationSection): Writable = when (section) {
         is OperationSection.FinalizeOperation -> emptySection
         is OperationSection.OperationImplBlock -> emptySection
@@ -39,6 +58,28 @@ class ApiGatewayAddAcceptHeader : OperationCustomization() {
                 RuntimeType.Http,
             )
         }
+
         else -> emptySection
+    }
+}
+
+private class ApiGatewayAcceptHeaderInterceptorCustomization(private val codegenContext: ClientCodegenContext) :
+    ServiceRuntimePluginCustomization() {
+    override fun section(section: ServiceRuntimePluginSection): Writable = writable {
+        if (section is ServiceRuntimePluginSection.AdditionalConfig) {
+            section.registerInterceptor(codegenContext.runtimeConfig, this) {
+                rustTemplate(
+                    "#{Interceptor}::default()",
+                    "Interceptor" to RuntimeType.forInlineDependency(
+                        InlineAwsDependency.forRustFile(
+                            "apigateway_interceptors",
+                            additionalDependency = arrayOf(
+                                CargoDependency.smithyRuntimeApi(codegenContext.runtimeConfig),
+                            ),
+                        ),
+                    ).resolve("AcceptHeaderInterceptor"),
+                )
+            }
+        }
     }
 }

--- a/aws/sdk/aws-models/apigateway.json
+++ b/aws/sdk/aws-models/apigateway.json
@@ -1,0 +1,12865 @@
+{
+    "smithy": "2.0",
+    "metadata": {
+        "suppressions": [
+            {
+                "id": "HttpMethodSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpResponseCodeSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "PaginatedTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpHeaderTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpUriConflict",
+                "namespace": "*"
+            },
+            {
+                "id": "Service",
+                "namespace": "*"
+            }
+        ]
+    },
+    "shapes": {
+        "com.amazonaws.apigateway#AccessLogSettings": {
+            "type": "structure",
+            "members": {
+                "format": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A single line format of the access logs of data, as specified by selected $context variables. The format must include at least <code>$context.requestId</code>.</p>"
+                    }
+                },
+                "destinationArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the CloudWatch Logs log group or Kinesis Data Firehose delivery stream to receive access logs. If you specify a Kinesis Data Firehose delivery stream, the stream name must begin with <code>amazon-apigateway-</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Access log settings, including the access log format and access log destination ARN.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Account": {
+            "type": "structure",
+            "members": {
+                "cloudwatchRoleArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of an Amazon CloudWatch role for the current Account. </p>"
+                    }
+                },
+                "throttleSettings": {
+                    "target": "com.amazonaws.apigateway#ThrottleSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the API request limits configured for the current Account.</p>"
+                    }
+                },
+                "features": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of features supported for the account. When usage plans are enabled, the features list will include an entry of <code>\"UsagePlans\"</code>.</p>"
+                    }
+                },
+                "apiKeyVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the API keys used for the account.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an AWS account that is associated with API Gateway.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ApiKey": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the API Key.</p>"
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of the API Key.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the API Key.</p>"
+                    }
+                },
+                "customerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An AWS Marketplace customer identifier , when integrating with the AWS SaaS Marketplace.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the API Key.</p>"
+                    }
+                },
+                "enabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether the API Key can be used by callers.</p>"
+                    }
+                },
+                "createdDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the API Key was created.</p>"
+                    }
+                },
+                "lastUpdatedDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the API Key was last updated.</p>"
+                    }
+                },
+                "stageKeys": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of Stage resources that are associated with the ApiKey resource.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A resource that can be distributed to callers for executing Method resources that require an API key. API keys can be mapped to any Stage on any RestApi, which indicates that the callers with the API key can make requests to that stage.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ApiKeyIds": {
+            "type": "structure",
+            "members": {
+                "ids": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of all the ApiKey identifiers.</p>"
+                    }
+                },
+                "warnings": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of warning messages.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The identifier of an ApiKey used in a UsagePlan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ApiKeySourceType": {
+            "type": "enum",
+            "members": {
+                "HEADER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HEADER"
+                    }
+                },
+                "AUTHORIZER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AUTHORIZER"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ApiKeys": {
+            "type": "structure",
+            "members": {
+                "warnings": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of warning messages logged during the import of API keys when the <code>failOnWarnings</code> option is set to true.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfApiKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of API keys as represented by an ApiKeys resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ApiKeysFormat": {
+            "type": "enum",
+            "members": {
+                "csv": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "csv"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ApiStage": {
+            "type": "structure",
+            "members": {
+                "apiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>API Id of the associated API stage in a usage plan.</p>"
+                    }
+                },
+                "stage": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>API stage name of the associated API stage in a usage plan.</p>"
+                    }
+                },
+                "throttle": {
+                    "target": "com.amazonaws.apigateway#MapOfApiStageThrottleSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Map containing method level throttling information for API stage in a usage plan.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>API stage name of the associated API stage in a usage plan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Authorizer": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the authorizer resource.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the authorizer.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.apigateway#AuthorizerType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authorizer type. Valid values are <code>TOKEN</code> for a Lambda function using a single authorization token submitted in a custom header, <code>REQUEST</code> for a Lambda function using incoming request parameters, and <code>COGNITO_USER_POOLS</code> for using an Amazon Cognito user pool.</p>"
+                    }
+                },
+                "providerARNs": {
+                    "target": "com.amazonaws.apigateway#ListOfARNs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of the Amazon Cognito user pool ARNs for the <code>COGNITO_USER_POOLS</code> authorizer. Each element is of this format: <code>arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}</code>. For a <code>TOKEN</code> or <code>REQUEST</code> authorizer, this is not defined. </p>"
+                    }
+                },
+                "authType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional customer-defined field, used in OpenAPI imports and exports without functional impact.</p>"
+                    }
+                },
+                "authorizerUri": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the authorizer's Uniform Resource Identifier (URI). For <code>TOKEN</code> or <code>REQUEST</code> authorizers, this must be a well-formed Lambda function URI, for example, <code>arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:{account_id}:function:{lambda_function_name}/invocations</code>. In general, the URI has this form  <code>arn:aws:apigateway:{region}:lambda:path/{service_api}</code>, where <code>{region}</code> is the same as the region hosting the Lambda function, <code>path</code> indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial <code>/</code>. For Lambda functions, this is usually of the form <code>/2015-03-31/functions/[FunctionARN]/invocations</code>.</p>"
+                    }
+                },
+                "authorizerCredentials": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, specify null.</p>"
+                    }
+                },
+                "identitySource": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identity source for which authorization is requested. For a <code>TOKEN</code> or\n        <code>COGNITO_USER_POOLS</code> authorizer, this is required and specifies the request\n      header mapping expression for the custom header holding the authorization token submitted by\n      the client. For example, if the token header name is <code>Auth</code>, the header mapping expression is\n      <code>method.request.header.Auth</code>. For the <code>REQUEST</code> authorizer, this is required when authorization\n      caching is enabled. The value is a comma-separated string of one or more mapping expressions\n      of the specified request parameters. For example, if an <code>Auth</code> header, a <code>Name</code> query string\n      parameter are defined as identity sources, this value is <code>method.request.header.Auth</code>,\n      <code>method.request.querystring.Name</code>. These parameters will be used to derive the authorization\n      caching key and to perform runtime validation of the <code>REQUEST</code> authorizer by verifying all of\n      the identity-related request parameters are present, not null and non-empty. Only when this is\n      true does the authorizer invoke the authorizer Lambda function, otherwise, it returns a 401\n      Unauthorized response without calling the Lambda function. The valid value is a string of\n      comma-separated mapping expressions of the specified request parameters. When the\n      authorization caching is not enabled, this property is optional. </p>"
+                    }
+                },
+                "identityValidationExpression": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A validation expression for the incoming identity token. For <code>TOKEN</code> authorizers, this value is a regular expression. For <code>COGNITO_USER_POOLS</code> authorizers, API Gateway will match the <code>aud</code> field of the incoming token from the client against the specified regular expression. It will invoke the authorizer's Lambda function when there is a match. Otherwise, it will return a 401 Unauthorized response without calling the Lambda function. The validation expression does not apply to the <code>REQUEST</code> authorizer.</p>"
+                    }
+                },
+                "authorizerResultTtlInSeconds": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The TTL in seconds of cached authorizer results. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway will cache authorizer responses. If this field is not set, the default value is 300. The maximum value is 3600, or 1 hour.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an authorization layer for methods. If enabled on a method, API Gateway will activate the authorizer when a client calls the method.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#AuthorizerType": {
+            "type": "enum",
+            "members": {
+                "TOKEN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TOKEN"
+                    }
+                },
+                "REQUEST": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REQUEST"
+                    }
+                },
+                "COGNITO_USER_POOLS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "COGNITO_USER_POOLS"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The authorizer type. Valid values are <code>TOKEN</code> for a Lambda function using a single authorization token submitted in a custom header, <code>REQUEST</code> for a Lambda function using incoming request parameters, and <code>COGNITO_USER_POOLS</code> for using an Amazon Cognito user pool.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Authorizers": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfAuthorizer",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of Authorizer resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#BackplaneControlService": {
+            "type": "service",
+            "version": "2015-07-09",
+            "operations": [
+                {
+                    "target": "com.amazonaws.apigateway#CreateApiKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateAuthorizer"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateBasePathMapping"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateDeployment"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateDocumentationPart"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateDocumentationVersion"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateDomainName"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateModel"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateRequestValidator"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateResource"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateRestApi"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateStage"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateUsagePlan"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateUsagePlanKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#CreateVpcLink"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteApiKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteAuthorizer"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteBasePathMapping"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteClientCertificate"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteDeployment"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteDocumentationPart"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteDocumentationVersion"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteDomainName"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteGatewayResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteIntegration"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteIntegrationResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteMethod"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteMethodResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteModel"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteRequestValidator"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteResource"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteRestApi"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteStage"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteUsagePlan"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteUsagePlanKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#DeleteVpcLink"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#FlushStageAuthorizersCache"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#FlushStageCache"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GenerateClientCertificate"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetAccount"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetApiKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetApiKeys"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetAuthorizer"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetAuthorizers"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetBasePathMapping"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetBasePathMappings"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetClientCertificate"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetClientCertificates"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDeployment"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDeployments"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDocumentationPart"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDocumentationParts"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDocumentationVersion"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDocumentationVersions"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDomainName"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetDomainNames"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetExport"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetGatewayResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetGatewayResponses"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetIntegration"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetIntegrationResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetMethod"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetMethodResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetModel"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetModels"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetModelTemplate"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetRequestValidator"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetRequestValidators"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetResource"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetResources"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetRestApi"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetRestApis"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetSdk"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetSdkType"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetSdkTypes"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetStage"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetStages"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetTags"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetUsage"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetUsagePlan"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetUsagePlanKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetUsagePlanKeys"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetUsagePlans"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetVpcLink"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#GetVpcLinks"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ImportApiKeys"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ImportDocumentationParts"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ImportRestApi"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#PutGatewayResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#PutIntegration"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#PutIntegrationResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#PutMethod"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#PutMethodResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#PutRestApi"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TagResource"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TestInvokeAuthorizer"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TestInvokeMethod"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UntagResource"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateAccount"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateApiKey"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateAuthorizer"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateBasePathMapping"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateClientCertificate"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateDeployment"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateDocumentationPart"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateDocumentationVersion"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateDomainName"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateGatewayResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateIntegration"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateIntegrationResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateMethod"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateMethodResponse"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateModel"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateRequestValidator"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateResource"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateRestApi"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateStage"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateUsage"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateUsagePlan"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UpdateVpcLink"
+                }
+            ],
+            "traits": {
+                "aws.api#service": {
+                    "sdkId": "API Gateway",
+                    "arnNamespace": "apigateway",
+                    "cloudFormationName": "ApiGateway",
+                    "cloudTrailEventSource": "apigateway.amazonaws.com",
+                    "endpointPrefix": "apigateway"
+                },
+                "aws.auth#sigv4": {
+                    "name": "apigateway"
+                },
+                "aws.protocols#restJson1": {},
+                "smithy.api#documentation": "<fullname>Amazon API Gateway</fullname>\n         <p>Amazon API Gateway helps developers deliver robust, secure, and scalable mobile and web application back ends. API Gateway allows developers to securely connect mobile and web applications to APIs that run on AWS Lambda, Amazon EC2, or other publicly addressable web services that are hosted outside of AWS.</p>",
+                "smithy.api#title": "Amazon API Gateway",
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
+                                            "type": "tree",
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://apigateway-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://apigateway-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://apigateway.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://apigateway.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "conditions": [],
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region af-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.af-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "af-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-northeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-northeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-northeast-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-northeast-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-northeast-3",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-southeast-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ap-southeast-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ap-southeast-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ap-southeast-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region ca-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.ca-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "ca-central-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-central-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.eu-central-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-central-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.eu-north-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.eu-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.eu-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.eu-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region eu-west-3 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.eu-west-3.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "eu-west-3",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region me-south-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.me-south-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "me-south-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region sa-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.sa-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "sa-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-east-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-west-2 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-west-2.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-west-2",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-northwest-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.cn-northwest-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-northwest-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-west-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-gov-west-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-west-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "error": "FIPS and DualStack are enabled, but this partition does not support one or both"
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "error": "DualStack is enabled but this partition does not support DualStack"
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://apigateway.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseFIPS": false,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": true,
+                                "UseDualStack": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseFIPS": false,
+                                "UseDualStack": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "Missing region",
+                            "expect": {
+                                "error": "Invalid Configuration: Missing Region"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#BadRequestException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The submitted request is not valid, for example, the input is incomplete or incorrect. See the accompanying error message for details.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.apigateway#BasePathMapping": {
+            "type": "structure",
+            "members": {
+                "basePath": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The base path name that callers of the API must provide as part of the URL after the domain name.</p>"
+                    }
+                },
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>"
+                    }
+                },
+                "stage": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the associated stage.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the base path that callers of the API must provide as part of the URL after the domain name.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#BasePathMappings": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfBasePathMapping",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of BasePathMapping resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Blob": {
+            "type": "blob"
+        },
+        "com.amazonaws.apigateway#Boolean": {
+            "type": "boolean",
+            "traits": {
+                "smithy.api#default": false
+            }
+        },
+        "com.amazonaws.apigateway#CacheClusterSize": {
+            "type": "enum",
+            "members": {
+                "SIZE_0_POINT_5_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "0.5"
+                    }
+                },
+                "SIZE_1_POINT_6_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "1.6"
+                    }
+                },
+                "SIZE_6_POINT_1_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "6.1"
+                    }
+                },
+                "SIZE_13_POINT_5_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "13.5"
+                    }
+                },
+                "SIZE_28_POINT_4_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "28.4"
+                    }
+                },
+                "SIZE_58_POINT_2_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "58.2"
+                    }
+                },
+                "SIZE_118_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "118"
+                    }
+                },
+                "SIZE_237_GB": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "237"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the size of the CacheCluster.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CacheClusterStatus": {
+            "type": "enum",
+            "members": {
+                "CREATE_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATE_IN_PROGRESS"
+                    }
+                },
+                "AVAILABLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AVAILABLE"
+                    }
+                },
+                "DELETE_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETE_IN_PROGRESS"
+                    }
+                },
+                "NOT_AVAILABLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NOT_AVAILABLE"
+                    }
+                },
+                "FLUSH_IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FLUSH_IN_PROGRESS"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Returns the status of the CacheCluster.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CanarySettings": {
+            "type": "structure",
+            "members": {
+                "percentTraffic": {
+                    "target": "com.amazonaws.apigateway#Double",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The percent (0-100) of traffic diverted to a canary deployment.</p>"
+                    }
+                },
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the canary deployment.</p>"
+                    }
+                },
+                "stageVariableOverrides": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Stage variables overridden for a canary release deployment, including new stage variables introduced in the canary. These stage variables are represented as a string-to-string map between stage variable names and their values.</p>"
+                    }
+                },
+                "useStageCache": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether the canary deployment uses the stage cache or not.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration settings of a canary deployment.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ClientCertificate": {
+            "type": "structure",
+            "members": {
+                "clientCertificateId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the client certificate.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the client certificate.</p>"
+                    }
+                },
+                "pemEncodedCertificate": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PEM-encoded public key of the client certificate, which can be used to configure certificate authentication in the integration endpoint .</p>"
+                    }
+                },
+                "createdDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the client certificate was created.</p>"
+                    }
+                },
+                "expirationDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the client certificate will expire.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a client certificate used to configure client-side SSL authentication while sending requests to the integration endpoint.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ClientCertificates": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfClientCertificate",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of ClientCertificate resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ConflictException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request configuration has conflicts. For details, see the accompanying error message.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.apigateway#ConnectionType": {
+            "type": "enum",
+            "members": {
+                "INTERNET": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTERNET"
+                    }
+                },
+                "VPC_LINK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VPC_LINK"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ContentHandlingStrategy": {
+            "type": "enum",
+            "members": {
+                "CONVERT_TO_BINARY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CONVERT_TO_BINARY"
+                    }
+                },
+                "CONVERT_TO_TEXT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CONVERT_TO_TEXT"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateApiKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateApiKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ApiKey"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Create an ApiKey resource. </p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/apikeys",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateApiKeyRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the ApiKey.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the ApiKey.</p>"
+                    }
+                },
+                "enabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether the ApiKey can be used by callers.</p>"
+                    }
+                },
+                "generateDistinctId": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether (<code>true</code>) or not (<code>false</code>) the key identifier is distinct from the created API key value. This parameter is deprecated and should not be used.</p>"
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a value of the API key.</p>"
+                    }
+                },
+                "stageKeys": {
+                    "target": "com.amazonaws.apigateway#ListOfStageKeys",
+                    "traits": {
+                        "smithy.api#documentation": "<p>DEPRECATED FOR USAGE PLANS - Specifies stages associated with the API key.</p>"
+                    }
+                },
+                "customerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An AWS Marketplace customer identifier , when integrating with the AWS SaaS Marketplace.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to create an ApiKey resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateAuthorizer": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateAuthorizerRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Authorizer"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds a new Authorizer resource to an existing RestApi resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/authorizers",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateAuthorizerRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the authorizer.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.apigateway#AuthorizerType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authorizer type. Valid values are <code>TOKEN</code> for a Lambda function using a single authorization token submitted in a custom header, <code>REQUEST</code> for a Lambda function using incoming request parameters, and <code>COGNITO_USER_POOLS</code> for using an Amazon Cognito user pool.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "providerARNs": {
+                    "target": "com.amazonaws.apigateway#ListOfARNs",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of the Amazon Cognito user pool ARNs for the <code>COGNITO_USER_POOLS</code> authorizer. Each element is of this format: <code>arn:aws:cognito-idp:{region}:{account_id}:userpool/{user_pool_id}</code>. For a <code>TOKEN</code> or <code>REQUEST</code> authorizer, this is not defined. </p>"
+                    }
+                },
+                "authType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Optional customer-defined field, used in OpenAPI imports and exports without functional impact.</p>"
+                    }
+                },
+                "authorizerUri": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the authorizer's Uniform Resource Identifier (URI). For <code>TOKEN</code> or <code>REQUEST</code> authorizers, this must be a well-formed Lambda function URI, for example, <code>arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:{account_id}:function:{lambda_function_name}/invocations</code>. In general, the URI has this form  <code>arn:aws:apigateway:{region}:lambda:path/{service_api}</code>, where <code>{region}</code> is the same as the region hosting the Lambda function, <code>path</code> indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial <code>/</code>. For Lambda functions, this is usually of the form <code>/2015-03-31/functions/[FunctionARN]/invocations</code>.</p>"
+                    }
+                },
+                "authorizerCredentials": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, specify null.</p>"
+                    }
+                },
+                "identitySource": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identity source for which authorization is requested. For a <code>TOKEN</code> or\n        <code>COGNITO_USER_POOLS</code> authorizer, this is required and specifies the request\n      header mapping expression for the custom header holding the authorization token submitted by\n      the client. For example, if the token header name is <code>Auth</code>, the header mapping\n      expression is <code>method.request.header.Auth</code>. For the <code>REQUEST</code>\n      authorizer, this is required when authorization caching is enabled. The value is a\n      comma-separated string of one or more mapping expressions of the specified request parameters.\n      For example, if an <code>Auth</code> header, a <code>Name</code> query string parameter are\n      defined as identity sources, this value is <code>method.request.header.Auth,\n        method.request.querystring.Name</code>. These parameters will be used to derive the\n      authorization caching key and to perform runtime validation of the <code>REQUEST</code>\n      authorizer by verifying all of the identity-related request parameters are present, not null\n      and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda\n      function, otherwise, it returns a 401 Unauthorized response without calling the Lambda\n      function. The valid value is a string of comma-separated mapping expressions of the specified\n      request parameters. When the authorization caching is not enabled, this property is\n      optional.</p>"
+                    }
+                },
+                "identityValidationExpression": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A validation expression for the incoming identity token. For <code>TOKEN</code> authorizers, this value is a regular expression. For <code>COGNITO_USER_POOLS</code> authorizers, API Gateway will match the <code>aud</code> field of the incoming token from the client against the specified regular expression. It will invoke the authorizer's Lambda function when there is a match. Otherwise, it will return a 401 Unauthorized response without calling the Lambda function. The validation expression does not apply to the <code>REQUEST</code> authorizer.</p>"
+                    }
+                },
+                "authorizerResultTtlInSeconds": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The TTL in seconds of cached authorizer results. If it equals 0, authorization caching is disabled. If it is greater than 0, API Gateway will cache authorizer responses. If this field is not set, the default value is 300. The maximum value is 3600, or 1 hour.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to add a new Authorizer to an existing RestApi resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateBasePathMapping": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateBasePathMappingRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#BasePathMapping"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new BasePathMapping resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/domainnames/{domainName}/basepathmappings",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateBasePathMappingRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name of the BasePathMapping resource to create.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "basePath": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The base path name that callers of the API must provide as part of the URL after the domain name. This value must be unique for all of the mappings across a single API. Specify '(none)' if you do not want callers to specify a base path name after the domain name.</p>"
+                    }
+                },
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stage": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the API's stage that you want to use for this mapping. Specify '(none)' if you want callers to explicitly specify the stage name after any base path name.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to create a new BasePathMapping resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateDeployment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateDeploymentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Deployment"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a Deployment resource, which makes a specified RestApi callable over the internet.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/deployments",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateDeploymentRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Stage resource for the Deployment resource to create.</p>"
+                    }
+                },
+                "stageDescription": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the Stage resource for the Deployment resource to create.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description for the Deployment resource to create.</p>"
+                    }
+                },
+                "cacheClusterEnabled": {
+                    "target": "com.amazonaws.apigateway#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Enables a cache cluster for the Stage resource specified in the input.</p>"
+                    }
+                },
+                "cacheClusterSize": {
+                    "target": "com.amazonaws.apigateway#CacheClusterSize",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stage's cache capacity in GB. For more information about choosing a cache size, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html\">Enabling API caching to enhance responsiveness</a>.</p>"
+                    }
+                },
+                "variables": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map that defines the stage variables for the Stage resource that is associated\n          with the new deployment. Variable names can have alphanumeric and underscore characters, and the values\n          must match <code>[A-Za-z0-9-._~:/?#&=,]+</code>.</p>"
+                    }
+                },
+                "canarySettings": {
+                    "target": "com.amazonaws.apigateway#DeploymentCanarySettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The input configuration for the canary deployment when the deployment is a canary release deployment. </p>"
+                    }
+                },
+                "tracingEnabled": {
+                    "target": "com.amazonaws.apigateway#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether active tracing with X-ray is enabled for the Stage.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to create a Deployment resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateDocumentationPart": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateDocumentationPartRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationPart"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a documentation part.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/documentation/parts",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateDocumentationPartRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "location": {
+                    "target": "com.amazonaws.apigateway#DocumentationPartLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The location of the targeted API entity of the to-be-created documentation part.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "properties": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new documentation content map of the targeted API entity. Enclosed key-value pairs are API-specific, but only OpenAPI-compliant key-value pairs can be exported and, hence, published.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new documentation part of a given API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateDocumentationVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateDocumentationVersionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationVersion"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a documentation version</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/documentation/versions",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateDocumentationVersionRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version identifier of the new snapshot.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stage name to be associated with the new documentation snapshot.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description about the new documentation snapshot.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new documentation version of a given API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateDomainName": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateDomainNameRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DomainName"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new domain name.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/domainnames",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateDomainNameRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the DomainName resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "certificateName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-friendly name of the certificate that will be used by edge-optimized endpoint for this domain name.</p>"
+                    }
+                },
+                "certificateBody": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>[Deprecated] The body of the server certificate that will be used by edge-optimized endpoint for this domain name provided by your certificate authority.</p>"
+                    }
+                },
+                "certificatePrivateKey": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>[Deprecated] Your edge-optimized endpoint's domain name certificate's private key.</p>"
+                    }
+                },
+                "certificateChain": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>[Deprecated] The intermediate certificates and optionally the root certificate, one after the other without any blank lines, used by an edge-optimized endpoint for this domain name. If you include the root certificate, your certificate chain must start with intermediate certificates and end with the root certificate. Use the intermediate certificates that were provided by your certificate authority. Do not include any intermediaries that are not in the chain of trust path.</p>"
+                    }
+                },
+                "certificateArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reference to an AWS-managed certificate that will be used by edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>"
+                    }
+                },
+                "regionalCertificateName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-friendly name of the certificate that will be used by regional endpoint for this domain name.</p>"
+                    }
+                },
+                "regionalCertificateArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reference to an AWS-managed certificate that will be used by regional endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>"
+                    }
+                },
+                "endpointConfiguration": {
+                    "target": "com.amazonaws.apigateway#EndpointConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint configuration of this DomainName showing the endpoint types of the domain name. </p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                },
+                "securityPolicy": {
+                    "target": "com.amazonaws.apigateway#SecurityPolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Transport Layer Security (TLS) version + cipher suite for this DomainName. The valid values are <code>TLS_1_0</code> and <code>TLS_1_2</code>.</p>"
+                    }
+                },
+                "mutualTlsAuthentication": {
+                    "target": "com.amazonaws.apigateway#MutualTlsAuthenticationInput"
+                },
+                "ownershipVerificationCertificateArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the public certificate issued by ACM to validate ownership of your custom\n      domain. Only required when configuring mutual TLS and using an ACM imported or private CA\n      certificate ARN as the regionalCertificateArn.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to create a new domain name.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateModel": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateModelRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Model"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds a new Model resource to an existing RestApi resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/models",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateModelRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The RestApi identifier under which the Model will be created.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the model. Must be alphanumeric.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the model.</p>"
+                    }
+                },
+                "schema": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The schema for the model. For <code>application/json</code> models, this should be JSON schema draft 4 model.</p>"
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-type for the model.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to add a new Model to an existing RestApi resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateRequestValidator": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateRequestValidatorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RequestValidator"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a RequestValidator of a given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/requestvalidators",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateRequestValidatorRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the to-be-created RequestValidator.</p>"
+                    }
+                },
+                "validateRequestBody": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether to validate request body according to the configured model schema for the method (<code>true</code>) or not (<code>false</code>).</p>"
+                    }
+                },
+                "validateRequestParameters": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether to validate request parameters, <code>true</code>, or not <code>false</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a RequestValidator of a given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Resource"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a Resource resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/resources/{parentId}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateResourceRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "parentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The parent resource's identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "pathPart": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The last path segment for this resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to create a Resource resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateRestApi": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateRestApiRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RestApi"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new RestApi resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateRestApiRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the RestApi.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the RestApi.</p>"
+                    }
+                },
+                "version": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A version identifier for the API.</p>"
+                    }
+                },
+                "cloneFrom": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the RestApi that you want to clone from.</p>"
+                    }
+                },
+                "binaryMediaTypes": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.</p>"
+                    }
+                },
+                "minimumCompressionSize": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A nullable integer that is used to enable compression (with non-negative between 0 and 10485760 (10M) bytes, inclusive) or disable compression (with a null value) on an API. When compression is enabled, compression or decompression is not applied on the payload if the payload size is smaller than this value. Setting it to zero allows compression for any payload size.</p>"
+                    }
+                },
+                "apiKeySource": {
+                    "target": "com.amazonaws.apigateway#ApiKeySourceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source of the API key for metering requests according to a usage plan. Valid values\n      are: ><code>HEADER</code> to read the API key from the <code>X-API-Key</code> header of a\n      request. <code>AUTHORIZER</code> to read the API key from the <code>UsageIdentifierKey</code>\n      from a custom authorizer.</p>"
+                    }
+                },
+                "endpointConfiguration": {
+                    "target": "com.amazonaws.apigateway#EndpointConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint configuration of this RestApi showing the endpoint types of the API. </p>"
+                    }
+                },
+                "policy": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A stringified JSON policy document that applies to this RestApi regardless of the caller and Method configuration.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                },
+                "disableExecuteApiEndpoint": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default <code>execute-api</code> endpoint.\n      By default, clients can invoke your API with the default\n      <code>https://{api_id}.execute-api.{region}.amazonaws.com</code> endpoint. To require that clients use a\n      custom domain name to invoke your API, disable the default endpoint</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The POST Request to add a new RestApi resource to your collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateStage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateStageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Stage"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a new Stage resource that references a pre-existing Deployment for the API. </p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/stages",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateStageRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name for the Stage resource. Stage names can only contain alphanumeric characters, hyphens, and underscores. Maximum length is 128 characters.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Deployment resource for the Stage resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the Stage resource.</p>"
+                    }
+                },
+                "cacheClusterEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Whether cache clustering is enabled for the stage.</p>"
+                    }
+                },
+                "cacheClusterSize": {
+                    "target": "com.amazonaws.apigateway#CacheClusterSize",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stage's cache capacity in GB. For more information about choosing a cache size, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html\">Enabling API caching to enhance responsiveness</a>.</p>"
+                    }
+                },
+                "variables": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map that defines the stage variables for the new Stage resource. Variable names\n          can have alphanumeric and underscore characters, and the values must match\n          <code>[A-Za-z0-9-._~:/?#&=,]+</code>.</p>"
+                    }
+                },
+                "documentationVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the associated API documentation.</p>"
+                    }
+                },
+                "canarySettings": {
+                    "target": "com.amazonaws.apigateway#CanarySettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The canary deployment settings of this stage.</p>"
+                    }
+                },
+                "tracingEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether active tracing with X-ray is enabled for the Stage.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to create a Stage resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateUsagePlan": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateUsagePlanRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlan"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a usage plan with the throttle and quota limits, as well as the associated API stages, specified in the payload. </p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/usageplans",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateUsagePlanKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateUsagePlanKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlanKey"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a usage plan key for adding an existing API key to a usage plan.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/usageplans/{usagePlanId}/keys",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateUsagePlanKeyRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the UsagePlan resource representing the usage plan containing the to-be-created UsagePlanKey resource representing a plan customer.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "keyId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a UsagePlanKey resource for a plan customer.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "keyType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of a UsagePlanKey resource for a plan customer.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The POST request to create a usage plan key for adding an existing API key to a usage plan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateUsagePlanRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the usage plan.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the usage plan.</p>"
+                    }
+                },
+                "apiStages": {
+                    "target": "com.amazonaws.apigateway#ListOfApiStage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The associated API stages of the usage plan.</p>"
+                    }
+                },
+                "throttle": {
+                    "target": "com.amazonaws.apigateway#ThrottleSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The throttling limits of the usage plan.</p>"
+                    }
+                },
+                "quota": {
+                    "target": "com.amazonaws.apigateway#QuotaSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The quota of the usage plan.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The POST request to create a usage plan with the name, description, throttle limits and quota limits, as well as the associated API stages, specified in the payload.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#CreateVpcLink": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#CreateVpcLinkRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#VpcLink"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a VPC link, under the caller's account in a selected region, in an asynchronous operation that typically takes 2-4 minutes to complete and become operational. The caller must have permissions to create and update VPC Endpoint services.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/vpclinks",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#CreateVpcLinkRequest": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name used to label and identify the VPC link.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the VPC link.</p>"
+                    }
+                },
+                "targetArns": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the network load balancer of the VPC targeted by the VPC link. The network load balancer must be owned by the same AWS account of the API owner.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a VPC link, under the caller's account in a selected region, in an asynchronous operation that typically takes 2-4 minutes to complete and become operational. The caller must have permissions to create and update VPC Endpoint services.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteApiKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteApiKeyRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes the ApiKey resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/apikeys/{apiKey}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteApiKeyRequest": {
+            "type": "structure",
+            "members": {
+                "apiKey": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the ApiKey resource to be deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete the ApiKey resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteAuthorizer": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteAuthorizerRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing Authorizer resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/authorizers/{authorizerId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteAuthorizerRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Authorizer resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to delete an existing Authorizer resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteBasePathMapping": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteBasePathMappingRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes the BasePathMapping resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/domainnames/{domainName}/basepathmappings/{basePath}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteBasePathMappingRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name of the BasePathMapping resource to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "basePath": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The base path name of the BasePathMapping resource to delete.</p>\n         <p>To specify an empty base path, set this parameter to <code>'(none)'</code>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete the BasePathMapping resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteClientCertificate": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteClientCertificateRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes the ClientCertificate resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/clientcertificates/{clientCertificateId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteClientCertificateRequest": {
+            "type": "structure",
+            "members": {
+                "clientCertificateId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the ClientCertificate resource to be deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete the ClientCertificate resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDeployment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteDeploymentRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a Deployment resource. Deleting a deployment will only succeed if there are no Stage resources associated with it.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/deployments/{deploymentId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDeploymentRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Deployment resource to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to delete a Deployment resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDocumentationPart": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteDocumentationPartRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a documentation part</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/documentation/parts/{documentationPartId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDocumentationPartRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationPartId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the to-be-deleted documentation part.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing documentation part of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDocumentationVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteDocumentationVersionRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a documentation version.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/documentation/versions/{documentationVersion}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDocumentationVersionRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version identifier of a to-be-deleted documentation snapshot.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing documentation version of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDomainName": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteDomainNameRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes the DomainName resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/domainnames/{domainName}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteDomainNameRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the DomainName resource to be deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete the DomainName resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteGatewayResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteGatewayResponseRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Clears any customization of a GatewayResponse of a specified response type on the given RestApi and resets it with the default settings.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/gatewayresponses/{responseType}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteGatewayResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "responseType": {
+                    "target": "com.amazonaws.apigateway#GatewayResponseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response type of the associated GatewayResponse.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Clears any customization of a GatewayResponse of a specified response type on the given RestApi and resets it with the default settings.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteIntegration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteIntegrationRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a delete integration.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteIntegrationRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a delete integration request's resource identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a delete integration request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a delete integration request.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteIntegrationResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteIntegrationResponseRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a delete integration response.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteIntegrationResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a delete integration response request's resource identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a delete integration response request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a delete integration response request's status code.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a delete integration response request.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteMethod": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteMethodRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing Method resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteMethodRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to delete an existing Method resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteMethodResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteMethodResponseRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing MethodResponse resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteMethodResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the MethodResponse resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status code identifier for the MethodResponse resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to delete an existing MethodResponse resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteModel": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteModelRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a model.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/models/{modelName}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteModelRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the model to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to delete an existing model in an existing RestApi resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteRequestValidator": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteRequestValidatorRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a RequestValidator of a given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/requestvalidators/{requestValidatorId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteRequestValidatorRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "requestValidatorId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the RequestValidator to be deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a specified RequestValidator of a given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a Resource resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteResourceRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Resource resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to delete a Resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteRestApi": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteRestApiRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes the specified API.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteRestApiRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to delete the specified API from your collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteStage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteStageRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a Stage resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteStageRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Stage resource to delete.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to delete a Stage resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteUsagePlan": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteUsagePlanRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a usage plan of a given plan Id.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/usageplans/{usagePlanId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteUsagePlanKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteUsagePlanKeyRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes a usage plan key  and remove the underlying API key from the associated usage plan.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/usageplans/{usagePlanId}/keys/{keyId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteUsagePlanKeyRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the UsagePlan resource representing the usage plan containing the to-be-deleted UsagePlanKey resource representing a plan customer.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "keyId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the UsagePlanKey resource to be deleted.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The DELETE request to delete a usage plan key and remove the underlying API key from the associated usage plan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteUsagePlanRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the to-be-deleted usage plan.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The DELETE request to delete a usage plan of a given plan Id.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeleteVpcLink": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#DeleteVpcLinkRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing VpcLink of a specified identifier.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/vpclinks/{vpcLinkId}",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DeleteVpcLinkRequest": {
+            "type": "structure",
+            "members": {
+                "vpcLinkId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the  VpcLink. It is used in an Integration to reference this VpcLink.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Deletes an existing VpcLink of a specified identifier.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Deployment": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the deployment resource.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description for the deployment resource.</p>"
+                    }
+                },
+                "createdDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date and time that the deployment resource was created.</p>"
+                    }
+                },
+                "apiSummary": {
+                    "target": "com.amazonaws.apigateway#PathToMapOfMethodSnapshot",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A summary of the RestApi at the date and time that the deployment resource was created.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An immutable representation of a RestApi resource that can be called by users using Stages. A deployment must be associated with a Stage for it to be callable over the Internet.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DeploymentCanarySettings": {
+            "type": "structure",
+            "members": {
+                "percentTraffic": {
+                    "target": "com.amazonaws.apigateway#Double",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The percentage (0.0-100.0) of traffic routed to the canary deployment.</p>"
+                    }
+                },
+                "stageVariableOverrides": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A stage variable overrides used for the canary release deployment. They can override existing stage variables or add new stage variables for the canary release deployment. These stage variables are represented as a string-to-string map between stage variable names and their values.</p>"
+                    }
+                },
+                "useStageCache": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether the canary release deployment uses the stage cache or not.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The input configuration for a canary deployment.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Deployments": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfDeployment",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection resource that contains zero or more references to your existing deployments, and links that guide you on how to interact with your collection. The collection offers a paginated view of the contained deployments.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationPart": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The DocumentationPart identifier, generated by API Gateway when the <code>DocumentationPart</code> is created.</p>"
+                    }
+                },
+                "location": {
+                    "target": "com.amazonaws.apigateway#DocumentationPartLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The location of the API entity to which the documentation applies. Valid fields depend on the targeted API entity type. All the valid location fields are not required. If not explicitly specified, a valid location field is treated as a wildcard and associated documentation content may be inherited by matching entities, unless overridden.</p>"
+                    }
+                },
+                "properties": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A content map of API-specific key-value pairs describing the targeted API entity. The map must be encoded as a JSON string, e.g., <code>\"{ \\\"description\\\": \\\"The API does ...\\\" }\"</code>.  Only OpenAPI-compliant documentation-related fields from the properties map are exported and, hence, published as part of the API entity definitions, while the original documentation parts are exported in a OpenAPI extension of <code>x-amazon-apigateway-documentation</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A documentation part for a targeted API entity.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationPartIds": {
+            "type": "structure",
+            "members": {
+                "ids": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of the returned documentation part identifiers.</p>"
+                    }
+                },
+                "warnings": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of warning messages reported during import of documentation parts.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A collection of the imported  DocumentationPart identifiers.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationPartLocation": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.apigateway#DocumentationPartType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of API entity to which the documentation content applies. Valid values are <code>API</code>, <code>AUTHORIZER</code>, <code>MODEL</code>, <code>RESOURCE</code>, <code>METHOD</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>,  <code>REQUEST_BODY</code>, <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. Content inheritance does not apply to any entity of the <code>API</code>, <code>AUTHORIZER</code>, <code>METHOD</code>,  <code>MODEL</code>, <code>REQUEST_BODY</code>, or <code>RESOURCE</code> type.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "path": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URL path of the target. It is a valid field for the API entity types of <code>RESOURCE</code>, <code>METHOD</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>, <code>REQUEST_BODY</code>, <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. The default value is <code>/</code> for the root resource. When an applicable child entity inherits the content of another entity of the same type with more general specifications of the other <code>location</code> attributes,  the child entity's <code>path</code> attribute must match that of the parent entity as a prefix.</p>"
+                    }
+                },
+                "method": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of a method. It is a valid field for the API entity types of  <code>METHOD</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>,  <code>REQUEST_BODY</code>, <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. The default value is <code>*</code> for any method.  When an applicable child entity inherits the content of an entity of the same type with more general specifications of the other <code>location</code> attributes,  the child entity's <code>method</code> attribute must match that of the parent entity exactly.</p>"
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#DocumentationPartLocationStatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP status code of a response. It is a valid field for the API entity types of <code>RESPONSE</code>, <code>RESPONSE_HEADER</code>, and <code>RESPONSE_BODY</code>. The default value is <code>*</code> for any status code. When an applicable child  entity inherits the content of an entity of the same type with more general specifications of the other <code>location</code> attributes, the child entity's <code>statusCode</code> attribute must match that of the parent entity exactly.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the targeted API entity. It is a valid and required field for the API entity types of <code>AUTHORIZER</code>, <code>MODEL</code>, <code>PATH_PARAMETER</code>, <code>QUERY_PARAMETER</code>, <code>REQUEST_HEADER</code>, <code>REQUEST_BODY</code> and <code>RESPONSE_HEADER</code>. It is an invalid field for any other entity type.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the target API entity to which the documentation applies.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationPartLocationStatusCode": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^([1-5]\\d\\d|\\*|\\s*)$"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationPartType": {
+            "type": "enum",
+            "members": {
+                "API": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "API"
+                    }
+                },
+                "AUTHORIZER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AUTHORIZER"
+                    }
+                },
+                "MODEL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MODEL"
+                    }
+                },
+                "RESOURCE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESOURCE"
+                    }
+                },
+                "METHOD": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "METHOD"
+                    }
+                },
+                "PATH_PARAMETER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PATH_PARAMETER"
+                    }
+                },
+                "QUERY_PARAMETER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "QUERY_PARAMETER"
+                    }
+                },
+                "REQUEST_HEADER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REQUEST_HEADER"
+                    }
+                },
+                "REQUEST_BODY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REQUEST_BODY"
+                    }
+                },
+                "RESPONSE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESPONSE"
+                    }
+                },
+                "RESPONSE_HEADER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESPONSE_HEADER"
+                    }
+                },
+                "RESPONSE_BODY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESPONSE_BODY"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationParts": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfDocumentationPart",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The collection of documentation parts of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationVersion": {
+            "type": "structure",
+            "members": {
+                "version": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version identifier of the API documentation snapshot.</p>"
+                    }
+                },
+                "createdDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The date when the API documentation snapshot is created.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the API documentation snapshot.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A snapshot of the documentation of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DocumentationVersions": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfDocumentationVersion",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The collection of documentation snapshots of an API. </p>"
+            }
+        },
+        "com.amazonaws.apigateway#DomainName": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The custom domain name as an API host name, for example, <code>my-api.example.com</code>.</p>"
+                    }
+                },
+                "certificateName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the certificate that will be used by edge-optimized endpoint for this domain name.</p>"
+                    }
+                },
+                "certificateArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reference to an AWS-managed certificate that will be used by edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>"
+                    }
+                },
+                "certificateUploadDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the certificate that was used by edge-optimized endpoint for this domain name was uploaded.</p>"
+                    }
+                },
+                "regionalDomainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name associated with the regional endpoint for this custom domain name. You set up this association by adding a DNS record that points the custom domain name to this regional domain name. The regional domain name is returned by API Gateway when you create a regional endpoint.</p>"
+                    }
+                },
+                "regionalHostedZoneId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The region-specific Amazon Route 53 Hosted Zone ID of the regional endpoint. For more information, see Set up a Regional Custom Domain Name and AWS Regions and Endpoints for API Gateway. </p>"
+                    }
+                },
+                "regionalCertificateName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the certificate that will be used for validating the regional domain name.</p>"
+                    }
+                },
+                "regionalCertificateArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The reference to an AWS-managed certificate that will be used for validating the regional domain name. AWS Certificate Manager is the only supported source.</p>"
+                    }
+                },
+                "distributionDomainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name of the Amazon CloudFront distribution associated with this custom domain name for an edge-optimized endpoint. You set up this association when adding a DNS record pointing the custom domain name to this distribution name. For more information about CloudFront distributions, see the Amazon CloudFront documentation.</p>"
+                    }
+                },
+                "distributionHostedZoneId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The region-agnostic Amazon Route 53 Hosted Zone ID of the edge-optimized endpoint. The valid value is <code>Z2FDTNDATAQYW2</code> for all the regions. For more information, see Set up a Regional Custom Domain Name and AWS Regions and Endpoints for API Gateway. </p>"
+                    }
+                },
+                "endpointConfiguration": {
+                    "target": "com.amazonaws.apigateway#EndpointConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint configuration of this DomainName showing the endpoint types of the domain name. </p>"
+                    }
+                },
+                "domainNameStatus": {
+                    "target": "com.amazonaws.apigateway#DomainNameStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the DomainName migration. The valid values are <code>AVAILABLE</code> and <code>UPDATING</code>. If the status is <code>UPDATING</code>, the domain cannot be modified further until the existing operation is complete. If it is <code>AVAILABLE</code>, the domain can be updated.</p>"
+                    }
+                },
+                "domainNameStatusMessage": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An optional text message containing detailed information about status of the DomainName migration.</p>"
+                    }
+                },
+                "securityPolicy": {
+                    "target": "com.amazonaws.apigateway#SecurityPolicy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Transport Layer Security (TLS) version + cipher suite for this DomainName. The valid values are <code>TLS_1_0</code> and <code>TLS_1_2</code>.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                },
+                "mutualTlsAuthentication": {
+                    "target": "com.amazonaws.apigateway#MutualTlsAuthentication",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name. If specified, API Gateway\n      performs two-way authentication between the client and the server. Clients must present a\n      trusted certificate to access your API.</p>"
+                    }
+                },
+                "ownershipVerificationCertificateArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the public certificate issued by ACM to validate ownership of your custom\n      domain. Only required when configuring mutual TLS and using an ACM imported or private CA\n      certificate ARN as the regionalCertificateArn.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a custom domain name as a user-friendly host name of an API (RestApi).</p>"
+            }
+        },
+        "com.amazonaws.apigateway#DomainNameStatus": {
+            "type": "enum",
+            "members": {
+                "AVAILABLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AVAILABLE"
+                    }
+                },
+                "UPDATING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UPDATING"
+                    }
+                },
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "PENDING_CERTIFICATE_REIMPORT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING_CERTIFICATE_REIMPORT"
+                    }
+                },
+                "PENDING_OWNERSHIP_VERIFICATION": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING_OWNERSHIP_VERIFICATION"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#DomainNames": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfDomainName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of DomainName resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Double": {
+            "type": "double",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.apigateway#EndpointConfiguration": {
+            "type": "structure",
+            "members": {
+                "types": {
+                    "target": "com.amazonaws.apigateway#ListOfEndpointType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of endpoint types of an API (RestApi) or its custom domain name (DomainName). For an edge-optimized API and its custom domain name, the endpoint type is <code>\"EDGE\"</code>. For a regional API and its custom domain name, the endpoint type is <code>REGIONAL</code>. For a private API, the endpoint type is <code>PRIVATE</code>.</p>"
+                    }
+                },
+                "vpcEndpointIds": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of VpcEndpointIds of an API (RestApi) against which to create Route53 ALIASes. It is only supported for <code>PRIVATE</code> endpoint type.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The endpoint configuration to indicate the types of endpoints an API (RestApi) or its custom domain name (DomainName) has. </p>"
+            }
+        },
+        "com.amazonaws.apigateway#EndpointType": {
+            "type": "enum",
+            "members": {
+                "REGIONAL": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REGIONAL"
+                    }
+                },
+                "EDGE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EDGE"
+                    }
+                },
+                "PRIVATE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PRIVATE"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The endpoint type. The valid values are <code>EDGE</code> for edge-optimized API setup, most suitable for mobile applications; <code>REGIONAL</code> for regional API endpoint setup, most suitable for calling from AWS Region; and <code>PRIVATE</code> for private APIs.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ExportResponse": {
+            "type": "structure",
+            "members": {
+                "contentType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-type header value in the HTTP response. This will correspond to a valid 'accept' type in the request.</p>",
+                        "smithy.api#httpHeader": "Content-Type"
+                    }
+                },
+                "contentDisposition": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-disposition header value in the HTTP response.</p>",
+                        "smithy.api#httpHeader": "Content-Disposition"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The binary blob response to GetExport, which contains the export.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The binary blob response to GetExport, which contains the generated SDK.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#FlushStageAuthorizersCache": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#FlushStageAuthorizersCacheRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Flushes all authorizer cache entries on a stage.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}/cache/authorizers",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#FlushStageAuthorizersCacheRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the stage to flush.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to flush authorizer cache entries on a specified stage.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#FlushStageCache": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#FlushStageCacheRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Flushes a stage's cache.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}/cache/data",
+                    "code": 202
+                }
+            }
+        },
+        "com.amazonaws.apigateway#FlushStageCacheRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the stage to flush its cache.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to flush a stage's cache.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GatewayResponse": {
+            "type": "structure",
+            "members": {
+                "responseType": {
+                    "target": "com.amazonaws.apigateway#GatewayResponseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response type of the associated GatewayResponse.</p>"
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP status code for this GatewayResponse.</p>"
+                    }
+                },
+                "responseParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Response parameters (paths, query strings and headers) of the GatewayResponse as a\n      string-to-string map of key-value pairs.</p>"
+                    }
+                },
+                "responseTemplates": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Response templates of the GatewayResponse as a string-to-string map of key-value pairs.</p>"
+                    }
+                },
+                "defaultResponse": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether this GatewayResponse is the default gateway response (<code>true</code>) or not (<code>false</code>). A default gateway response is one generated by API Gateway without any customization by an API developer. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A gateway response of a given response type and status code, with optional response parameters and mapping templates.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GatewayResponseType": {
+            "type": "enum",
+            "members": {
+                "DEFAULT_4XX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DEFAULT_4XX"
+                    }
+                },
+                "DEFAULT_5XX": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DEFAULT_5XX"
+                    }
+                },
+                "RESOURCE_NOT_FOUND": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESOURCE_NOT_FOUND"
+                    }
+                },
+                "UNAUTHORIZED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNAUTHORIZED"
+                    }
+                },
+                "INVALID_API_KEY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INVALID_API_KEY"
+                    }
+                },
+                "ACCESS_DENIED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACCESS_DENIED"
+                    }
+                },
+                "AUTHORIZER_FAILURE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AUTHORIZER_FAILURE"
+                    }
+                },
+                "AUTHORIZER_CONFIGURATION_ERROR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AUTHORIZER_CONFIGURATION_ERROR"
+                    }
+                },
+                "INVALID_SIGNATURE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INVALID_SIGNATURE"
+                    }
+                },
+                "EXPIRED_TOKEN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "EXPIRED_TOKEN"
+                    }
+                },
+                "MISSING_AUTHENTICATION_TOKEN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MISSING_AUTHENTICATION_TOKEN"
+                    }
+                },
+                "INTEGRATION_FAILURE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTEGRATION_FAILURE"
+                    }
+                },
+                "INTEGRATION_TIMEOUT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "INTEGRATION_TIMEOUT"
+                    }
+                },
+                "API_CONFIGURATION_ERROR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "API_CONFIGURATION_ERROR"
+                    }
+                },
+                "UNSUPPORTED_MEDIA_TYPE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNSUPPORTED_MEDIA_TYPE"
+                    }
+                },
+                "BAD_REQUEST_PARAMETERS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BAD_REQUEST_PARAMETERS"
+                    }
+                },
+                "BAD_REQUEST_BODY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BAD_REQUEST_BODY"
+                    }
+                },
+                "REQUEST_TOO_LARGE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "REQUEST_TOO_LARGE"
+                    }
+                },
+                "THROTTLED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "THROTTLED"
+                    }
+                },
+                "QUOTA_EXCEEDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "QUOTA_EXCEEDED"
+                    }
+                },
+                "WAF_FILTERED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "WAF_FILTERED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GatewayResponses": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfGatewayResponse",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Returns the entire collection, because of no pagination support.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set. The GatewayResponse collection does not support pagination and the position does not apply here.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The collection of the GatewayResponse instances of a RestApi as a <code>responseType</code>-to-GatewayResponse object map of key-value pairs. As such, pagination is not supported for querying this collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GenerateClientCertificate": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GenerateClientCertificateRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ClientCertificate"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Generates a ClientCertificate resource.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/clientcertificates",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GenerateClientCertificateRequest": {
+            "type": "structure",
+            "members": {
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the ClientCertificate.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to generate a ClientCertificate resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetAccount": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetAccountRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Account"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the current Account resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/account",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetAccountRequest": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to get information about the current Account resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetApiKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetApiKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ApiKey"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the current ApiKey resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/apikeys/{apiKey}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetApiKeyRequest": {
+            "type": "structure",
+            "members": {
+                "apiKey": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the ApiKey resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "includeValue": {
+                    "target": "com.amazonaws.apigateway#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A boolean flag to specify whether (<code>true</code>) or not (<code>false</code>) the result contains the key value.</p>",
+                        "smithy.api#httpQuery": "includeValue"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about the current ApiKey resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetApiKeys": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetApiKeysRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ApiKeys"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the current ApiKeys resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/apikeys",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetApiKeysRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                },
+                "nameQuery": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of queried API keys.</p>",
+                        "smithy.api#httpQuery": "name"
+                    }
+                },
+                "customerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a customer in AWS Marketplace or an external system, such as a developer portal.</p>",
+                        "smithy.api#httpQuery": "customerId"
+                    }
+                },
+                "includeValues": {
+                    "target": "com.amazonaws.apigateway#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A boolean flag to specify whether (<code>true</code>) or not (<code>false</code>) the result contains key values.</p>",
+                        "smithy.api#httpQuery": "includeValues"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about the current ApiKeys resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetAuthorizer": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetAuthorizerRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Authorizer"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describe an existing Authorizer resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/authorizers/{authorizerId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetAuthorizerRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Authorizer resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to describe an existing Authorizer resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetAuthorizers": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetAuthorizersRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Authorizers"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describe an existing Authorizers resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/authorizers",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetAuthorizersRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to describe an existing Authorizers resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetBasePathMapping": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetBasePathMappingRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#BasePathMapping"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describe a BasePathMapping resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/domainnames/{domainName}/basepathmappings/{basePath}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetBasePathMappingRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name of the BasePathMapping resource to be described.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "basePath": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The base path name that callers of the API must provide as part of the URL after the domain name. This value must be unique for all of the mappings across a single API. Specify '(none)' if you do not want callers to specify any base path name after the domain name.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to describe a BasePathMapping resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetBasePathMappings": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetBasePathMappingsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#BasePathMappings"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of BasePathMapping resources.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/domainnames/{domainName}/basepathmappings",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetBasePathMappingsRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name of a BasePathMapping resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about a collection of BasePathMapping resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetClientCertificate": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetClientCertificateRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ClientCertificate"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about the current ClientCertificate resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/clientcertificates/{clientCertificateId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetClientCertificateRequest": {
+            "type": "structure",
+            "members": {
+                "clientCertificateId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the ClientCertificate resource to be described.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about the current ClientCertificate resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetClientCertificates": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetClientCertificatesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ClientCertificates"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a collection of ClientCertificate resources.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/clientcertificates",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetClientCertificatesRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to get information about a collection of ClientCertificate resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDeployment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDeploymentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Deployment"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a Deployment resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/deployments/{deploymentId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDeploymentRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Deployment resource to get information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "embed": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A query parameter to retrieve the specified embedded resources of the returned Deployment resource in the response. In a REST API call, this <code>embed</code> parameter value is a list of comma-separated strings, as in  <code>GET /restapis/{restapi_id}/deployments/{deployment_id}?embed=var1,var2</code>. The SDK and other platform-dependent libraries might use a different format for the list. Currently, this request supports only retrieval of the embedded API summary this way. Hence, the parameter value must be a single-valued list containing only the <code>\"apisummary\"</code> string.  For example, <code>GET /restapis/{restapi_id}/deployments/{deployment_id}?embed=apisummary</code>.</p>",
+                        "smithy.api#httpQuery": "embed"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to get information about a Deployment resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDeployments": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDeploymentsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Deployments"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a Deployments collection.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/deployments",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDeploymentsRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to get information about a Deployments collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationPart": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDocumentationPartRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationPart"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a documentation part.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/documentation/parts/{documentationPartId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationPartRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationPartId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a specified documentation part of a given API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationParts": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDocumentationPartsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationParts"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets documentation parts.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/documentation/parts",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationPartsRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.apigateway#DocumentationPartType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of API entities of the to-be-retrieved documentation parts. </p>",
+                        "smithy.api#httpQuery": "type"
+                    }
+                },
+                "nameQuery": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of API entities of the to-be-retrieved documentation parts.</p>",
+                        "smithy.api#httpQuery": "name"
+                    }
+                },
+                "path": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The path of API entities of the to-be-retrieved documentation parts.</p>",
+                        "smithy.api#httpQuery": "path"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                },
+                "locationStatus": {
+                    "target": "com.amazonaws.apigateway#LocationStatusType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the API documentation parts to retrieve. Valid values are <code>DOCUMENTED</code> for retrieving DocumentationPart resources with content and <code>UNDOCUMENTED</code> for DocumentationPart resources without content.</p>",
+                        "smithy.api#httpQuery": "locationStatus"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the documentation parts of an API. The result may be filtered by the type, name, or path of API entities (targets).</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDocumentationVersionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationVersion"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a documentation version.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/documentation/versions/{documentationVersion}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationVersionRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version identifier of the to-be-retrieved documentation snapshot.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a documentation snapshot of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationVersions": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDocumentationVersionsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationVersions"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets documentation versions.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/documentation/versions",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDocumentationVersionsRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the documentation versions of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDomainName": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDomainNameRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DomainName"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a domain name that is contained in a simpler, more intuitive URL that can be called.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/domainnames/{domainName}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDomainNameRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the DomainName resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to get the name of a DomainName resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetDomainNames": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetDomainNamesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DomainNames"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of DomainName resources.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/domainnames",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetDomainNamesRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to describe a collection of DomainName resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetExport": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetExportRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ExportResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Exports a deployed version of a RestApi in a specified format.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}/exports/{exportType}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetExportRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Stage that will be exported.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "exportType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of export. Acceptable values are 'oas30' for OpenAPI 3.0.x and 'swagger' for Swagger/OpenAPI 2.0.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "parameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of query string parameters that specify properties of the export, depending on the requested <code>exportType</code>. For <code>exportType</code>\n            <code>oas30</code> and <code>swagger</code>, any combination of the following parameters are supported: <code>extensions='integrations'</code> or <code>extensions='apigateway'</code> will export the API with x-amazon-apigateway-integration extensions. <code>extensions='authorizers'</code> will export the API with  x-amazon-apigateway-authorizer extensions. <code>postman</code> will export the API with Postman extensions, allowing for import to the Postman tool</p>",
+                        "smithy.api#httpQueryParams": {}
+                    }
+                },
+                "accepts": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-type of the export, for example <code>application/json</code>. Currently <code>application/json</code> and <code>application/yaml</code> are supported for <code>exportType</code> of<code>oas30</code> and <code>swagger</code>. This should be specified in the <code>Accept</code> header for direct API requests.</p>",
+                        "smithy.api#httpHeader": "Accept"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request a new export of a RestApi for a particular Stage.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetGatewayResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetGatewayResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#GatewayResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a GatewayResponse of a specified response type on the given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/gatewayresponses/{responseType}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetGatewayResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "responseType": {
+                    "target": "com.amazonaws.apigateway#GatewayResponseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response type of the associated GatewayResponse.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a GatewayResponse of a specified response type on the given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetGatewayResponses": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetGatewayResponsesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#GatewayResponses"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the GatewayResponses collection on the given RestApi. If an API developer has not added any definitions for gateway responses, the result will be the API Gateway-generated default GatewayResponses collection for the supported response types.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/gatewayresponses",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetGatewayResponsesRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set. The GatewayResponse collection does not support pagination and the position does not apply here.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500. The GatewayResponses collection does not support pagination and the limit does not apply here.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the GatewayResponses collection on the given RestApi. If an API developer has not added any definitions for gateway responses, the result will be the API Gateway-generated default GatewayResponses collection for the supported response types.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetIntegration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetIntegrationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Integration"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Get the integration settings.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetIntegrationRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a get integration request's resource identifier</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a get integration request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a request to get the integration configuration.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetIntegrationResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetIntegrationResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#IntegrationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a get integration response.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetIntegrationResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a get integration response request's resource identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a get integration response request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a get integration response request's status code.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a get integration response request.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetMethod": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetMethodRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Method"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describe an existing Method resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetMethodRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the method request's HTTP method type.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to describe an existing Method resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetMethodResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetMethodResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#MethodResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describes a MethodResponse resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetMethodResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the MethodResponse resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status code for the MethodResponse resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to describe a MethodResponse resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetModel": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetModelRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Model"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describes an existing model defined for a RestApi resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/models/{modelName}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetModelRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The RestApi identifier under which the Model exists.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the model as an identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "flatten": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A query parameter of a Boolean value to resolve (<code>true</code>) all external model references and returns a flattened model schema or not (<code>false</code>) The default is <code>false</code>.</p>",
+                        "smithy.api#httpQuery": "flatten"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to list information about a model in an existing RestApi resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetModelTemplate": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetModelTemplateRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Template"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Generates a sample mapping template that can be used to transform a payload into the structure of a model.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/models/{modelName}/default_template",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetModelTemplateRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the model for which to generate a template.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to generate a sample mapping template used to transform the payload.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetModels": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetModelsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Models"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Describes existing Models defined for a RestApi resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/models",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetModelsRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to list existing Models defined for a RestApi resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetRequestValidator": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetRequestValidatorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RequestValidator"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a RequestValidator of a given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/requestvalidators/{requestValidatorId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetRequestValidatorRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "requestValidatorId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the RequestValidator to be retrieved.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a RequestValidator of a given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetRequestValidators": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetRequestValidatorsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RequestValidators"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the RequestValidators collection of a given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/requestvalidators",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetRequestValidatorsRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the RequestValidators collection of a given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Resource"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists information about a resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetResourceRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the Resource resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "embed": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A query parameter to retrieve the specified resources embedded in the returned Resource representation in the response. This <code>embed</code> parameter value is a list of comma-separated strings. Currently, the request supports only retrieval of the embedded Method resources this way. The query parameter value must be a single-valued list and contain the <code>\"methods\"</code> string. For example, <code>GET /restapis/{restapi_id}/resources/{resource_id}?embed=methods</code>.</p>",
+                        "smithy.api#httpQuery": "embed"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to list information about a resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetResources": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetResourcesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Resources"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists information about a collection of Resource resources.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/resources",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetResourcesRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                },
+                "embed": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A query parameter used to retrieve the specified resources embedded in the returned Resources resource in the response.  This <code>embed</code> parameter value is a list of comma-separated strings. Currently, the request supports only retrieval of the embedded Method resources this way. The query parameter value must be a single-valued list and contain the <code>\"methods\"</code> string. For example, <code>GET /restapis/{restapi_id}/resources?embed=methods</code>.</p>",
+                        "smithy.api#httpQuery": "embed"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to list information about a collection of resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetRestApi": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetRestApiRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RestApi"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the RestApi resource in the collection.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetRestApiRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to list an existing RestApi defined for your collection. </p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetRestApis": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetRestApisRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RestApis"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Lists the RestApis resources for your collection.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetRestApisRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to list existing RestApis defined for your collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetSdk": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetSdkRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#SdkResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Generates a client SDK for a RestApi and Stage.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}/sdks/{sdkType}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetSdkRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Stage that the SDK will use.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "sdkType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The language for the generated SDK. Currently <code>java</code>, <code>javascript</code>, <code>android</code>, <code>objectivec</code> (for iOS), <code>swift</code> (for iOS), and <code>ruby</code>  are supported.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "parameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A string-to-string key-value map of query parameters <code>sdkType</code>-dependent properties of the SDK. For <code>sdkType</code> of <code>objectivec</code> or <code>swift</code>,  a parameter named <code>classPrefix</code> is required. For <code>sdkType</code> of <code>android</code>, parameters named <code>groupId</code>, <code>artifactId</code>, <code>artifactVersion</code>, and <code>invokerPackage</code> are required. For <code>sdkType</code> of <code>java</code>, parameters named <code>serviceName</code> and <code>javaPackageName</code> are required. </p>",
+                        "smithy.api#httpQueryParams": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request a new generated client SDK for a RestApi and Stage.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetSdkType": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetSdkTypeRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#SdkType"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets an SDK type.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/sdktypes/{id}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetSdkTypeRequest": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the queried SdkType instance.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Get an SdkType instance.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetSdkTypes": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetSdkTypesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#SdkTypes"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets SDK types</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/sdktypes",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetSdkTypesRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Get the SdkTypes collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetStage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetStageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Stage"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about a Stage resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetStageRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Stage resource to get information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to get information about a Stage resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetStages": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetStagesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Stages"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets information about one or more Stage resources.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/restapis/{restApiId}/stages",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetStagesRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stages' deployment identifiers.</p>",
+                        "smithy.api#httpQuery": "deploymentId"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to get information about one or more Stage resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetTags": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetTagsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Tags"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the Tags collection for a given resource.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/tags/{resourceArn}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetTagsRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of a resource that can be tagged.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Not currently supported) The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>(Not currently supported) The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the Tags collection for a given resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetUsage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetUsageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Usage"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the usage data of a usage plan in a specified time interval.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/usageplans/{usagePlanId}/usage",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlan": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetUsagePlanRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlan"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a usage plan of a given plan identifier.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/usageplans/{usagePlanId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlanKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetUsagePlanKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlanKey"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a usage plan key of a given key identifier.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/usageplans/{usagePlanId}/keys/{keyId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlanKeyRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the UsagePlan resource representing the usage plan containing the to-be-retrieved UsagePlanKey resource representing a plan customer.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "keyId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key Id of the to-be-retrieved UsagePlanKey resource representing a plan customer.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to get a usage plan key of a given key identifier.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlanKeys": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetUsagePlanKeysRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlanKeys"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets all the usage plan keys representing the API keys added to a specified usage plan.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/usageplans/{usagePlanId}/keys",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlanKeysRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the UsagePlan resource representing the usage plan containing the to-be-retrieved UsagePlanKey resource representing a plan customer.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                },
+                "nameQuery": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A query parameter specifying the name of the to-be-returned usage plan keys.</p>",
+                        "smithy.api#httpQuery": "name"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to get all the usage plan keys representing the API keys added to a specified usage plan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlanRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the UsagePlan resource to be retrieved.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to get a usage plan of a given plan identifier.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlans": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetUsagePlansRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlans"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets all the usage plans of the caller's account.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/usageplans",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetUsagePlansRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "keyId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the API key associated with the usage plans.</p>",
+                        "smithy.api#httpQuery": "keyId"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to get all the usage plans of the caller's account.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetUsageRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the usage plan associated with the usage data.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "keyId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the API key associated with the resultant usage data.</p>",
+                        "smithy.api#httpQuery": "keyId"
+                    }
+                },
+                "startDate": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The starting date (e.g., 2016-01-01) of the usage data.</p>",
+                        "smithy.api#httpQuery": "startDate",
+                        "smithy.api#required": {}
+                    }
+                },
+                "endDate": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ending date (e.g., 2016-12-31) of the usage data.</p>",
+                        "smithy.api#httpQuery": "endDate",
+                        "smithy.api#required": {}
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The GET request to get the usage data of a usage plan in a specified time interval.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetVpcLink": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetVpcLinkRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#VpcLink"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a specified VPC link under the caller's account in a region.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/vpclinks/{vpcLinkId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetVpcLinkRequest": {
+            "type": "structure",
+            "members": {
+                "vpcLinkId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the  VpcLink. It is used in an Integration to reference this VpcLink.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets a specified VPC link under the caller's account in a region.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#GetVpcLinks": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#GetVpcLinksRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#VpcLinks"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the VpcLinks collection under the caller's account in a selected region.</p>",
+                "smithy.api#http": {
+                    "method": "GET",
+                    "uri": "/vpclinks",
+                    "code": 200
+                },
+                "smithy.api#paginated": {
+                    "inputToken": "position",
+                    "outputToken": "position",
+                    "items": "items",
+                    "pageSize": "limit"
+                }
+            }
+        },
+        "com.amazonaws.apigateway#GetVpcLinksRequest": {
+            "type": "structure",
+            "members": {
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                },
+                "limit": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of returned results per page. The default value is 25 and the maximum value is 500.</p>",
+                        "smithy.api#httpQuery": "limit"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Gets the VpcLinks collection under the caller's account in a selected region.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ImportApiKeys": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#ImportApiKeysRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ApiKeyIds"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Import API keys from an external source, such as a CSV-formatted file.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/apikeys?mode=import",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ImportApiKeysRequest": {
+            "type": "structure",
+            "members": {
+                "body": {
+                    "target": "com.amazonaws.apigateway#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The payload of the POST request to import API keys. For the payload format, see API Key File Format.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "format": {
+                    "target": "com.amazonaws.apigateway#ApiKeysFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A query parameter to specify the input format to imported API keys. Currently, only the <code>csv</code> format is supported.</p>",
+                        "smithy.api#httpQuery": "format",
+                        "smithy.api#required": {}
+                    }
+                },
+                "failOnWarnings": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A query parameter to indicate whether to rollback ApiKey importation (<code>true</code>) or not (<code>false</code>) when error is encountered.</p>",
+                        "smithy.api#httpQuery": "failonwarnings"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The POST request to import API keys from an external source, such as a CSV-formatted file.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ImportDocumentationParts": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#ImportDocumentationPartsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationPartIds"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Imports documentation parts</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}/documentation/parts",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ImportDocumentationPartsRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "mode": {
+                    "target": "com.amazonaws.apigateway#PutMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A query parameter to indicate whether to overwrite (<code>OVERWRITE</code>) any existing DocumentationParts definition or to merge (<code>MERGE</code>) the new definition into the existing one. The default value is <code>MERGE</code>.</p>",
+                        "smithy.api#httpQuery": "mode"
+                    }
+                },
+                "failOnWarnings": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A query parameter to specify whether to rollback the documentation importation (<code>true</code>) or not (<code>false</code>) when a warning is encountered. The default value is <code>false</code>.</p>",
+                        "smithy.api#httpQuery": "failonwarnings"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Raw byte array representing the to-be-imported documentation parts. To import from an OpenAPI file, this is a JSON object.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Import documentation parts from an external (e.g., OpenAPI) definition file. </p>"
+            }
+        },
+        "com.amazonaws.apigateway#ImportRestApi": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#ImportRestApiRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RestApi"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>A feature of the API Gateway control service for creating a new API from an external API definition file.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis?mode=import",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ImportRestApiRequest": {
+            "type": "structure",
+            "members": {
+                "failOnWarnings": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A query parameter to indicate whether to rollback the API creation (<code>true</code>) or not (<code>false</code>)\n            when a warning is encountered. The default value is <code>false</code>.</p>",
+                        "smithy.api#httpQuery": "failonwarnings"
+                    }
+                },
+                "parameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of context-specific query string parameters specifying the behavior of different API importing operations. The following shows operation-specific parameters and their supported values.</p>\n         <p> To exclude DocumentationParts from the import, set <code>parameters</code> as <code>ignore=documentation</code>.</p>\n         <p> To configure the endpoint type, set <code>parameters</code> as <code>endpointConfigurationTypes=EDGE</code>, <code>endpointConfigurationTypes=REGIONAL</code>, or <code>endpointConfigurationTypes=PRIVATE</code>. The default endpoint type is <code>EDGE</code>.</p>\n         <p> To handle imported <code>basepath</code>, set <code>parameters</code> as <code>basepath=ignore</code>, <code>basepath=prepend</code> or <code>basepath=split</code>.</p>\n         <p>For example, the AWS CLI command to exclude documentation from the imported API is:</p>\n         <p>The AWS CLI command to set the regional endpoint on the imported API is:</p>",
+                        "smithy.api#httpQueryParams": {}
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The POST request body containing external API definitions. Currently, only OpenAPI definition JSON/YAML files are supported. The maximum size of the API definition file is 6MB.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A POST request to import an API to API Gateway using an input of an API definition file.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Integer": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.apigateway#Integration": {
+            "type": "structure",
+            "members": {
+                "type": {
+                    "target": "com.amazonaws.apigateway#IntegrationType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies an API method integration type. The valid value is one of the following:</p>\n         <p>For the HTTP and HTTP proxy integrations, each integration can specify a protocol (<code>http/https</code>), port and path. Standard 80 and 443 ports are supported as well as custom ports above 1024. An HTTP or HTTP proxy integration with a <code>connectionType</code> of <code>VPC_LINK</code> is referred to as a private integration and uses a VpcLink to connect API Gateway to a network load balancer of a VPC.</p>"
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the integration's HTTP method type.</p>"
+                    }
+                },
+                "uri": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies Uniform Resource Identifier (URI) of the integration endpoint.</p>\n         <p>For <code>HTTP</code> or <code>HTTP_PROXY</code> integrations, the URI must be a fully formed, encoded HTTP(S) URL\n      according to the RFC-3986 specification, for either standard integration, where <code>connectionType</code>\n      is not <code>VPC_LINK</code>, or private integration, where <code>connectionType</code> is <code>VPC_LINK</code>. For a private HTTP\n      integration, the URI is not used for routing. For <code>AWS</code> or <code>AWS_PROXY</code> integrations, the URI is of\n      the form <code>arn:aws:apigateway:{region}:{subdomain.service|service}:path|action/{service_api}</code>.\n      Here, {Region} is the API Gateway region (e.g., us-east-1); {service} is the name of the\n      integrated Amazon Web Services service (e.g., s3); and {subdomain} is a designated subdomain supported by\n      certain Amazon Web Services  service for fast host-name lookup. action can be used for an Amazon Web Services  service\n      action-based API, using an Action={name}&{p1}={v1}&p2={v2}... query string. The ensuing\n      {service_api} refers to a supported action {name} plus any required input parameters.\n      Alternatively, path can be used for an AWS service path-based API. The ensuing service_api\n      refers to the path to an Amazon Web Services  service resource, including the region of the integrated Amazon Web Services \n      service, if applicable. For example, for integration with the S3 API of GetObject, the uri can\n      be either <code>arn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key}</code> or\n      <code>arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}</code>\n         </p>"
+                    }
+                },
+                "connectionType": {
+                    "target": "com.amazonaws.apigateway#ConnectionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. The valid value is <code>INTERNET</code> for connections through the public routable internet or <code>VPC_LINK</code> for private connections between API Gateway and a network load balancer in a VPC. The default value is <code>INTERNET</code>.</p>"
+                    }
+                },
+                "connectionId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the VpcLink used for the integration when <code>connectionType=VPC_LINK</code> and undefined, otherwise.</p>"
+                    }
+                },
+                "credentials": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string <code>arn:aws:iam::\\*:user/\\*</code>. To use resource-based permissions on supported AWS services, specify null.</p>"
+                    }
+                },
+                "requestParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying request parameters that are passed from the method request to the back end. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the back end. The method request parameter value must match the pattern of  <code>method.request.{location}.{name}</code>, where <code>location</code> is <code>querystring</code>, <code>path</code>, or <code>header</code> and <code>name</code> must be a valid and unique method request parameter name.</p>"
+                    }
+                },
+                "requestTemplates": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value.</p>"
+                    }
+                },
+                "passthroughBehavior": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how the method request body of an unmapped content type will be passed through\n      the integration request to the back end without transformation. A content type is unmapped if\n      no mapping template is defined in the integration or the content type does not match any of\n      the mapped content types, as specified in <code>requestTemplates</code>. The valid value is one of the\n      following: <code>WHEN_NO_MATCH</code>: passes the method request body through the integration request to\n      the back end without transformation when the method request content type does not match any\n      content type associated with the mapping templates defined in the integration request.\n      <code>WHEN_NO_TEMPLATES</code>: passes the method request body through the integration request to the back\n      end without transformation when no mapping template is defined in the integration request. If\n      a template is defined when this option is selected, the method request of an unmapped\n      content-type will be rejected with an HTTP 415 Unsupported Media Type response. <code>NEVER</code>: rejects\n      the method request with an HTTP 415 Unsupported Media Type response when either the method\n      request content type does not match any content type associated with the mapping templates\n      defined in the integration request or no mapping template is defined in the integration\n      request.</p>"
+                    }
+                },
+                "contentHandling": {
+                    "target": "com.amazonaws.apigateway#ContentHandlingStrategy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how to handle request payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p>\n         <p>If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the <code>passthroughBehavior</code> is configured to support payload pass-through.</p>"
+                    }
+                },
+                "timeoutInMillis": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds or 29 seconds.</p>"
+                    }
+                },
+                "cacheNamespace": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a group of related cached parameters. By default, API Gateway uses the resource ID as the <code>cacheNamespace</code>. You can specify the same <code>cacheNamespace</code> across resources to return the same cached data for requests to different resources.</p>"
+                    }
+                },
+                "cacheKeyParameters": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of request parameters whose values API Gateway caches. To be valid values for <code>cacheKeyParameters</code>, these parameters must also be specified for Method <code>requestParameters</code>.</p>"
+                    }
+                },
+                "integrationResponses": {
+                    "target": "com.amazonaws.apigateway#MapOfIntegrationResponse",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the integration's responses.</p>"
+                    }
+                },
+                "tlsConfig": {
+                    "target": "com.amazonaws.apigateway#TlsConfig",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the TLS configuration for an integration.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an HTTP, HTTP_PROXY, AWS, AWS_PROXY, or Mock integration.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#IntegrationResponse": {
+            "type": "structure",
+            "members": {
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the status code that is used to map the integration response to an existing MethodResponse.</p>"
+                    }
+                },
+                "selectionPattern": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the regular expression (regex) pattern used to choose an integration response based on the response from the back end. For example, if the success response returns nothing and the error response returns some string, you could use the <code>.+</code> regex to match error response. However, make sure that the error response does not contain any newline (<code>\\n</code>) character in such cases. If the back end is an AWS Lambda function, the AWS Lambda function error header is matched. For all other HTTP and AWS back ends, the HTTP status code is matched.</p>"
+                    }
+                },
+                "responseParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the back end.\n            The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of <code>method.response.header.{name}</code>, where <code>name</code> is a valid and unique header name. The mapped non-static value must match the pattern of <code>integration.response.header.{name}</code> or <code>integration.response.body.{JSON-expression}</code>, where <code>name</code> is a valid and unique response header name and <code>JSON-expression</code> is a valid JSON expression without the <code>$</code> prefix.</p>"
+                    }
+                },
+                "responseTemplates": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the templates used to transform the integration response body. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>"
+                    }
+                },
+                "contentHandling": {
+                    "target": "com.amazonaws.apigateway#ContentHandlingStrategy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p>\n         <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an integration response. The status code must map to an existing MethodResponse, and parameters and templates can be used to transform the back-end response.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#IntegrationType": {
+            "type": "enum",
+            "members": {
+                "HTTP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTP"
+                    }
+                },
+                "AWS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS"
+                    }
+                },
+                "MOCK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MOCK"
+                    }
+                },
+                "HTTP_PROXY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "HTTP_PROXY"
+                    }
+                },
+                "AWS_PROXY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AWS_PROXY"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The integration type. The valid value is <code>HTTP</code> for integrating an API method with an HTTP backend; <code>AWS</code> with any AWS service endpoints; <code>MOCK</code> for testing without actually invoking the backend; <code>HTTP_PROXY</code> for integrating with the HTTP proxy integration; <code>AWS_PROXY</code> for integrating with the Lambda proxy integration. </p>"
+            }
+        },
+        "com.amazonaws.apigateway#LimitExceededException": {
+            "type": "structure",
+            "members": {
+                "retryAfterSeconds": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                },
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request exceeded the rate limit. Retry after the specified time period.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.apigateway#ListOfARNs": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#ProviderARN"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfApiKey": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#ApiKey"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfApiStage": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#ApiStage"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfAuthorizer": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#Authorizer"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfBasePathMapping": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#BasePathMapping"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfClientCertificate": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#ClientCertificate"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfDeployment": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#Deployment"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfDocumentationPart": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#DocumentationPart"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfDocumentationVersion": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#DocumentationVersion"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfDomainName": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#DomainName"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfEndpointType": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#EndpointType"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfGatewayResponse": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#GatewayResponse"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfLong": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#Long"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfModel": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#Model"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfPatchOperation": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#PatchOperation"
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of operations describing the updates to apply to the specified resource. The patches are applied\n      in the order specified in the list.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfRequestValidator": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#RequestValidator"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfResource": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#Resource"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfRestApi": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#RestApi"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfSdkConfigurationProperty": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#SdkConfigurationProperty"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfSdkType": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#SdkType"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfStage": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#Stage"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfStageKeys": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#StageKey"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfString": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#String"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfUsage": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#ListOfLong"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfUsagePlan": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#UsagePlan"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfUsagePlanKey": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#UsagePlanKey"
+            }
+        },
+        "com.amazonaws.apigateway#ListOfVpcLink": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.apigateway#VpcLink"
+            }
+        },
+        "com.amazonaws.apigateway#LocationStatusType": {
+            "type": "enum",
+            "members": {
+                "DOCUMENTED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DOCUMENTED"
+                    }
+                },
+                "UNDOCUMENTED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "UNDOCUMENTED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#Long": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.apigateway#MapOfApiStageThrottleSettings": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#ThrottleSettings"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfIntegrationResponse": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#IntegrationResponse"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfKeyUsages": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#ListOfUsage"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfMethod": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#Method"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfMethodResponse": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#MethodResponse"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfMethodSettings": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#MethodSetting"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfMethodSnapshot": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#MethodSnapshot"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfStringToBoolean": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#NullableBoolean"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfStringToList": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#ListOfString"
+            }
+        },
+        "com.amazonaws.apigateway#MapOfStringToString": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#String"
+            }
+        },
+        "com.amazonaws.apigateway#Method": {
+            "type": "structure",
+            "members": {
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The method's HTTP verb.</p>"
+                    }
+                },
+                "authorizationType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The method's authorization type. Valid values are <code>NONE</code> for open access, <code>AWS_IAM</code> for using AWS IAM permissions, <code>CUSTOM</code> for using a custom authorizer, or <code>COGNITO_USER_POOLS</code> for using a Cognito user pool.</p>"
+                    }
+                },
+                "authorizerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an Authorizer to use on this method. The <code>authorizationType</code> must be <code>CUSTOM</code>.</p>"
+                    }
+                },
+                "apiKeyRequired": {
+                    "target": "com.amazonaws.apigateway#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A boolean flag specifying whether a valid ApiKey is required to invoke this method.</p>"
+                    }
+                },
+                "requestValidatorId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a RequestValidator for request validation.</p>"
+                    }
+                },
+                "operationName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A human-friendly operation identifier for the method. For example, you can assign the <code>operationName</code> of <code>ListPets</code> for the <code>GET /pets</code> method in the <code>PetStore</code> example.</p>"
+                    }
+                },
+                "requestParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map defining required or optional method request parameters that can be accepted by API Gateway. A key is a method request parameter name matching the pattern of  <code>method.request.{location}.{name}</code>, where <code>location</code> is <code>querystring</code>, <code>path</code>, or <code>header</code> and <code>name</code> is a valid and unique parameter name. The value associated with the key is a Boolean flag indicating whether the parameter is required (<code>true</code>) or optional (<code>false</code>).  The method request parameter names defined here are available in Integration to be mapped to integration request parameters or templates.</p>"
+                    }
+                },
+                "requestModels": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying data schemas, represented by Model resources, (as the mapped value) of the request payloads of given content types (as the mapping key).</p>"
+                    }
+                },
+                "methodResponses": {
+                    "target": "com.amazonaws.apigateway#MapOfMethodResponse",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Gets a method response associated with a given HTTP status code. </p>"
+                    }
+                },
+                "methodIntegration": {
+                    "target": "com.amazonaws.apigateway#Integration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Gets the method's integration responsible for passing the client-submitted request to the back end and performing necessary transformations to make the request compliant with the back end.</p>"
+                    }
+                },
+                "authorizationScopes": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of authorization scopes configured on the method. The scopes are used with a <code>COGNITO_USER_POOLS</code> authorizer to authorize the method invocation. The authorization works by matching the method scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any method scopes matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the method scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            Represents a client-facing interface by which the client calls the API to access back-end resources. A Method resource is\n            integrated with an Integration resource. Both consist of a request and one or more responses. The method request takes\n            the client input that is passed to the back end through the integration request. A method response returns the output from\n            the back end to the client through an integration response. A method request is embodied in a Method resource, whereas\n            an integration request is embodied in an Integration resource.  On the other hand, a method response is represented\n            by a MethodResponse resource, whereas an integration response is represented by an IntegrationResponse resource.\n        </p>"
+            }
+        },
+        "com.amazonaws.apigateway#MethodResponse": {
+            "type": "structure",
+            "members": {
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The method response's status code.</p>"
+                    }
+                },
+                "responseParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying required or optional response parameters that API Gateway can send back to the caller. A key defines a method response header and the value specifies whether the associated method response header is required or not. The expression of the key must match the pattern <code>method.response.header.{name}</code>, where <code>name</code> is a valid and unique header name. API Gateway passes certain integration response data to the method response headers specified here according to the mapping you prescribe in the API's IntegrationResponse. The integration response data that can be mapped include an integration response header expressed in <code>integration.response.header.{name}</code>, a static value enclosed within a pair of single quotes (e.g., <code>'application/json'</code>), or a JSON expression from the back-end response payload in the form of <code>integration.response.body.{JSON-expression}</code>, where <code>JSON-expression</code> is a valid JSON expression without the <code>$</code> prefix.)</p>"
+                    }
+                },
+                "responseModels": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the Model resources used for the response's content-type. Response models are represented as a key/value map, with a content-type as the key and a Model name as the value.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a method response of a given HTTP status code returned to the client. The method response is passed from the back end through the associated integration response that can be transformed using a mapping template. </p>"
+            }
+        },
+        "com.amazonaws.apigateway#MethodSetting": {
+            "type": "structure",
+            "members": {
+                "metricsEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether Amazon CloudWatch metrics are enabled for this method. The PATCH path for this setting is <code>/{method_setting_key}/metrics/enabled</code>, and the value is a Boolean.</p>"
+                    }
+                },
+                "loggingLevel": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the logging level for this method, which affects the log entries pushed to Amazon CloudWatch Logs. The PATCH path for this setting is <code>/{method_setting_key}/logging/loglevel</code>, and the available levels are <code>OFF</code>, <code>ERROR</code>, and <code>INFO</code>. Choose <code>ERROR</code> to write only error-level entries to CloudWatch Logs, or choose <code>INFO</code> to include all <code>ERROR</code> events as well as extra informational events.</p>"
+                    }
+                },
+                "dataTraceEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether data trace logging is enabled for this method, which affects the log entries pushed to Amazon CloudWatch Logs. The PATCH path for this setting is <code>/{method_setting_key}/logging/dataTrace</code>, and the value is a Boolean.</p>"
+                    }
+                },
+                "throttlingBurstLimit": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Specifies the throttling burst limit. The PATCH path for this setting is <code>/{method_setting_key}/throttling/burstLimit</code>, and the value is an integer.</p>"
+                    }
+                },
+                "throttlingRateLimit": {
+                    "target": "com.amazonaws.apigateway#Double",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Specifies the throttling rate limit. The PATCH path for this setting is <code>/{method_setting_key}/throttling/rateLimit</code>, and the value is a double.</p>"
+                    }
+                },
+                "cachingEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether responses should be cached and returned for requests. A cache cluster must be enabled on the stage for responses to be cached. The PATCH path for this setting is <code>/{method_setting_key}/caching/enabled</code>, and the value is a Boolean.</p>"
+                    }
+                },
+                "cacheTtlInSeconds": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Specifies the time to live (TTL), in seconds, for cached responses. The higher the TTL, the longer the response will be cached. The PATCH path for this setting is <code>/{method_setting_key}/caching/ttlInSeconds</code>, and the value is an integer.</p>"
+                    }
+                },
+                "cacheDataEncrypted": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether the cached responses are encrypted. The PATCH path for this setting is <code>/{method_setting_key}/caching/dataEncrypted</code>, and the value is a Boolean.</p>"
+                    }
+                },
+                "requireAuthorizationForCacheControl": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether authorization is required for a cache invalidation request. The PATCH path for this setting is <code>/{method_setting_key}/caching/requireAuthorizationForCacheControl</code>, and the value is a Boolean.</p>"
+                    }
+                },
+                "unauthorizedCacheControlHeaderStrategy": {
+                    "target": "com.amazonaws.apigateway#UnauthorizedCacheControlHeaderStrategy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how to handle unauthorized requests for cache invalidation. The PATCH path for this setting is <code>/{method_setting_key}/caching/unauthorizedCacheControlHeaderStrategy</code>, and the available values are <code>FAIL_WITH_403</code>, <code>SUCCEED_WITH_RESPONSE_HEADER</code>, <code>SUCCEED_WITHOUT_RESPONSE_HEADER</code>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the method setting properties.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#MethodSnapshot": {
+            "type": "structure",
+            "members": {
+                "authorizationType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The method's authorization type. Valid values are <code>NONE</code> for open access, <code>AWS_IAM</code> for using AWS IAM permissions, <code>CUSTOM</code> for using a custom authorizer, or <code>COGNITO_USER_POOLS</code> for using a Cognito user pool.</p>"
+                    }
+                },
+                "apiKeyRequired": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether the method requires a valid ApiKey.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a summary of a Method resource, given a particular date and time.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Model": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier for the model resource.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the model. Must be an alphanumeric string.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the model.</p>"
+                    }
+                },
+                "schema": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The schema for the model. For <code>application/json</code> models, this should be JSON schema draft 4 model. Do not include \"\\*/\" characters in the description of any properties because such \"\\*/\" characters may be interpreted as the closing marker for comments in some languages, such as Java or JavaScript, causing the installation of your API's SDK generated by API Gateway to fail.</p>"
+                    }
+                },
+                "contentType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-type for the model.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the data structure of a method's request or response payload.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Models": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfModel",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of Model resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#MutualTlsAuthentication": {
+            "type": "structure",
+            "members": {
+                "truststoreUri": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example\n      <code>s3://bucket-name/key-name</code>. The truststore can contain certificates from public or private\n      certificate authorities. To update the truststore, upload a new version to S3, and then update\n      your custom domain name to use the new version. To update the truststore, you must have\n      permissions to access the S3 object.</p>"
+                    }
+                },
+                "truststoreVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the S3 object that contains your truststore. To specify a version, you must have versioning enabled for the S3 bucket.</p>"
+                    }
+                },
+                "truststoreWarnings": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of warnings that API Gateway returns while processing your truststore. Invalid\n      certificates produce warnings. Mutual TLS is still enabled, but some clients might not be able\n      to access your API. To resolve warnings, upload a new truststore to S3, and then update you\n      domain name to use the new version.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name. If specified, API Gateway\n      performs two-way authentication between the client and the server. Clients must present a\n      trusted certificate to access your API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#MutualTlsAuthenticationInput": {
+            "type": "structure",
+            "members": {
+                "truststoreUri": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An Amazon S3 URL that specifies the truststore for mutual TLS authentication, for example\n      <code>s3://bucket-name/key-name</code>. The truststore can contain certificates from public or private\n      certificate authorities. To update the truststore, upload a new version to S3, and then update\n      your custom domain name to use the new version. To update the truststore, you must have\n      permissions to access the S3 object.</p>"
+                    }
+                },
+                "truststoreVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the S3 object that contains your truststore. To specify a version, you must have versioning enabled for the S3 bucket</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The mutual TLS authentication configuration for a custom domain name. If specified, API Gateway\n      performs two-way authentication between the client and the server. Clients must present a\n      trusted certificate to access your API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#NotFoundException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The requested resource is not found. Make sure that the request URI is correct.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.apigateway#NullableBoolean": {
+            "type": "boolean"
+        },
+        "com.amazonaws.apigateway#NullableInteger": {
+            "type": "integer"
+        },
+        "com.amazonaws.apigateway#Op": {
+            "type": "enum",
+            "members": {
+                "add": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "add"
+                    }
+                },
+                "remove": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "remove"
+                    }
+                },
+                "replace": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "replace"
+                    }
+                },
+                "move": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "move"
+                    }
+                },
+                "copy": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "copy"
+                    }
+                },
+                "test": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "test"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PatchOperation": {
+            "type": "structure",
+            "members": {
+                "op": {
+                    "target": "com.amazonaws.apigateway#Op",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An update operation to be performed with this PATCH request. The valid value can be\n            add, remove, replace or copy. Not all valid operations are supported for a given\n            resource. Support of the operations depends on specific operational contexts. Attempts\n            to apply an unsupported operation on a resource will return an error message..</p>"
+                    }
+                },
+                "path": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The op operation's target, as identified by a JSON Pointer value that references a\n            location within the targeted resource. For example, if the target resource has an\n            updateable property of {\"name\":\"value\"}, the path for this property is /name. If the\n            name property value is a JSON object (e.g., {\"name\": {\"child/name\": \"child-value\"}}),\n            the path for the child/name property will be /name/child~1name. Any slash (\"/\")\n            character appearing in path names must be escaped with \"~1\", as shown in the example\n            above. Each op operation can have only one path associated with it.</p>"
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The new target value of the update operation. It is applicable for the add or replace\n            operation. When using AWS CLI to update a property of a JSON value, enclose the JSON\n            object with a pair of single quotes in a Linux shell, e.g., '{\"a\": ...}'.</p>"
+                    }
+                },
+                "from": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The copy update operation's source as identified by a JSON-Pointer value referencing\n            the location within the targeted resource to copy the value from. For example, to\n            promote a canary deployment, you copy the canary deployment ID to the affiliated\n            deployment ID by calling a PATCH request on a Stage resource with \"op\":\"copy\",\n            \"from\":\"/canarySettings/deploymentId\" and \"path\":\"/deploymentId\".</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#PathToMapOfMethodSnapshot": {
+            "type": "map",
+            "key": {
+                "target": "com.amazonaws.apigateway#String"
+            },
+            "value": {
+                "target": "com.amazonaws.apigateway#MapOfMethodSnapshot"
+            }
+        },
+        "com.amazonaws.apigateway#ProviderARN": {
+            "type": "string"
+        },
+        "com.amazonaws.apigateway#PutGatewayResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#PutGatewayResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#GatewayResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a customization of a GatewayResponse of a specified response type and status code on the given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}/gatewayresponses/{responseType}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutGatewayResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "responseType": {
+                    "target": "com.amazonaws.apigateway#GatewayResponseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response type of the associated GatewayResponse</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP status code of the GatewayResponse.</p>"
+                    }
+                },
+                "responseParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Response parameters (paths, query strings and headers) of the GatewayResponse as a string-to-string map of key-value  pairs.</p>"
+                    }
+                },
+                "responseTemplates": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Response templates of the GatewayResponse as a string-to-string map of key-value pairs.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Creates a customization of a GatewayResponse of a specified response type and status code on the given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#PutIntegration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#PutIntegrationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Integration"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Sets up a method's integration.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutIntegrationRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a put integration request's resource ID.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the HTTP method for the integration.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#jsonName": "requestHttpMethod",
+                        "smithy.api#required": {}
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.apigateway#IntegrationType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a put integration input's type.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "integrationHttpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP method for the integration.</p>",
+                        "smithy.api#jsonName": "httpMethod"
+                    }
+                },
+                "uri": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies Uniform Resource Identifier (URI) of the integration endpoint. For HTTP or\n      <code>HTTP_PROXY</code> integrations, the URI must be a fully formed, encoded HTTP(S) URL according to the\n      RFC-3986 specification, for either standard integration, where <code>connectionType</code> is not <code>VPC_LINK</code>,\n      or private integration, where <code>connectionType</code> is <code>VPC_LINK</code>. For a private HTTP integration, the\n      URI is not used for routing. For <code>AWS</code> or <code>AWS_PROXY</code> integrations, the URI is of the form\n      <code>arn:aws:apigateway:{region}:{subdomain.service|service}:path|action/{service_api</code>}. Here,\n      {Region} is the API Gateway region (e.g., us-east-1); {service} is the name of the integrated\n      Amazon Web Services service (e.g., s3); and {subdomain} is a designated subdomain supported by certain Amazon Web Services\n      service for fast host-name lookup. action can be used for an Amazon Web Services service action-based API,\n      using an Action={name}&{p1}={v1}&p2={v2}... query string. The ensuing {service_api} refers to\n      a supported action {name} plus any required input parameters. Alternatively, path can be used\n      for an Amazon Web Services service path-based API. The ensuing service_api refers to the path to an Amazon Web Services\n      service resource, including the region of the integrated Amazon Web Services service, if applicable. For\n      example, for integration with the S3 API of <code>GetObject</code>, the <code>uri</code> can be either\n      <code>arn:aws:apigateway:us-west-2:s3:action/GetObject&Bucket={bucket}&Key={key}</code> or\n      <code>arn:aws:apigateway:us-west-2:s3:path/{bucket}/{key}</code>.</p>"
+                    }
+                },
+                "connectionType": {
+                    "target": "com.amazonaws.apigateway#ConnectionType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of the network connection to the integration endpoint. The valid value is <code>INTERNET</code> for connections through the public routable internet or <code>VPC_LINK</code> for private connections between API Gateway and a network load balancer in a VPC. The default value is <code>INTERNET</code>.</p>"
+                    }
+                },
+                "connectionId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the VpcLink used for the integration. Specify this value only if you specify <code>VPC_LINK</code> as the connection type.</p>"
+                    }
+                },
+                "credentials": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies whether credentials are required for a put integration.</p>"
+                    }
+                },
+                "requestParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying request parameters that are passed from the method request to the back end. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the back end. The method request parameter value must match the pattern of  <code>method.request.{location}.{name}</code>, where <code>location</code> is <code>querystring</code>, <code>path</code>, or <code>header</code> and <code>name</code> must be a valid and unique method request parameter name.</p>"
+                    }
+                },
+                "requestTemplates": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value.</p>"
+                    }
+                },
+                "passthroughBehavior": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the <code>requestTemplates</code> property on the Integration resource. There are three valid values:  <code>WHEN_NO_MATCH</code>, <code>WHEN_NO_TEMPLATES</code>, and <code>NEVER</code>.\n        </p>"
+                    }
+                },
+                "cacheNamespace": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a group of related cached parameters. By default, API Gateway uses the resource ID as the <code>cacheNamespace</code>. You can specify the same <code>cacheNamespace</code> across resources to return the same cached data for requests to different resources.</p>"
+                    }
+                },
+                "cacheKeyParameters": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of request parameters whose values API Gateway caches. To be valid values for <code>cacheKeyParameters</code>, these parameters must also be specified for Method <code>requestParameters</code>.</p>"
+                    }
+                },
+                "contentHandling": {
+                    "target": "com.amazonaws.apigateway#ContentHandlingStrategy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how to handle request payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p>\n         <p>If this property is not defined, the request payload will be passed through from the method request to integration request without modification, provided that the <code>passthroughBehavior</code> is configured to support payload pass-through.</p>"
+                    }
+                },
+                "timeoutInMillis": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Custom timeout between 50 and 29,000 milliseconds. The default value is 29,000 milliseconds or 29 seconds.</p>"
+                    }
+                },
+                "tlsConfig": {
+                    "target": "com.amazonaws.apigateway#TlsConfig"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Sets up a method's integration.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#PutIntegrationResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#PutIntegrationResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#IntegrationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a put integration.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutIntegrationResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a put integration response request's resource identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a put integration response request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the status code that is used to map the integration response to an existing MethodResponse.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "selectionPattern": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the selection pattern of a put integration response.</p>"
+                    }
+                },
+                "responseParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying response parameters that are passed to the method response from the back end.\n            The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of <code>method.response.header.{name}</code>, where <code>name</code> is a valid and unique header name. The mapped non-static value must match the pattern of <code>integration.response.header.{name}</code> or <code>integration.response.body.{JSON-expression}</code>, where <code>name</code> must be a valid and unique response header name and <code>JSON-expression</code> a valid JSON expression without the <code>$</code> prefix.</p>"
+                    }
+                },
+                "responseTemplates": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a put integration response's templates.</p>"
+                    }
+                },
+                "contentHandling": {
+                    "target": "com.amazonaws.apigateway#ContentHandlingStrategy",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how to handle response payload content type conversions. Supported values are <code>CONVERT_TO_BINARY</code> and <code>CONVERT_TO_TEXT</code>, with the following behaviors:</p>\n         <p>If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a put integration response request.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#PutMethod": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#PutMethodRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Method"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Add a method to an existing Resource resource.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutMethodRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the new Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the method request's HTTP method type.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizationType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The method's authorization type. Valid values are <code>NONE</code> for open access, <code>AWS_IAM</code> for using AWS IAM permissions, <code>CUSTOM</code> for using a custom authorizer, or <code>COGNITO_USER_POOLS</code> for using a Cognito user pool.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the identifier of an Authorizer to use on this Method, if the type is CUSTOM or COGNITO_USER_POOLS. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>"
+                    }
+                },
+                "apiKeyRequired": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether the method required a valid ApiKey.</p>"
+                    }
+                },
+                "operationName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A human-friendly operation identifier for the method. For example, you can assign the <code>operationName</code> of <code>ListPets</code> for the <code>GET /pets</code> method in the <code>PetStore</code> example.</p>"
+                    }
+                },
+                "requestParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map defining required or optional method request parameters that can be accepted by API Gateway. A key defines a method request parameter name matching the pattern of  <code>method.request.{location}.{name}</code>, where <code>location</code> is <code>querystring</code>, <code>path</code>, or <code>header</code> and <code>name</code> is a valid and unique parameter name. The value associated with the key is a Boolean flag indicating whether the parameter is required (<code>true</code>) or optional (<code>false</code>).  The method request parameter names defined here are available in Integration to be mapped to integration request parameters or body-mapping templates.</p>"
+                    }
+                },
+                "requestModels": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the Model resources used for the request's content type. Request models are represented as a key/value map, with a content type as the key and a Model name as the value.</p>"
+                    }
+                },
+                "requestValidatorId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a RequestValidator for validating the method request.</p>"
+                    }
+                },
+                "authorizationScopes": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of authorization scopes configured on the method. The scopes are used with a <code>COGNITO_USER_POOLS</code> authorizer to authorize the method invocation. The authorization works by matching the method scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any method scopes matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the method scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to add a method to an existing Resource resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#PutMethodResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#PutMethodResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#MethodResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds a MethodResponse to an existing Method resource.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutMethodResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The method response's status code.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "responseParameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map specifying required or optional response parameters that API Gateway can send back to the caller. A key defines a method response header name and the associated value is a Boolean flag indicating whether the method response parameter is required or not. The method response header names must match the pattern of <code>method.response.header.{name}</code>, where <code>name</code> is a valid and unique header name. The response parameter names defined here are available in the integration response to be mapped from an integration response header expressed in <code>integration.response.header.{name}</code>, a static value enclosed within a pair of single quotes (e.g., <code>'application/json'</code>), or a JSON expression from the back-end response payload in the form of <code>integration.response.body.{JSON-expression}</code>, where <code>JSON-expression</code> is a valid JSON expression without the <code>$</code> prefix.)</p>"
+                    }
+                },
+                "responseModels": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies the Model resources used for the response's content type. Response models are represented as a key/value map, with a content type as the key and a Model name as the value.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to add a MethodResponse to an existing Method resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#PutMode": {
+            "type": "enum",
+            "members": {
+                "Merge": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "merge"
+                    }
+                },
+                "Overwrite": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "overwrite"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutRestApi": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#PutRestApiRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RestApi"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>A feature of the API Gateway control service for updating an existing API with an input of external API definitions.\n            The update can take the form of merging the supplied definition into the existing API or overwriting the existing API.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/restapis/{restApiId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#PutRestApiRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "mode": {
+                    "target": "com.amazonaws.apigateway#PutMode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The <code>mode</code> query parameter to specify the update mode. Valid values are \"merge\" and \"overwrite\". By default,\n        the update mode is \"merge\".</p>",
+                        "smithy.api#httpQuery": "mode"
+                    }
+                },
+                "failOnWarnings": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A query parameter to indicate whether to rollback the API update (<code>true</code>) or not (<code>false</code>)\n            when a warning is encountered. The default value is <code>false</code>.</p>",
+                        "smithy.api#httpQuery": "failonwarnings"
+                    }
+                },
+                "parameters": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Custom header parameters as part of the request. For example, to exclude DocumentationParts from an imported API, set <code>ignore=documentation</code> as a <code>parameters</code> value, as in the AWS CLI command of <code>aws apigateway import-rest-api --parameters ignore=documentation --body 'file:///path/to/imported-api-body.json'</code>.</p>",
+                        "smithy.api#httpQueryParams": {}
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The PUT request body containing external API definitions. Currently, only OpenAPI definition JSON/YAML files are supported. The maximum size of the API definition file is 6MB.</p>",
+                        "smithy.api#httpPayload": {},
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A PUT request to update an existing API, with external API definitions specified as the request body.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#QuotaPeriodType": {
+            "type": "enum",
+            "members": {
+                "DAY": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DAY"
+                    }
+                },
+                "WEEK": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "WEEK"
+                    }
+                },
+                "MONTH": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MONTH"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#QuotaSettings": {
+            "type": "structure",
+            "members": {
+                "limit": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The target maximum number of requests that can be made in a given time period.</p>"
+                    }
+                },
+                "offset": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The number of requests subtracted from the given limit in the initial time period.</p>"
+                    }
+                },
+                "period": {
+                    "target": "com.amazonaws.apigateway#QuotaPeriodType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time period in which the limit applies. Valid values are \"DAY\", \"WEEK\" or \"MONTH\".</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Quotas configured for a usage plan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#RequestValidator": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of this RequestValidator.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of this RequestValidator</p>"
+                    }
+                },
+                "validateRequestBody": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether to validate a request body according to the configured Model schema.</p>"
+                    }
+                },
+                "validateRequestParameters": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A Boolean flag to indicate whether to validate request parameters (<code>true</code>) or not (<code>false</code>).</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A set of validation rules for incoming Method requests.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#RequestValidators": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfRequestValidator",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A collection of RequestValidator resources of a given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Resource": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The resource's identifier.</p>"
+                    }
+                },
+                "parentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The parent resource's identifier.</p>"
+                    }
+                },
+                "pathPart": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The last path segment for this resource.</p>"
+                    }
+                },
+                "path": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The full path for this resource.</p>"
+                    }
+                },
+                "resourceMethods": {
+                    "target": "com.amazonaws.apigateway#MapOfMethod",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Gets an API resource's method of a given HTTP verb.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an API resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Resources": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfResource",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of Resource resources.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#RestApi": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The API's identifier. This identifier is unique across all of your APIs in API Gateway.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The API's name.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The API's description.</p>"
+                    }
+                },
+                "createdDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the API was created.</p>"
+                    }
+                },
+                "version": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A version identifier for the API.</p>"
+                    }
+                },
+                "warnings": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The warning messages reported when <code>failonwarnings</code> is turned on during API import.</p>"
+                    }
+                },
+                "binaryMediaTypes": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The list of binary media types supported by the RestApi. By default, the RestApi supports only UTF-8-encoded text payloads.</p>"
+                    }
+                },
+                "minimumCompressionSize": {
+                    "target": "com.amazonaws.apigateway#NullableInteger",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A nullable integer that is used to enable compression (with non-negative between 0 and 10485760 (10M) bytes, inclusive) or disable compression (with a null value) on an API. When compression is enabled, compression or decompression is not applied on the payload if the payload size is smaller than this value. Setting it to zero allows compression for any payload size.</p>"
+                    }
+                },
+                "apiKeySource": {
+                    "target": "com.amazonaws.apigateway#ApiKeySourceType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The source of the API key for metering requests according to a usage plan. Valid values\n      are: ><code>HEADER</code> to read the API key from the <code>X-API-Key</code> header of a\n      request. <code>AUTHORIZER</code> to read the API key from the <code>UsageIdentifierKey</code>\n      from a custom authorizer.</p>"
+                    }
+                },
+                "endpointConfiguration": {
+                    "target": "com.amazonaws.apigateway#EndpointConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The endpoint configuration of this RestApi showing the endpoint types of the API. </p>"
+                    }
+                },
+                "policy": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A stringified JSON policy document that applies to this RestApi regardless of the caller and Method configuration.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                },
+                "disableExecuteApiEndpoint": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether clients can invoke your API by using the default <code>execute-api</code> endpoint.\n      By default, clients can invoke your API with the default\n      <code>https://{api_id}.execute-api.{region}.amazonaws.com</code> endpoint. To require that clients use a\n      custom domain name to invoke your API, disable the default endpoint.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a REST API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#RestApis": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfRestApi",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains references to your APIs and links that guide you in how to interact with your collection. A collection offers a paginated view of your APIs.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#SdkConfigurationProperty": {
+            "type": "structure",
+            "members": {
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of a an SdkType configuration property.</p>"
+                    }
+                },
+                "friendlyName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-friendly name of an SdkType configuration property.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of an SdkType configuration property.</p>"
+                    }
+                },
+                "required": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>A boolean flag of an SdkType configuration property to indicate if the associated SDK configuration property is required (<code>true</code>) or not (<code>false</code>).</p>"
+                    }
+                },
+                "defaultValue": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The default value of an SdkType configuration property.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A configuration property of an SDK type.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#SdkResponse": {
+            "type": "structure",
+            "members": {
+                "contentType": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-type header value in the HTTP response.</p>",
+                        "smithy.api#httpHeader": "Content-Type"
+                    }
+                },
+                "contentDisposition": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The content-disposition header value in the HTTP response.</p>",
+                        "smithy.api#httpHeader": "Content-Disposition"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#Blob",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The binary blob response to GetSdk, which contains the generated SDK.</p>",
+                        "smithy.api#httpPayload": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The binary blob response to GetSdk, which contains the generated SDK.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#SdkType": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of an SdkType instance.</p>"
+                    }
+                },
+                "friendlyName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The user-friendly name of an SdkType instance.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of an SdkType.</p>"
+                    }
+                },
+                "configurationProperties": {
+                    "target": "com.amazonaws.apigateway#ListOfSdkConfigurationProperty",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of configuration properties of an SdkType.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A type of SDK that API Gateway can generate.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#SdkTypes": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfSdkType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The collection of SdkType instances.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#SecurityPolicy": {
+            "type": "enum",
+            "members": {
+                "TLS_1_0": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TLS_1_0"
+                    }
+                },
+                "TLS_1_2": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TLS_1_2"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#ServiceUnavailableException": {
+            "type": "structure",
+            "members": {
+                "retryAfterSeconds": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                },
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The requested service is not available. For details see the accompanying error message. Retry after the specified time period.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 503
+            }
+        },
+        "com.amazonaws.apigateway#Stage": {
+            "type": "structure",
+            "members": {
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Deployment that the stage points to.</p>"
+                    }
+                },
+                "clientCertificateId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a client certificate for an API stage.</p>"
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the stage is the first path segment in the Uniform Resource Identifier (URI) of a call to API Gateway. Stage names can only contain alphanumeric characters, hyphens, and underscores. Maximum length is 128 characters.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stage's description.</p>"
+                    }
+                },
+                "cacheClusterEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether a cache cluster is enabled for the stage.</p>"
+                    }
+                },
+                "cacheClusterSize": {
+                    "target": "com.amazonaws.apigateway#CacheClusterSize",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stage's cache capacity in GB. For more information about choosing a cache size, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-caching.html\">Enabling API caching to enhance responsiveness</a>.</p>"
+                    }
+                },
+                "cacheClusterStatus": {
+                    "target": "com.amazonaws.apigateway#CacheClusterStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the cache cluster for the stage, if enabled.</p>"
+                    }
+                },
+                "methodSettings": {
+                    "target": "com.amazonaws.apigateway#MapOfMethodSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map that defines the method settings for a Stage resource. Keys (designated as <code>/{method_setting_key</code> below) are method paths defined as <code>{resource_path}/{http_method}</code> for an individual method override, or <code>/\\*/\\*</code> for overriding all methods in the stage.  </p>"
+                    }
+                },
+                "variables": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map that defines the stage variables for a Stage resource. Variable names can\n          have alphanumeric and underscore characters, and the values must match <code>[A-Za-z0-9-._~:/?#&=,]+</code>.</p>"
+                    }
+                },
+                "documentationVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version of the associated API documentation.</p>"
+                    }
+                },
+                "accessLogSettings": {
+                    "target": "com.amazonaws.apigateway#AccessLogSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Settings for logging access in this stage.</p>"
+                    }
+                },
+                "canarySettings": {
+                    "target": "com.amazonaws.apigateway#CanarySettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Settings for the canary deployment in this stage.</p>"
+                    }
+                },
+                "tracingEnabled": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether active tracing with X-ray is enabled for the Stage.</p>"
+                    }
+                },
+                "webAclArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the WebAcl associated with the Stage.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                },
+                "createdDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the stage was created.</p>"
+                    }
+                },
+                "lastUpdatedDate": {
+                    "target": "com.amazonaws.apigateway#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the stage last updated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a unique identifier for a version of a deployed RestApi that is callable by users.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#StageKey": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>"
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The stage name associated with the stage key.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A reference to a unique stage identified in the format <code>{restApiId}/{stage}</code>.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Stages": {
+            "type": "structure",
+            "members": {
+                "item": {
+                    "target": "com.amazonaws.apigateway#ListOfStage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A list of Stage resources that are associated with the ApiKey resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#StatusCode": {
+            "type": "string",
+            "traits": {
+                "smithy.api#documentation": "<p>The status code.</p>",
+                "smithy.api#pattern": "^[1-5]\\d\\d$"
+            }
+        },
+        "com.amazonaws.apigateway#String": {
+            "type": "string"
+        },
+        "com.amazonaws.apigateway#TagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#TagResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Adds or updates a tag on a given resource.</p>",
+                "smithy.api#http": {
+                    "method": "PUT",
+                    "uri": "/tags/{resourceArn}",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.apigateway#TagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of a resource that can be tagged.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key-value map of strings. The valid character set is [a-zA-Z+-=._:/]. The tag key can be up to 128 characters and must not start with <code>aws:</code>. The tag value can be up to 256 characters.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Adds or updates a tag on a given resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Tags": {
+            "type": "structure",
+            "members": {
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Template": {
+            "type": "structure",
+            "members": {
+                "value": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Apache Velocity Template Language (VTL) template content used for the template resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a mapping template used to transform a payload.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#TestInvokeAuthorizer": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#TestInvokeAuthorizerRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#TestInvokeAuthorizerResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Simulate the execution of an Authorizer in your RestApi with headers, parameters, and an incoming request body.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/authorizers/{authorizerId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#TestInvokeAuthorizerRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a test invoke authorizer request's Authorizer ID.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "headers": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of headers to simulate an incoming invocation request. This is where the incoming authorization token, or identity source, should be specified.</p>"
+                    }
+                },
+                "multiValueHeaders": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The headers as a map from string to list of values to simulate an incoming invocation request. This is where the incoming authorization token, or identity source, may be specified.</p>"
+                    }
+                },
+                "pathWithQueryString": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URI path, including query string, of the simulated invocation request. Use this to specify path parameters and query string parameters.</p>"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The simulated request body of an incoming invocation request.</p>"
+                    }
+                },
+                "stageVariables": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of stage variables to simulate an invocation on a deployed Stage.</p>"
+                    }
+                },
+                "additionalContext": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of additional context variables.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Make a request to simulate the invocation of an Authorizer.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#TestInvokeAuthorizerResponse": {
+            "type": "structure",
+            "members": {
+                "clientStatus": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The HTTP status code that the client would have received. Value is 0 if the authorizer succeeded.</p>"
+                    }
+                },
+                "log": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The API Gateway execution log for the test authorizer request.</p>"
+                    }
+                },
+                "latency": {
+                    "target": "com.amazonaws.apigateway#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The execution latency of the test authorizer request.</p>"
+                    }
+                },
+                "principalId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The principal identity returned by the Authorizer</p>"
+                    }
+                },
+                "policy": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The JSON policy document returned by the Authorizer</p>"
+                    }
+                },
+                "authorization": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The authorization response.</p>"
+                    }
+                },
+                "claims": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The open identity claims, with any supported custom attributes, returned from the Cognito Your User Pool configured for the API.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the response of the test invoke request for a custom Authorizer</p>"
+            }
+        },
+        "com.amazonaws.apigateway#TestInvokeMethod": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#TestInvokeMethodRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#TestInvokeMethodResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Simulate the invocation of a Method in your RestApi with headers, parameters, and an incoming request body.</p>",
+                "smithy.api#http": {
+                    "method": "POST",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#TestInvokeMethodRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a test invoke method request's resource ID.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies a test invoke method request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "pathWithQueryString": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The URI path, including query string, of the simulated invocation request. Use this to specify path parameters and query string parameters.</p>"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The simulated request body of an incoming invocation request.</p>"
+                    }
+                },
+                "headers": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of headers to simulate an incoming invocation request.</p>"
+                    }
+                },
+                "multiValueHeaders": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The headers as a map from string to list of values to simulate an incoming invocation request.</p>"
+                    }
+                },
+                "clientCertificateId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A ClientCertificate identifier to use in the test invocation. API Gateway will use the certificate when making the HTTPS request to the defined back-end endpoint.</p>"
+                    }
+                },
+                "stageVariables": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A key-value map of stage variables to simulate an invocation on a deployed Stage.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Make a request to simulate the invocation of a Method.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#TestInvokeMethodResponse": {
+            "type": "structure",
+            "members": {
+                "status": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The HTTP status code.</p>"
+                    }
+                },
+                "body": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The body of the HTTP response.</p>"
+                    }
+                },
+                "headers": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The headers of the HTTP response.</p>"
+                    }
+                },
+                "multiValueHeaders": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The headers of the HTTP response as a map from string to list of values.</p>"
+                    }
+                },
+                "log": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The API Gateway execution log for the test invoke request.</p>"
+                    }
+                },
+                "latency": {
+                    "target": "com.amazonaws.apigateway#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The execution latency of the test invoke request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the response of the test invoke request in the HTTP method.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#ThrottleSettings": {
+            "type": "structure",
+            "members": {
+                "burstLimit": {
+                    "target": "com.amazonaws.apigateway#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The API target request burst rate limit. This allows more requests through for a period of time than the target rate limit.</p>"
+                    }
+                },
+                "rateLimit": {
+                    "target": "com.amazonaws.apigateway#Double",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The API target request rate limit.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The API request rate limits.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Timestamp": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.apigateway#TlsConfig": {
+            "type": "structure",
+            "members": {
+                "insecureSkipVerification": {
+                    "target": "com.amazonaws.apigateway#Boolean",
+                    "traits": {
+                        "smithy.api#default": false,
+                        "smithy.api#documentation": "<p>Specifies whether or not API Gateway skips verification that the certificate for an integration endpoint is\n            issued by a supported certificate authority. This isn’t recommended, but it enables you to\n            use certificates that are signed by private certificate authorities, or certificates\n            that are self-signed. If enabled, API Gateway still performs basic certificate\n            validation, which includes checking the certificate's expiration date, hostname, and\n            presence of a root certificate authority. Supported only for <code>HTTP</code> and\n            <code>HTTP_PROXY</code> integrations.</p>\n         <important>\n            <p>Enabling <code>insecureSkipVerification</code> isn't recommended, especially for integrations with public\n          HTTPS endpoints. If you enable <code>insecureSkipVerification</code>, you increase the risk of man-in-the-middle attacks.</p>\n         </important>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Specifies the TLS configuration for an integration.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#TooManyRequestsException": {
+            "type": "structure",
+            "members": {
+                "retryAfterSeconds": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#httpHeader": "Retry-After"
+                    }
+                },
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request has reached its throttling limit. Retry after the specified time period.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.apigateway#UnauthorizedCacheControlHeaderStrategy": {
+            "type": "enum",
+            "members": {
+                "FAIL_WITH_403": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAIL_WITH_403"
+                    }
+                },
+                "SUCCEED_WITH_RESPONSE_HEADER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCEED_WITH_RESPONSE_HEADER"
+                    }
+                },
+                "SUCCEED_WITHOUT_RESPONSE_HEADER": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCEED_WITHOUT_RESPONSE_HEADER"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UnauthorizedException": {
+            "type": "structure",
+            "members": {
+                "message": {
+                    "target": "com.amazonaws.apigateway#String"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request is denied because the caller has insufficient permissions.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 401
+            }
+        },
+        "com.amazonaws.apigateway#UntagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UntagResourceRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Removes a tag from a given resource.</p>",
+                "smithy.api#http": {
+                    "method": "DELETE",
+                    "uri": "/tags/{resourceArn}",
+                    "code": 204
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UntagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "resourceArn": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of a resource that can be tagged.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "tagKeys": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Tag keys to delete.</p>",
+                        "smithy.api#httpQuery": "tagKeys",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Removes a tag from a given resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateAccount": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateAccountRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Account"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about the current Account resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/account",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateAccountRequest": {
+            "type": "structure",
+            "members": {
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to change information about the current Account resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateApiKey": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateApiKeyRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ApiKey"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about an ApiKey resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/apikeys/{apiKey}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateApiKeyRequest": {
+            "type": "structure",
+            "members": {
+                "apiKey": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the ApiKey resource to be updated.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to change information about an ApiKey resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateAuthorizer": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateAuthorizerRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Authorizer"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing Authorizer resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/authorizers/{authorizerId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateAuthorizerRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "authorizerId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Authorizer resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to update an existing Authorizer resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateBasePathMapping": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateBasePathMappingRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#BasePathMapping"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about the BasePathMapping resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/domainnames/{domainName}/basepathmappings/{basePath}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateBasePathMappingRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The domain name of the BasePathMapping resource to change.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "basePath": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The base path of the BasePathMapping resource to change.</p>\n         <p>To specify an empty base path, set this parameter to <code>'(none)'</code>.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to change information about the BasePathMapping resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateClientCertificate": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateClientCertificateRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#ClientCertificate"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about an ClientCertificate resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/clientcertificates/{clientCertificateId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateClientCertificateRequest": {
+            "type": "structure",
+            "members": {
+                "clientCertificateId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the ClientCertificate resource to be updated.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to change information about an ClientCertificate resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDeployment": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateDeploymentRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Deployment"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ServiceUnavailableException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about a Deployment resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/deployments/{deploymentId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDeploymentRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "deploymentId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The replacement identifier for the Deployment resource to change information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to change information about a Deployment resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDocumentationPart": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateDocumentationPartRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationPart"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a documentation part.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/documentation/parts/{documentationPartId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDocumentationPartRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationPartId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the to-be-updated documentation part.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing documentation part of a given API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDocumentationVersion": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateDocumentationVersionRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DocumentationVersion"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a documentation version.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/documentation/versions/{documentationVersion}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDocumentationVersionRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi..</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "documentationVersion": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The version identifier of the to-be-updated documentation version.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing documentation version of an API.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDomainName": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateDomainNameRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#DomainName"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about the DomainName resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/domainnames/{domainName}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateDomainNameRequest": {
+            "type": "structure",
+            "members": {
+                "domainName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the DomainName resource to be changed.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to change information about the DomainName resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateGatewayResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateGatewayResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#GatewayResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a GatewayResponse of a specified response type on the given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/gatewayresponses/{responseType}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateGatewayResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "responseType": {
+                    "target": "com.amazonaws.apigateway#GatewayResponseType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The response type of the associated GatewayResponse.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a GatewayResponse of a specified response type on the given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateIntegration": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateIntegrationRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Integration"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an update integration.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateIntegrationRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Represents an update integration request's resource identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Represents an update integration request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an update integration request.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateIntegrationResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateIntegrationResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#IntegrationResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an update integration response.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/integration/responses/{statusCode}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateIntegrationResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies an update integration response request's resource identifier.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies an update integration response request's HTTP method.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies an update integration response request's status code.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an update integration response request.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateMethod": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateMethodRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Method"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing Method resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateMethodRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to update an existing Method resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateMethodResponse": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateMethodResponseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#MethodResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing MethodResponse resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}/methods/{httpMethod}/responses/{statusCode}",
+                    "code": 201
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateMethodResponseRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Resource identifier for the MethodResponse resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "httpMethod": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The HTTP verb of the Method resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "statusCode": {
+                    "target": "com.amazonaws.apigateway#StatusCode",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status code for the MethodResponse resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A request to update an existing MethodResponse resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateModel": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateModelRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Model"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about a model.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/models/{modelName}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateModelRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "modelName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the model to update.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to update an existing model in an existing RestApi resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateRequestValidator": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateRequestValidatorRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RequestValidator"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a RequestValidator of a given RestApi.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/requestvalidators/{requestValidatorId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateRequestValidatorRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "requestValidatorId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of RequestValidator to be updated.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a RequestValidator of a given RestApi.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Resource"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about a Resource resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/resources/{resourceId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateResourceRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "resourceId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the Resource resource.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to change information about a Resource resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateRestApi": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateRestApiRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#RestApi"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about the specified API.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateRestApiRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Request to update an existing RestApi resource in your collection.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateStage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateStageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Stage"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Changes information about a Stage resource.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/restapis/{restApiId}/stages/{stageName}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateStageRequest": {
+            "type": "structure",
+            "members": {
+                "restApiId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The string identifier of the associated RestApi.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "stageName": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Stage resource to change information about.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Requests API Gateway to change information about a Stage resource.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateUsage": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateUsageRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#Usage"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Grants a temporary extension to the remaining quota of a usage plan associated with a specified API key.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/usageplans/{usagePlanId}/keys/{keyId}/usage",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateUsagePlan": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateUsagePlanRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#UsagePlan"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates a usage plan of a given plan Id.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/usageplans/{usagePlanId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateUsagePlanRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the to-be-updated usage plan.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The PATCH request to update a usage plan of a given plan Id.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateUsageRequest": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of the usage plan associated with the usage data.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "keyId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the API key associated with the usage plan in which a temporary extension is granted to the remaining quota.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The PATCH request to grant a temporary extension to the remaining quota of a usage plan associated with a specified API key.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UpdateVpcLink": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.apigateway#UpdateVpcLinkRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.apigateway#VpcLink"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.apigateway#BadRequestException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#LimitExceededException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#NotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#TooManyRequestsException"
+                },
+                {
+                    "target": "com.amazonaws.apigateway#UnauthorizedException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing VpcLink of a specified identifier.</p>",
+                "smithy.api#http": {
+                    "method": "PATCH",
+                    "uri": "/vpclinks/{vpcLinkId}",
+                    "code": 200
+                }
+            }
+        },
+        "com.amazonaws.apigateway#UpdateVpcLinkRequest": {
+            "type": "structure",
+            "members": {
+                "vpcLinkId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the  VpcLink. It is used in an Integration to reference this VpcLink.</p>",
+                        "smithy.api#httpLabel": {},
+                        "smithy.api#required": {}
+                    }
+                },
+                "patchOperations": {
+                    "target": "com.amazonaws.apigateway#ListOfPatchOperation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>For more information about supported patch operations, see <a href=\"https://docs.aws.amazon.com/apigateway/latest/api/patch-operations.html\">Patch Operations</a>.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Updates an existing VpcLink of a specified identifier.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#Usage": {
+            "type": "structure",
+            "members": {
+                "usagePlanId": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The plan Id associated with this usage data.</p>"
+                    }
+                },
+                "startDate": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The starting date of the usage data.</p>"
+                    }
+                },
+                "endDate": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ending date of the usage data.</p>"
+                    }
+                },
+                "items": {
+                    "target": "com.amazonaws.apigateway#MapOfKeyUsages",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The usage data, as daily logs of used and remaining quotas, over the specified time interval indexed over the API keys in a usage plan. For example, <code>{..., \"values\" : { \"{api_key}\" : [ [0, 100], [10, 90], [100, 10]]}</code>, where <code>{api_key}</code> stands for an API key value and the daily log entry is of the format <code>[used quota, remaining quota]</code>.</p>",
+                        "smithy.api#jsonName": "values"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the usage data of a usage plan.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UsagePlan": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of a UsagePlan resource.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of a usage plan.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of a usage plan.</p>"
+                    }
+                },
+                "apiStages": {
+                    "target": "com.amazonaws.apigateway#ListOfApiStage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The associated API stages of a usage plan.</p>"
+                    }
+                },
+                "throttle": {
+                    "target": "com.amazonaws.apigateway#ThrottleSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A map containing method level throttling information for API stage in a usage plan.</p>"
+                    }
+                },
+                "quota": {
+                    "target": "com.amazonaws.apigateway#QuotaSettings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The target maximum number of permitted requests per a given unit time interval.</p>"
+                    }
+                },
+                "productCode": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The AWS Markeplace product identifier to associate with the usage plan as a SaaS product on AWS Marketplace.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a usage plan used to specify who can assess associated API stages. Optionally, target request rate and quota limits can be set. \n        In some cases clients can exceed the targets that you set. Don’t rely on usage plans to control costs. \n        Consider using <a href=\"https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html\">Amazon Web Services Budgets</a> to monitor costs \n        and <a href=\"https://docs.aws.amazon.com/waf/latest/developerguide/waf-chapter.html\">WAF</a> to manage API requests.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UsagePlanKey": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Id of a usage plan key.</p>"
+                    }
+                },
+                "type": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The type of a usage plan key. Currently, the valid key type is <code>API_KEY</code>.</p>"
+                    }
+                },
+                "value": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of a usage plan key.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of a usage plan key.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a usage plan key to identify a plan customer.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UsagePlanKeys": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfUsagePlanKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the collection of usage plan keys added to usage plans for the associated API keys and, possibly, other types of keys.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#UsagePlans": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfUsagePlan",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a collection of usage plans for an AWS account.</p>"
+            }
+        },
+        "com.amazonaws.apigateway#VpcLink": {
+            "type": "structure",
+            "members": {
+                "id": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the  VpcLink. It is used in an Integration to reference this VpcLink.</p>"
+                    }
+                },
+                "name": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name used to label and identify the VPC link.</p>"
+                    }
+                },
+                "description": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The description of the VPC link.</p>"
+                    }
+                },
+                "targetArns": {
+                    "target": "com.amazonaws.apigateway#ListOfString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the network load balancer of the VPC targeted by the VPC link. The network load balancer must be owned by the same AWS account of the API owner.</p>"
+                    }
+                },
+                "status": {
+                    "target": "com.amazonaws.apigateway#VpcLinkStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of the VPC link. The valid values are <code>AVAILABLE</code>, <code>PENDING</code>, <code>DELETING</code>, or <code>FAILED</code>. Deploying an API will wait if the status is <code>PENDING</code> and will fail if the status is <code>DELETING</code>.  </p>"
+                    }
+                },
+                "statusMessage": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A description about the VPC link status.</p>"
+                    }
+                },
+                "tags": {
+                    "target": "com.amazonaws.apigateway#MapOfStringToString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The collection of tags. Each tag element is associated with a given resource.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>An API Gateway VPC link for a RestApi to access resources in an Amazon Virtual Private Cloud (VPC).</p>"
+            }
+        },
+        "com.amazonaws.apigateway#VpcLinkStatus": {
+            "type": "enum",
+            "members": {
+                "AVAILABLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "AVAILABLE"
+                    }
+                },
+                "PENDING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.apigateway#VpcLinks": {
+            "type": "structure",
+            "members": {
+                "items": {
+                    "target": "com.amazonaws.apigateway#ListOfVpcLink",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current page of elements from this collection.</p>",
+                        "smithy.api#jsonName": "item"
+                    }
+                },
+                "position": {
+                    "target": "com.amazonaws.apigateway#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current pagination position in the paged result set.</p>",
+                        "smithy.api#httpQuery": "position"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The collection of VPC links under the caller's account in a region.</p>"
+            }
+        }
+    }
+}

--- a/aws/sdk/integration-tests/Cargo.toml
+++ b/aws/sdk/integration-tests/Cargo.toml
@@ -2,6 +2,7 @@
 # `./gradlew -Paws.fullsdk=true :aws:sdk:assemble` these tests are copied into their respective Service crates.
 [workspace]
 members = [
+    "apigateway",
     "dynamodb",
     "ec2",
     "glacier",

--- a/aws/sdk/integration-tests/apigateway/Cargo.toml
+++ b/aws/sdk/integration-tests/apigateway/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "apigateway-tests"
+version = "0.1.0"
+authors = ["AWS Rust SDK Team <aws-sdk-rust@amazon.com>"]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/smithy-rs"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
+aws-sdk-apigateway = { path = "../../build/aws-sdk/sdk/apigateway" }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
+aws-smithy-protocol-test = { path = "../../build/aws-sdk/sdk/aws-smithy-protocol-test"}
+tokio = { version = "1.23.1", features = ["full", "test-util"]}

--- a/aws/sdk/integration-tests/apigateway/tests/accept_header.rs
+++ b/aws/sdk/integration-tests/apigateway/tests/accept_header.rs
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_sdk_apigateway::config::{Credentials, Region};
+use aws_sdk_apigateway::{Client, Config};
+use aws_smithy_client::test_connection::capture_request;
+use aws_smithy_protocol_test::{assert_ok, validate_headers};
+
+#[tokio::test]
+async fn accept_header_is_application_json() {
+    let (conn, handler) = capture_request(None);
+    let conf = Config::builder()
+        .region(Region::new("us-east-1"))
+        .credentials_provider(Credentials::for_tests())
+        .http_connector(conn)
+        .build();
+
+    let client = Client::from_conf(conf);
+    let _result = client
+        .delete_resource()
+        .rest_api_id("some-rest-api-id")
+        .resource_id("some-resource-id")
+        .send()
+        .await;
+    let request = handler.expect_request();
+    assert_ok(validate_headers(
+        request.headers(),
+        [("accept", "application/json")],
+    ));
+}

--- a/rust-runtime/aws-smithy-runtime/src/client.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client.rs
@@ -5,10 +5,11 @@
 
 pub mod auth;
 
-pub mod orchestrator;
-
 /// Smithy connector runtime plugins
 pub mod connections;
+
+/// The client orchestrator implementation
+pub mod orchestrator;
 
 /// Smithy code related to retry handling and token buckets.
 ///


### PR DESCRIPTION
## Motivation and Context
This PR ports the API Gateway `Accept` header customization into the orchestrator implementation. The original implementation of this customization in #287 didn't include a test, so this PR also adds an integration test for it.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
