### PR TITLE
Add support for TimeStreamWrite and TimeStreamQuery

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -115,3 +115,9 @@ no longer requires `Service::Error = OperationError<Op::Error, PollError>`, inst
 references = ["smithy-rs#2457"]
 meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "server" }
 author = "hlbarber"
+
+[[aws-sdk-rust]]
+message = "The SDK has added support for timestreamwrite and timestreamquery. Support for these services is considered experimental at this time. In order to use these services, you MUST call `.enable_endpoint_discovery()` on the `Client` after construction."
+meta = { "breaking" = false, "tada" = true, "bug" = false }
+references = ["smithy-rs#2707", "aws-sdk-rust#114"]
+author = "rcoh"

--- a/aws/rust-runtime/aws-credential-types/src/cache/expiring_cache.rs
+++ b/aws/rust-runtime/aws-credential-types/src/cache/expiring_cache.rs
@@ -59,14 +59,6 @@ where
             .map(|(creds, _expiry)| creds)
     }
 
-    /// Attempts to load the cached value if it has been set
-    ///
-    /// # Panics
-    /// This function panics if it is called from an asynchronous context
-    pub fn try_blocking_get(&self) -> Option<T> {
-        self.value.blocking_read().get().map(|(v, _exp)| v.clone())
-    }
-
     /// Attempts to refresh the cached value with the given future.
     /// If multiple threads attempt to refresh at the same time, one of them will win,
     /// and the others will await that thread's result rather than multiple refreshes occurring.

--- a/aws/rust-runtime/aws-credential-types/src/cache/expiring_cache.rs
+++ b/aws/rust-runtime/aws-credential-types/src/cache/expiring_cache.rs
@@ -59,6 +59,14 @@ where
             .map(|(creds, _expiry)| creds)
     }
 
+    /// Attempts to load the cached value if it has been set
+    ///
+    /// # Panics
+    /// This function panics if it is called from an asynchronous context
+    pub fn try_blocking_get(&self) -> Option<T> {
+        self.value.blocking_read().get().map(|(v, _exp)| v.clone())
+    }
+
     /// Attempts to refresh the cached value with the given future.
     /// If multiple threads attempt to refresh at the same time, one of them will win,
     /// and the others will await that thread's result rather than multiple refreshes occurring.

--- a/aws/rust-runtime/aws-inlineable/Cargo.toml
+++ b/aws/rust-runtime/aws-inlineable/Cargo.toml
@@ -24,6 +24,7 @@ aws-smithy-http = { path = "../../../rust-runtime/aws-smithy-http" }
 aws-smithy-http-tower = { path = "../../../rust-runtime/aws-smithy-http-tower" }
 aws-smithy-runtime-api = { path = "../../../rust-runtime/aws-smithy-runtime-api" }
 aws-smithy-types = { path = "../../../rust-runtime/aws-smithy-types" }
+aws-smithy-async = { path = "../../../rust-runtime/aws-smithy-async" }
 aws-types = { path = "../aws-types" }
 bytes = "1"
 bytes-utils = "0.1.1"

--- a/aws/rust-runtime/aws-inlineable/src/endpoint_discovery.rs
+++ b/aws/rust-runtime/aws-inlineable/src/endpoint_discovery.rs
@@ -154,12 +154,10 @@ impl EndpointCache {
 
 #[cfg(test)]
 mod test {
-    use crate::endpoint_discovery::{create_cache, EndpointCache};
-    use aws_credential_types::time_source::TimeSource;
+    use crate::endpoint_discovery::create_cache;
     use aws_smithy_async::rt::sleep::TokioSleep;
     use aws_smithy_async::test_util::controlled_time_and_sleep;
     use aws_smithy_async::time::SystemTimeSource;
-    use aws_smithy_http::endpoint::ResolveEndpointError;
     use aws_smithy_types::endpoint::Endpoint;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;

--- a/aws/rust-runtime/aws-inlineable/src/endpoint_discovery.rs
+++ b/aws/rust-runtime/aws-inlineable/src/endpoint_discovery.rs
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Maintain a cache of discovered endpoints
+
+use aws_smithy_async::rt::sleep::AsyncSleep;
+use aws_smithy_client::erase::boxclone::BoxFuture;
+use aws_smithy_http::endpoint::{ResolveEndpoint, ResolveEndpointError};
+use aws_smithy_types::endpoint::Endpoint;
+use std::fmt::{Debug, Formatter};
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+use tokio::sync::oneshot::error::TryRecvError;
+use tokio::sync::oneshot::{Receiver, Sender};
+
+/// Endpoint reloader
+#[must_use]
+pub struct ReloadEndpoint {
+    loader: Box<dyn Fn() -> BoxFuture<(Endpoint, SystemTime), ResolveEndpointError> + Send + Sync>,
+    endpoint: Arc<Mutex<Option<ExpiringEndpoint>>>,
+    error: Arc<Mutex<Option<ResolveEndpointError>>>,
+    rx: Receiver<()>,
+    sleep: Arc<dyn AsyncSleep>,
+}
+
+impl Debug for ReloadEndpoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReloadEndpoint").finish()
+    }
+}
+
+impl ReloadEndpoint {
+    /// Reload the endpoint once
+    pub async fn reload_once(&self) {
+        match (self.loader)().await {
+            Ok((endpoint, expiry)) => {
+                *self.endpoint.lock().unwrap() = Some(ExpiringEndpoint { endpoint, expiry })
+            }
+            Err(err) => *self.error.lock().unwrap() = Some(err),
+        }
+    }
+
+    /// An infinite loop task that will reload the endpoint
+    ///
+    /// This task will terminate when the corresponding [`EndpointCache`] is dropped.
+    pub async fn reload_task(mut self) {
+        loop {
+            match self.rx.try_recv() {
+                Ok(_) | Err(TryRecvError::Closed) => break,
+                _ => {}
+            }
+            let should_reload = self
+                .endpoint
+                .lock()
+                .unwrap()
+                .as_ref()
+                .map(|e| e.is_expired())
+                .unwrap_or(true);
+            if should_reload {
+                self.reload_once().await;
+            }
+            self.sleep.sleep(Duration::from_secs(60)).await
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct EndpointCache {
+    error: Arc<Mutex<Option<ResolveEndpointError>>>,
+    endpoint: Arc<Mutex<Option<ExpiringEndpoint>>>,
+    // When the sender is dropped, this allows the reload loop to stop
+    _drop_guard: Arc<Sender<()>>,
+}
+
+impl<T> ResolveEndpoint<T> for EndpointCache {
+    fn resolve_endpoint(&self, _params: &T) -> aws_smithy_http::endpoint::Result {
+        self.resolve_endpoint()
+    }
+}
+
+#[derive(Debug)]
+struct ExpiringEndpoint {
+    endpoint: Endpoint,
+    expiry: SystemTime,
+}
+
+impl ExpiringEndpoint {
+    fn is_expired(&self) -> bool {
+        match SystemTime::now().duration_since(self.expiry) {
+            Err(e) => true,
+            Ok(t) => t < Duration::from_secs(120),
+        }
+    }
+}
+
+pub(crate) async fn create_cache<F>(
+    loader_fn: impl Fn() -> F + Send + Sync + 'static,
+    sleep: Arc<dyn AsyncSleep>,
+) -> Result<(EndpointCache, ReloadEndpoint), ResolveEndpointError>
+where
+    F: Future<Output = Result<(Endpoint, SystemTime), ResolveEndpointError>> + Send + 'static,
+{
+    let error_holder = Arc::new(Mutex::new(None));
+    let endpoint_holder = Arc::new(Mutex::new(None));
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let cache = EndpointCache {
+        error: error_holder.clone(),
+        endpoint: endpoint_holder.clone(),
+        _drop_guard: Arc::new(tx),
+    };
+    let reloader = ReloadEndpoint {
+        loader: Box::new(move || Box::pin((loader_fn)()) as _),
+        endpoint: endpoint_holder,
+        error: error_holder,
+        rx,
+        sleep,
+    };
+    reloader.reload_once().await;
+    if let Err(e) = cache.resolve_endpoint() {
+        return Err(e);
+    }
+    Ok((cache, reloader))
+}
+
+impl EndpointCache {
+    fn resolve_endpoint(&self) -> aws_smithy_http::endpoint::Result {
+        self.endpoint
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|e| e.endpoint.clone())
+            .ok_or_else(|| {
+                self.error
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .unwrap_or_else(|| ResolveEndpointError::message("no endpoint loaded"))
+            })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::endpoint_discovery::{create_cache, EndpointCache};
+    use aws_smithy_async::rt::sleep::TokioSleep;
+    use aws_smithy_http::endpoint::ResolveEndpointError;
+    use std::sync::Arc;
+
+    fn check_send<T: Send>() {}
+
+    fn check_send_v<T: Send>(t: T) -> T {
+        t
+    }
+
+    #[tokio::test]
+    async fn check_traits() {
+        // check_send::<EndpointCache>();
+
+        let (cache, reloader) = create_cache(
+            || async { Err(ResolveEndpointError::message("stub")) },
+            Arc::new(TokioSleep::new()),
+        )
+        .await
+        .unwrap();
+        check_send_v(reloader.reload_task());
+    }
+}

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -46,4 +46,5 @@ pub mod route53_resource_id_preprocessor;
 /// Convert a streaming `SdkBody` into an aws-chunked streaming body with checksum trailers
 pub mod http_body_checksum;
 
+#[allow(dead_code)]
 pub mod endpoint_discovery;

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -45,3 +45,5 @@ pub mod route53_resource_id_preprocessor;
 
 /// Convert a streaming `SdkBody` into an aws-chunked streaming body with checksum trailers
 pub mod http_body_checksum;
+
+pub mod endpoint_discovery;

--- a/aws/rust-runtime/aws-inlineable/src/lib.rs
+++ b/aws/rust-runtime/aws-inlineable/src/lib.rs
@@ -48,3 +48,9 @@ pub mod http_body_checksum;
 
 #[allow(dead_code)]
 pub mod endpoint_discovery;
+
+// just so docs work
+#[allow(dead_code)]
+/// allow docs to work
+#[derive(Debug)]
+pub struct Client;

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCodegenDecorator.kt
@@ -21,6 +21,7 @@ import software.amazon.smithy.rustsdk.customize.s3.S3ExtendedRequestIdDecorator
 import software.amazon.smithy.rustsdk.customize.s3control.S3ControlDecorator
 import software.amazon.smithy.rustsdk.customize.sso.SSODecorator
 import software.amazon.smithy.rustsdk.customize.sts.STSDecorator
+import software.amazon.smithy.rustsdk.customize.timestream.TimestreamDecorator
 import software.amazon.smithy.rustsdk.endpoints.AwsEndpointsStdLib
 import software.amazon.smithy.rustsdk.endpoints.OperationInputTestDecorator
 import software.amazon.smithy.rustsdk.endpoints.RequireEndpointRules
@@ -69,6 +70,8 @@ val DECORATORS: List<ClientCodegenDecorator> = listOf(
     S3ControlDecorator().onlyApplyTo("com.amazonaws.s3control#AWSS3ControlServiceV20180820"),
     STSDecorator().onlyApplyTo("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
     SSODecorator().onlyApplyTo("com.amazonaws.sso#SWBPortalService"),
+    TimestreamDecorator().onlyApplyTo("com.amazonaws.timestreamwrite#Timestream_20181101"),
+    TimestreamDecorator().onlyApplyTo("com.amazonaws.timestreamquery#Timestream_20181101"),
 
     // Only build docs-rs for linux to reduce load on docs.rs
     listOf(

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
@@ -9,6 +9,9 @@ import software.amazon.smithy.model.shapes.ShapeId
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.docsTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.writable
+import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizationsOrElse
 import software.amazon.smithy.rust.codegen.core.util.toSnakeCase
 
 object AwsDocs {
@@ -22,6 +25,24 @@ object AwsDocs {
                 ShapeId.from("com.amazonaws.sts#AWSSecurityTokenServiceV20110615"),
                 ShapeId.from("com.amazonaws.sso#SWBPortalService"),
             ).contains(codegenContext.serviceShape.id)
+
+    fun constructClient(codegenContext: ClientCodegenContext, indent: String): Writable {
+        val crateName = codegenContext.moduleName.toSnakeCase()
+        return writable {
+            writeCustomizationsOrElse(
+                codegenContext.rootDecorator.extraSections(codegenContext),
+                DocSection.CreateClient(crateName = crateName, indent = indent),
+            ) {
+                addDependency(AwsCargoDependency.awsConfig(codegenContext.runtimeConfig).toDevDependency())
+                rustTemplate(
+                    """
+                    let config = aws_config::load_from_env().await;
+                    let client = $crateName::Client::new(&config);
+                    """.trimIndent().prependIndent(indent),
+                )
+            }
+        }
+    }
 
     fun clientConstructionDocs(codegenContext: ClientCodegenContext): Writable = {
         if (canRelyOnAwsConfig(codegenContext)) {
@@ -40,8 +61,7 @@ object AwsDocs {
                 In the simplest case, creating a client looks as follows:
                 ```rust,no_run
                 ## async fn wrapper() {
-                let config = #{aws_config}::load_from_env().await;
-                let client = $crateName::Client::new(&config);
+                #{constructClient}
                 ## }
                 ```
 
@@ -76,6 +96,7 @@ object AwsDocs {
                 [builder pattern]: https://rust-lang.github.io/api-guidelines/type-safety.html##builders-enable-construction-of-complex-values-c-builder
                 """.trimIndent(),
                 "aws_config" to AwsCargoDependency.awsConfig(codegenContext.runtimeConfig).toDevDependency().toType(),
+                "constructClient" to constructClient(codegenContext, indent = ""),
             )
         }
     }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsDocs.kt
@@ -33,7 +33,9 @@ object AwsDocs {
                 codegenContext.rootDecorator.extraSections(codegenContext),
                 DocSection.CreateClient(crateName = crateName, indent = indent),
             ) {
-                addDependency(AwsCargoDependency.awsConfig(codegenContext.runtimeConfig).toDevDependency())
+                if (canRelyOnAwsConfig(codegenContext)) {
+                    addDependency(AwsCargoDependency.awsConfig(codegenContext.runtimeConfig).toDevDependency())
+                }
                 rustTemplate(
                     """
                     let config = aws_config::load_from_env().await;

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
@@ -77,7 +77,10 @@ class IntegrationTestDependencies(
             if (hasTests) {
                 val smithyClient = CargoDependency.smithyClient(codegenContext.runtimeConfig)
                     .copy(features = setOf("test-util"), scope = DependencyScope.Dev)
+                val smithyAsync = CargoDependency.smithyAsync(codegenContext.runtimeConfig)
+                    .copy(features = setOf("test-util"), scope = DependencyScope.Dev)
                 addDependency(smithyClient)
+                addDependency(smithyAsync)
                 addDependency(CargoDependency.smithyProtocolTestHelpers(codegenContext.runtimeConfig))
                 addDependency(SerdeJson)
                 addDependency(Tokio)

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/ServiceSpecificDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/ServiceSpecificDecorator.kt
@@ -20,6 +20,7 @@ import software.amazon.smithy.rust.codegen.client.smithy.generators.config.Confi
 import software.amazon.smithy.rust.codegen.client.smithy.generators.error.ErrorCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.customize.OperationCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderCustomization
 import software.amazon.smithy.rust.codegen.core.smithy.generators.LibRsCustomization
@@ -147,6 +148,11 @@ class ServiceSpecificDecorator(
     ): ProtocolTestGenerator = baseGenerator.maybeApply(codegenContext.serviceShape) {
         delegateTo.protocolTestGenerator(codegenContext, baseGenerator)
     }
+
+    override fun extraSections(codegenContext: ClientCodegenContext): List<AdHocCustomization> =
+        listOf<AdHocCustomization>().maybeApply(codegenContext.serviceShape) {
+            delegateTo.extraSections(codegenContext)
+        }
 
     override fun operationRuntimePluginCustomizations(
         codegenContext: ClientCodegenContext,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
@@ -39,7 +39,7 @@ class TimestreamDecorator : ClientCodegenDecorator {
                     """
                     let config = aws_config::load_from_env().await;
                     // You MUST call `enable_endpoint_discovery` to produce a working client for this service.
-                    let ${it.clientName} = ${it.crateName}::Client::new(&config).enable_endpoint_discovery();
+                    let ${it.clientName} = ${it.crateName}::Client::new(&config).enable_endpoint_discovery().await;
                     """.replaceIndent(it.indent),
                 )
             },

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.rustsdk.customize.timestream
+
+import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
+import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.Types
+import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
+import software.amazon.smithy.rust.codegen.core.rustlang.DependencyScope
+import software.amazon.smithy.rust.codegen.core.rustlang.Visibility
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.toType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
+import software.amazon.smithy.rustsdk.InlineAwsDependency
+
+/** Adds Endpoint Discovery Utility to Timestream */
+class TimestreamDecorator : ClientCodegenDecorator {
+    override val name: String = "Timestream"
+    override val order: Byte = 0
+
+    override fun extras(codegenContext: ClientCodegenContext, rustCrate: RustCrate) {
+        val endpointDiscovery = InlineAwsDependency.forRustFile(
+            "endpoint_discovery",
+            Visibility.PUBLIC,
+            CargoDependency.Tokio.copy(scope = DependencyScope.Compile, features = setOf("sync")),
+        )
+        rustCrate.lib {
+            rustTemplate(
+                """
+                async fn resolve_endpoint(client: &crate::Client) -> Result<(#{Endpoint}, #{SystemTime}), #{ResolveEndpointError}> {
+                    let describe_endpoints =
+                        client.describe_endpoints().send().await.map_err(|e| {
+                            #{ResolveEndpointError}::from_source("failed to call describe_endpoints", e)
+                        })?;
+                    let endpoint = describe_endpoints.endpoints().unwrap().get(0).unwrap();
+                    let expiry =
+                        #{SystemTime}::now() + #{Duration}::from_secs(endpoint.cache_period_in_minutes() as u64 * 60);
+                    Ok((
+                        #{Endpoint}::builder()
+                            .url(format!("https://{}", endpoint.address().unwrap()))
+                            .build(),
+                        expiry,
+                    ))
+                }
+
+                impl Client {
+                    pub async fn enable_endpoint_discovery(self) -> Result<(Self, #{endpoint_discovery}::ReloadEndpoint), #{ResolveEndpointError}> {
+                        let mut new_conf = self.conf().clone();
+                        let sleep = self.conf().sleep_impl().expect("sleep impl must be provided");
+                        let (resolver, reloader) = #{endpoint_discovery}::create_cache(
+                            move || {
+                                let client = self.clone();
+                                async move { resolve_endpoint(&client).await }
+                            },
+                            sleep,
+                        )
+                        .await?;
+                        new_conf.endpoint_resolver = std::sync::Arc::new(resolver);
+                        Ok((Self::from_conf(new_conf), reloader))
+                    }
+                }
+
+                """,
+                "endpoint_discovery" to endpointDiscovery.toType(),
+                "SystemTime" to RuntimeType.std.resolve("time::SystemTime"),
+                "Duration" to RuntimeType.std.resolve("time::Duration"),
+                *Types(codegenContext.runtimeConfig).toArray(),
+            )
+        }
+    }
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/timestream/TimestreamDecorator.kt
@@ -74,7 +74,6 @@ class TimestreamDecorator : ClientCodegenDecorator {
                     /// Enable endpoint discovery for this client
                     ///
                     /// This method MUST be called to construct a working client.
-                    ##[must_use]
                     pub async fn enable_endpoint_discovery(self) -> #{Result}<(Self, #{endpoint_discovery}::ReloadEndpoint), #{ResolveEndpointError}> {
                         let mut new_conf = self.conf().clone();
                         let sleep = self.conf().sleep_impl().expect("sleep impl must be provided");

--- a/aws/sdk/aws-models/timestream-query.json
+++ b/aws/sdk/aws-models/timestream-query.json
@@ -1,0 +1,3047 @@
+{
+    "smithy": "2.0",
+    "metadata": {
+        "suppressions": [
+            {
+                "id": "HttpMethodSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpResponseCodeSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "PaginatedTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpHeaderTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpUriConflict",
+                "namespace": "*"
+            },
+            {
+                "id": "Service",
+                "namespace": "*"
+            }
+        ]
+    },
+    "shapes": {
+        "com.amazonaws.timestreamquery#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ServiceErrorMessage"
+                }
+            },
+            "traits": {
+                "aws.protocols#awsQueryError": {
+                    "code": "AccessDenied",
+                    "httpResponseCode": 403
+                },
+                "smithy.api#documentation": "<p> You are not authorized to perform this action. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.timestreamquery#AmazonResourceName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#CancelQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#CancelQueryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#CancelQueryResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> Cancels a query that has been issued. Cancellation is provided only if the query has\n            not completed running before the cancellation request was issued. Because cancellation\n            is an idempotent operation, subsequent cancellation requests will return a\n                <code>CancellationMessage</code>, indicating that the query has already been\n            canceled. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.cancel-query.html\">code\n                sample</a> for details. </p>",
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#CancelQueryRequest": {
+            "type": "structure",
+            "members": {
+                "QueryId": {
+                    "target": "com.amazonaws.timestreamquery#QueryId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The ID of the query that needs to be cancelled. <code>QueryID</code> is returned as\n            part of the query result. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#CancelQueryResponse": {
+            "type": "structure",
+            "members": {
+                "CancellationMessage": {
+                    "target": "com.amazonaws.timestreamquery#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A <code>CancellationMessage</code> is returned when a <code>CancelQuery</code>\n            request for the query specified by <code>QueryId</code> has already been issued. </p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ClientRequestToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 32,
+                    "max": 128
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#ClientToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 32,
+                    "max": 128
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#ColumnInfo": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The name of the result set column. The name of the result set is available for\n            columns of all data types except for arrays. </p>"
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.timestreamquery#Type",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data type of the result set column. The data type can be a scalar or complex.\n            Scalar data types are integers, strings, doubles, Booleans, and others. Complex data\n            types are types such as arrays, rows, and others. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Contains the metadata for query results such as the column names, data types, and\n            other attributes. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ColumnInfoList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#ColumnInfo"
+            }
+        },
+        "com.amazonaws.timestreamquery#ConflictException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Unable to poll results for a cancelled query. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.timestreamquery#CreateScheduledQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#CreateScheduledQueryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#CreateScheduledQueryResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> Create a scheduled query that will be run on your behalf at the configured schedule.\n            Timestream assumes the execution role provided as part of the\n                <code>ScheduledQueryExecutionRoleArn</code> parameter to run the query. You can use\n            the <code>NotificationConfiguration</code> parameter to configure notification for your\n            scheduled query operations.</p>",
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#CreateScheduledQueryRequest": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "QueryString": {
+                    "target": "com.amazonaws.timestreamquery#QueryString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The query string to run. Parameter\n            names can be specified in the query string <code>@</code> character followed by an\n            identifier. The named Parameter <code>@scheduled_runtime</code> is reserved and can be used in the query to get the time at which the query is scheduled to run.</p>\n            <p>The timestamp calculated according to the ScheduleConfiguration parameter, will be the value of <code>@scheduled_runtime</code> paramater for each query run. \n            For example, consider an instance of a scheduled query executing on 2021-12-01 00:00:00. For this instance, the <code>@scheduled_runtime</code> parameter is \n            initialized to the timestamp 2021-12-01 00:00:00 when invoking the query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ScheduleConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#ScheduleConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The schedule configuration for the query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NotificationConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#NotificationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Notification configuration for the scheduled query. A notification is sent by\n            Timestream when a query run finishes, when the state is updated or when you delete it. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TargetConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#TargetConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration used for writing the result of a query.</p>"
+                    }
+                },
+                "ClientToken": {
+                    "target": "com.amazonaws.timestreamquery#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Using a ClientToken makes the call to CreateScheduledQuery idempotent, in other words, making the same request repeatedly will produce the same result. Making \n            multiple identical CreateScheduledQuery requests has the same effect as making a single request.\n\n </p>\n         <ul>\n            <li>\n                <p> If CreateScheduledQuery is called without a <code>ClientToken</code>, the\n                    Query SDK generates a <code>ClientToken</code> on your behalf.</p>\n            </li>\n            <li>\n                <p> After 8 hours, any request with the same <code>ClientToken</code> is treated\n                    as a new request. </p>\n            </li>\n         </ul>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "ScheduledQueryExecutionRoleArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN for the IAM role that Timestream will assume when running the scheduled query. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.timestreamquery#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of key-value pairs to label the scheduled query.</p>"
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamquery#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon KMS key used to encrypt the scheduled query resource, at-rest. If the Amazon KMS\n            key is not specified, the scheduled query resource will be encrypted with a Timestream\n            owned Amazon KMS key. To specify a KMS key, use the key ID, key ARN, alias name, or alias\n            ARN. When using an alias name, prefix the name with <i>alias/</i>\n         </p>\n            <p>If ErrorReportConfiguration uses <code>SSE_KMS</code> as encryption type, the same KmsKeyId is used to encrypt the error report at rest.</p>"
+                    }
+                },
+                "ErrorReportConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#ErrorReportConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration for error reporting. Error reports will be generated when a problem is encountered when writing the query results. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#CreateScheduledQueryResponse": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>ARN for the created scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#Datum": {
+            "type": "structure",
+            "members": {
+                "ScalarValue": {
+                    "target": "com.amazonaws.timestreamquery#ScalarValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Indicates if the data point is a scalar value such as integer, string, double, or\n            Boolean. </p>"
+                    }
+                },
+                "TimeSeriesValue": {
+                    "target": "com.amazonaws.timestreamquery#TimeSeriesDataPointList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Indicates if the data point is a timeseries data type. </p>"
+                    }
+                },
+                "ArrayValue": {
+                    "target": "com.amazonaws.timestreamquery#DatumList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Indicates if the data point is an array. </p>"
+                    }
+                },
+                "RowValue": {
+                    "target": "com.amazonaws.timestreamquery#Row",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Indicates if the data point is a row. </p>"
+                    }
+                },
+                "NullValue": {
+                    "target": "com.amazonaws.timestreamquery#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Indicates if the data point is null. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Datum represents a single data point in a query result. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#DatumList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#Datum"
+            }
+        },
+        "com.amazonaws.timestreamquery#DeleteScheduledQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#DeleteScheduledQueryRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Deletes a given scheduled query. This is an irreversible operation. </p>",
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#DeleteScheduledQueryRequest": {
+            "type": "structure",
+            "members": {
+                "ScheduledQueryArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the scheduled query. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#DescribeEndpoints": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#DescribeEndpointsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#DescribeEndpointsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>DescribeEndpoints returns a list of available endpoints to make Timestream\n            API calls against. This API is available through both Write and Query.</p>\n        <p>Because the Timestream SDKs are designed to transparently work with the\n            service’s architecture, including the management and mapping of the service endpoints,\n                <i>it is not recommended that you use this API unless</i>:</p>\n        <ul>\n            <li>\n                <p>You are using <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/VPCEndpoints\">VPC endpoints (Amazon Web Services PrivateLink) with Timestream\n                    </a>\n               </p>\n            </li>\n            <li>\n                <p>Your application uses a programming language that does not yet have SDK\n                    support</p>\n            </li>\n            <li>\n                <p>You require better control over the client-side implementation</p>\n            </li>\n         </ul>\n        <p>For detailed information on how and when to use and implement DescribeEndpoints, see\n                <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/Using.API.html#Using-API.endpoint-discovery\">The Endpoint Discovery Pattern</a>.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#DescribeEndpointsRequest": {
+            "type": "structure",
+            "members": {}
+        },
+        "com.amazonaws.timestreamquery#DescribeEndpointsResponse": {
+            "type": "structure",
+            "members": {
+                "Endpoints": {
+                    "target": "com.amazonaws.timestreamquery#Endpoints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An <code>Endpoints</code> object is returned when a <code>DescribeEndpoints</code>\n            request is made.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#DescribeScheduledQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#DescribeScheduledQueryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#DescribeScheduledQueryResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Provides detailed information about a scheduled query.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#DescribeScheduledQueryRequest": {
+            "type": "structure",
+            "members": {
+                "ScheduledQueryArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#DescribeScheduledQueryResponse": {
+            "type": "structure",
+            "members": {
+                "ScheduledQuery": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#DimensionMapping": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Column name from query result.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DimensionValueType": {
+                    "target": "com.amazonaws.timestreamquery#DimensionValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Type for the dimension. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This type is used to map column(s) from the query result to a dimension in the\n            destination table.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#DimensionMappingList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#DimensionMapping"
+            }
+        },
+        "com.amazonaws.timestreamquery#DimensionValueType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "VARCHAR",
+                        "name": "VARCHAR"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#Double": {
+            "type": "double",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.timestreamquery#Endpoint": {
+            "type": "structure",
+            "members": {
+                "Address": {
+                    "target": "com.amazonaws.timestreamquery#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An endpoint address.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CachePeriodInMinutes": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The TTL for the endpoint, in minutes.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an available endpoint against which to make API calls against, as well as\n            the TTL for that endpoint.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#Endpoints": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#Endpoint"
+            }
+        },
+        "com.amazonaws.timestreamquery#ErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#ErrorReportConfiguration": {
+            "type": "structure",
+            "members": {
+                "S3Configuration": {
+                    "target": "com.amazonaws.timestreamquery#S3Configuration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The S3 configuration for the error reports.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration required for error reporting.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ErrorReportLocation": {
+            "type": "structure",
+            "members": {
+                "S3ReportLocation": {
+                    "target": "com.amazonaws.timestreamquery#S3ReportLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The S3 location where error reports are written.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>This contains the location of the error report for a single scheduled query call.\n        </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ExecuteScheduledQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#ExecuteScheduledQueryRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> You can use this API to run a scheduled query manually. </p>",
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#ExecuteScheduledQueryRequest": {
+            "type": "structure",
+            "members": {
+                "ScheduledQueryArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>ARN of the scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "InvocationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp in UTC. Query will be run as if it was invoked at this timestamp. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ClientToken": {
+                    "target": "com.amazonaws.timestreamquery#ClientToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Not used. </p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ExecutionStats": {
+            "type": "structure",
+            "members": {
+                "ExecutionTimeInMillis": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Total time, measured in milliseconds, that was needed for the scheduled query run to complete.</p>"
+                    }
+                },
+                "DataWrites": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Data writes metered for records ingested in a single scheduled query run.</p>"
+                    }
+                },
+                "BytesMetered": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Bytes metered for a single scheduled query run.</p>"
+                    }
+                },
+                "RecordsIngested": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The number of records ingested for a single scheduled query run. </p>"
+                    }
+                },
+                "QueryResultRows": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Number of rows present in the output from running a query before ingestion to\n            destination data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Statistics for a single scheduled query run.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#InternalServerException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            Timestream was unable to fully process this request because of an internal\n            server error. </p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.timestreamquery#InvalidEndpointException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The requested endpoint was not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 421
+            }
+        },
+        "com.amazonaws.timestreamquery#ListScheduledQueries": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#ListScheduledQueriesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#ListScheduledQueriesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Gets a list of all scheduled queries in the caller's Amazon account and Region. <code>ListScheduledQueries</code> is eventually consistent. </p>",
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ListScheduledQueriesRequest": {
+            "type": "structure",
+            "members": {
+                "MaxResults": {
+                    "target": "com.amazonaws.timestreamquery#MaxScheduledQueriesResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of items to return in the output. If the total number of items\n            available is more than the value specified, a <code>NextToken</code> is provided in the\n            output. To resume pagination, provide the <code>NextToken</code> value as the argument\n            to the subsequent call to <code>ListScheduledQueriesRequest</code>.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamquery#NextScheduledQueriesResultsToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A pagination token to resume pagination.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ListScheduledQueriesResponse": {
+            "type": "structure",
+            "members": {
+                "ScheduledQueries": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of scheduled queries.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamquery#NextScheduledQueriesResultsToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token to specify where to start paginating. This is the NextToken from a previously\n            truncated response.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ListTagsForResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#ListTagsForResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#ListTagsForResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>List all tags on a Timestream query resource.</p>",
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ListTagsForResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceARN": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Timestream resource with tags to be listed. This value is an Amazon Resource Name\n            (ARN).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MaxResults": {
+                    "target": "com.amazonaws.timestreamquery#MaxTagsForResourceResult",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The maximum number of tags to return.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamquery#NextTagsForResourceResultsToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A pagination token to resume pagination.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ListTagsForResourceResponse": {
+            "type": "structure",
+            "members": {
+                "Tags": {
+                    "target": "com.amazonaws.timestreamquery#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The tags currently associated with the Timestream resource. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamquery#NextTagsForResourceResultsToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A pagination token to resume pagination with a subsequent call to\n                <code>ListTagsForResourceResponse</code>.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#Long": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.timestreamquery#MaxQueryResults": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#MaxScheduledQueriesResults": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 1000
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#MaxTagsForResourceResult": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#MeasureValueType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "BIGINT",
+                        "name": "BIGINT"
+                    },
+                    {
+                        "value": "BOOLEAN",
+                        "name": "BOOLEAN"
+                    },
+                    {
+                        "value": "DOUBLE",
+                        "name": "DOUBLE"
+                    },
+                    {
+                        "value": "VARCHAR",
+                        "name": "VARCHAR"
+                    },
+                    {
+                        "value": "MULTI",
+                        "name": "MULTI"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#MixedMeasureMapping": {
+            "type": "structure",
+            "members": {
+                "MeasureName": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Refers to the value of measure_name in a result row. This field is required if\n            MeasureNameColumn is provided.</p>"
+                    }
+                },
+                "SourceColumn": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This field refers to the source column from which measure-value is to be read for\n            result materialization.</p>"
+                    }
+                },
+                "TargetMeasureName": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Target measure name to be used. If not provided, the target measure name by default\n            would be measure-name if provided, or sourceColumn otherwise. </p>"
+                    }
+                },
+                "MeasureValueType": {
+                    "target": "com.amazonaws.timestreamquery#MeasureValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Type of the value that is to be read from sourceColumn. If the mapping is for MULTI,\n            use MeasureValueType.MULTI.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MultiMeasureAttributeMappings": {
+                    "target": "com.amazonaws.timestreamquery#MultiMeasureAttributeMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Required when measureValueType is MULTI. Attribute mappings for MULTI value\n            measures.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>MixedMeasureMappings are mappings that can be used to ingest data into a mixture of\n            narrow and multi measures in the derived table.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#MixedMeasureMappingList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#MixedMeasureMapping"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#MultiMeasureAttributeMapping": {
+            "type": "structure",
+            "members": {
+                "SourceColumn": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Source column from where the attribute value is to be read.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TargetMultiMeasureAttributeName": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Custom name to be used for attribute name in derived table. If not provided, source\n            column name would be used.</p>"
+                    }
+                },
+                "MeasureValueType": {
+                    "target": "com.amazonaws.timestreamquery#ScalarMeasureValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Type of the attribute to be read from the source column.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Attribute mapping for MULTI value measures.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#MultiMeasureAttributeMappingList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#MultiMeasureAttributeMapping"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#MultiMeasureMappings": {
+            "type": "structure",
+            "members": {
+                "TargetMultiMeasureName": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the target multi-measure name in the derived table. This input is required\n            when measureNameColumn is not provided. If MeasureNameColumn is provided, then value\n            from that column will be used as multi-measure name.</p>"
+                    }
+                },
+                "MultiMeasureAttributeMappings": {
+                    "target": "com.amazonaws.timestreamquery#MultiMeasureAttributeMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Required. Attribute mappings to be used for mapping query results to ingest data for\n            multi-measure attributes.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Only one of MixedMeasureMappings or MultiMeasureMappings is to be provided.\n            MultiMeasureMappings can be used to ingest data as multi measures in the derived\n            table.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#NextScheduledQueriesResultsToken": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#NextTagsForResourceResultsToken": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#NotificationConfiguration": {
+            "type": "structure",
+            "members": {
+                "SnsConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#SnsConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Details on SNS configuration. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Notification configuration for a scheduled query. A notification is sent by\n            Timestream when a scheduled query is created, its state is updated or when it is deleted. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#NullableBoolean": {
+            "type": "boolean"
+        },
+        "com.amazonaws.timestreamquery#PaginationToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ParameterMapping": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Parameter name.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.timestreamquery#Type",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Mapping for named parameters.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ParameterMappingList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#ParameterMapping"
+            }
+        },
+        "com.amazonaws.timestreamquery#PrepareQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#PrepareQueryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#PrepareQueryResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>A synchronous operation that allows you to submit a query with parameters to be stored\n            by Timestream for later running. Timestream only supports using this operation with the\n                <code>PrepareQueryRequest$ValidateOnly</code> set to <code>true</code>. </p>",
+                "smithy.api#idempotent": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#PrepareQueryRequest": {
+            "type": "structure",
+            "members": {
+                "QueryString": {
+                    "target": "com.amazonaws.timestreamquery#QueryString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Timestream query string that you want to use as a prepared statement. Parameter\n            names can be specified in the query string <code>@</code> character followed by an\n            identifier. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ValidateOnly": {
+                    "target": "com.amazonaws.timestreamquery#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>By setting this value to <code>true</code>, Timestream will only validate that the\n            query string is a valid Timestream query, and not store the prepared query for later\n            use.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#PrepareQueryResponse": {
+            "type": "structure",
+            "members": {
+                "QueryString": {
+                    "target": "com.amazonaws.timestreamquery#QueryString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The query string that you want prepare.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Columns": {
+                    "target": "com.amazonaws.timestreamquery#SelectColumnList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of SELECT clause columns of the submitted query string. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Parameters": {
+                    "target": "com.amazonaws.timestreamquery#ParameterMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of parameters used in the submitted query string. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#Query": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#QueryRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#QueryResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#QueryExecutionException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>\n            <code>Query</code> is a synchronous operation that enables you to run a query against\n            your Amazon Timestream data. <code>Query</code> will time out after 60 seconds.\n            You must update the default timeout in the SDK to support a timeout of 60 seconds. See\n            the <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.run-query.html\">code\n                sample</a> for details. </p>\n        <p>Your query request will fail in the following cases:</p>\n        <ul>\n            <li>\n                <p> If you submit a <code>Query</code> request with the same client token outside\n                    of the 5-minute idempotency window. </p>\n            </li>\n            <li>\n                <p> If you submit a <code>Query</code> request with the same client token, but\n                    change other parameters, within the 5-minute idempotency window. </p>\n            </li>\n            <li>\n                <p> If the size of the row (including the query metadata) exceeds 1 MB, then the\n                    query will fail with the following error message: </p>\n                <p>\n                  <code>Query aborted as max page response size has been exceeded by the output\n                        result row</code>\n                </p>\n            </li>\n            <li>\n                <p> If the IAM principal of the query initiator and the result reader are not the\n                    same and/or the query initiator and the result reader do not have the same query\n                    string in the query requests, the query will fail with an <code>Invalid\n                        pagination token</code> error. </p>\n            </li>\n         </ul>",
+                "smithy.api#idempotent": {},
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "items": "Rows",
+                    "pageSize": "MaxRows"
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#QueryExecutionException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n            Timestream was unable to run the query successfully. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.timestreamquery#QueryId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9]+$"
+            }
+        },
+        "com.amazonaws.timestreamquery#QueryRequest": {
+            "type": "structure",
+            "members": {
+                "QueryString": {
+                    "target": "com.amazonaws.timestreamquery#QueryString",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The query to be run by Timestream. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ClientToken": {
+                    "target": "com.amazonaws.timestreamquery#ClientRequestToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Unique, case-sensitive string of up to 64 ASCII characters specified when a\n                <code>Query</code> request is made. Providing a <code>ClientToken</code> makes the\n            call to <code>Query</code>\n            <i>idempotent</i>. This means that running the same query repeatedly will\n            produce the same result. In other words, making multiple identical <code>Query</code>\n            requests has the same effect as making a single request. When using\n                <code>ClientToken</code> in a query, note the following: </p>\n        <ul>\n            <li>\n                <p> If the Query API is instantiated without a <code>ClientToken</code>, the\n                    Query SDK generates a <code>ClientToken</code> on your behalf.</p>\n            </li>\n            <li>\n                <p>If the <code>Query</code> invocation only contains the\n                        <code>ClientToken</code> but does not include a <code>NextToken</code>, that\n                    invocation of <code>Query</code> is assumed to be a new query run.</p>\n            </li>\n            <li>\n                <p>If the invocation contains <code>NextToken</code>, that particular invocation\n                    is assumed to be a subsequent invocation of a prior call to the Query API, and a\n                    result set is returned.</p>\n            </li>\n            <li>\n                <p> After 4 hours, any request with the same <code>ClientToken</code> is treated\n                    as a new request. </p>\n            </li>\n         </ul>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamquery#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A pagination token used to return a set of results. When the <code>Query</code> API\n            is invoked using <code>NextToken</code>, that particular invocation is assumed to be a\n            subsequent invocation of a prior call to <code>Query</code>, and a result set is\n            returned. However, if the <code>Query</code> invocation only contains the\n                <code>ClientToken</code>, that invocation of <code>Query</code> is assumed to be a\n            new query run. </p>\n        <p>Note the following when using NextToken in a query:</p>\n        <ul>\n            <li>\n                <p>A pagination token can be used for up to five <code>Query</code> invocations,\n                    OR for a duration of up to 1 hour – whichever comes first.</p>\n            </li>\n            <li>\n                <p>Using the same <code>NextToken</code> will return the same set of records. To\n                    keep paginating through the result set, you must to use the most recent\n                        <code>nextToken</code>.</p>\n            </li>\n            <li>\n                <p>Suppose a <code>Query</code> invocation returns two <code>NextToken</code>\n                    values, <code>TokenA</code> and <code>TokenB</code>. If <code>TokenB</code> is\n                    used in a subsequent <code>Query</code> invocation, then <code>TokenA</code> is\n                    invalidated and cannot be reused.</p>\n            </li>\n            <li>\n                <p>To request a previous result set from a query after pagination has begun, you\n                    must re-invoke the Query API.</p>\n            </li>\n            <li>\n                <p>The latest <code>NextToken</code> should be used to paginate until\n                        <code>null</code> is returned, at which point a new <code>NextToken</code>\n                    should be used.</p>\n            </li>\n            <li>\n                <p> If the IAM principal of the query initiator and the result reader are not the\n                    same and/or the query initiator and the result reader do not have the same query\n                    string in the query requests, the query will fail with an <code>Invalid\n                        pagination token</code> error. </p>\n            </li>\n         </ul>"
+                    }
+                },
+                "MaxRows": {
+                    "target": "com.amazonaws.timestreamquery#MaxQueryResults",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The total number of rows to be returned in the <code>Query</code> output. The initial\n            run of <code>Query</code> with a <code>MaxRows</code> value specified will return the\n            result set of the query in two cases: </p>\n        <ul>\n            <li>\n                <p>The size of the result is less than <code>1MB</code>.</p>\n            </li>\n            <li>\n                <p>The number of rows in the result set is less than the value of\n                        <code>maxRows</code>.</p>\n            </li>\n         </ul>\n        <p>Otherwise, the initial invocation of <code>Query</code> only returns a\n                <code>NextToken</code>, which can then be used in subsequent calls to fetch the\n            result set. To resume pagination, provide the <code>NextToken</code> value in the\n            subsequent command.</p>\n        <p>If the row size is large (e.g. a row has many columns), Timestream may return\n            fewer rows to keep the response size from exceeding the 1 MB limit. If\n                <code>MaxRows</code> is not provided, Timestream will send the necessary\n            number of rows to meet the 1 MB limit.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#QueryResponse": {
+            "type": "structure",
+            "members": {
+                "QueryId": {
+                    "target": "com.amazonaws.timestreamquery#QueryId",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A unique ID for the given query. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamquery#PaginationToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A pagination token that can be used again on a <code>Query</code> call to get the\n            next set of results. </p>"
+                    }
+                },
+                "Rows": {
+                    "target": "com.amazonaws.timestreamquery#RowList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The result set rows returned by the query. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ColumnInfo": {
+                    "target": "com.amazonaws.timestreamquery#ColumnInfoList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The column data types of the returned result set. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "QueryStatus": {
+                    "target": "com.amazonaws.timestreamquery#QueryStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information about the status of the query, including progress and bytes\n            scanned.</p>"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#QueryStatus": {
+            "type": "structure",
+            "members": {
+                "ProgressPercentage": {
+                    "target": "com.amazonaws.timestreamquery#Double",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The progress of the query, expressed as a percentage.</p>"
+                    }
+                },
+                "CumulativeBytesScanned": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of data scanned by the query in bytes. This is a cumulative sum and\n            represents the total amount of bytes scanned since the query was started. </p>"
+                    }
+                },
+                "CumulativeBytesMetered": {
+                    "target": "com.amazonaws.timestreamquery#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The amount of data scanned by the query in bytes that you will be charged for. This is\n            a cumulative sum and represents the total amount of data that you will be charged for\n            since the query was started. The charge is applied only once and is either applied when\n            the query completes running or when the query is cancelled. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information about the status of the query, including progress and bytes\n            scanned.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#QueryString": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 262144
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.timestreamquery#ResourceName": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                },
+                "ScheduledQueryArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ARN of the scheduled query.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The requested resource could not be found.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.timestreamquery#Row": {
+            "type": "structure",
+            "members": {
+                "Data": {
+                    "target": "com.amazonaws.timestreamquery#DatumList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>List of data points in a single row of the result set.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a single row in the query results.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#RowList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#Row"
+            }
+        },
+        "com.amazonaws.timestreamquery#S3BucketName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 63
+                },
+                "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+            }
+        },
+        "com.amazonaws.timestreamquery#S3Configuration": {
+            "type": "structure",
+            "members": {
+                "BucketName": {
+                    "target": "com.amazonaws.timestreamquery#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Name of the S3 bucket under which error reports will be created.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ObjectKeyPrefix": {
+                    "target": "com.amazonaws.timestreamquery#S3ObjectKeyPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Prefix for the error report key. Timestream by default adds the following prefix to\n            the error report path. </p>"
+                    }
+                },
+                "EncryptionOption": {
+                    "target": "com.amazonaws.timestreamquery#S3EncryptionOption",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Encryption at rest options for the error reports. If no encryption option is\n            specified, Timestream will choose SSE_S3 as default. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details on S3 location for error reports that result from running a query. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#S3EncryptionOption": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "SSE_S3",
+                        "name": "SSE_S3"
+                    },
+                    {
+                        "value": "SSE_KMS",
+                        "name": "SSE_KMS"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#S3ObjectKey": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#S3ObjectKeyPrefix": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 896
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+            }
+        },
+        "com.amazonaws.timestreamquery#S3ReportLocation": {
+            "type": "structure",
+            "members": {
+                "BucketName": {
+                    "target": "com.amazonaws.timestreamquery#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> S3 bucket name. </p>"
+                    }
+                },
+                "ObjectKey": {
+                    "target": "com.amazonaws.timestreamquery#S3ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>S3 key. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> S3 report location for the scheduled query run.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScalarMeasureValueType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "BIGINT",
+                        "name": "BIGINT"
+                    },
+                    {
+                        "value": "BOOLEAN",
+                        "name": "BOOLEAN"
+                    },
+                    {
+                        "value": "DOUBLE",
+                        "name": "DOUBLE"
+                    },
+                    {
+                        "value": "VARCHAR",
+                        "name": "VARCHAR"
+                    },
+                    {
+                        "value": "TIMESTAMP",
+                        "name": "TIMESTAMP"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#ScalarType": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "VARCHAR",
+                        "name": "VARCHAR"
+                    },
+                    {
+                        "value": "BOOLEAN",
+                        "name": "BOOLEAN"
+                    },
+                    {
+                        "value": "BIGINT",
+                        "name": "BIGINT"
+                    },
+                    {
+                        "value": "DOUBLE",
+                        "name": "DOUBLE"
+                    },
+                    {
+                        "value": "TIMESTAMP",
+                        "name": "TIMESTAMP"
+                    },
+                    {
+                        "value": "DATE",
+                        "name": "DATE"
+                    },
+                    {
+                        "value": "TIME",
+                        "name": "TIME"
+                    },
+                    {
+                        "value": "INTERVAL_DAY_TO_SECOND",
+                        "name": "INTERVAL_DAY_TO_SECOND"
+                    },
+                    {
+                        "value": "INTERVAL_YEAR_TO_MONTH",
+                        "name": "INTERVAL_YEAR_TO_MONTH"
+                    },
+                    {
+                        "value": "UNKNOWN",
+                        "name": "UNKNOWN"
+                    },
+                    {
+                        "value": "INTEGER",
+                        "name": "INTEGER"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#ScalarValue": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#ScheduleConfiguration": {
+            "type": "structure",
+            "members": {
+                "ScheduleExpression": {
+                    "target": "com.amazonaws.timestreamquery#ScheduleExpression",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An expression that denotes when to trigger the scheduled query run. This can be a cron\n            expression or a rate expression. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration of the schedule of the query.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduleExpression": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQuery": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The creation time of the scheduled query.</p>"
+                    }
+                },
+                "State": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>State of scheduled query. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "PreviousInvocationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The last time the scheduled query was run.</p>"
+                    }
+                },
+                "NextInvocationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The next time the scheduled query is to be run.</p>"
+                    }
+                },
+                "ErrorReportConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#ErrorReportConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration for scheduled query error reporting.</p>"
+                    }
+                },
+                "TargetDestination": {
+                    "target": "com.amazonaws.timestreamquery#TargetDestination",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Target data source where final scheduled query result will be written.</p>"
+                    }
+                },
+                "LastRunStatus": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryRunStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status of the last scheduled query run.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Scheduled Query</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryDescription": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Scheduled query ARN.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the scheduled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "QueryString": {
+                    "target": "com.amazonaws.timestreamquery#QueryString",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The query to be run.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Creation time of the scheduled query.</p>"
+                    }
+                },
+                "State": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>State of the scheduled query. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "PreviousInvocationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Last time the query was run.</p>"
+                    }
+                },
+                "NextInvocationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The next time the scheduled query is scheduled to run.</p>"
+                    }
+                },
+                "ScheduleConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#ScheduleConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Schedule configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "NotificationConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#NotificationConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Notification configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TargetConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#TargetConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Scheduled query target store configuration.</p>"
+                    }
+                },
+                "ScheduledQueryExecutionRoleArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>IAM role that Timestream uses to run the schedule query.</p>"
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamquery#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A customer provided KMS key used to encrypt the scheduled query resource.</p>"
+                    }
+                },
+                "ErrorReportConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#ErrorReportConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Error-reporting configuration for the scheduled query.</p>"
+                    }
+                },
+                "LastRunSummary": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryRunSummary",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Runtime summary for the last scheduled query run. </p>"
+                    }
+                },
+                "RecentlyFailedRuns": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryRunSummaryList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Runtime summary for the last five failed scheduled query runs.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Structure that describes scheduled query.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#ScheduledQuery"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9_.-]+$"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryRunStatus": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "AUTO_TRIGGER_SUCCESS",
+                        "name": "AUTO_TRIGGER_SUCCESS"
+                    },
+                    {
+                        "value": "AUTO_TRIGGER_FAILURE",
+                        "name": "AUTO_TRIGGER_FAILURE"
+                    },
+                    {
+                        "value": "MANUAL_TRIGGER_SUCCESS",
+                        "name": "MANUAL_TRIGGER_SUCCESS"
+                    },
+                    {
+                        "value": "MANUAL_TRIGGER_FAILURE",
+                        "name": "MANUAL_TRIGGER_FAILURE"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryRunSummary": {
+            "type": "structure",
+            "members": {
+                "InvocationTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>InvocationTime for this run. This is the time at which the query is scheduled to run.\n            Parameter <code>@scheduled_runtime</code> can be used in the query to get the value. </p>"
+                    }
+                },
+                "TriggerTime": {
+                    "target": "com.amazonaws.timestreamquery#Time",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The actual time when the query was run.</p>"
+                    }
+                },
+                "RunStatus": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryRunStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The status of a scheduled query run.</p>"
+                    }
+                },
+                "ExecutionStats": {
+                    "target": "com.amazonaws.timestreamquery#ExecutionStats",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Runtime statistics for a scheduled run.</p>"
+                    }
+                },
+                "ErrorReportLocation": {
+                    "target": "com.amazonaws.timestreamquery#ErrorReportLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>S3 location for error report.</p>"
+                    }
+                },
+                "FailureReason": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Error message for the scheduled query in case of failure. You might have to look at\n            the error report to get more detailed error reasons. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Run summary for the scheduled query</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryRunSummaryList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#ScheduledQueryRunSummary"
+            }
+        },
+        "com.amazonaws.timestreamquery#ScheduledQueryState": {
+            "type": "string",
+            "traits": {
+                "smithy.api#enum": [
+                    {
+                        "value": "ENABLED",
+                        "name": "ENABLED"
+                    },
+                    {
+                        "value": "DISABLED",
+                        "name": "DISABLED"
+                    }
+                ]
+            }
+        },
+        "com.amazonaws.timestreamquery#SchemaName": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#SelectColumn": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamquery#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the column.</p>"
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.timestreamquery#Type"
+                },
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamquery#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Database that has this column.</p>"
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamquery#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Table within the database that has this column. </p>"
+                    }
+                },
+                "Aliased": {
+                    "target": "com.amazonaws.timestreamquery#NullableBoolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>True, if the column name was aliased by the query. False otherwise.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details of the column that is returned by the query. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#SelectColumnList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#SelectColumn"
+            }
+        },
+        "com.amazonaws.timestreamquery#ServiceErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You have exceeded the service quota.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.timestreamquery#SnsConfiguration": {
+            "type": "structure",
+            "members": {
+                "TopicArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>SNS topic ARN that the scheduled query status notifications will be sent to.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details on SNS that are required to send the notification.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#String": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#StringValue2048": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#Tag": {
+            "type": "structure",
+            "members": {
+                "Key": {
+                    "target": "com.amazonaws.timestreamquery#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The key of the tag. Tag keys are case sensitive. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.timestreamquery#TagValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of the tag. Tag values are case sensitive and can be null. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A tag is a label that you assign to a Timestream database and/or table. Each tag\n            consists of a key and an optional value, both of which you define. Tags enable you to\n            categorize databases and/or tables, for example, by purpose, owner, or environment.\n        </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#TagKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#TagKey"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#TagList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#Tag"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#TagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#TagResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#TagResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Associate a set of tags with a Timestream resource. You can then activate these\n            user-defined tags so that they appear on the Billing and Cost Management console for\n            cost allocation tracking. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#TagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceARN": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Identifies the Timestream resource to which tags should be added. This value is an\n            Amazon Resource Name (ARN).</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.timestreamquery#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The tags to be assigned to the Timestream resource.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#TagResourceResponse": {
+            "type": "structure",
+            "members": {}
+        },
+        "com.amazonaws.timestreamquery#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#TargetConfiguration": {
+            "type": "structure",
+            "members": {
+                "TimestreamConfiguration": {
+                    "target": "com.amazonaws.timestreamquery#TimestreamConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration needed to write data into the Timestream database and table.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Configuration used for writing the output of a query.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#TargetDestination": {
+            "type": "structure",
+            "members": {
+                "TimestreamDestination": {
+                    "target": "com.amazonaws.timestreamquery#TimestreamDestination",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Query result destination details for Timestream data source.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Destination details to write data for a target data source. Current supported data\n            source is Timestream.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The request was denied due to request throttling.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.timestreamquery#Time": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.timestreamquery#TimeSeriesDataPoint": {
+            "type": "structure",
+            "members": {
+                "Time": {
+                    "target": "com.amazonaws.timestreamquery#Timestamp",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The timestamp when the measure value was collected.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.timestreamquery#Datum",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The measure value for the data point.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The timeseries data type represents the values of a measure over time. A time series\n            is an array of rows of timestamps and measure values, with rows sorted in ascending\n            order of time. A TimeSeriesDataPoint is a single data point in the time series. It\n            represents a tuple of (time, measure value) in a time series. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#TimeSeriesDataPointList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamquery#TimeSeriesDataPoint"
+            }
+        },
+        "com.amazonaws.timestreamquery#Timestamp": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamquery#TimestreamConfiguration": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamquery#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of Timestream database to which the query result will be written.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamquery#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of Timestream table that the query result will be written to. The table should\n            be within the same database that is provided in Timestream configuration.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TimeColumn": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Column from query result that should be used as the time column in destination table.\n            Column type for this should be TIMESTAMP.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DimensionMappings": {
+                    "target": "com.amazonaws.timestreamquery#DimensionMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> This is to allow mapping column(s) from the query result to the dimension in the\n            destination table. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MultiMeasureMappings": {
+                    "target": "com.amazonaws.timestreamquery#MultiMeasureMappings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Multi-measure mappings.</p>"
+                    }
+                },
+                "MixedMeasureMappings": {
+                    "target": "com.amazonaws.timestreamquery#MixedMeasureMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies how to map measures to multi-measure records.</p>"
+                    }
+                },
+                "MeasureNameColumn": {
+                    "target": "com.amazonaws.timestreamquery#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Name of the measure column.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Configuration to write data into Timestream database and table. This configuration\n            allows the user to map the query result select columns into the destination table\n            columns. </p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#TimestreamDestination": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamquery#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Timestream database name. </p>"
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamquery#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Timestream table name. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Destination for scheduled query.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#Timestream_20181101": {
+            "type": "service",
+            "version": "2018-11-01",
+            "operations": [
+                {
+                    "target": "com.amazonaws.timestreamquery#CancelQuery"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#CreateScheduledQuery"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#DeleteScheduledQuery"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#DescribeEndpoints"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#DescribeScheduledQuery"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ExecuteScheduledQuery"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ListScheduledQueries"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ListTagsForResource"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#PrepareQuery"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#Query"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#TagResource"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#UntagResource"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#UpdateScheduledQuery"
+                }
+            ],
+            "traits": {
+                "aws.api#clientEndpointDiscovery": {
+                    "operation": "com.amazonaws.timestreamquery#DescribeEndpoints",
+                    "error": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                "aws.api#service": {
+                    "sdkId": "Timestream Query",
+                    "arnNamespace": "timestream",
+                    "cloudFormationName": "TimestreamQuery",
+                    "cloudTrailEventSource": "timestreamquery.amazonaws.com",
+                    "endpointPrefix": "query.timestream"
+                },
+                "aws.auth#sigv4": {
+                    "name": "timestream"
+                },
+                "aws.protocols#awsJson1_0": {},
+                "smithy.api#documentation": "<fullname>Amazon Timestream Query\n        </fullname>\n        <p></p>",
+                "smithy.api#title": "Amazon Timestream Query",
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
+                                            "type": "tree",
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://query.timestream-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://query.timestream-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://query.timestream.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://query.timestream.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "conditions": [],
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "Region": "cn-north-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-gov-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-iso-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://query.timestream.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-isob-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "Region": "us-east-1",
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#Type": {
+            "type": "structure",
+            "members": {
+                "ScalarType": {
+                    "target": "com.amazonaws.timestreamquery#ScalarType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates if the column is of type string, integer, Boolean, double, timestamp, date,\n            time. </p>"
+                    }
+                },
+                "ArrayColumnInfo": {
+                    "target": "com.amazonaws.timestreamquery#ColumnInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates if the column is an array.</p>"
+                    }
+                },
+                "TimeSeriesMeasureValueColumnInfo": {
+                    "target": "com.amazonaws.timestreamquery#ColumnInfo",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates if the column is a timeseries data type.</p>"
+                    }
+                },
+                "RowColumnInfo": {
+                    "target": "com.amazonaws.timestreamquery#ColumnInfoList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Indicates if the column is a row.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Contains the data type of a column in a query result set. The data type can be scalar\n            or complex. The supported scalar data types are integers, Boolean, string, double,\n            timestamp, date, time, and intervals. The supported complex data types are arrays, rows,\n            and timeseries.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#UntagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#UntagResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamquery#UntagResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Removes the association of tags from a Timestream query resource.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#UntagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceARN": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Timestream resource that the tags will be removed from. This value is an Amazon\n            Resource Name (ARN). </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TagKeys": {
+                    "target": "com.amazonaws.timestreamquery#TagKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tags keys. Existing tags of the resource whose keys are members of this list\n            will be removed from the Timestream resource. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#UntagResourceResponse": {
+            "type": "structure",
+            "members": {}
+        },
+        "com.amazonaws.timestreamquery#UpdateScheduledQuery": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamquery#UpdateScheduledQueryRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamquery#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamquery#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Update a scheduled query.</p>"
+            }
+        },
+        "com.amazonaws.timestreamquery#UpdateScheduledQueryRequest": {
+            "type": "structure",
+            "members": {
+                "ScheduledQueryArn": {
+                    "target": "com.amazonaws.timestreamquery#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>ARN of the scheuled query.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "State": {
+                    "target": "com.amazonaws.timestreamquery#ScheduledQueryState",
+                    "traits": {
+                        "smithy.api#documentation": "<p>State of the scheduled query. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamquery#ValidationException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamquery#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Invalid or malformed request. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        }
+    }
+}

--- a/aws/sdk/aws-models/timestream-write.json
+++ b/aws/sdk/aws-models/timestream-write.json
@@ -1,0 +1,3663 @@
+{
+    "smithy": "2.0",
+    "metadata": {
+        "suppressions": [
+            {
+                "id": "HttpMethodSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpResponseCodeSemantics",
+                "namespace": "*"
+            },
+            {
+                "id": "PaginatedTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpHeaderTrait",
+                "namespace": "*"
+            },
+            {
+                "id": "HttpUriConflict",
+                "namespace": "*"
+            },
+            {
+                "id": "Service",
+                "namespace": "*"
+            }
+        ]
+    },
+    "shapes": {
+        "com.amazonaws.timestreamwrite#AccessDeniedException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>You are not authorized to perform this action.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 403
+            }
+        },
+        "com.amazonaws.timestreamwrite#AmazonResourceName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1011
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadDataFormat": {
+            "type": "enum",
+            "members": {
+                "CSV": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CSV"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadProgressReport": {
+            "type": "structure",
+            "members": {
+                "RecordsProcessed": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "RecordsIngested": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "ParseFailures": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "RecordIngestionFailures": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "FileFailures": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "BytesMetered": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about the progress of a batch load task.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadStatus": {
+            "type": "enum",
+            "members": {
+                "CREATED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "CREATED"
+                    }
+                },
+                "IN_PROGRESS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "IN_PROGRESS"
+                    }
+                },
+                "FAILED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "FAILED"
+                    }
+                },
+                "SUCCEEDED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SUCCEEDED"
+                    }
+                },
+                "PROGRESS_STOPPED": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PROGRESS_STOPPED"
+                    }
+                },
+                "PENDING_RESUME": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "PENDING_RESUME"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadTask": {
+            "type": "structure",
+            "members": {
+                "TaskId": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the batch load task.</p>"
+                    }
+                },
+                "TaskStatus": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status of the batch load task.</p>"
+                    }
+                },
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Database name for the database into which a batch load task loads data.</p>"
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Table name for the table into which a batch load task loads data.</p>"
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Timestream batch load task was created.</p>"
+                    }
+                },
+                "LastUpdatedTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Timestream batch load task was last updated.</p>"
+                    }
+                },
+                "ResumableUntil": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about a batch load task.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadTaskDescription": {
+            "type": "structure",
+            "members": {
+                "TaskId": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the batch load task.</p>"
+                    }
+                },
+                "ErrorMessage": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "DataSourceConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#DataSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration details about the data source for a batch load task.</p>"
+                    }
+                },
+                "ProgressReport": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadProgressReport",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "ReportConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#ReportConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Report configuration for a batch load task. This contains details about where error reports are stored.</p>"
+                    }
+                },
+                "DataModelConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#DataModelConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Data model configuration for a batch load task. This contains details about where a data model for a batch load task is stored.</p>"
+                    }
+                },
+                "TargetDatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "TargetTableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "TaskStatus": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status of the batch load task.</p>"
+                    }
+                },
+                "RecordVersion": {
+                    "target": "com.amazonaws.timestreamwrite#RecordVersion",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Timestream batch load task was created.</p>"
+                    }
+                },
+                "LastUpdatedTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Timestream batch load task was last updated.</p>"
+                    }
+                },
+                "ResumableUntil": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Details about a batch load task.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadTaskId": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 32
+                },
+                "smithy.api#pattern": "^[A-Z0-9]+$"
+            }
+        },
+        "com.amazonaws.timestreamwrite#BatchLoadTaskList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#BatchLoadTask"
+            }
+        },
+        "com.amazonaws.timestreamwrite#Boolean": {
+            "type": "boolean"
+        },
+        "com.amazonaws.timestreamwrite#ClientRequestToken": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 64
+                },
+                "smithy.api#sensitive": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ConflictException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Timestream was unable to process this request because it contains resource that\n         already exists.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 409
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateBatchLoadTask": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#CreateBatchLoadTaskRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#CreateBatchLoadTaskResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Creates a new Timestream batch load task. A batch load task processes data from\n         a CSV source in an S3 location and writes to a Timestream table. A mapping from\n         source to target is defined in a batch load task. Errors and events are written to a report\n         at an S3 location. For the report, if the KMS key is not specified, the\n         batch load task will be encrypted with a Timestream managed KMS key\n         located in your account. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed\n            keys</a>. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. For\n         details, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.create-batch-load.html\">code\n            sample</a>.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateBatchLoadTaskRequest": {
+            "type": "structure",
+            "members": {
+                "ClientToken": {
+                    "target": "com.amazonaws.timestreamwrite#ClientRequestToken",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>",
+                        "smithy.api#idempotencyToken": {}
+                    }
+                },
+                "DataModelConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#DataModelConfiguration"
+                },
+                "DataSourceConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#DataSourceConfiguration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Defines configuration details about the data source for a batch load task.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ReportConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#ReportConfiguration",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                },
+                "TargetDatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Target Timestream database for a batch load task.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TargetTableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Target Timestream table for a batch load task.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RecordVersion": {
+                    "target": "com.amazonaws.timestreamwrite#RecordVersion",
+                    "traits": {
+                        "smithy.api#default": null,
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateBatchLoadTaskResponse": {
+            "type": "structure",
+            "members": {
+                "TaskId": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the batch load task.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateDatabase": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#CreateDatabaseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#CreateDatabaseResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Creates a new Timestream database. If the KMS key is not\n         specified, the database will be encrypted with a Timestream managed KMS key located in your account. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed keys</a>. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. For\n         details, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.create-db.html\">code sample</a>.\n      </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateDatabaseRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The KMS key for the database. If the KMS key is not\n         specified, the database will be encrypted with a Timestream managed KMS key located in your account. For more information, see <a href=\"https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#aws-managed-cmk\">Amazon Web Services managed keys</a>.</p>"
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.timestreamwrite#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A list of key-value pairs to label the table. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateDatabaseResponse": {
+            "type": "structure",
+            "members": {
+                "Database": {
+                    "target": "com.amazonaws.timestreamwrite#Database",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The newly created Timestream database.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateTable": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#CreateTableRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#CreateTableResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ConflictException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Adds a new table to an existing database in your account. In an Amazon Web Services account, table names must be at least unique within each Region if they are in the same\n         database. You might have identical table names in the same Region if the tables are in\n         separate databases. While creating the table, you must specify the table name, database\n         name, and the retention properties. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.create-table.html\">code\n            sample</a> for details. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateTableRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceCreateAPIName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RetentionProperties": {
+                    "target": "com.amazonaws.timestreamwrite#RetentionProperties",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The duration for which your time-series data must be stored in the memory store and the\n         magnetic store.</p>"
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.timestreamwrite#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A list of key-value pairs to label the table. </p>"
+                    }
+                },
+                "MagneticStoreWriteProperties": {
+                    "target": "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains properties to set on the table when enabling magnetic store writes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#CreateTableResponse": {
+            "type": "structure",
+            "members": {
+                "Table": {
+                    "target": "com.amazonaws.timestreamwrite#Table",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The newly created Timestream table.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#CsvConfiguration": {
+            "type": "structure",
+            "members": {
+                "ColumnSeparator": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue1",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Column separator can be one of comma (','), pipe ('|), semicolon (';'), tab('/t'), or\n         blank space (' '). </p>"
+                    }
+                },
+                "EscapeChar": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue1",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Escape character can be one of </p>"
+                    }
+                },
+                "QuoteChar": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue1",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Can be single quote (') or double quote (\").</p>"
+                    }
+                },
+                "NullValue": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue256",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Can be blank space (' ').</p>"
+                    }
+                },
+                "TrimWhiteSpace": {
+                    "target": "com.amazonaws.timestreamwrite#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Specifies to trim leading and trailing white space.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A delimited data format where the column separator can be a comma and the record\n         separator is a newline character.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DataModel": {
+            "type": "structure",
+            "members": {
+                "TimeColumn": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue256",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Source column to be mapped to time.</p>"
+                    }
+                },
+                "TimeUnit": {
+                    "target": "com.amazonaws.timestreamwrite#TimeUnit",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The granularity of the timestamp unit. It indicates if the time value is in seconds,\n         milliseconds, nanoseconds, or other supported values. Default is <code>MILLISECONDS</code>.\n      </p>"
+                    }
+                },
+                "DimensionMappings": {
+                    "target": "com.amazonaws.timestreamwrite#DimensionMappings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Source to target mappings for dimensions.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MultiMeasureMappings": {
+                    "target": "com.amazonaws.timestreamwrite#MultiMeasureMappings",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Source to target mappings for multi-measure records.</p>"
+                    }
+                },
+                "MixedMeasureMappings": {
+                    "target": "com.amazonaws.timestreamwrite#MixedMeasureMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Source to target mappings for measures.</p>"
+                    }
+                },
+                "MeasureNameColumn": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue256",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Data model for a batch load task.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DataModelConfiguration": {
+            "type": "structure",
+            "members": {
+                "DataModel": {
+                    "target": "com.amazonaws.timestreamwrite#DataModel",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "DataModelS3Configuration": {
+                    "target": "com.amazonaws.timestreamwrite#DataModelS3Configuration",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DataModelS3Configuration": {
+            "type": "structure",
+            "members": {
+                "BucketName": {
+                    "target": "com.amazonaws.timestreamwrite#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "ObjectKey": {
+                    "target": "com.amazonaws.timestreamwrite#S3ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DataSourceConfiguration": {
+            "type": "structure",
+            "members": {
+                "DataSourceS3Configuration": {
+                    "target": "com.amazonaws.timestreamwrite#DataSourceS3Configuration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration of an S3 location for a file which contains data to load.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CsvConfiguration": {
+                    "target": "com.amazonaws.timestreamwrite#CsvConfiguration"
+                },
+                "DataFormat": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadDataFormat",
+                    "traits": {
+                        "smithy.api#documentation": "<p>This is currently CSV.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Defines configuration details about the data source.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DataSourceS3Configuration": {
+            "type": "structure",
+            "members": {
+                "BucketName": {
+                    "target": "com.amazonaws.timestreamwrite#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The bucket name of the customer S3 bucket.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ObjectKeyPrefix": {
+                    "target": "com.amazonaws.timestreamwrite#S3ObjectKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n      </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#Database": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name that uniquely identifies this database.</p>"
+                    }
+                },
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>"
+                    }
+                },
+                "TableCount": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The total number of tables found within a Timestream database. </p>"
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The identifier of the KMS key used to encrypt the data stored in the\n         database.</p>"
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the database was created, calculated from the Unix epoch time.</p>"
+                    }
+                },
+                "LastUpdatedTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The last time that this database was updated. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>A top-level container for a table. Databases and tables are the fundamental management\n         concepts in Amazon Timestream. All tables in a database are encrypted with the\n         same KMS key.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DatabaseList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#Database"
+            }
+        },
+        "com.amazonaws.timestreamwrite#Date": {
+            "type": "timestamp"
+        },
+        "com.amazonaws.timestreamwrite#DeleteDatabase": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#DeleteDatabaseRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Deletes a given Timestream database. <i>This is an irreversible\n            operation. After a database is deleted, the time-series data from its tables cannot be\n            recovered.</i>\n         </p>\n         <note>\n            <p>All tables in the database must be deleted first, or a ValidationException error will\n            be thrown. </p>\n            <p>Due to the nature of distributed retries, the operation can return either success or\n            a ResourceNotFoundException. Clients should consider them equivalent.</p>\n         </note>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.delete-db.html\">code sample</a>\n         for details.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DeleteDatabaseRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database to be deleted.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DeleteTable": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#DeleteTableRequest"
+            },
+            "output": {
+                "target": "smithy.api#Unit"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Deletes a given Timestream table. This is an irreversible operation. After a\n            Timestream database table is deleted, the time-series data stored in the table\n         cannot be recovered. </p>\n         <note>\n            <p>Due to the nature of distributed retries, the operation can return either success or\n            a ResourceNotFoundException. Clients should consider them equivalent.</p>\n         </note>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.delete-table.html\">code\n            sample</a> for details.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DeleteTableRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the database where the Timestream database is to be deleted.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table to be deleted.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeBatchLoadTask": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Returns information about the batch load task, including configurations, mappings,\n         progress, and other details. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.describe-batch-load.html\">code\n            sample</a> for details.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskRequest": {
+            "type": "structure",
+            "members": {
+                "TaskId": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the batch load task.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeBatchLoadTaskResponse": {
+            "type": "structure",
+            "members": {
+                "BatchLoadTaskDescription": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskDescription",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Description of the batch load task.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeDatabase": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#DescribeDatabaseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#DescribeDatabaseResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Returns information about the database, including the database name, time that the\n         database was created, and the total number of tables found within the database. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service\n            quotas apply</a>. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.describe-db.html\">code sample</a>\n         for details.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeDatabaseRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeDatabaseResponse": {
+            "type": "structure",
+            "members": {
+                "Database": {
+                    "target": "com.amazonaws.timestreamwrite#Database",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeEndpoints": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#DescribeEndpointsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#DescribeEndpointsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "smithy.api#documentation": "<p>Returns a list of available endpoints to make Timestream API calls against.\n         This API operation is available through both the Write and Query APIs.</p>\n         <p>Because the Timestream SDKs are designed to transparently work with the\n         service’s architecture, including the management and mapping of the service endpoints,\n            <i>we don't recommend that you use this API operation unless</i>:</p>\n         <ul>\n            <li>\n               <p>You are using <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/VPCEndpoints\">VPC endpoints (Amazon Web Services PrivateLink) with Timestream</a>\n               </p>\n            </li>\n            <li>\n               <p>Your application uses a programming language that does not yet have SDK\n               support</p>\n            </li>\n            <li>\n               <p>You require better control over the client-side implementation</p>\n            </li>\n         </ul>\n         <p>For detailed information on how and when to use and implement DescribeEndpoints, see\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/Using.API.html#Using-API.endpoint-discovery\">The\n            Endpoint Discovery Pattern</a>.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeEndpointsRequest": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeEndpointsResponse": {
+            "type": "structure",
+            "members": {
+                "Endpoints": {
+                    "target": "com.amazonaws.timestreamwrite#Endpoints",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An <code>Endpoints</code> object is returned when a <code>DescribeEndpoints</code>\n         request is made.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeTable": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#DescribeTableRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#DescribeTableResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Returns information about the table, including the table name, database name, retention\n         duration of the memory store and the magnetic store. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.describe-table.html\">code\n            sample</a> for details. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeTableRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#DescribeTableResponse": {
+            "type": "structure",
+            "members": {
+                "Table": {
+                    "target": "com.amazonaws.timestreamwrite#Table",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Timestream table.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#Dimension": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Dimension represents the metadata attributes of the time series. For example, the name\n         and Availability Zone of an EC2 instance or the name of the manufacturer of a wind turbine\n         are dimensions. </p>\n         <p>For constraints on dimension names, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.naming\">Naming\n            Constraints</a>.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The value of the dimension.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "DimensionValueType": {
+                    "target": "com.amazonaws.timestreamwrite#DimensionValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The data type of the dimension for the time-series data point.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents the metadata attributes of the time series. For example, the name and\n         Availability Zone of an EC2 instance or the name of the manufacturer of a wind turbine are\n         dimensions. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DimensionMapping": {
+            "type": "structure",
+            "members": {
+                "SourceColumn": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "DestinationColumn": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#DimensionMappings": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#DimensionMapping"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#DimensionValueType": {
+            "type": "enum",
+            "members": {
+                "VARCHAR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VARCHAR"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#Dimensions": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#Dimension"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#Endpoint": {
+            "type": "structure",
+            "members": {
+                "Address": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An endpoint address.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CachePeriodInMinutes": {
+                    "target": "com.amazonaws.timestreamwrite#Long",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The TTL for the endpoint, in minutes.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents an available endpoint against which to make API calls against, as well as the\n         TTL for that endpoint.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#Endpoints": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#Endpoint"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ErrorMessage": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamwrite#Integer": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.timestreamwrite#InternalServerException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>\n         Timestream was unable to fully process this request because of an internal server\n         error.</p>",
+                "smithy.api#error": "server",
+                "smithy.api#httpError": 500
+            }
+        },
+        "com.amazonaws.timestreamwrite#InvalidEndpointException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The requested endpoint was not valid.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 421
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListBatchLoadTasks": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#ListBatchLoadTasksRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#ListBatchLoadTasksResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Provides a list of batch load tasks, along with the name, status, when the task is\n         resumable until, and other details. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.list-batch-load-tasks.html\">code\n            sample</a> for details.</p>",
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListBatchLoadTasksRequest": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token to specify where to start paginating. This is the NextToken from a previously\n         truncated response.</p>"
+                    }
+                },
+                "MaxResults": {
+                    "target": "com.amazonaws.timestreamwrite#PageLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total number of items to return in the output. If the total number of items\n         available is more than the value specified, a NextToken is provided in the output. To\n         resume pagination, provide the NextToken value as argument of a subsequent API\n         invocation.</p>"
+                    }
+                },
+                "TaskStatus": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Status of the batch load task.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListBatchLoadTasksResponse": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token to specify where to start paginating. Provide the next\n         ListBatchLoadTasksRequest.</p>"
+                    }
+                },
+                "BatchLoadTasks": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of batch load task details.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListDatabases": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#ListDatabasesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#ListDatabasesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Returns a list of your Timestream databases. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. See\n            <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.list-db.html\">code sample</a> for\n         details. </p>",
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListDatabasesRequest": {
+            "type": "structure",
+            "members": {
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token. To resume pagination, provide the NextToken value as argument of a\n         subsequent API invocation.</p>"
+                    }
+                },
+                "MaxResults": {
+                    "target": "com.amazonaws.timestreamwrite#PaginationLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total number of items to return in the output. If the total number of items\n         available is more than the value specified, a NextToken is provided in the output. To\n         resume pagination, provide the NextToken value as argument of a subsequent API\n         invocation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListDatabasesResponse": {
+            "type": "structure",
+            "members": {
+                "Databases": {
+                    "target": "com.amazonaws.timestreamwrite#DatabaseList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of database names.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token. This parameter is returned when the response is truncated.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListTables": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#ListTablesRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#ListTablesResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Provides a list of tables, along with the name, status, and retention properties of each\n         table. See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.list-table.html\">code sample</a>\n         for details. </p>",
+                "smithy.api#paginated": {
+                    "inputToken": "NextToken",
+                    "outputToken": "NextToken",
+                    "pageSize": "MaxResults"
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListTablesRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The pagination token. To resume pagination, provide the NextToken value as argument of a\n         subsequent API invocation.</p>"
+                    }
+                },
+                "MaxResults": {
+                    "target": "com.amazonaws.timestreamwrite#PaginationLimit",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The total number of items to return in the output. If the total number of items\n         available is more than the value specified, a NextToken is provided in the output. To\n         resume pagination, provide the NextToken value as argument of a subsequent API\n         invocation.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListTablesResponse": {
+            "type": "structure",
+            "members": {
+                "Tables": {
+                    "target": "com.amazonaws.timestreamwrite#TableList",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A list of tables.</p>"
+                    }
+                },
+                "NextToken": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A token to specify where to start paginating. This is the NextToken from a previously\n         truncated response.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListTagsForResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#ListTagsForResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#ListTagsForResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> Lists all tags on a Timestream resource. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListTagsForResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceARN": {
+                    "target": "com.amazonaws.timestreamwrite#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Timestream resource with tags to be listed. This value is an Amazon\n         Resource Name (ARN). </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ListTagsForResourceResponse": {
+            "type": "structure",
+            "members": {
+                "Tags": {
+                    "target": "com.amazonaws.timestreamwrite#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The tags currently associated with the Timestream resource. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#Long": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.timestreamwrite#MagneticStoreRejectedDataLocation": {
+            "type": "structure",
+            "members": {
+                "S3Configuration": {
+                    "target": "com.amazonaws.timestreamwrite#S3Configuration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration of an S3 location to write error reports for records rejected,\n         asynchronously, during magnetic store writes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The location to write error reports for records rejected, asynchronously, during\n         magnetic store writes.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#MagneticStoreRetentionPeriodInDays": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0,
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 73000
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties": {
+            "type": "structure",
+            "members": {
+                "EnableMagneticStoreWrites": {
+                    "target": "com.amazonaws.timestreamwrite#Boolean",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A flag to enable magnetic store writes.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MagneticStoreRejectedDataLocation": {
+                    "target": "com.amazonaws.timestreamwrite#MagneticStoreRejectedDataLocation",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The location to write error reports for records rejected asynchronously during magnetic\n         store writes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The set of properties on a table for configuring magnetic store writes.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#MeasureValue": {
+            "type": "structure",
+            "members": {
+                "Name": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The name of the MeasureValue. </p>\n         <p> For constraints on MeasureValue names, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html#limits.naming\"> Naming Constraints</a> in the Amazon Timestream Developer Guide.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The value for the MeasureValue. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Type": {
+                    "target": "com.amazonaws.timestreamwrite#MeasureValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains the data type of the MeasureValue for the time-series data point.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Represents the data attribute of the time series. For example, the CPU utilization of\n         an EC2 instance or the RPM of a wind turbine are measures. MeasureValue has both name and\n         value. </p>\n         <p> MeasureValue is only allowed for type <code>MULTI</code>. Using <code>MULTI</code>\n         type, you can pass multiple data attributes associated with the same time series in a\n         single record </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#MeasureValueType": {
+            "type": "enum",
+            "members": {
+                "DOUBLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DOUBLE"
+                    }
+                },
+                "BIGINT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BIGINT"
+                    }
+                },
+                "VARCHAR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VARCHAR"
+                    }
+                },
+                "BOOLEAN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BOOLEAN"
+                    }
+                },
+                "TIMESTAMP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TIMESTAMP"
+                    }
+                },
+                "MULTI": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MULTI"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#MeasureValues": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#MeasureValue"
+            }
+        },
+        "com.amazonaws.timestreamwrite#MemoryStoreRetentionPeriodInHours": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0,
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 8766
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#MixedMeasureMapping": {
+            "type": "structure",
+            "members": {
+                "MeasureName": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "SourceColumn": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "TargetMeasureName": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "MeasureValueType": {
+                    "target": "com.amazonaws.timestreamwrite#MeasureValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MultiMeasureAttributeMappings": {
+                    "target": "com.amazonaws.timestreamwrite#MultiMeasureAttributeMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#MixedMeasureMappingList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#MixedMeasureMapping"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#MultiMeasureAttributeMapping": {
+            "type": "structure",
+            "members": {
+                "SourceColumn": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TargetMultiMeasureAttributeName": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "MeasureValueType": {
+                    "target": "com.amazonaws.timestreamwrite#ScalarMeasureValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#MultiMeasureAttributeMappingList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#MultiMeasureAttributeMapping"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#MultiMeasureMappings": {
+            "type": "structure",
+            "members": {
+                "TargetMultiMeasureName": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "MultiMeasureAttributeMappings": {
+                    "target": "com.amazonaws.timestreamwrite#MultiMeasureAttributeMappingList",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#PageLimit": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#PaginationLimit": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#range": {
+                    "min": 1,
+                    "max": 20
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#Record": {
+            "type": "structure",
+            "members": {
+                "Dimensions": {
+                    "target": "com.amazonaws.timestreamwrite#Dimensions",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains the list of dimensions for time-series data points.</p>"
+                    }
+                },
+                "MeasureName": {
+                    "target": "com.amazonaws.timestreamwrite#SchemaName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Measure represents the data attribute of the time series. For example, the CPU\n         utilization of an EC2 instance or the RPM of a wind turbine are measures. </p>"
+                    }
+                },
+                "MeasureValue": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Contains the measure value for the time-series data point. </p>"
+                    }
+                },
+                "MeasureValueType": {
+                    "target": "com.amazonaws.timestreamwrite#MeasureValueType",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Contains the data type of the measure value for the time-series data point. Default\n         type is <code>DOUBLE</code>. </p>"
+                    }
+                },
+                "Time": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue256",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Contains the time at which the measure value for the data point was collected. The time\n         value plus the unit provides the time elapsed since the epoch. For example, if the time\n         value is <code>12345</code> and the unit is <code>ms</code>, then <code>12345 ms</code>\n         have elapsed since the epoch. </p>"
+                    }
+                },
+                "TimeUnit": {
+                    "target": "com.amazonaws.timestreamwrite#TimeUnit",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The granularity of the timestamp unit. It indicates if the time value is in seconds,\n         milliseconds, nanoseconds, or other supported values. Default is <code>MILLISECONDS</code>.\n      </p>"
+                    }
+                },
+                "Version": {
+                    "target": "com.amazonaws.timestreamwrite#RecordVersion",
+                    "traits": {
+                        "smithy.api#default": null,
+                        "smithy.api#documentation": "<p>64-bit attribute used for record updates. Write requests for duplicate data with a\n         higher version number will update the existing measure value and version. In cases where\n         the measure value is the same, <code>Version</code> will still be updated. Default value is\n            <code>1</code>.</p>\n         <note>\n            <p>\n               <code>Version</code> must be <code>1</code> or greater, or you will receive a\n               <code>ValidationException</code> error.</p>\n         </note>"
+                    }
+                },
+                "MeasureValues": {
+                    "target": "com.amazonaws.timestreamwrite#MeasureValues",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Contains the list of MeasureValue for time-series data points. </p>\n         <p> This is only allowed for type <code>MULTI</code>. For scalar values, use\n            <code>MeasureValue</code> attribute of the record directly. </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a time-series data point being written into Timestream. Each record\n         contains an array of dimensions. Dimensions represent the metadata attributes of a\n         time-series data point, such as the instance name or Availability Zone of an EC2 instance.\n         A record also contains the measure name, which is the name of the measure being collected\n         (for example, the CPU utilization of an EC2 instance). Additionally, a record contains the\n         measure value and the value type, which is the data type of the measure value. Also, the\n         record contains the timestamp of when the measure was collected and the timestamp unit,\n         which represents the granularity of the timestamp. </p>\n         <p> Records have a <code>Version</code> field, which is a 64-bit <code>long</code> that you\n         can use for updating data points. Writes of a duplicate record with the same dimension,\n         timestamp, and measure name but different measure value will only succeed if the\n            <code>Version</code> attribute of the record in the write request is higher than that of\n         the existing record. Timestream defaults to a <code>Version</code> of\n            <code>1</code> for records without the <code>Version</code> field. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#RecordIndex": {
+            "type": "integer",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.timestreamwrite#RecordVersion": {
+            "type": "long",
+            "traits": {
+                "smithy.api#default": 0
+            }
+        },
+        "com.amazonaws.timestreamwrite#Records": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#Record"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 100
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#RecordsIngested": {
+            "type": "structure",
+            "members": {
+                "Total": {
+                    "target": "com.amazonaws.timestreamwrite#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Total count of successfully ingested records.</p>"
+                    }
+                },
+                "MemoryStore": {
+                    "target": "com.amazonaws.timestreamwrite#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Count of records ingested into the memory store.</p>"
+                    }
+                },
+                "MagneticStore": {
+                    "target": "com.amazonaws.timestreamwrite#Integer",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>Count of records ingested into the magnetic store.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Information on the records ingested by this request.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#RejectedRecord": {
+            "type": "structure",
+            "members": {
+                "RecordIndex": {
+                    "target": "com.amazonaws.timestreamwrite#RecordIndex",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p> The index of the record in the input request for WriteRecords. Indexes begin with 0.\n      </p>"
+                    }
+                },
+                "Reason": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The reason why a record was not successfully inserted into Timestream.\n         Possible causes of failure include: </p>\n         <ul>\n            <li>\n               <p>Records with duplicate data where there are multiple records with the same\n               dimensions, timestamps, and measure names but: </p>\n               <ul>\n                  <li>\n                     <p>Measure values are different</p>\n                  </li>\n                  <li>\n                     <p>Version is not present in the request, <i>or</i> the value of\n                     version in the new record is equal to or lower than the existing value</p>\n                  </li>\n               </ul>\n               <p>If Timestream rejects data for this case, the\n                  <code>ExistingVersion</code> field in the <code>RejectedRecords</code> response\n               will indicate the current record’s version. To force an update, you can resend the\n               request with a version for the record set to a value greater than the\n                  <code>ExistingVersion</code>.</p>\n            </li>\n            <li>\n               <p> Records with timestamps that lie outside the retention duration of the memory\n               store. </p>\n               <note>\n                  <p>When the retention window is updated, you will receive a\n                     <code>RejectedRecords</code> exception if you immediately try to ingest data\n                  within the new window. To avoid a <code>RejectedRecords</code> exception, wait\n                  until the duration of the new window to ingest new data. For further information,\n                  see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/best-practices.html#configuration\"> Best\n                     Practices for Configuring Timestream</a> and <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/storage.html\">the\n                     explanation of how storage works in Timestream</a>.</p>\n               </note>\n            </li>\n            <li>\n               <p> Records with dimensions or measures that exceed the Timestream defined\n               limits. </p>\n            </li>\n         </ul>\n         <p> For more information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Access Management</a> in the\n            Timestream Developer Guide. </p>"
+                    }
+                },
+                "ExistingVersion": {
+                    "target": "com.amazonaws.timestreamwrite#RecordVersion",
+                    "traits": {
+                        "smithy.api#default": null,
+                        "smithy.api#documentation": "<p>The existing version of the record. This value is populated in scenarios where an\n         identical record exists with a higher version than the version in the write request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Represents records that were not successfully inserted into Timestream due to\n         data validation issues that must be resolved before reinserting time-series data into the\n         system. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#RejectedRecords": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#RejectedRecord"
+            }
+        },
+        "com.amazonaws.timestreamwrite#RejectedRecordsException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+                },
+                "RejectedRecords": {
+                    "target": "com.amazonaws.timestreamwrite#RejectedRecords",
+                    "traits": {
+                        "smithy.api#documentation": "<p>\n      </p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> WriteRecords would throw this exception in the following cases: </p>\n         <ul>\n            <li>\n               <p>Records with duplicate data where there are multiple records with the same\n               dimensions, timestamps, and measure names but: </p>\n               <ul>\n                  <li>\n                     <p>Measure values are different</p>\n                  </li>\n                  <li>\n                     <p>Version is not present in the request <i>or</i> the value of\n                     version in the new record is equal to or lower than the existing value</p>\n                  </li>\n               </ul>\n               <p> In this case, if Timestream rejects data, the\n                  <code>ExistingVersion</code> field in the <code>RejectedRecords</code> response\n               will indicate the current record’s version. To force an update, you can resend the\n               request with a version for the record set to a value greater than the\n                  <code>ExistingVersion</code>.</p>\n            </li>\n            <li>\n               <p> Records with timestamps that lie outside the retention duration of the memory\n               store. </p>\n            </li>\n            <li>\n               <p> Records with dimensions or measures that exceed the Timestream defined\n               limits. </p>\n            </li>\n         </ul>\n         <p> For more information, see <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Quotas</a> in the Amazon Timestream Developer Guide. </p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 419
+            }
+        },
+        "com.amazonaws.timestreamwrite#ReportConfiguration": {
+            "type": "structure",
+            "members": {
+                "ReportS3Configuration": {
+                    "target": "com.amazonaws.timestreamwrite#ReportS3Configuration",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Configuration of an S3 location to write error reports and events for a batch\n         load.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Report configuration for a batch load task. This contains details about where error reports are stored.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ReportS3Configuration": {
+            "type": "structure",
+            "members": {
+                "BucketName": {
+                    "target": "com.amazonaws.timestreamwrite#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "ObjectKeyPrefix": {
+                    "target": "com.amazonaws.timestreamwrite#S3ObjectKeyPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "EncryptionOption": {
+                    "target": "com.amazonaws.timestreamwrite#S3EncryptionOption",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p></p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p></p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ResourceCreateAPIName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#pattern": "^[a-zA-Z0-9_.-]+$"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ResourceName": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamwrite#ResourceNotFoundException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The operation tried to access a nonexistent resource. The resource might not be\n         specified correctly, or its status might not be ACTIVE.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 404
+            }
+        },
+        "com.amazonaws.timestreamwrite#ResumeBatchLoadTask": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>\n      </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskRequest": {
+            "type": "structure",
+            "members": {
+                "TaskId": {
+                    "target": "com.amazonaws.timestreamwrite#BatchLoadTaskId",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The ID of the batch load task to resume.</p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ResumeBatchLoadTaskResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#RetentionProperties": {
+            "type": "structure",
+            "members": {
+                "MemoryStoreRetentionPeriodInHours": {
+                    "target": "com.amazonaws.timestreamwrite#MemoryStoreRetentionPeriodInHours",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The duration for which data must be stored in the memory store. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "MagneticStoreRetentionPeriodInDays": {
+                    "target": "com.amazonaws.timestreamwrite#MagneticStoreRetentionPeriodInDays",
+                    "traits": {
+                        "smithy.api#default": 0,
+                        "smithy.api#documentation": "<p>The duration for which data must be stored in the magnetic store. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Retention properties contain the duration for which your time-series data must be stored\n         in the magnetic store and the memory store. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#S3BucketName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 3,
+                    "max": 63
+                },
+                "smithy.api#pattern": "^[a-z0-9][\\.\\-a-z0-9]{1,61}[a-z0-9]$"
+            }
+        },
+        "com.amazonaws.timestreamwrite#S3Configuration": {
+            "type": "structure",
+            "members": {
+                "BucketName": {
+                    "target": "com.amazonaws.timestreamwrite#S3BucketName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The bucket name of the customer S3 bucket.</p>"
+                    }
+                },
+                "ObjectKeyPrefix": {
+                    "target": "com.amazonaws.timestreamwrite#S3ObjectKeyPrefix",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The object key preview for the customer S3 location.</p>"
+                    }
+                },
+                "EncryptionOption": {
+                    "target": "com.amazonaws.timestreamwrite#S3EncryptionOption",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The encryption option for the customer S3 location. Options are S3 server-side\n         encryption with an S3 managed key or Amazon Web Services managed key.</p>"
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The KMS key ID for the customer S3 location when encrypting with an\n            Amazon Web Services managed key.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>The configuration that specifies an S3 location.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#S3EncryptionOption": {
+            "type": "enum",
+            "members": {
+                "SSE_S3": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SSE_S3"
+                    }
+                },
+                "SSE_KMS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SSE_KMS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#S3ObjectKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1024
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+            }
+        },
+        "com.amazonaws.timestreamwrite#S3ObjectKeyPrefix": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 928
+                },
+                "smithy.api#pattern": "^[a-zA-Z0-9|!\\-_*'\\(\\)]([a-zA-Z0-9]|[!\\-_*'\\(\\)\\/.])+$"
+            }
+        },
+        "com.amazonaws.timestreamwrite#ScalarMeasureValueType": {
+            "type": "enum",
+            "members": {
+                "DOUBLE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DOUBLE"
+                    }
+                },
+                "BIGINT": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BIGINT"
+                    }
+                },
+                "BOOLEAN": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "BOOLEAN"
+                    }
+                },
+                "VARCHAR": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "VARCHAR"
+                    }
+                },
+                "TIMESTAMP": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "TIMESTAMP"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#SchemaName": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#SchemaValue": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamwrite#ServiceQuotaExceededException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage"
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> The instance quota of resource exceeded for this account.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 402
+            }
+        },
+        "com.amazonaws.timestreamwrite#String": {
+            "type": "string"
+        },
+        "com.amazonaws.timestreamwrite#StringValue1": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 1
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#StringValue2048": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 2048
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#StringValue256": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#Table": {
+            "type": "structure",
+            "members": {
+                "Arn": {
+                    "target": "com.amazonaws.timestreamwrite#String",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The Amazon Resource Name that uniquely identifies this table.</p>"
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table.</p>"
+                    }
+                },
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database that contains this table.</p>"
+                    }
+                },
+                "TableStatus": {
+                    "target": "com.amazonaws.timestreamwrite#TableStatus",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The current state of the table:</p>\n         <ul>\n            <li>\n               <p>\n                  <code>DELETING</code> - The table is being deleted.</p>\n            </li>\n            <li>\n               <p>\n                  <code>ACTIVE</code> - The table is ready for use.</p>\n            </li>\n         </ul>"
+                    }
+                },
+                "RetentionProperties": {
+                    "target": "com.amazonaws.timestreamwrite#RetentionProperties",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retention duration for the memory store and magnetic store.</p>"
+                    }
+                },
+                "CreationTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Timestream table was created. </p>"
+                    }
+                },
+                "LastUpdatedTime": {
+                    "target": "com.amazonaws.timestreamwrite#Date",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The time when the Timestream table was last updated.</p>"
+                    }
+                },
+                "MagneticStoreWriteProperties": {
+                    "target": "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains properties to set on the table when enabling magnetic store writes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p>Represents a database table in Timestream. Tables contain one or more related\n         time series. You can modify the retention duration of the memory store and the magnetic\n         store for a table. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#TableList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#Table"
+            }
+        },
+        "com.amazonaws.timestreamwrite#TableStatus": {
+            "type": "enum",
+            "members": {
+                "ACTIVE": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "ACTIVE"
+                    }
+                },
+                "DELETING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "DELETING"
+                    }
+                },
+                "RESTORING": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "RESTORING"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#Tag": {
+            "type": "structure",
+            "members": {
+                "Key": {
+                    "target": "com.amazonaws.timestreamwrite#TagKey",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The key of the tag. Tag keys are case sensitive. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Value": {
+                    "target": "com.amazonaws.timestreamwrite#TagValue",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The value of the tag. Tag values are case-sensitive and can be null. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> A tag is a label that you assign to a Timestream database and/or table. Each\n         tag consists of a key and an optional value, both of which you define. With tags, you can\n         categorize databases and/or tables, for example, by purpose, owner, or environment. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagKey": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 1,
+                    "max": 128
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagKeyList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#TagKey"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagList": {
+            "type": "list",
+            "member": {
+                "target": "com.amazonaws.timestreamwrite#Tag"
+            },
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 200
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#TagResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#TagResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> Associates a set of tags with a Timestream resource. You can then activate\n         these user-defined tags so that they appear on the Billing and Cost Management console for\n         cost allocation tracking. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceARN": {
+                    "target": "com.amazonaws.timestreamwrite#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> Identifies the Timestream resource to which tags should be added. This value\n         is an Amazon Resource Name (ARN). </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "Tags": {
+                    "target": "com.amazonaws.timestreamwrite#TagList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The tags to be assigned to the Timestream resource. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagResourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#TagValue": {
+            "type": "string",
+            "traits": {
+                "smithy.api#length": {
+                    "min": 0,
+                    "max": 256
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#ThrottlingException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> Too many requests were made by a user and they exceeded the service quotas. The request\n         was throttled.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 429
+            }
+        },
+        "com.amazonaws.timestreamwrite#TimeUnit": {
+            "type": "enum",
+            "members": {
+                "MILLISECONDS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MILLISECONDS"
+                    }
+                },
+                "SECONDS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "SECONDS"
+                    }
+                },
+                "MICROSECONDS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "MICROSECONDS"
+                    }
+                },
+                "NANOSECONDS": {
+                    "target": "smithy.api#Unit",
+                    "traits": {
+                        "smithy.api#enumValue": "NANOSECONDS"
+                    }
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#Timestream_20181101": {
+            "type": "service",
+            "version": "2018-11-01",
+            "operations": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#CreateBatchLoadTask"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#CreateDatabase"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#CreateTable"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#DeleteDatabase"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#DeleteTable"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#DescribeBatchLoadTask"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#DescribeDatabase"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#DescribeEndpoints"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#DescribeTable"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ListBatchLoadTasks"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ListDatabases"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ListTables"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ListTagsForResource"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResumeBatchLoadTask"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#TagResource"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#UntagResource"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#UpdateDatabase"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#UpdateTable"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#WriteRecords"
+                }
+            ],
+            "traits": {
+                "aws.api#clientEndpointDiscovery": {
+                    "operation": "com.amazonaws.timestreamwrite#DescribeEndpoints",
+                    "error": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                "aws.api#service": {
+                    "sdkId": "Timestream Write",
+                    "arnNamespace": "timestream",
+                    "cloudFormationName": "TimestreamWrite",
+                    "cloudTrailEventSource": "timestreamwrite.amazonaws.com",
+                    "endpointPrefix": "ingest.timestream"
+                },
+                "aws.auth#sigv4": {
+                    "name": "timestream"
+                },
+                "aws.protocols#awsJson1_0": {},
+                "smithy.api#documentation": "<fullname>Amazon Timestream Write</fullname>\n         <p>Amazon Timestream is a fast, scalable, fully managed time-series database service\n         that makes it easy to store and analyze trillions of time-series data points per day. With\n            Timestream, you can easily store and analyze IoT sensor data to derive insights\n         from your IoT applications. You can analyze industrial telemetry to streamline equipment\n         management and maintenance. You can also store and analyze log data and metrics to improve\n         the performance and availability of your applications. </p>\n         <p>Timestream is built from the ground up to effectively ingest, process, and\n         store time-series data. It organizes data to optimize query processing. It automatically\n         scales based on the volume of data ingested and on the query volume to ensure you receive\n         optimal performance while inserting and querying data. As your data grows over time,\n            Timestream’s adaptive query processing engine spans across storage tiers to\n         provide fast analysis while reducing costs.</p>",
+                "smithy.api#title": "Amazon Timestream Write",
+                "smithy.rules#endpointRuleSet": {
+                    "version": "1.0",
+                    "parameters": {
+                        "Region": {
+                            "builtIn": "AWS::Region",
+                            "required": false,
+                            "documentation": "The AWS region used to dispatch the request.",
+                            "type": "String"
+                        },
+                        "UseDualStack": {
+                            "builtIn": "AWS::UseDualStack",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, use the dual-stack endpoint. If the configured endpoint does not support dual-stack, dispatching the request MAY return an error.",
+                            "type": "Boolean"
+                        },
+                        "UseFIPS": {
+                            "builtIn": "AWS::UseFIPS",
+                            "required": true,
+                            "default": false,
+                            "documentation": "When true, send this request to the FIPS-compliant regional endpoint. If the configured endpoint does not have a FIPS compliant endpoint, dispatching the request will return an error.",
+                            "type": "Boolean"
+                        },
+                        "Endpoint": {
+                            "builtIn": "SDK::Endpoint",
+                            "required": false,
+                            "documentation": "Override the endpoint used to send this request",
+                            "type": "String"
+                        }
+                    },
+                    "rules": [
+                        {
+                            "conditions": [
+                                {
+                                    "fn": "isSet",
+                                    "argv": [
+                                        {
+                                            "ref": "Endpoint"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "booleanEquals",
+                                            "argv": [
+                                                {
+                                                    "ref": "UseFIPS"
+                                                },
+                                                true
+                                            ]
+                                        }
+                                    ],
+                                    "error": "Invalid Configuration: FIPS and custom endpoint are not supported",
+                                    "type": "error"
+                                },
+                                {
+                                    "conditions": [],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "booleanEquals",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "UseDualStack"
+                                                        },
+                                                        true
+                                                    ]
+                                                }
+                                            ],
+                                            "error": "Invalid Configuration: Dualstack and custom endpoint are not supported",
+                                            "type": "error"
+                                        },
+                                        {
+                                            "conditions": [],
+                                            "endpoint": {
+                                                "url": {
+                                                    "ref": "Endpoint"
+                                                },
+                                                "properties": {},
+                                                "headers": {}
+                                            },
+                                            "type": "endpoint"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "conditions": [],
+                            "type": "tree",
+                            "rules": [
+                                {
+                                    "conditions": [
+                                        {
+                                            "fn": "isSet",
+                                            "argv": [
+                                                {
+                                                    "ref": "Region"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "type": "tree",
+                                    "rules": [
+                                        {
+                                            "conditions": [
+                                                {
+                                                    "fn": "aws.partition",
+                                                    "argv": [
+                                                        {
+                                                            "ref": "Region"
+                                                        }
+                                                    ],
+                                                    "assign": "PartitionResult"
+                                                }
+                                            ],
+                                            "type": "tree",
+                                            "rules": [
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        },
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://ingest.timestream-fips.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS and DualStack are enabled, but this partition does not support one or both",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseFIPS"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsFIPS"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://ingest.timestream-fips.{Region}.{PartitionResult#dnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "FIPS is enabled but this partition does not support FIPS",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [
+                                                        {
+                                                            "fn": "booleanEquals",
+                                                            "argv": [
+                                                                {
+                                                                    "ref": "UseDualStack"
+                                                                },
+                                                                true
+                                                            ]
+                                                        }
+                                                    ],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [
+                                                                {
+                                                                    "fn": "booleanEquals",
+                                                                    "argv": [
+                                                                        true,
+                                                                        {
+                                                                            "fn": "getAttr",
+                                                                            "argv": [
+                                                                                {
+                                                                                    "ref": "PartitionResult"
+                                                                                },
+                                                                                "supportsDualStack"
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ],
+                                                            "type": "tree",
+                                                            "rules": [
+                                                                {
+                                                                    "conditions": [],
+                                                                    "type": "tree",
+                                                                    "rules": [
+                                                                        {
+                                                                            "conditions": [],
+                                                                            "endpoint": {
+                                                                                "url": "https://ingest.timestream.{Region}.{PartitionResult#dualStackDnsSuffix}",
+                                                                                "properties": {},
+                                                                                "headers": {}
+                                                                            },
+                                                                            "type": "endpoint"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "conditions": [],
+                                                            "error": "DualStack is enabled but this partition does not support DualStack",
+                                                            "type": "error"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "conditions": [],
+                                                    "type": "tree",
+                                                    "rules": [
+                                                        {
+                                                            "conditions": [],
+                                                            "endpoint": {
+                                                                "url": "https://ingest.timestream.{Region}.{PartitionResult#dnsSuffix}",
+                                                                "properties": {},
+                                                                "headers": {}
+                                                            },
+                                                            "type": "endpoint"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "conditions": [],
+                                    "error": "Invalid Configuration: Missing Region",
+                                    "type": "error"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "smithy.rules#endpointTests": {
+                    "testCases": [
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.us-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.us-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.cn-north-1.api.amazonwebservices.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region cn-north-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.cn-north-1.amazonaws.com.cn"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "cn-north-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack enabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.us-gov-east-1.api.aws"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-gov-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.us-gov-east-1.amazonaws.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-gov-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-iso-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.us-iso-east-1.c2s.ic.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-iso-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS enabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream-fips.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For region us-isob-east-1 with FIPS disabled and DualStack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://ingest.timestream.us-isob-east-1.sc2s.sgov.gov"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-isob-east-1"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with region not set and fips disabled and dualstack disabled",
+                            "expect": {
+                                "endpoint": {
+                                    "url": "https://example.com"
+                                }
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": false,
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips enabled and dualstack disabled",
+                            "expect": {
+                                "error": "Invalid Configuration: FIPS and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "UseDualStack": false,
+                                "UseFIPS": true,
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        },
+                        {
+                            "documentation": "For custom endpoint with fips disabled and dualstack enabled",
+                            "expect": {
+                                "error": "Invalid Configuration: Dualstack and custom endpoint are not supported"
+                            },
+                            "params": {
+                                "UseDualStack": true,
+                                "UseFIPS": false,
+                                "Region": "us-east-1",
+                                "Endpoint": "https://example.com"
+                            }
+                        }
+                    ],
+                    "version": "1.0"
+                }
+            }
+        },
+        "com.amazonaws.timestreamwrite#UntagResource": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#UntagResourceRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#UntagResourceResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> Removes the association of tags from a Timestream resource. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#UntagResourceRequest": {
+            "type": "structure",
+            "members": {
+                "ResourceARN": {
+                    "target": "com.amazonaws.timestreamwrite#AmazonResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The Timestream resource that the tags will be removed from. This value is an\n         Amazon Resource Name (ARN). </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TagKeys": {
+                    "target": "com.amazonaws.timestreamwrite#TagKeyList",
+                    "traits": {
+                        "smithy.api#documentation": "<p> A list of tags keys. Existing tags of the resource whose keys are members of this list\n         will be removed from the Timestream resource. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#UntagResourceResponse": {
+            "type": "structure",
+            "members": {},
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#UpdateDatabase": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#UpdateDatabaseRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#UpdateDatabaseResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ServiceQuotaExceededException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p> Modifies the KMS key for an existing database. While updating the\n         database, you must specify the database name and the identifier of the new KMS key to be used (<code>KmsKeyId</code>). If there are any concurrent\n            <code>UpdateDatabase</code> requests, first writer wins. </p>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.update-db.html\">code sample</a>\n         for details.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#UpdateDatabaseRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The name of the database. </p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "KmsKeyId": {
+                    "target": "com.amazonaws.timestreamwrite#StringValue2048",
+                    "traits": {
+                        "smithy.api#documentation": "<p> The identifier of the new KMS key (<code>KmsKeyId</code>) to be used to\n         encrypt the data stored in the database. If the <code>KmsKeyId</code> currently registered\n         with the database is the same as the <code>KmsKeyId</code> in the request, there will not\n         be any update. </p>\n         <p>You can specify the <code>KmsKeyId</code> using any of the following:</p>\n         <ul>\n            <li>\n               <p>Key ID: <code>1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Key ARN:\n                  <code>arn:aws:kms:us-east-1:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias name: <code>alias/ExampleAlias</code>\n               </p>\n            </li>\n            <li>\n               <p>Alias ARN:\n               <code>arn:aws:kms:us-east-1:111122223333:alias/ExampleAlias</code>\n               </p>\n            </li>\n         </ul>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#UpdateDatabaseResponse": {
+            "type": "structure",
+            "members": {
+                "Database": {
+                    "target": "com.amazonaws.timestreamwrite#Database"
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#UpdateTable": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#UpdateTableRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#UpdateTableResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Modifies the retention duration of the memory store and magnetic store for your Timestream table. Note that the change in retention duration takes effect immediately.\n         For example, if the retention period of the memory store was initially set to 2 hours and\n         then changed to 24 hours, the memory store will be capable of holding 24 hours of data, but\n         will be populated with 24 hours of data 22 hours after this change was made. Timestream does not retrieve data from the magnetic store to populate the memory store. </p>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.update-table.html\">code\n            sample</a> for details.</p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#UpdateTableRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "RetentionProperties": {
+                    "target": "com.amazonaws.timestreamwrite#RetentionProperties",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The retention duration of the memory store and the magnetic store.</p>"
+                    }
+                },
+                "MagneticStoreWriteProperties": {
+                    "target": "com.amazonaws.timestreamwrite#MagneticStoreWriteProperties",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Contains properties to set on the table when enabling magnetic store writes.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#UpdateTableResponse": {
+            "type": "structure",
+            "members": {
+                "Table": {
+                    "target": "com.amazonaws.timestreamwrite#Table",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The updated Timestream table.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#ValidationException": {
+            "type": "structure",
+            "members": {
+                "Message": {
+                    "target": "com.amazonaws.timestreamwrite#ErrorMessage",
+                    "traits": {
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#documentation": "<p> An invalid or malformed request.</p>",
+                "smithy.api#error": "client",
+                "smithy.api#httpError": 400
+            }
+        },
+        "com.amazonaws.timestreamwrite#WriteRecords": {
+            "type": "operation",
+            "input": {
+                "target": "com.amazonaws.timestreamwrite#WriteRecordsRequest"
+            },
+            "output": {
+                "target": "com.amazonaws.timestreamwrite#WriteRecordsResponse"
+            },
+            "errors": [
+                {
+                    "target": "com.amazonaws.timestreamwrite#AccessDeniedException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InternalServerException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#InvalidEndpointException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#RejectedRecordsException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ResourceNotFoundException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ThrottlingException"
+                },
+                {
+                    "target": "com.amazonaws.timestreamwrite#ValidationException"
+                }
+            ],
+            "traits": {
+                "aws.api#clientDiscoveredEndpoint": {
+                    "required": true
+                },
+                "smithy.api#documentation": "<p>Enables you to write your time-series data into Timestream. You can specify a\n         single data point or a batch of data points to be inserted into the system. Timestream offers you a flexible schema that auto detects the column names and data\n         types for your Timestream tables based on the dimension names and data types of\n         the data points you specify when invoking writes into the database. </p>\n         <p>Timestream supports eventual consistency read semantics. This means that when\n         you query data immediately after writing a batch of data into Timestream, the\n         query results might not reflect the results of a recently completed write operation. The\n         results may also include some stale data. If you repeat the query request after a short\n         time, the results should return the latest data. <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/ts-limits.html\">Service quotas apply</a>. </p>\n         <p>See <a href=\"https://docs.aws.amazon.com/timestream/latest/developerguide/code-samples.write.html\">code sample</a> for\n         details.</p>\n         <p>\n            <b>Upserts</b>\n         </p>\n         <p>You can use the <code>Version</code> parameter in a <code>WriteRecords</code> request to\n         update data points. Timestream tracks a version number with each record.\n            <code>Version</code> defaults to <code>1</code> when it's not specified for the record\n         in the request. Timestream updates an existing record’s measure value along with\n         its <code>Version</code> when it receives a write request with a higher\n            <code>Version</code> number for that record. When it receives an update request where\n         the measure value is the same as that of the existing record, Timestream still\n         updates <code>Version</code>, if it is greater than the existing value of\n            <code>Version</code>. You can update a data point as many times as desired, as long as\n         the value of <code>Version</code> continuously increases. </p>\n         <p> For example, suppose you write a new record without indicating <code>Version</code> in\n         the request. Timestream stores this record, and set <code>Version</code> to\n            <code>1</code>. Now, suppose you try to update this record with a\n            <code>WriteRecords</code> request of the same record with a different measure value but,\n         like before, do not provide <code>Version</code>. In this case, Timestream will\n         reject this update with a <code>RejectedRecordsException</code> since the updated record’s\n         version is not greater than the existing value of Version. </p>\n         <p>However, if you were to resend the update request with <code>Version</code> set to\n            <code>2</code>, Timestream would then succeed in updating the record’s value,\n         and the <code>Version</code> would be set to <code>2</code>. Next, suppose you sent a\n            <code>WriteRecords</code> request with this same record and an identical measure value,\n         but with <code>Version</code> set to <code>3</code>. In this case, Timestream\n         would only update <code>Version</code> to <code>3</code>. Any further updates would need to\n         send a version number greater than <code>3</code>, or the update requests would receive a\n            <code>RejectedRecordsException</code>. </p>"
+            }
+        },
+        "com.amazonaws.timestreamwrite#WriteRecordsRequest": {
+            "type": "structure",
+            "members": {
+                "DatabaseName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream database.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "TableName": {
+                    "target": "com.amazonaws.timestreamwrite#ResourceName",
+                    "traits": {
+                        "smithy.api#documentation": "<p>The name of the Timestream table.</p>",
+                        "smithy.api#required": {}
+                    }
+                },
+                "CommonAttributes": {
+                    "target": "com.amazonaws.timestreamwrite#Record",
+                    "traits": {
+                        "smithy.api#documentation": "<p>A record that contains the common measure, dimension, time, and version attributes\n         shared across all the records in the request. The measure and dimension attributes\n         specified will be merged with the measure and dimension attributes in the records object\n         when the data is written into Timestream. Dimensions may not overlap, or a\n            <code>ValidationException</code> will be thrown. In other words, a record must contain\n         dimensions with unique names. </p>"
+                    }
+                },
+                "Records": {
+                    "target": "com.amazonaws.timestreamwrite#Records",
+                    "traits": {
+                        "smithy.api#documentation": "<p>An array of records that contain the unique measure, dimension, time, and version\n         attributes for each time-series data point. </p>",
+                        "smithy.api#required": {}
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#input": {}
+            }
+        },
+        "com.amazonaws.timestreamwrite#WriteRecordsResponse": {
+            "type": "structure",
+            "members": {
+                "RecordsIngested": {
+                    "target": "com.amazonaws.timestreamwrite#RecordsIngested",
+                    "traits": {
+                        "smithy.api#documentation": "<p>Information on the records ingested by this request.</p>"
+                    }
+                }
+            },
+            "traits": {
+                "smithy.api#output": {}
+            }
+        }
+    }
+}

--- a/aws/sdk/gradle.properties
+++ b/aws/sdk/gradle.properties
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# timestream requires endpoint discovery: https://github.com/awslabs/aws-sdk-rust/issues/114
-aws.services=-timestreamwrite,-timestreamquery
+aws.services=
 
 # List of services to generate Event Stream operations for:
 aws.services.eventstream.allowlist=\

--- a/aws/sdk/integration-tests/Cargo.toml
+++ b/aws/sdk/integration-tests/Cargo.toml
@@ -15,5 +15,6 @@ members = [
     "s3control",
     "sts",
     "transcribestreaming",
+    "timestreamquery",
     "webassembly",
 ]

--- a/aws/sdk/integration-tests/timestreamquery/Cargo.toml
+++ b/aws/sdk/integration-tests/timestreamquery/Cargo.toml
@@ -1,0 +1,20 @@
+# This Cargo.toml is unused in generated code. It exists solely to enable these tests to compile in-situ
+[package]
+name = "timestream-tests"
+version = "0.1.0"
+authors = ["Russell Cohen <rcoh@amazon.com>"]
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/awslabs/smithy-rs"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dev-dependencies]
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
+aws-sdk-timestreamquery = { path = "../../build/aws-sdk/sdk/timestreamquery" }
+tokio = { version = "1.23.1", features = ["full", "test-util"] }
+aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util"] }
+aws-smithy-async = { path = "../../build/aws-sdk/sdk/aws-smithy-async", features = ["test-util"] }
+aws-types = { path = "../../build/aws-sdk/sdk/aws-types" }
+tracing-subscriber = "0.3.17"

--- a/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
+++ b/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
@@ -1,0 +1,76 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_credential_types::provider::SharedCredentialsProvider;
+use aws_sdk_timestreamquery as query;
+use aws_sdk_timestreamquery::config::Credentials;
+use aws_smithy_async::test_util::controlled_time_and_sleep;
+use aws_smithy_async::time::{SharedTimeSource, TimeSource};
+use aws_smithy_client::dvr::{MediaType, ReplayingConnection};
+use aws_types::region::Region;
+use aws_types::SdkConfig;
+use std::sync::Arc;
+use std::time::{Duration, UNIX_EPOCH};
+
+#[tokio::test]
+async fn do_endpoint_discovery() {
+    tracing_subscriber::fmt::init();
+    let conn = ReplayingConnection::from_file("tests/traffic.json").unwrap();
+    //let conn = aws_smithy_client::dvr::RecordingConnection::new(conn);
+    let start = UNIX_EPOCH + Duration::from_secs(1234567890);
+    let (ts, sleep, mut gate) = controlled_time_and_sleep(start);
+    let config = SdkConfig::builder()
+        .http_connector(conn.clone())
+        .region(Region::from_static("us-west-2"))
+        .sleep_impl(Arc::new(sleep))
+        .credentials_provider(SharedCredentialsProvider::new(Credentials::for_tests()))
+        .time_source(SharedTimeSource::new(ts.clone()))
+        .build();
+    let conf = query::config::Builder::from(&config)
+        .make_token("0000-0000-0000")
+        .build();
+    let (client, reloader) = query::Client::from_conf(conf)
+        .enable_endpoint_discovery()
+        .await
+        .expect("initial setup of endpoint discovery failed");
+
+    tokio::spawn(reloader.reload_task());
+
+    let _resp = client
+        .query()
+        .query_string("SELECT now() as time_now")
+        .send()
+        .await
+        .unwrap();
+
+    // wait 10 minutes for the endpoint to expire
+    while ts.now() < start + Duration::from_secs(60 * 10) {
+        assert_eq!(
+            gate.expect_sleep().await.duration(),
+            Duration::from_secs(60)
+        );
+    }
+
+    // the recording validates that this request hits another endpoint
+    let _resp = client
+        .query()
+        .query_string("SELECT now() as time_now")
+        .send()
+        .await
+        .unwrap();
+    // if you want to update this test:
+    // conn.dump_to_file("tests/traffic.json").unwrap();
+    conn.validate_body_and_headers(
+        Some(&[
+            "x-amz-security-token",
+            "x-amz-date",
+            "content-type",
+            "x-amz-target",
+        ]),
+        MediaType::Json,
+    )
+    .await
+    .unwrap();
+}

--- a/aws/sdk/integration-tests/timestreamquery/tests/traffic.json
+++ b/aws/sdk/integration-tests/timestreamquery/tests/traffic.json
@@ -1,0 +1,407 @@
+{
+  "events": [
+    {
+      "connection_id": 0,
+      "action": {
+        "Request": {
+          "request": {
+            "uri": "https://query.timestream.us-west-2.amazonaws.com/",
+            "headers": {
+              "content-type": [
+                "application/x-amz-json-1.0"
+              ],
+              "x-amz-user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head api/timestreamquery/0.0.0-local os/macos lang/rust/1.67.1"
+              ],
+              "authorization": [
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/timestream/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, Signature=1b50e2545f06c8e1ca0e205c20f25a34b6aab82f3a47e4cc370e9a5fea01d08c"
+              ],
+              "x-amz-security-token": [
+                "notarealsessiontoken"
+              ],
+              "x-amz-target": [
+                "Timestream_20181101.DescribeEndpoints"
+              ],
+              "user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head os/macos lang/rust/1.67.1"
+              ],
+              "x-amz-date": [
+                "20090213T233130Z"
+              ]
+            },
+            "method": "POST"
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{}"
+          },
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Response": {
+          "response": {
+            "Ok": {
+              "status": 200,
+              "version": "HTTP/1.1",
+              "headers": {
+                "x-amzn-requestid": [
+                  "fcfdab03-2bb8-45e9-a284-b789cf7efb63"
+                ],
+                "content-type": [
+                  "application/x-amz-json-1.0"
+                ],
+                "date": [
+                  "Wed, 24 May 2023 15:51:07 GMT"
+                ],
+                "content-length": [
+                  "104"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"Endpoints\":[{\"Address\":\"query-cell1.timestream.us-west-2.amazonaws.com\",\"CachePeriodInMinutes\":10}]}"
+          },
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 0,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 1,
+      "action": {
+        "Request": {
+          "request": {
+            "uri": "https://query-cell1.timestream.us-west-2.amazonaws.com/",
+            "headers": {
+              "content-type": [
+                "application/x-amz-json-1.0"
+              ],
+              "content-length": [
+                "73"
+              ],
+              "x-amz-security-token": [
+                "notarealsessiontoken"
+              ],
+              "user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head os/macos lang/rust/1.67.1"
+              ],
+              "x-amz-date": [
+                "20090213T233130Z"
+              ],
+              "authorization": [
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/timestream/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, Signature=8174b6ca0ece22834b562b60785f47ef354b2c1ddf7a541482f255006b5f98c2"
+              ],
+              "x-amz-user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head api/timestreamquery/0.0.0-local os/macos lang/rust/1.67.1"
+              ],
+              "x-amz-target": [
+                "Timestream_20181101.Query"
+              ]
+            },
+            "method": "POST"
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 1,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"QueryString\":\"SELECT now() as time_now\",\"ClientToken\":\"0000-0000-0000\"}"
+          },
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 1,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 1,
+      "action": {
+        "Response": {
+          "response": {
+            "Ok": {
+              "status": 200,
+              "version": "HTTP/1.1",
+              "headers": {
+                "content-type": [
+                  "application/x-amz-json-1.0"
+                ],
+                "date": [
+                  "Wed, 24 May 2023 15:51:08 GMT"
+                ],
+                "x-amzn-requestid": [
+                  "OFO47BQ6XAXGTIK3XH4S6GBFLQ"
+                ],
+                "content-length": [
+                  "318"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 1,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"ColumnInfo\":[{\"Name\":\"time_now\",\"Type\":{\"ScalarType\":\"TIMESTAMP\"}}],\"QueryId\":\"AEDACANMQDLSTQR3SPDV6HEWYACX5IALTEWGK7JM3VSFQQ5J5F3HGKVEMNHBRHY\",\"QueryStatus\":{\"CumulativeBytesMetered\":10000000,\"CumulativeBytesScanned\":0,\"ProgressPercentage\":100.0},\"Rows\":[{\"Data\":[{\"ScalarValue\":\"2023-05-24 15:51:08.760000000\"}]}]}"
+          },
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 1,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 2,
+      "action": {
+        "Request": {
+          "request": {
+            "uri": "https://query.timestream.us-west-2.amazonaws.com/",
+            "headers": {
+              "content-type": [
+                "application/x-amz-json-1.0"
+              ],
+              "user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head os/macos lang/rust/1.67.1"
+              ],
+              "x-amz-user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head api/timestreamquery/0.0.0-local os/macos lang/rust/1.67.1"
+              ],
+              "x-amz-date": [
+                "20090213T234030Z"
+              ],
+              "authorization": [
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/timestream/aws4_request, SignedHeaders=content-type;host;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, Signature=32e468e574c514ba0fa4a0f0304cef82b72f82965b9e8792fd63f6efb67b297c"
+              ],
+              "x-amz-target": [
+                "Timestream_20181101.DescribeEndpoints"
+              ],
+              "x-amz-security-token": [
+                "notarealsessiontoken"
+              ]
+            },
+            "method": "POST"
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 2,
+      "action": {
+        "Response": {
+          "response": {
+            "Ok": {
+              "status": 200,
+              "version": "HTTP/1.1",
+              "headers": {
+                "content-type": [
+                  "application/x-amz-json-1.0"
+                ],
+                "content-length": [
+                  "104"
+                ],
+                "date": [
+                  "Wed, 24 May 2023 15:51:07 GMT"
+                ],
+                "x-amzn-requestid": [
+                  "fcfdab03-2bb8-45e9-a284-b789cf7efb63"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 2,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{}"
+          },
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 2,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 2,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"Endpoints\":[{\"Address\":\"query-cell2.timestream.us-west-2.amazonaws.com\",\"CachePeriodInMinutes\":10}]}"
+          },
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 2,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 3,
+      "action": {
+        "Request": {
+          "request": {
+            "uri": "https://query-cell2.timestream.us-west-2.amazonaws.com/",
+            "headers": {
+              "authorization": [
+                "AWS4-HMAC-SHA256 Credential=ANOTREAL/20090213/us-west-2/timestream/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token;x-amz-target;x-amz-user-agent, Signature=8b2abd7688aefb4004200e5fa087f6c154fde879f2df79d3f6c57934cdc8f62a"
+              ],
+              "x-amz-date": [
+                "20090213T234130Z"
+              ],
+              "user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head os/macos lang/rust/1.67.1"
+              ],
+              "x-amz-target": [
+                "Timestream_20181101.Query"
+              ],
+              "x-amz-user-agent": [
+                "aws-sdk-rust/0.0.0-smithy-rs-head api/timestreamquery/0.0.0-local os/macos lang/rust/1.67.1"
+              ],
+              "content-type": [
+                "application/x-amz-json-1.0"
+              ],
+              "content-length": [
+                "73"
+              ],
+              "x-amz-security-token": [
+                "notarealsessiontoken"
+              ]
+            },
+            "method": "POST"
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 3,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"QueryString\":\"SELECT now() as time_now\",\"ClientToken\":\"0000-0000-0000\"}"
+          },
+          "direction": "Request"
+        }
+      }
+    },
+    {
+      "connection_id": 3,
+      "action": {
+        "Response": {
+          "response": {
+            "Ok": {
+              "status": 200,
+              "version": "HTTP/1.1",
+              "headers": {
+                "content-type": [
+                  "application/x-amz-json-1.0"
+                ],
+                "date": [
+                  "Wed, 24 May 2023 15:51:08 GMT"
+                ],
+                "x-amzn-requestid": [
+                  "OFO47BQ6XAXGTIK3XH4S6GBFLQ"
+                ],
+                "content-length": [
+                  "318"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "connection_id": 3,
+      "action": {
+        "Data": {
+          "data": {
+            "Utf8": "{\"ColumnInfo\":[{\"Name\":\"time_now\",\"Type\":{\"ScalarType\":\"TIMESTAMP\"}}],\"QueryId\":\"AEDACANMQDLSTQR3SPDV6HEWYACX5IALTEWGK7JM3VSFQQ5J5F3HGKVEMNHBRHY\",\"QueryStatus\":{\"CumulativeBytesMetered\":10000000,\"CumulativeBytesScanned\":0,\"ProgressPercentage\":100.0},\"Rows\":[{\"Data\":[{\"ScalarValue\":\"2023-05-24 15:51:08.760000000\"}]}]}"
+          },
+          "direction": "Response"
+        }
+      }
+    },
+    {
+      "connection_id": 3,
+      "action": {
+        "Eof": {
+          "ok": true,
+          "direction": "Response"
+        }
+      }
+    }
+  ],
+  "docs": "todo docs",
+  "version": "V0"
+}

--- a/aws/sra-test/integration-tests/aws-sdk-s3/Cargo.toml
+++ b/aws/sra-test/integration-tests/aws-sdk-s3/Cargo.toml
@@ -12,6 +12,7 @@ aws-sdk-s3 = { path = "../../build/sdk/aws-sdk-s3", features = ["test-util"] }
 aws-smithy-client = { path = "../../../../rust-runtime/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-runtime = { path = "../../../../rust-runtime/aws-smithy-runtime" }
 aws-smithy-runtime-api = { path = "../../../../rust-runtime/aws-smithy-runtime-api" }
+aws-smithy-async = { path = "../../../../rust-runtime/aws-smithy-async", features = ["test-util"]}
 aws-types = { path = "../../../rust-runtime/aws-types" }
 criterion = { version = "0.4", features = ["async_tokio"] }
 http = "0.2.3"

--- a/buildSrc/src/main/kotlin/aws/sdk/ServiceLoader.kt
+++ b/buildSrc/src/main/kotlin/aws/sdk/ServiceLoader.kt
@@ -207,7 +207,7 @@ fun parseMembership(rawList: String): Membership {
     val inclusions = mutableSetOf<String>()
     val exclusions = mutableSetOf<String>()
 
-    rawList.split(",").map { it.trim() }.forEach { item ->
+    rawList.split(",").map { it.trim() }.filter { it.isNotEmpty() }.forEach { item ->
         when {
             item.startsWith('-') -> exclusions.add(item.substring(1))
             item.startsWith('+') -> inclusions.add(item.substring(1))

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/Util.kt
@@ -50,6 +50,8 @@ class Types(runtimeConfig: RuntimeConfig) {
     val resolveEndpoint = smithyHttpEndpointModule.resolve("ResolveEndpoint")
     val smithyEndpoint = smithyTypesEndpointModule.resolve("Endpoint")
     val resolveEndpointError = smithyHttpEndpointModule.resolve("ResolveEndpointError")
+
+    fun toArray() = arrayOf("ResolveEndpointError" to resolveEndpointError, "Endpoint" to smithyEndpoint)
 }
 
 /**

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/RustWriter.kt
@@ -466,6 +466,7 @@ class RustWriter private constructor(
     val devDependenciesOnly: Boolean = false,
 ) :
     SymbolWriter<RustWriter, UseDeclarations>(UseDeclarations(namespace)) {
+
     companion object {
         fun root() = forModule(null)
         fun forModule(module: String?): RustWriter = if (module == null) {
@@ -486,6 +487,7 @@ class RustWriter private constructor(
                     debugMode = debugMode,
                     devDependenciesOnly = true,
                 )
+
                 fileName == "package.json" -> rawWriter(fileName, debugMode = debugMode)
                 fileName == "stubgen.sh" -> rawWriter(fileName, debugMode = debugMode)
                 else -> RustWriter(fileName, namespace, debugMode = debugMode)
@@ -514,6 +516,8 @@ class RustWriter private constructor(
 
         return super.write(content, *args)
     }
+
+    fun dirty() = super.toString().isNotBlank() || preamble.isNotEmpty()
 
     /** Helper function to determine if a stack frame is relevant for debug purposes */
     private fun StackTraceElement.isRelevant(): Boolean {
@@ -711,7 +715,8 @@ class RustWriter private constructor(
     override fun toString(): String {
         val contents = super.toString()
         val preheader = if (preamble.isNotEmpty()) {
-            val prewriter = RustWriter(filename, namespace, printWarning = false, devDependenciesOnly = devDependenciesOnly)
+            val prewriter =
+                RustWriter(filename, namespace, printWarning = false, devDependenciesOnly = devDependenciesOnly)
             preamble.forEach { it(prewriter) }
             prewriter.toString()
         } else {
@@ -757,7 +762,8 @@ class RustWriter private constructor(
             @Suppress("UNCHECKED_CAST")
             val func =
                 t as? Writable ?: throw CodegenException("RustWriteableInjector.apply choked on non-function t ($t)")
-            val innerWriter = RustWriter(filename, namespace, printWarning = false, devDependenciesOnly = devDependenciesOnly)
+            val innerWriter =
+                RustWriter(filename, namespace, printWarning = false, devDependenciesOnly = devDependenciesOnly)
             func(innerWriter)
             innerWriter.dependencies.forEach { addDependencyTestAware(it) }
             return innerWriter.toString().trimEnd()
@@ -790,7 +796,8 @@ class RustWriter private constructor(
                     @Suppress("UNCHECKED_CAST")
                     val func =
                         t as? Writable ?: throw CodegenException("Invalid function type (expected writable) ($t)")
-                    val innerWriter = RustWriter(filename, namespace, printWarning = false, devDependenciesOnly = devDependenciesOnly)
+                    val innerWriter =
+                        RustWriter(filename, namespace, printWarning = false, devDependenciesOnly = devDependenciesOnly)
                     func(innerWriter)
                     innerWriter.dependencies.forEach { addDependencyTestAware(it) }
                     return innerWriter.toString().trimEnd()

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/customize/Customization.kt
@@ -60,3 +60,18 @@ fun <T : Section> RustWriter.writeCustomizations(customizations: List<NamedCusto
         customization.section(section)(this)
     }
 }
+
+/** Convenience for rendering a list of customizations for a given section */
+fun <T : Section> RustWriter.writeCustomizationsOrElse(
+    customizations: List<NamedCustomization<T>>,
+    section: T,
+    orElse: Writable,
+) {
+    val test = RustWriter.root()
+    test.writeCustomizations(customizations, section)
+    if (test.dirty()) {
+        writeCustomizations(customizations, section)
+    } else {
+        orElse(this)
+    }
+}


### PR DESCRIPTION
TODO:
- [x] docs
- [x] integration test (canary even?)
- [x] customize README for timestream
## Motivation and Context
- #613 
- https://github.com/awslabs/aws-sdk-rust/issues/114


## Description
This adds support for TSW and TSQ by adding endpoint discovery as a customization. This is made much simpler by the fact that endpoint discovery for these services **has no parameters** which means that there is no complexity from caching the returned endpoint.

Customers call `.enable_endpoint_discovery()` on the client to create a version of the client with endpoint discovery enabled. This returns a new client and a Reloader from which customers must spawn the reload task if they want endpoint discovery to rerun.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
