### PR TITLE
Fix the error message for SSO credential providers

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -35,3 +35,9 @@ message = "Fix compiler errors in generated code when naming shapes after types 
 references = ["smithy-rs#2696"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" = "client"}
 author = "jdisanti"
+
+[[aws-sdk-rust]]
+message = "Fix error message when `credentials-sso` feature is not enabled on `aws-config`. NOTE: if you use `no-default-features`, you will need to manually able `credentials-sso` after 0.55.*"
+references = ["smithy-rs#2722", "aws-sdk-rust#703"]
+meta = { "breaking" = false, "tada" = false, "bug" = true }
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/src/profile/credentials.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials.rs
@@ -257,6 +257,13 @@ pub enum ProfileFileError {
         /// The name of the provider
         name: String,
     },
+
+    /// Feature not enabled
+    #[non_exhaustive]
+    FeatureNotEnabled {
+        /// The feature or comma delimited list of features that must be enabled
+        feature: Cow<'static, str>,
+    },
 }
 
 impl ProfileFileError {
@@ -309,6 +316,12 @@ impl Display for ProfileFileError {
                 "profile `{}` did not contain credential information",
                 profile
             ),
+            ProfileFileError::FeatureNotEnabled { feature: message } => {
+                write!(
+                    f,
+                    "This behavior requires following cargo feature(s) enabled: {message}",
+                )
+            }
         }
     }
 }

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -137,8 +137,8 @@ impl ProviderChain {
                 }
                 #[cfg(not(feature = "credentials-sso"))]
                 {
-                    Err(ProfileFileError::UnknownProvider {
-                        name: "sso".to_string(),
+                    Err(ProfileFileError::FeatureNotEnabled {
+                        feature: "credentials-sso".into(),
                     })?
                 }
             }

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -114,7 +114,7 @@ where
                 );
             }
             (Err(actual_error), GenericTestResult::Ok(expected_creds)) => panic!(
-                "expected credentials ({:?}) but an error was returned: {}",
+                "expected credentials ({:?}) but an error was returned: {:?}",
                 expected_creds, actual_error
             ),
             (Ok(creds), GenericTestResult::ErrorContains(substr)) => panic!(


### PR DESCRIPTION
## Motivation and Context
The current error if the SSO error message is not enabled is inscrutable and doesn't point the customer towards the removed feature.

## Description
Fix the error message, add tests.

## Testing
tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
