### PR TITLE
Restore `--location` to `publisher`

### DIFF
--- a/tools/ci-build/publisher/src/subcommand/generate_version_manifest.rs
+++ b/tools/ci-build/publisher/src/subcommand/generate_version_manifest.rs
@@ -26,12 +26,15 @@ pub struct GenerateVersionManifestArgs {
     /// Revision of `aws-doc-sdk-examples` repository used to retrieve examples
     #[clap(long)]
     examples_revision: String,
+    /// Same as `input_location` but kept for backwards compatibility
+    #[clap(long, required_unless_present = "input-location")]
+    location: Option<PathBuf>,
     /// Path containing the generated SDK to generate a version manifest for
-    #[clap(long)]
-    input_location: PathBuf,
+    #[clap(long, required_unless_present = "location")]
+    input_location: Option<PathBuf>,
     /// Path to a directory in which a version manifest is generated
-    #[clap(long)]
-    output_location: PathBuf,
+    #[clap(long, required_unless_present = "location")]
+    output_location: Option<PathBuf>,
     /// Optional path to the `versions.toml` manifest from the previous SDK release
     #[clap(long)]
     previous_release_versions: Option<PathBuf>,
@@ -41,6 +44,7 @@ pub async fn subcommand_generate_version_manifest(
     GenerateVersionManifestArgs {
         smithy_build,
         examples_revision,
+        location,
         input_location,
         output_location,
         previous_release_versions,
@@ -56,6 +60,16 @@ pub async fn subcommand_generate_version_manifest(
     info!("Resolved smithy-rs revision to {}", smithy_rs_revision);
 
     let smithy_build_root = SmithyBuildRoot::from_file(smithy_build)?;
+    let input_location = match (location, input_location) {
+        (Some(location), None) => location,
+        (None, Some(input_location)) => input_location,
+        _ => bail!("Only one of `--location` or `--input-location` should be provided"),
+    };
+    let output_location = match (location, output_location) {
+        (Some(location), None) => location,
+        (None, Some(output_location)) => output_location,
+        _ => bail!("Only one of `--location` or `--output-location` should be provided"),
+    };
     let manifests = discover_package_manifests(input_location.into())
         .await
         .context("discover package manifests")?;


### PR DESCRIPTION
## Motivation and Context
This PR adds back `--location` to the subcommand `generate-version-manifest` for the `publisher`. Without this, CI would fail due to the PR bot trying to use the already deleted command option ([link](https://github.com/awslabs/smithy-rs/actions/runs/5023168618/jobs/9007489752?pr=2712)). It's important to note that all changes to `tools` need to be backwards compatible across releases.

## Testing
Against the old and the new versions of [`build.gradle.kts`](https://github.com/awslabs/smithy-rs/pull/2663/files), manually ran
```
./gradlew :aws:sdk:assemble
```
and confirmed that `versions.toml` got created under `smithy-rs/aws/sdk/build/aws-sdk`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
