### PR TITLE
fix type-erasure bug for errors

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/type_erasure.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/type_erasure.rs
@@ -297,12 +297,14 @@ mod tests {
             .expect("type erased error can be downcast into original type");
         assert_eq!(test_err, *actual);
     }
-        
+
     #[test]
     fn test_typed_erased_errors_can_be_unwrapped() {
         let test_err = TestErr::new("something failed!");
         let type_erased_test_err = TypedBox::new(test_err.clone()).erase_error();
-        let actual = TypedBox::<TestErr>::assume_from(type_erased_test_err.into()).expect("type erased error can be downcast into original type").unwrap();
+        let actual = TypedBox::<TestErr>::assume_from(type_erased_test_err.into())
+            .expect("type erased error can be downcast into original type")
+            .unwrap();
         assert_eq!(test_err, actual);
     }
 }

--- a/rust-runtime/aws-smithy-runtime-api/src/type_erasure.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/type_erasure.rs
@@ -69,8 +69,7 @@ where
 {
     /// Converts `TypedBox<T>` to a `TypeErasedError` where `T` implements `Error`.
     pub fn erase_error(self) -> TypeErasedError {
-        let inner = self.inner.downcast::<T>().expect("typechecked");
-        TypeErasedError::new(inner)
+        TypeErasedError::new(self.unwrap())
     }
 }
 
@@ -297,5 +296,13 @@ mod tests {
             .downcast::<TestErr>()
             .expect("type erased error can be downcast into original type");
         assert_eq!(test_err, *actual);
+    }
+        
+    #[test]
+    fn test_typed_erased_errors_can_be_unwrapped() {
+        let test_err = TestErr::new("something failed!");
+        let type_erased_test_err = TypedBox::new(test_err.clone()).erase_error();
+        let actual = TypedBox::<TestErr>::assume_from(type_erased_test_err.into()).expect("type erased error can be downcast into original type").unwrap();
+        assert_eq!(test_err, actual);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We were unintentionally double-boxing type-erased errors. This fix correctly de-references the errors, solving the problem.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I wrote a test.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
