### PR TITLE
Remove middleware code when generating the orchestrator exclusively

### DIFF
--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -14,7 +14,6 @@ use crate::web_identity_token::{StaticConfiguration, WebIdentityTokenCredentials
 use aws_credential_types::provider::{self, error::CredentialsError, ProvideCredentials};
 use aws_sdk_sts::config::{Builder as StsConfigBuilder, Credentials};
 use aws_sdk_sts::Client as StsClient;
-use aws_types::region::Region;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -114,6 +113,7 @@ impl ProviderChain {
             } => {
                 #[cfg(feature = "credentials-sso")]
                 {
+                    use aws_types::region::Region;
                     let sso_config = SsoProviderConfig {
                         account_id: sso_account_id.to_string(),
                         role_name: sso_role_name.to_string(),

--- a/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
+++ b/aws/rust-runtime/aws-config/src/profile/credentials/exec.rs
@@ -8,14 +8,12 @@ use crate::credential_process::CredentialProcessProvider;
 use crate::profile::credentials::ProfileFileError;
 use crate::provider_config::ProviderConfig;
 #[cfg(feature = "credentials-sso")]
-use crate::sso::{SsoConfig, SsoCredentialsProvider};
+use crate::sso::{SsoCredentialsProvider, SsoProviderConfig};
 use crate::sts;
 use crate::web_identity_token::{StaticConfiguration, WebIdentityTokenCredentialsProvider};
 use aws_credential_types::provider::{self, error::CredentialsError, ProvideCredentials};
-use aws_sdk_sts::middleware::DefaultMiddleware;
-use aws_sdk_sts::operation::assume_role::AssumeRoleInput;
-use aws_sdk_sts::{config::Credentials, Config};
-use aws_smithy_client::erase::DynConnector;
+use aws_sdk_sts::config::{Builder as StsConfigBuilder, Credentials};
+use aws_sdk_sts::Client as StsClient;
 use aws_types::region::Region;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -27,39 +25,28 @@ pub(super) struct AssumeRoleProvider {
     session_name: Option<String>,
 }
 
-#[derive(Debug)]
-pub(super) struct ClientConfiguration {
-    pub(super) sts_client: aws_smithy_client::Client<DynConnector, DefaultMiddleware>,
-    pub(super) region: Option<Region>,
-}
-
 impl AssumeRoleProvider {
     pub(super) async fn credentials(
         &self,
         input_credentials: Credentials,
-        client_config: &ClientConfiguration,
+        sts_config: &StsConfigBuilder,
     ) -> provider::Result {
-        let config = Config::builder()
+        let config = sts_config
+            .clone()
             .credentials_provider(input_credentials)
-            .region(client_config.region.clone())
             .build();
+        let client = StsClient::from_conf(config);
         let session_name = &self
             .session_name
             .as_ref()
             .cloned()
             .unwrap_or_else(|| sts::util::default_session_name("assume-role-from-profile"));
-        let operation = AssumeRoleInput::builder()
+        let assume_role_creds = client
+            .assume_role()
             .role_arn(&self.role_arn)
             .set_external_id(self.external_id.clone())
             .role_session_name(session_name)
-            .build()
-            .expect("operation is valid")
-            .make_operation(&config)
-            .await
-            .expect("valid operation");
-        let assume_role_creds = client_config
-            .sts_client
-            .call(operation)
+            .send()
             .await
             .map_err(CredentialsError::provider_error)?
             .credentials;
@@ -127,7 +114,7 @@ impl ProviderChain {
             } => {
                 #[cfg(feature = "credentials-sso")]
                 {
-                    let sso_config = SsoConfig {
+                    let sso_config = SsoProviderConfig {
                         account_id: sso_account_id.to_string(),
                         role_name: sso_role_name.to_string(),
                         start_url: sso_start_url.to_string(),

--- a/aws/rust-runtime/aws-config/src/sso.rs
+++ b/aws/rust-runtime/aws-config/src/sso.rs
@@ -16,10 +16,8 @@ use crate::provider_config::ProviderConfig;
 
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
 use aws_credential_types::Credentials;
-use aws_sdk_sso::middleware::DefaultMiddleware as SsoMiddleware;
-use aws_sdk_sso::operation::get_role_credentials::GetRoleCredentialsInput;
 use aws_sdk_sso::types::RoleCredentials;
-use aws_smithy_client::erase::DynConnector;
+use aws_sdk_sso::{config::Builder as SsoConfigBuilder, Client as SsoClient, Config as SsoConfig};
 use aws_smithy_json::deserialize::Token;
 use aws_smithy_types::date_time::Format;
 use aws_smithy_types::DateTime;
@@ -32,22 +30,9 @@ use std::fmt::{Display, Formatter};
 use std::io;
 use std::path::PathBuf;
 
+use crate::connector::expect_connector;
 use ring::digest;
 use zeroize::Zeroizing;
-
-impl crate::provider_config::ProviderConfig {
-    pub(crate) fn sso_client(
-        &self,
-    ) -> aws_smithy_client::Client<aws_smithy_client::erase::DynConnector, SsoMiddleware> {
-        use crate::connector::expect_connector;
-
-        let mut client_builder = aws_smithy_client::Client::builder()
-            .connector(expect_connector(self.connector(&Default::default())))
-            .middleware(SsoMiddleware::default());
-        client_builder.set_sleep_impl(self.sleep());
-        client_builder.build()
-    }
-}
 
 /// SSO Credentials Provider
 ///
@@ -59,8 +44,8 @@ impl crate::provider_config::ProviderConfig {
 pub struct SsoCredentialsProvider {
     fs: Fs,
     env: Env,
-    sso_config: SsoConfig,
-    client: aws_smithy_client::Client<DynConnector, SsoMiddleware>,
+    sso_provider_config: SsoProviderConfig,
+    sso_config: SsoConfigBuilder,
 }
 
 impl SsoCredentialsProvider {
@@ -69,20 +54,34 @@ impl SsoCredentialsProvider {
         Builder::new()
     }
 
-    pub(crate) fn new(provider_config: &ProviderConfig, sso_config: SsoConfig) -> Self {
+    pub(crate) fn new(
+        provider_config: &ProviderConfig,
+        sso_provider_config: SsoProviderConfig,
+    ) -> Self {
         let fs = provider_config.fs();
         let env = provider_config.env();
+
+        let mut sso_config = SsoConfig::builder().http_connector(expect_connector(
+            provider_config.connector(&Default::default()),
+        ));
+        sso_config.set_sleep_impl(provider_config.sleep());
 
         SsoCredentialsProvider {
             fs,
             env,
-            client: provider_config.sso_client(),
+            sso_provider_config,
             sso_config,
         }
     }
 
     async fn credentials(&self) -> provider::Result {
-        load_sso_credentials(&self.sso_config, &self.client, &self.env, &self.fs).await
+        load_sso_credentials(
+            &self.sso_provider_config,
+            &self.sso_config,
+            &self.env,
+            &self.fs,
+        )
+        .await
     }
 }
 
@@ -151,7 +150,7 @@ impl Builder {
     /// - [`region`](Self::region)
     pub fn build(self) -> SsoCredentialsProvider {
         let provider_config = self.provider_config.unwrap_or_default();
-        let sso_config = SsoConfig {
+        let sso_config = SsoProviderConfig {
             account_id: self.account_id.expect("account_id must be set"),
             role_name: self.role_name.expect("role_name must be set"),
             start_url: self.start_url.expect("start_url must be set"),
@@ -193,7 +192,7 @@ impl Error for LoadTokenError {
 }
 
 #[derive(Debug)]
-pub(crate) struct SsoConfig {
+pub(crate) struct SsoProviderConfig {
     pub(crate) account_id: String,
     pub(crate) role_name: String,
     pub(crate) start_url: String,
@@ -201,30 +200,26 @@ pub(crate) struct SsoConfig {
 }
 
 async fn load_sso_credentials(
-    sso_config: &SsoConfig,
-    sso: &aws_smithy_client::Client<DynConnector, SsoMiddleware>,
+    sso_provider_config: &SsoProviderConfig,
+    sso_config: &SsoConfigBuilder,
     env: &Env,
     fs: &Fs,
 ) -> provider::Result {
-    let token = load_token(&sso_config.start_url, env, fs)
+    let token = load_token(&sso_provider_config.start_url, env, fs)
         .await
         .map_err(CredentialsError::provider_error)?;
-    let config = aws_sdk_sso::Config::builder()
-        .region(sso_config.region.clone())
+    let config = sso_config
+        .clone()
+        .region(sso_provider_config.region.clone())
         .build();
-    let operation = GetRoleCredentialsInput::builder()
-        .role_name(&sso_config.role_name)
+    // TODO(enableNewSmithyRuntime): Use `customize().config_override()` to set the region instead of creating a new client once middleware is removed
+    let client = SsoClient::from_conf(config);
+    let resp = client
+        .get_role_credentials()
+        .role_name(&sso_provider_config.role_name)
         .access_token(&*token.access_token)
-        .account_id(&sso_config.account_id)
-        .build()
-        .map_err(|err| {
-            CredentialsError::unhandled(format!("could not construct SSO token input: {}", err))
-        })?
-        .make_operation(&config)
-        .await
-        .map_err(CredentialsError::unhandled)?;
-    let resp = sso
-        .call(operation)
+        .account_id(&sso_provider_config.account_id)
+        .send()
         .await
         .map_err(CredentialsError::provider_error)?;
     let credentials: RoleCredentials = resp

--- a/aws/rust-runtime/aws-config/src/sso.rs
+++ b/aws/rust-runtime/aws-config/src/sso.rs
@@ -31,6 +31,7 @@ use std::io;
 use std::path::PathBuf;
 
 use crate::connector::expect_connector;
+use aws_smithy_types::retry::RetryConfig;
 use ring::digest;
 use zeroize::Zeroizing;
 
@@ -61,9 +62,11 @@ impl SsoCredentialsProvider {
         let fs = provider_config.fs();
         let env = provider_config.env();
 
-        let mut sso_config = SsoConfig::builder().http_connector(expect_connector(
-            provider_config.connector(&Default::default()),
-        ));
+        let mut sso_config = SsoConfig::builder()
+            .http_connector(expect_connector(
+                provider_config.connector(&Default::default()),
+            ))
+            .retry_config(RetryConfig::standard());
         sso_config.set_sleep_impl(provider_config.sleep());
 
         SsoCredentialsProvider {

--- a/aws/rust-runtime/aws-config/src/sts.rs
+++ b/aws/rust-runtime/aws-config/src/sts.rs
@@ -5,23 +5,21 @@
 
 //! Credential provider augmentation through the AWS Security Token Service (STS).
 
-use crate::connector::expect_connector;
-use aws_sdk_sts::middleware::DefaultMiddleware;
-use aws_smithy_client::erase::DynConnector;
-use aws_smithy_client::Client;
-
 pub(crate) mod util;
 
 pub use assume_role::{AssumeRoleProvider, AssumeRoleProviderBuilder};
 
 mod assume_role;
 
+use crate::connector::expect_connector;
+use aws_sdk_sts::config::Builder as StsConfigBuilder;
+
 impl crate::provider_config::ProviderConfig {
-    pub(crate) fn sts_client(&self) -> Client<DynConnector, DefaultMiddleware> {
-        let mut builder = Client::builder()
-            .connector(expect_connector(self.connector(&Default::default())))
-            .middleware(DefaultMiddleware::default());
+    pub(crate) fn sts_client_config(&self) -> StsConfigBuilder {
+        let mut builder = aws_sdk_sts::Config::builder()
+            .http_connector(expect_connector(self.connector(&Default::default())))
+            .region(self.region());
         builder.set_sleep_impl(self.sleep());
-        builder.build()
+        builder
     }
 }

--- a/aws/rust-runtime/aws-config/src/sts.rs
+++ b/aws/rust-runtime/aws-config/src/sts.rs
@@ -13,11 +13,13 @@ mod assume_role;
 
 use crate::connector::expect_connector;
 use aws_sdk_sts::config::Builder as StsConfigBuilder;
+use aws_smithy_types::retry::RetryConfig;
 
 impl crate::provider_config::ProviderConfig {
     pub(crate) fn sts_client_config(&self) -> StsConfigBuilder {
         let mut builder = aws_sdk_sts::Config::builder()
             .http_connector(expect_connector(self.connector(&Default::default())))
+            .retry_config(RetryConfig::standard())
             .region(self.region());
         builder.set_sleep_impl(self.sleep());
         builder

--- a/aws/rust-runtime/aws-config/src/sts/assume_role.rs
+++ b/aws/rust-runtime/aws-config/src/sts/assume_role.rs
@@ -5,12 +5,14 @@
 
 //! Assume credentials for a role through the AWS Security Token Service (STS).
 
+use crate::connector::expect_connector;
 use crate::provider_config::ProviderConfig;
 use aws_credential_types::cache::CredentialsCache;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
-use aws_sdk_sts::middleware::DefaultMiddleware;
-use aws_sdk_sts::operation::assume_role::{AssumeRoleError, AssumeRoleInput};
+use aws_sdk_sts::operation::assume_role::builders::AssumeRoleFluentBuilder;
+use aws_sdk_sts::operation::assume_role::AssumeRoleError;
 use aws_sdk_sts::types::PolicyDescriptorType;
+use aws_sdk_sts::Client as StsClient;
 use aws_smithy_client::erase::DynConnector;
 use aws_smithy_http::result::SdkError;
 use aws_smithy_types::error::display::DisplayErrorContext;
@@ -46,9 +48,7 @@ pub struct AssumeRoleProvider {
 
 #[derive(Debug)]
 struct Inner {
-    sts: aws_smithy_client::Client<DynConnector, DefaultMiddleware>,
-    conf: aws_sdk_sts::Config,
-    op: AssumeRoleInput,
+    fluent_builder: AssumeRoleFluentBuilder,
 }
 
 impl AssumeRoleProvider {
@@ -204,41 +204,29 @@ impl AssumeRoleProviderBuilder {
             builder.into_credentials_cache()
         });
 
-        let config = aws_sdk_sts::Config::builder()
+        let mut config = aws_sdk_sts::Config::builder()
             .credentials_cache(credentials_cache)
             .credentials_provider(provider)
             .region(self.region.clone())
-            .build();
-
-        let conn = conf
-            .connector(&Default::default())
-            .expect("A connector must be provided");
-        let mut client_builder = aws_smithy_client::Client::builder()
-            .connector(conn)
-            .middleware(DefaultMiddleware::new());
-        client_builder.set_sleep_impl(conf.sleep());
-        let client = client_builder.build();
+            .http_connector(expect_connector(conf.connector(&Default::default())));
+        config.set_sleep_impl(conf.sleep());
 
         let session_name = self
             .session_name
             .unwrap_or_else(|| super::util::default_session_name("assume-role-provider"));
 
-        let operation = AssumeRoleInput::builder()
+        let sts_client = StsClient::from_conf(config.build());
+        let fluent_builder = sts_client
+            .assume_role()
             .set_role_arn(Some(self.role_arn))
             .set_external_id(self.external_id)
             .set_role_session_name(Some(session_name))
             .set_policy(self.policy)
             .set_policy_arns(self.policy_arns)
-            .set_duration_seconds(self.session_length.map(|dur| dur.as_secs() as i32))
-            .build()
-            .expect("operation is valid");
+            .set_duration_seconds(self.session_length.map(|dur| dur.as_secs() as i32));
 
         AssumeRoleProvider {
-            inner: Inner {
-                sts: client,
-                conf: config,
-                op: operation,
-            },
+            inner: Inner { fluent_builder },
         }
     }
 }
@@ -246,14 +234,8 @@ impl AssumeRoleProviderBuilder {
 impl Inner {
     async fn credentials(&self) -> provider::Result {
         tracing::debug!("retrieving assumed credentials");
-        let op = self
-            .op
-            .clone()
-            .make_operation(&self.conf)
-            .await
-            .expect("valid operation");
 
-        let assumed = self.sts.call(op).in_current_span().await;
+        let assumed = self.fluent_builder.clone().send().in_current_span().await;
         match assumed {
             Ok(assumed) => {
                 tracing::debug!(

--- a/aws/rust-runtime/aws-config/src/test_case.rs
+++ b/aws/rust-runtime/aws-config/src/test_case.rs
@@ -114,8 +114,9 @@ where
                 );
             }
             (Err(actual_error), GenericTestResult::Ok(expected_creds)) => panic!(
-                "expected credentials ({:?}) but an error was returned: {:?}",
-                expected_creds, actual_error
+                "expected credentials ({:?}) but an error was returned: {}",
+                expected_creds,
+                DisplayErrorContext(&actual_error)
             ),
             (Ok(creds), GenericTestResult::ErrorContains(substr)) => panic!(
                 "expected an error containing: `{}`, but a result was returned: {:?}",

--- a/aws/rust-runtime/aws-config/src/web_identity_token.rs
+++ b/aws/rust-runtime/aws-config/src/web_identity_token.rs
@@ -64,10 +64,7 @@
 use crate::provider_config::ProviderConfig;
 use crate::sts;
 use aws_credential_types::provider::{self, error::CredentialsError, future, ProvideCredentials};
-use aws_sdk_sts::config::Region;
-use aws_sdk_sts::middleware::DefaultMiddleware;
-use aws_sdk_sts::operation::assume_role_with_web_identity::AssumeRoleWithWebIdentityInput;
-use aws_smithy_client::erase::DynConnector;
+use aws_sdk_sts::Client as StsClient;
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::os_shim_internal::{Env, Fs};
 use std::borrow::Cow;
@@ -84,8 +81,7 @@ const ENV_VAR_SESSION_NAME: &str = "AWS_ROLE_SESSION_NAME";
 pub struct WebIdentityTokenCredentialsProvider {
     source: Source,
     fs: Fs,
-    client: aws_smithy_client::Client<DynConnector, DefaultMiddleware>,
-    region: Option<Region>,
+    sts_client: StsClient,
 }
 
 impl WebIdentityTokenCredentialsProvider {
@@ -151,12 +147,7 @@ impl WebIdentityTokenCredentialsProvider {
         let conf = self.source()?;
         load_credentials(
             &self.fs,
-            &self.client,
-            &self.region.as_ref().cloned().ok_or_else(|| {
-                CredentialsError::invalid_configuration(
-                    "region is required for WebIdentityTokenProvider",
-                )
-            })?,
+            &self.sts_client,
             &conf.web_identity_token_file,
             &conf.role_arn,
             &conf.session_name,
@@ -207,21 +198,18 @@ impl Builder {
     /// builder, this function will panic.
     pub fn build(self) -> WebIdentityTokenCredentialsProvider {
         let conf = self.config.unwrap_or_default();
-        let client = conf.sts_client();
         let source = self.source.unwrap_or_else(|| Source::Env(conf.env()));
         WebIdentityTokenCredentialsProvider {
             source,
             fs: conf.fs(),
-            client,
-            region: conf.region(),
+            sts_client: StsClient::from_conf(conf.sts_client_config().build()),
         }
     }
 }
 
 async fn load_credentials(
     fs: &Fs,
-    client: &aws_smithy_client::Client<DynConnector, DefaultMiddleware>,
-    region: &Region,
+    sts_client: &StsClient,
     token_file: impl AsRef<Path>,
     role_arn: &str,
     session_name: &str,
@@ -233,23 +221,17 @@ async fn load_credentials(
     let token = String::from_utf8(token).map_err(|_utf_8_error| {
         CredentialsError::unhandled("WebIdentityToken was not valid UTF-8")
     })?;
-    let conf = aws_sdk_sts::Config::builder()
-        .region(region.clone())
-        .build();
 
-    let operation = AssumeRoleWithWebIdentityInput::builder()
+    let resp = sts_client.assume_role_with_web_identity()
         .role_arn(role_arn)
         .role_session_name(session_name)
         .web_identity_token(token)
-        .build()
-        .expect("valid operation")
-        .make_operation(&conf)
+        .send()
         .await
-        .expect("valid operation");
-    let resp = client.call(operation).await.map_err(|sdk_error| {
-        tracing::warn!(error = %DisplayErrorContext(&sdk_error), "STS returned an error assuming web identity role");
-        CredentialsError::provider_error(sdk_error)
-    })?;
+        .map_err(|sdk_error| {
+            tracing::warn!(error = %DisplayErrorContext(&sdk_error), "STS returned an error assuming web identity role");
+            CredentialsError::provider_error(sdk_error)
+        })?;
     sts::util::into_credentials(resp.credentials, "WebIdentityToken")
 }
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsFluentClientDecorator.kt
@@ -11,15 +11,13 @@ import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegen
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientDocs
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientGenerator
-import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientGenerics
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.FluentClientSection
 import software.amazon.smithy.rust.codegen.client.smithy.generators.client.NoClientGenerics
+import software.amazon.smithy.rust.codegen.client.smithy.generators.client.renderCustomizableOperationSend
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.DefaultProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.client.smithy.generators.protocol.ProtocolTestGenerator
 import software.amazon.smithy.rust.codegen.core.rustlang.Attribute
 import software.amazon.smithy.rust.codegen.core.rustlang.Feature
-import software.amazon.smithy.rust.codegen.core.rustlang.GenericTypeArg
-import software.amazon.smithy.rust.codegen.core.rustlang.RustGenerics
 import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
@@ -42,7 +40,6 @@ private class Types(runtimeConfig: RuntimeConfig) {
     val awsTypes = AwsRuntimeType.awsTypes(runtimeConfig)
     val connectorError = smithyHttp.resolve("result::ConnectorError")
     val connectorSettings = smithyClient.resolve("http_connector::ConnectorSettings")
-    val defaultMiddleware = runtimeConfig.defaultMiddleware()
     val dynConnector = smithyClient.resolve("erase::DynConnector")
     val dynMiddleware = smithyClient.resolve("erase::DynMiddleware")
     val retryConfig = smithyTypes.resolve("retry::RetryConfig")
@@ -73,10 +70,10 @@ class AwsFluentClientDecorator : ClientCodegenDecorator {
             retryClassifier = AwsRuntimeType.awsHttp(runtimeConfig).resolve("retry::AwsResponseRetryClassifier"),
         ).render(rustCrate, listOf(CustomizableOperationTestHelpers(runtimeConfig)))
         rustCrate.withModule(ClientRustModule.Client.customize) {
-            renderCustomizableOperationSendMethod(runtimeConfig, generics, this)
+            renderCustomizableOperationSend(codegenContext, generics, this)
         }
         rustCrate.withModule(ClientRustModule.client) {
-            AwsFluentClientExtensions(types).render(this)
+            AwsFluentClientExtensions(codegenContext, types).render(this)
         }
         val awsSmithyClient = "aws-smithy-client"
         rustCrate.mergeFeature(Feature("rustls", default = true, listOf("$awsSmithyClient/rustls")))
@@ -123,13 +120,13 @@ class AwsFluentClientDecorator : ClientCodegenDecorator {
     )
 }
 
-private class AwsFluentClientExtensions(types: Types) {
+private class AwsFluentClientExtensions(private val codegenContext: ClientCodegenContext, private val types: Types) {
     private val codegenScope = arrayOf(
+        "Arc" to RuntimeType.Arc,
         "ConnectorError" to types.connectorError,
+        "ConnectorSettings" to types.connectorSettings,
         "DynConnector" to types.dynConnector,
         "DynMiddleware" to types.dynMiddleware,
-        "ConnectorSettings" to types.connectorSettings,
-        "Middleware" to types.defaultMiddleware,
         "RetryConfig" to types.retryConfig,
         "SmithyConnector" to types.smithyConnector,
         "TimeoutConfig" to types.timeoutConfig,
@@ -153,65 +150,72 @@ private class AwsFluentClientExtensions(types: Types) {
                 pub fn new(sdk_config: &#{aws_types}::sdk_config::SdkConfig) -> Self {
                     Self::from_conf(sdk_config.into())
                 }
-
-                /// Creates a new client from the service [`Config`](crate::Config).
-                ///
-                /// ## Panics
-                ///
-                /// - This method will panic if the `conf` is missing an async sleep implementation. If you experience this panic, set
-                ///     the `sleep_impl` on the Config passed into this function to fix it.
-                /// - This method will panic if the `conf` is missing an HTTP connector. If you experience this panic, set the
-                ///     `http_connector` on the Config passed into this function to fix it.
-                pub fn from_conf(conf: crate::Config) -> Self {
-                    let retry_config = conf.retry_config().cloned().unwrap_or_else(#{RetryConfig}::disabled);
-                    let timeout_config = conf.timeout_config().cloned().unwrap_or_else(#{TimeoutConfig}::disabled);
-                    let sleep_impl = conf.sleep_impl();
-                    if (retry_config.has_retry() || timeout_config.has_timeouts()) && sleep_impl.is_none() {
-                        panic!("An async sleep implementation is required for retries or timeouts to work. \
-                                Set the `sleep_impl` on the Config passed into this function to fix this panic.");
-                    }
-
-                    let connector = conf.http_connector().and_then(|c| {
-                        let timeout_config = conf
-                            .timeout_config()
-                            .cloned()
-                            .unwrap_or_else(#{TimeoutConfig}::disabled);
-                        let connector_settings = #{ConnectorSettings}::from_timeout_config(
-                            &timeout_config,
-                        );
-                        c.connector(&connector_settings, conf.sleep_impl())
-                    });
-
-                    let builder = #{SmithyClientBuilder}::new();
-
-                    let builder = match connector {
-                        // Use provided connector
-                        Some(c) => builder.connector(c),
-                        None =>{
-                            ##[cfg(any(feature = "rustls", feature = "native-tls"))]
-                            {
-                                // Use default connector based on enabled features
-                                builder.dyn_https_connector(#{ConnectorSettings}::from_timeout_config(&timeout_config))
-                            }
-                            ##[cfg(not(any(feature = "rustls", feature = "native-tls")))]
-                            {
-                                panic!("No HTTP connector was available. Enable the `rustls` or `native-tls` crate feature or set a connector to fix this.");
-                            }
-                        }
-                    };
-                    let mut builder = builder
-                        .middleware(#{DynMiddleware}::new(#{Middleware}::new()))
-                        .reconnect_mode(retry_config.reconnect_mode())
-                        .retry_config(retry_config.into())
-                        .operation_timeout_config(timeout_config.into());
-                    builder.set_sleep_impl(sleep_impl);
-                    let client = builder.build();
-
-                    Self { handle: std::sync::Arc::new(Handle { client, conf }) }
-                }
                 """,
                 *codegenScope,
             )
+            if (codegenContext.smithyRuntimeMode.generateMiddleware) {
+                rustTemplate(
+                    """
+                    /// Creates a new client from the service [`Config`](crate::Config).
+                    ///
+                    /// ## Panics
+                    ///
+                    /// - This method will panic if the `conf` is missing an async sleep implementation. If you experience this panic, set
+                    ///     the `sleep_impl` on the Config passed into this function to fix it.
+                    /// - This method will panic if the `conf` is missing an HTTP connector. If you experience this panic, set the
+                    ///     `http_connector` on the Config passed into this function to fix it.
+                    pub fn from_conf(conf: crate::Config) -> Self {
+                        let retry_config = conf.retry_config().cloned().unwrap_or_else(#{RetryConfig}::disabled);
+                        let timeout_config = conf.timeout_config().cloned().unwrap_or_else(#{TimeoutConfig}::disabled);
+                        let sleep_impl = conf.sleep_impl();
+                        if (retry_config.has_retry() || timeout_config.has_timeouts()) && sleep_impl.is_none() {
+                            panic!("An async sleep implementation is required for retries or timeouts to work. \
+                                    Set the `sleep_impl` on the Config passed into this function to fix this panic.");
+                        }
+
+                        let connector = conf.http_connector().and_then(|c| {
+                            let timeout_config = conf
+                                .timeout_config()
+                                .cloned()
+                                .unwrap_or_else(#{TimeoutConfig}::disabled);
+                            let connector_settings = #{ConnectorSettings}::from_timeout_config(
+                                &timeout_config,
+                            );
+                            c.connector(&connector_settings, conf.sleep_impl())
+                        });
+
+                        let builder = #{SmithyClientBuilder}::new();
+
+                        let builder = match connector {
+                            // Use provided connector
+                            Some(c) => builder.connector(c),
+                            None =>{
+                                ##[cfg(any(feature = "rustls", feature = "native-tls"))]
+                                {
+                                    // Use default connector based on enabled features
+                                    builder.dyn_https_connector(#{ConnectorSettings}::from_timeout_config(&timeout_config))
+                                }
+                                ##[cfg(not(any(feature = "rustls", feature = "native-tls")))]
+                                {
+                                    panic!("No HTTP connector was available. Enable the `rustls` or `native-tls` crate feature or set a connector to fix this.");
+                                }
+                            }
+                        };
+                        let mut builder = builder
+                            .middleware(#{DynMiddleware}::new(#{Middleware}::new()))
+                            .reconnect_mode(retry_config.reconnect_mode())
+                            .retry_config(retry_config.into())
+                            .operation_timeout_config(timeout_config.into());
+                        builder.set_sleep_impl(sleep_impl);
+                        let client = builder.build();
+
+                        Self { handle: #{Arc}::new(Handle { client, conf }) }
+                    }
+                    """,
+                    *codegenScope,
+                    "Middleware" to codegenContext.runtimeConfig.defaultMiddleware(),
+                )
+            }
         }
     }
 }
@@ -236,44 +240,4 @@ private class AwsFluentClientDocs(private val codegenContext: ClientCodegenConte
             else -> emptySection
         }
     }
-}
-
-private fun renderCustomizableOperationSendMethod(
-    runtimeConfig: RuntimeConfig,
-    generics: FluentClientGenerics,
-    writer: RustWriter,
-) {
-    val operationGenerics = RustGenerics(GenericTypeArg("O"), GenericTypeArg("Retry"))
-    val handleGenerics = generics.toRustGenerics()
-    val combinedGenerics = operationGenerics + handleGenerics
-
-    val codegenScope = arrayOf(
-        *RuntimeType.preludeScope,
-        "combined_generics_decl" to combinedGenerics.declaration(),
-        "handle_generics_bounds" to handleGenerics.bounds(),
-        "SdkSuccess" to RuntimeType.sdkSuccess(runtimeConfig),
-        "SdkError" to RuntimeType.sdkError(runtimeConfig),
-        "ClassifyRetry" to RuntimeType.classifyRetry(runtimeConfig),
-        "ParseHttpResponse" to RuntimeType.parseHttpResponse(runtimeConfig),
-    )
-
-    writer.rustTemplate(
-        """
-        impl#{combined_generics_decl:W} CustomizableOperation#{combined_generics_decl:W}
-        where
-            #{handle_generics_bounds:W}
-        {
-            /// Sends this operation's request
-            pub async fn send<T, E>(self) -> #{Result}<T, #{SdkError}<E>>
-            where
-                E: std::error::Error + #{Send} + #{Sync} + 'static,
-                O: #{ParseHttpResponse}<Output = #{Result}<T, E>> + #{Send} + #{Sync} + #{Clone} + 'static,
-                Retry: #{ClassifyRetry}<#{SdkSuccess}<T>, #{SdkError}<E>> + #{Send} + #{Sync} + #{Clone},
-            {
-                self.handle.client.call(self.operation).await
-            }
-        }
-        """,
-        *codegenScope,
-    )
 }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -38,6 +38,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpBoundProtoc
 import software.amazon.smithy.rust.codegen.core.util.cloneOperation
 import software.amazon.smithy.rust.codegen.core.util.expectTrait
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
+import software.amazon.smithy.rust.codegen.core.util.letIf
 import software.amazon.smithy.rustsdk.AwsRuntimeType.defaultMiddleware
 import software.amazon.smithy.rustsdk.traits.PresignableTrait
 import kotlin.streams.toList
@@ -100,7 +101,12 @@ class AwsPresigningDecorator internal constructor(
         codegenContext: ClientCodegenContext,
         operation: OperationShape,
         baseCustomizations: List<OperationCustomization>,
-    ): List<OperationCustomization> = baseCustomizations + listOf(AwsInputPresignedMethod(codegenContext, operation))
+    ): List<OperationCustomization> =
+        baseCustomizations.letIf(codegenContext.smithyRuntimeMode.generateMiddleware) {
+            it + listOf(
+                AwsInputPresignedMethod(codegenContext, operation),
+            )
+        }
 
     /**
      * Adds presignable trait to known presignable operations and creates synthetic presignable shapes for codegen

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeType.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeType.kt
@@ -44,6 +44,7 @@ object AwsRuntimeType {
     fun presigning(): RuntimeType =
         RuntimeType.forInlineDependency(InlineAwsDependency.forRustFile("presigning", visibility = Visibility.PUBLIC))
 
+    // TODO(enableNewSmithyRuntime): Delete defaultMiddleware and middleware.rs, and remove tower dependency from inlinables, when cleaning up middleware
     fun RuntimeConfig.defaultMiddleware() = RuntimeType.forInlineDependency(
         InlineAwsDependency.forRustFile(
             "middleware", visibility = Visibility.PUBLIC,

--- a/aws/sdk/integration-tests/dynamodb/benches/deserialization_bench.rs
+++ b/aws/sdk/integration-tests/dynamodb/benches/deserialization_bench.rs
@@ -3,13 +3,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_dynamodb::operation::query::Query;
-use aws_smithy_http::response::ParseHttpResponse;
-use bytes::Bytes;
 use criterion::{criterion_group, criterion_main, Criterion};
 
 fn do_bench() {
-    let response = http::Response::builder()
+    #[cfg(not(aws_sdk_orchestrator_mode))]
+    {
+        use aws_sdk_dynamodb::operation::query::Query;
+        use aws_smithy_http::response::ParseHttpResponse;
+        use bytes::Bytes;
+
+        let response = http::Response::builder()
         .header("server", "Server")
         .header("date", "Mon, 08 Mar 2021 15:51:23 GMT")
         .header("content-type", "application/x-amz-json-1.0")
@@ -21,9 +24,10 @@ fn do_bench() {
         .body(Bytes::copy_from_slice(br#"{"Count":2,"Items":[{"year":{"N":"2013"},"info":{"M":{"actors":{"L":[{"S":"Daniel Bruhl"},{"S":"Chris Hemsworth"},{"S":"Olivia Wilde"}]},"plot":{"S":"A re-creation of the merciless 1970s rivalry between Formula One rivals James Hunt and Niki Lauda."},"release_date":{"S":"2013-09-02T00:00:00Z"},"image_url":{"S":"http://ia.media-imdb.com/images/M/MV5BMTQyMDE0MTY0OV5BMl5BanBnXkFtZTcwMjI2OTI0OQ@@._V1_SX400_.jpg"},"genres":{"L":[{"S":"Action"},{"S":"Biography"},{"S":"Drama"},{"S":"Sport"}]},"directors":{"L":[{"S":"Ron Howard"}]},"rating":{"N":"8.3"},"rank":{"N":"2"},"running_time_secs":{"N":"7380"}}},"title":{"S":"Rush"}},{"year":{"N":"2013"},"info":{"M":{"actors":{"L":[{"S":"David Matthewman"},{"S":"Ann Thomas"},{"S":"Jonathan G. Neff"}]},"release_date":{"S":"2013-01-18T00:00:00Z"},"plot":{"S":"A rock band plays their music at high volumes, annoying the neighbors."},"genres":{"L":[{"S":"Comedy"},{"S":"Drama"}]},"image_url":{"S":"http://ia.media-imdb.com/images/N/O9ERWAU7FS797AJ7LU8HN09AMUP908RLlo5JF90EWR7LJKQ7@@._V1_SX400_.jpg"},"directors":{"L":[{"S":"Alice Smith"},{"S":"Bob Jones"}]},"rating":{"N":"6.2"},"rank":{"N":"11"},"running_time_secs":{"N":"5215"}}},"title":{"S":"Turn It Down, Or Else!"}}],"ScannedCount":2}"#))
         .unwrap();
 
-    let parser = Query::new();
-    let output = <Query as ParseHttpResponse>::parse_loaded(&parser, &response).unwrap();
-    assert_eq!(2, output.count);
+        let parser = Query::new();
+        let output = <Query as ParseHttpResponse>::parse_loaded(&parser, &response).unwrap();
+        assert_eq!(2, output.count);
+    }
 }
 
 fn bench_group(c: &mut Criterion) {

--- a/aws/sdk/integration-tests/dynamodb/benches/serialization_bench.rs
+++ b/aws/sdk/integration-tests/dynamodb/benches/serialization_bench.rs
@@ -7,7 +7,6 @@ use aws_sdk_dynamodb::operation::put_item::PutItemInput;
 use aws_sdk_dynamodb::types::AttributeValue;
 use aws_sdk_dynamodb::Config;
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures_util::FutureExt;
 
 macro_rules! attr_s {
     ($str_val:expr) => {
@@ -34,15 +33,20 @@ macro_rules! attr_obj {
     };
 }
 
-fn do_bench(config: &Config, input: &PutItemInput) {
-    let operation = input
-        .make_operation(&config)
-        .now_or_never()
-        .unwrap()
-        .expect("operation failed to build");
-    let (http_request, _parts) = operation.into_request_response().0.into_parts();
-    let body = http_request.body().bytes().unwrap();
-    assert_eq!(body[0], b'{');
+fn do_bench(_config: &Config, _input: &PutItemInput) {
+    #[cfg(not(aws_sdk_orchestrator_mode))]
+    {
+        use futures_util::FutureExt;
+
+        let operation = _input
+            .make_operation(&_config)
+            .now_or_never()
+            .unwrap()
+            .expect("operation failed to build");
+        let (http_request, _parts) = operation.into_request_response().0.into_parts();
+        let body = http_request.body().bytes().unwrap();
+        assert_eq!(body[0], b'{');
+    }
 }
 
 fn bench_group(c: &mut Criterion) {

--- a/aws/sdk/integration-tests/kms/Cargo.toml
+++ b/aws/sdk/integration-tests/kms/Cargo.toml
@@ -13,10 +13,12 @@ publish = false
 [dev-dependencies]
 aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
+aws-runtime = { path = "../../build/aws-sdk/sdk/aws-runtime" }
 aws-sdk-kms = { path = "../../build/aws-sdk/sdk/kms" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-http = { path = "../../build/aws-sdk/sdk/aws-smithy-http" }
 aws-smithy-types = { path = "../../build/aws-sdk/sdk/aws-smithy-types" }
+aws-smithy-runtime-api = { path = "../../build/aws-sdk/sdk/aws-smithy-runtime-api" }
 bytes = "1.0.0"
 http = "0.2.0"
 tokio = { version = "1.23.1", features = ["full", "test-util"]}

--- a/aws/sdk/integration-tests/kms/tests/retryable_errors.rs
+++ b/aws/sdk/integration-tests/kms/tests/retryable_errors.rs
@@ -1,0 +1,139 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#[cfg(not(aws_sdk_orchestrator_mode))]
+mod middleware_mode_tests {
+    use aws_http::retry::AwsResponseRetryClassifier;
+    use aws_sdk_kms as kms;
+    use aws_smithy_http::body::SdkBody;
+    use aws_smithy_http::operation::{self, Parts};
+    use aws_smithy_http::response::ParseStrictResponse;
+    use aws_smithy_http::result::SdkError;
+    use aws_smithy_http::retry::ClassifyRetry;
+    use aws_smithy_types::retry::{ErrorKind, RetryKind};
+    use bytes::Bytes;
+    use kms::operation::create_alias::{CreateAlias, CreateAliasInput};
+
+    async fn create_alias_op() -> Parts<CreateAlias, AwsResponseRetryClassifier> {
+        let conf = kms::Config::builder().build();
+        let (_, parts) = CreateAliasInput::builder()
+            .build()
+            .unwrap()
+            .make_operation(&conf)
+            .await
+            .expect("valid request")
+            .into_request_response();
+        parts
+    }
+
+    /// Parse a semi-real response body and assert that the correct retry status is returned
+    #[tokio::test]
+    async fn errors_are_retryable() {
+        let op = create_alias_op().await;
+        let http_response = http::Response::builder()
+            .status(400)
+            .body(Bytes::from_static(
+                br#"{ "code": "LimitExceededException" }"#,
+            ))
+            .unwrap();
+        let err = op.response_handler.parse(&http_response).map_err(|e| {
+            SdkError::service_error(
+                e,
+                operation::Response::new(http_response.map(SdkBody::from)),
+            )
+        });
+        let retry_kind = op.retry_classifier.classify_retry(err.as_ref());
+        assert_eq!(retry_kind, RetryKind::Error(ErrorKind::ThrottlingError));
+    }
+
+    #[tokio::test]
+    async fn unmodeled_errors_are_retryable() {
+        let op = create_alias_op().await;
+        let http_response = http::Response::builder()
+            .status(400)
+            .body(Bytes::from_static(br#"{ "code": "ThrottlingException" }"#))
+            .unwrap();
+        let err = op.response_handler.parse(&http_response).map_err(|e| {
+            SdkError::service_error(
+                e,
+                operation::Response::new(http_response.map(SdkBody::from)),
+            )
+        });
+        let retry_kind = op.retry_classifier.classify_retry(err.as_ref());
+        assert_eq!(retry_kind, RetryKind::Error(ErrorKind::ThrottlingError));
+    }
+}
+
+#[cfg(aws_sdk_orchestrator_mode)]
+mod orchestrator_mode_tests {
+    use aws_credential_types::Credentials;
+    use aws_runtime::retries::classifier::AwsErrorCodeClassifier;
+    use aws_sdk_kms as kms;
+    use aws_smithy_client::test_connection::infallible_connection_fn;
+    use aws_smithy_http::result::SdkError;
+    use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+    use aws_smithy_runtime_api::client::retries::RetryReason;
+    use aws_smithy_types::retry::ErrorKind;
+    use bytes::Bytes;
+    use kms::operation::create_alias::CreateAliasError;
+
+    async fn make_err(
+        response: impl Fn() -> http::Response<Bytes> + Send + Sync + 'static,
+    ) -> SdkError<CreateAliasError, HttpResponse> {
+        let conn = infallible_connection_fn(move |_| response());
+        let conf = kms::Config::builder()
+            .http_connector(conn)
+            .credentials_provider(Credentials::for_tests())
+            .region(kms::config::Region::from_static("us-east-1"))
+            .build();
+        let client = kms::Client::from_conf(conf);
+        client
+            .create_alias()
+            .send()
+            .await
+            .expect_err("response was a failure")
+    }
+
+    /// Parse a semi-real response body and assert that the correct retry status is returned
+    #[tokio::test]
+    async fn errors_are_retryable() {
+        let err = make_err(|| {
+            http::Response::builder()
+                .status(400)
+                .body(Bytes::from_static(
+                    br#"{ "code": "LimitExceededException" }"#,
+                ))
+                .unwrap()
+        })
+        .await;
+
+        dbg!(&err);
+        let classifier = AwsErrorCodeClassifier;
+        let retry_kind = classifier.classify_error(&err);
+        assert_eq!(
+            Some(RetryReason::Error(ErrorKind::ThrottlingError)),
+            retry_kind
+        );
+    }
+
+    #[tokio::test]
+    async fn unmodeled_errors_are_retryable() {
+        let err = make_err(|| {
+            http::Response::builder()
+                .status(400)
+                .body(Bytes::from_static(br#"{ "code": "ThrottlingException" }"#))
+                .unwrap()
+        })
+        .await;
+
+        dbg!(&err);
+        let classifier = AwsErrorCodeClassifier;
+        let retry_kind = classifier.classify_error(&err);
+        assert_eq!(
+            Some(RetryReason::Error(ErrorKind::ThrottlingError)),
+            retry_kind
+        );
+    }
+}

--- a/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
+++ b/aws/sdk/integration-tests/kms/tests/sensitive-it.rs
@@ -3,17 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_http::retry::AwsResponseRetryClassifier;
 use aws_sdk_kms as kms;
-use aws_smithy_http::body::SdkBody;
-use aws_smithy_http::operation::{self, Parts};
-use aws_smithy_http::response::ParseStrictResponse;
-use aws_smithy_http::result::SdkError;
-use aws_smithy_http::retry::ClassifyRetry;
-use aws_smithy_types::retry::{ErrorKind, RetryKind};
-use bytes::Bytes;
-use kms::operation::create_alias::{CreateAlias, CreateAliasError, CreateAliasInput};
-use kms::operation::generate_random::{GenerateRandom, GenerateRandomOutput};
+use kms::operation::generate_random::GenerateRandomOutput;
 use kms::primitives::Blob;
 
 #[test]
@@ -30,95 +21,4 @@ fn validate_sensitive_trait() {
         format!("{:?}", output),
         "GenerateRandomOutput { plaintext: \"*** Sensitive Data Redacted ***\", ciphertext_for_recipient: None, _request_id: None }"
     );
-}
-
-fn assert_send_sync<T: Send + Sync + 'static>() {}
-fn assert_send_fut<T: Send + 'static>(_: T) {}
-fn assert_debug<T: std::fmt::Debug>() {}
-
-#[tokio::test]
-async fn types_are_send_sync() {
-    assert_send_sync::<kms::Error>();
-    assert_send_sync::<kms::error::SdkError<CreateAliasError>>();
-    assert_send_sync::<kms::operation::create_alias::CreateAliasError>();
-    assert_send_sync::<kms::operation::create_alias::CreateAliasOutput>();
-    assert_send_sync::<kms::Client>();
-    assert_send_sync::<GenerateRandom>();
-    let conf = kms::Config::builder().build();
-    assert_send_fut(kms::Client::from_conf(conf).list_keys().send());
-}
-
-#[tokio::test]
-async fn client_is_debug() {
-    let conf = kms::Config::builder().build();
-    let client = kms::Client::from_conf(conf);
-    assert_ne!(format!("{:?}", client), "");
-}
-
-#[tokio::test]
-async fn client_is_clone() {
-    let conf = kms::Config::builder().build();
-    let client = kms::Client::from_conf(conf);
-
-    fn is_clone(it: impl Clone) {
-        drop(it)
-    }
-
-    is_clone(client);
-}
-
-#[test]
-fn types_are_debug() {
-    assert_debug::<kms::Client>();
-    assert_debug::<kms::operation::generate_random::builders::GenerateRandomFluentBuilder>();
-    assert_debug::<kms::operation::create_alias::builders::CreateAliasFluentBuilder>();
-}
-
-async fn create_alias_op() -> Parts<CreateAlias, AwsResponseRetryClassifier> {
-    let conf = kms::Config::builder().build();
-    let (_, parts) = CreateAliasInput::builder()
-        .build()
-        .unwrap()
-        .make_operation(&conf)
-        .await
-        .expect("valid request")
-        .into_request_response();
-    parts
-}
-
-/// Parse a semi-real response body and assert that the correct retry status is returned
-#[tokio::test]
-async fn errors_are_retryable() {
-    let op = create_alias_op().await;
-    let http_response = http::Response::builder()
-        .status(400)
-        .body(Bytes::from_static(
-            br#"{ "code": "LimitExceededException" }"#,
-        ))
-        .unwrap();
-    let err = op.response_handler.parse(&http_response).map_err(|e| {
-        SdkError::service_error(
-            e,
-            operation::Response::new(http_response.map(SdkBody::from)),
-        )
-    });
-    let retry_kind = op.retry_classifier.classify_retry(err.as_ref());
-    assert_eq!(retry_kind, RetryKind::Error(ErrorKind::ThrottlingError));
-}
-
-#[tokio::test]
-async fn unmodeled_errors_are_retryable() {
-    let op = create_alias_op().await;
-    let http_response = http::Response::builder()
-        .status(400)
-        .body(Bytes::from_static(br#"{ "code": "ThrottlingException" }"#))
-        .unwrap();
-    let err = op.response_handler.parse(&http_response).map_err(|e| {
-        SdkError::service_error(
-            e,
-            operation::Response::new(http_response.map(SdkBody::from)),
-        )
-    });
-    let retry_kind = op.retry_classifier.classify_retry(err.as_ref());
-    assert_eq!(retry_kind, RetryKind::Error(ErrorKind::ThrottlingError));
 }

--- a/aws/sdk/integration-tests/kms/tests/traits.rs
+++ b/aws/sdk/integration-tests/kms/tests/traits.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use aws_sdk_kms as kms;
+use kms::operation::create_alias::CreateAliasError;
+use kms::operation::generate_random::GenerateRandom;
+
+fn assert_send_sync<T: Send + Sync + 'static>() {}
+fn assert_send_fut<T: Send + 'static>(_: T) {}
+fn assert_debug<T: std::fmt::Debug>() {}
+
+#[tokio::test]
+async fn types_are_send_sync() {
+    assert_send_sync::<kms::Error>();
+    assert_send_sync::<kms::error::SdkError<CreateAliasError>>();
+    assert_send_sync::<kms::operation::create_alias::CreateAliasError>();
+    assert_send_sync::<kms::operation::create_alias::CreateAliasOutput>();
+    assert_send_sync::<kms::Client>();
+    assert_send_sync::<GenerateRandom>();
+    let conf = kms::Config::builder().build();
+    assert_send_fut(kms::Client::from_conf(conf).list_keys().send());
+}
+
+#[tokio::test]
+async fn client_is_debug() {
+    let conf = kms::Config::builder().build();
+    let client = kms::Client::from_conf(conf);
+    assert_ne!(format!("{:?}", client), "");
+}
+
+#[tokio::test]
+async fn client_is_clone() {
+    let conf = kms::Config::builder().build();
+    let client = kms::Client::from_conf(conf);
+
+    fn is_clone(it: impl Clone) {
+        drop(it)
+    }
+
+    is_clone(client);
+}
+
+#[test]
+fn types_are_debug() {
+    assert_debug::<kms::Client>();
+    assert_debug::<kms::operation::generate_random::builders::GenerateRandomFluentBuilder>();
+    assert_debug::<kms::operation::create_alias::builders::CreateAliasFluentBuilder>();
+}

--- a/aws/sdk/integration-tests/lambda/Cargo.toml
+++ b/aws/sdk/integration-tests/lambda/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dev-dependencies]
 async-stream = "0.3.0"
 aws-http = { path = "../../build/aws-sdk/sdk/aws-http" }
+aws-credential-types = { path = "../../build/aws-sdk/sdk/aws-credential-types", features = ["test-util"] }
 aws-sdk-lambda = { path = "../../build/aws-sdk/sdk/lambda" }
 aws-smithy-client = { path = "../../build/aws-sdk/sdk/aws-smithy-client", features = ["test-util", "rustls"] }
 aws-smithy-eventstream = { path = "../../build/aws-sdk/sdk/aws-smithy-eventstream" }

--- a/aws/sdk/integration-tests/lambda/tests/request_id.rs
+++ b/aws/sdk/integration-tests/lambda/tests/request_id.rs
@@ -3,36 +3,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-use aws_sdk_lambda::operation::list_functions::{ListFunctions, ListFunctionsError};
+use aws_sdk_lambda::config::{Credentials, Region};
+use aws_sdk_lambda::operation::list_functions::ListFunctionsError;
 use aws_sdk_lambda::operation::RequestId;
-use aws_smithy_http::response::ParseHttpResponse;
-use bytes::Bytes;
+use aws_sdk_lambda::{Client, Config};
+use aws_smithy_client::test_connection::infallible_connection_fn;
 
-#[test]
-fn get_request_id_from_unmodeled_error() {
-    let resp = http::Response::builder()
-        .header("x-amzn-RequestId", "correct-request-id")
-        .header("X-Amzn-Errortype", "ListFunctions")
-        .status(500)
-        .body("{}")
-        .unwrap();
-    let err = ListFunctions::new()
-        .parse_loaded(&resp.map(Bytes::from))
-        .expect_err("status was 500, this is an error");
-    assert!(matches!(err, ListFunctionsError::Unhandled(_)));
-    assert_eq!(Some("correct-request-id"), err.request_id());
-    assert_eq!(Some("correct-request-id"), err.meta().request_id());
+async fn run_test(
+    response: impl Fn() -> http::Response<&'static str> + Send + Sync + 'static,
+    expect_error: bool,
+) {
+    let conn = infallible_connection_fn(move |_| response());
+    let conf = Config::builder()
+        .http_connector(conn)
+        .credentials_provider(Credentials::for_tests())
+        .region(Region::from_static("us-east-1"))
+        .build();
+    let client = Client::from_conf(conf);
+    let resp = client.list_functions().send().await;
+    if expect_error {
+        let err = resp.err().expect("should be an error").into_service_error();
+        assert!(matches!(err, ListFunctionsError::Unhandled(_)));
+        assert_eq!(Some("correct-request-id"), err.request_id());
+        assert_eq!(Some("correct-request-id"), err.meta().request_id());
+    } else {
+        let output = resp.expect("should be successful");
+        assert_eq!(Some("correct-request-id"), output.request_id());
+    }
 }
 
-#[test]
-fn get_request_id_from_successful_response() {
-    let resp = http::Response::builder()
-        .header("x-amzn-RequestId", "correct-request-id")
-        .status(200)
-        .body(r#"{"Functions":[],"NextMarker":null}"#)
-        .unwrap();
-    let output = ListFunctions::new()
-        .parse_loaded(&resp.map(Bytes::from))
-        .expect("valid successful response");
-    assert_eq!(Some("correct-request-id"), output.request_id());
+#[tokio::test]
+async fn get_request_id_from_unmodeled_error() {
+    run_test(
+        || {
+            http::Response::builder()
+                .header("x-amzn-RequestId", "correct-request-id")
+                .header("X-Amzn-Errortype", "ListFunctions")
+                .status(500)
+                .body("{}")
+                .unwrap()
+        },
+        true,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn get_request_id_from_successful_response() {
+    run_test(
+        || {
+            http::Response::builder()
+                .header("x-amzn-RequestId", "correct-request-id")
+                .status(200)
+                .body(r#"{"Functions":[],"NextMarker":null}"#)
+                .unwrap()
+        },
+        false,
+    )
+    .await;
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -150,6 +150,8 @@ class CustomizableOperationGenerator(
 
         val codegenScope = arrayOf(
             *preludeScope,
+            "HttpRequest" to RuntimeType.smithyRuntimeApi(runtimeConfig)
+                .resolve("client::orchestrator::HttpRequest"),
             "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig)
                 .resolve("client::orchestrator::HttpResponse"),
             "Interceptor" to RuntimeType.smithyRuntimeApi(runtimeConfig)
@@ -193,7 +195,7 @@ class CustomizableOperationGenerator(
                 /// Allows for customizing the operation's request.
                 pub fn map_request<F, E>(mut self, f: F) -> Self
                 where
-                    F: #{Fn}(&mut http::Request<#{SdkBody}>) -> #{Result}<(), E>
+                    F: #{Fn}(#{HttpRequest}) -> #{Result}<#{HttpRequest}, E>
                         + #{Send}
                         + #{Sync}
                         + 'static,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientDecorator.kt
@@ -53,7 +53,7 @@ class FluentClientDecorator : ClientCodegenDecorator {
             customizations = listOf(GenericFluentClient(codegenContext)),
         ).render(rustCrate)
         rustCrate.withModule(ClientRustModule.Client.customize) {
-            renderCustomizableOperationSend(codegenContext.runtimeConfig, generics, this)
+            renderCustomizableOperationSend(codegenContext, generics, this)
         }
 
         rustCrate.mergeFeature(Feature("rustls", default = true, listOf("aws-smithy-client/rustls")))

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -408,8 +408,11 @@ class FluentClientGenerator(
                     ##[doc(hidden)]
                     pub async fn send_middleware(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}>>
                     #{send_bounds:W} {
-                        let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
-                        #{Operation}::orchestrate_with_middleware(input, self.handle, #{None}).await
+                        let op = self.inner.build().map_err(#{SdkError}::construction_failure)?
+                            .make_operation(&self.handle.conf)
+                            .await
+                            .map_err(#{SdkError}::construction_failure)?;
+                        self.handle.client.call(op).await
                     }
                     """,
                     *middlewareScope,
@@ -461,7 +464,7 @@ class FluentClientGenerator(
                     ##[doc(hidden)]
                     pub async fn send_orchestrator(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}, #{HttpResponse}>> {
                         let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
-                        #{Operation}::orchestrate_with_invoke(input, self.handle, self.config_override).await
+                        #{Operation}::orchestrate(input, self.handle, self.config_override).await
                     }
 
                     ##[doc(hidden)]

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -108,53 +108,9 @@ class FluentClientGenerator(
                     "client" to RuntimeType.smithyClient(runtimeConfig),
                 )
             }
-            rustTemplate(
-                """
-                ##[derive(Debug)]
-                pub(crate) struct Handle#{generics_decl:W} {
-                    pub(crate) client: #{client}::Client#{smithy_inst:W},
-                    pub(crate) conf: crate::Config,
-                }
-
-                #{client_docs:W}
-                ##[derive(::std::fmt::Debug)]
-                pub struct Client#{generics_decl:W} {
-                    handle: #{Arc}<Handle${generics.inst}>
-                }
-
-                impl${generics.inst} #{Clone} for Client${generics.inst} {
-                    fn clone(&self) -> Self {
-                        Self { handle: self.handle.clone() }
-                    }
-                }
-
-                impl${generics.inst} From<#{client}::Client#{smithy_inst:W}> for Client${generics.inst} {
-                    fn from(client: #{client}::Client#{smithy_inst:W}) -> Self {
-                        Self::with_config(client, crate::Config::builder().build())
-                    }
-                }
-
-                impl${generics.inst} Client${generics.inst} {
-                    /// Creates a client with the given service configuration.
-                    pub fn with_config(client: #{client}::Client#{smithy_inst:W}, conf: crate::Config) -> Self {
-                        Self {
-                            handle: #{Arc}::new(Handle {
-                                client,
-                                conf,
-                            })
-                        }
-                    }
-
-                    /// Returns the client's configuration.
-                    pub fn conf(&self) -> &crate::Config {
-                        &self.handle.conf
-                    }
-                }
-                """,
+            val clientScope = arrayOf(
                 *preludeScope,
                 "Arc" to RuntimeType.Arc,
-                "generics_decl" to generics.decl,
-                "smithy_inst" to generics.smithyInst,
                 "client" to RuntimeType.smithyClient(runtimeConfig),
                 "client_docs" to writable
                     {
@@ -166,7 +122,128 @@ class FluentClientGenerator(
                             )(this)
                         }
                     },
+                "RetryConfig" to RuntimeType.smithyTypes(runtimeConfig).resolve("retry::RetryConfig"),
+                "TimeoutConfig" to RuntimeType.smithyTypes(runtimeConfig).resolve("timeout::TimeoutConfig"),
+                // TODO(enableNewSmithyRuntime): Delete the generics when cleaning up middleware
+                "generics_decl" to generics.decl,
+                "smithy_inst" to generics.smithyInst,
             )
+            if (codegenContext.smithyRuntimeMode.generateMiddleware) {
+                rustTemplate(
+                    """
+                    ##[derive(Debug)]
+                    pub(crate) struct Handle#{generics_decl:W} {
+                        pub(crate) client: #{client}::Client#{smithy_inst:W},
+                        pub(crate) conf: crate::Config,
+                    }
+
+                    #{client_docs:W}
+                    ##[derive(::std::fmt::Debug)]
+                    pub struct Client#{generics_decl:W} {
+                        handle: #{Arc}<Handle${generics.inst}>
+                    }
+
+                    impl${generics.inst} #{Clone} for Client${generics.inst} {
+                        fn clone(&self) -> Self {
+                            Self { handle: self.handle.clone() }
+                        }
+                    }
+
+                    impl${generics.inst} From<#{client}::Client#{smithy_inst:W}> for Client${generics.inst} {
+                        fn from(client: #{client}::Client#{smithy_inst:W}) -> Self {
+                            Self::with_config(client, crate::Config::builder().build())
+                        }
+                    }
+
+                    impl${generics.inst} Client${generics.inst} {
+                        /// Creates a client with the given service configuration.
+                        pub fn with_config(client: #{client}::Client#{smithy_inst:W}, conf: crate::Config) -> Self {
+                            Self {
+                                handle: #{Arc}::new(Handle {
+                                    client,
+                                    conf,
+                                })
+                            }
+                        }
+
+                        /// Returns the client's configuration.
+                        pub fn conf(&self) -> &crate::Config {
+                            &self.handle.conf
+                        }
+                    }
+                    """,
+                    *clientScope,
+                )
+            } else {
+                rustTemplate(
+                    """
+                    ##[derive(Debug)]
+                    pub(crate) struct Handle {
+                        pub(crate) conf: crate::Config,
+                    }
+
+                    #{client_docs:W}
+                    ##[derive(::std::fmt::Debug)]
+                    pub struct Client {
+                        handle: #{Arc}<Handle>
+                    }
+
+                    impl #{Clone} for Client {
+                        fn clone(&self) -> Self {
+                            Self { handle: self.handle.clone() }
+                        }
+                    }
+
+                    impl Client {
+                        /// Creates a new client from the service [`Config`](crate::Config).
+                        ///
+                        /// ## Panics
+                        ///
+                        /// - This method will panic if the `conf` is missing an async sleep implementation. If you experience this panic, set
+                        ///     the `sleep_impl` on the Config passed into this function to fix it.
+                        /// - This method will panic if the `conf` is missing an HTTP connector. If you experience this panic, set the
+                        ///     `http_connector` on the Config passed into this function to fix it.
+                        pub fn from_conf(conf: crate::Config) -> Self {
+                            let retry_config = conf.retry_config().cloned().unwrap_or_else(#{RetryConfig}::disabled);
+                            let timeout_config = conf.timeout_config().cloned().unwrap_or_else(#{TimeoutConfig}::disabled);
+                            let sleep_impl = conf.sleep_impl();
+                            if (retry_config.has_retry() || timeout_config.has_timeouts()) && sleep_impl.is_none() {
+                                panic!("An async sleep implementation is required for retries or timeouts to work. \
+                                        Set the `sleep_impl` on the Config passed into this function to fix this panic.");
+                            }
+
+                            Self {
+                                handle: #{Arc}::new(Handle { conf })
+                            }
+                        }
+
+                        /// Returns the client's configuration.
+                        pub fn config(&self) -> &crate::Config {
+                            &self.handle.conf
+                        }
+
+                        ##[doc(hidden)]
+                        // TODO(enableNewSmithyRuntime): Delete this function when cleaning up middleware
+                        // This is currently kept around so the tests still compile in both modes
+                        /// Creates a client with the given service configuration.
+                        pub fn with_config<C, M, R>(_client: #{client}::Client<C, M, R>, conf: crate::Config) -> Self {
+                            Self {
+                                handle: #{Arc}::new(Handle { conf })
+                            }
+                        }
+
+                        ##[doc(hidden)]
+                        // TODO(enableNewSmithyRuntime): Delete this function when cleaning up middleware
+                        // This is currently kept around so the tests still compile in both modes
+                        /// Returns the client's configuration.
+                        pub fn conf(&self) -> &crate::Config {
+                            &self.handle.conf
+                        }
+                    }
+                    """,
+                    *clientScope,
+                )
+            }
         }
 
         operations.forEach { operation ->
@@ -293,78 +370,78 @@ class FluentClientGenerator(
                     }
                 }
             }
-            val middlewareScope = arrayOf(
-                *preludeScope,
-                "CustomizableOperation" to ClientRustModule.Client.customize.toType()
-                    .resolve("CustomizableOperation"),
-                "ClassifyRetry" to RuntimeType.classifyRetry(runtimeConfig),
-                "OperationError" to errorType,
-                "OperationOutput" to outputType,
-                "SdkError" to RuntimeType.sdkError(runtimeConfig),
-                "SdkSuccess" to RuntimeType.sdkSuccess(runtimeConfig),
-                "send_bounds" to generics.sendBounds(operationSymbol, outputType, errorType, retryClassifier),
-                "customizable_op_type_params" to rustTypeParameters(
-                    symbolProvider.toSymbol(operation),
-                    retryClassifier,
-                    generics.toRustGenerics(),
-                ),
-            )
-            rustTemplate(
-                """
-                // This function will go away in the near future. Do not rely on it.
-                ##[doc(hidden)]
-                pub async fn customize_middleware(self) -> #{Result}<
-                    #{CustomizableOperation}#{customizable_op_type_params:W},
-                    #{SdkError}<#{OperationError}>
-                > #{send_bounds:W} {
-                    let handle = self.handle.clone();
-                    let operation = self.inner.build().map_err(#{SdkError}::construction_failure)?
-                        .make_operation(&handle.conf)
-                        .await
-                        .map_err(#{SdkError}::construction_failure)?;
-                    #{Ok}(#{CustomizableOperation} { handle, operation })
-                }
-
-                // This function will go away in the near future. Do not rely on it.
-                ##[doc(hidden)]
-                pub async fn send_middleware(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}>>
-                #{send_bounds:W} {
-                    let op = self.inner.build().map_err(#{SdkError}::construction_failure)?
-                        .make_operation(&self.handle.conf)
-                        .await
-                        .map_err(#{SdkError}::construction_failure)?;
-                    self.handle.client.call(op).await
-                }
-                """,
-                *middlewareScope,
-            )
-            if (smithyRuntimeMode.defaultToMiddleware) {
+            if (smithyRuntimeMode.generateMiddleware) {
+                val middlewareScope = arrayOf(
+                    *preludeScope,
+                    "CustomizableOperation" to ClientRustModule.Client.customize.toType()
+                        .resolve("CustomizableOperation"),
+                    "ClassifyRetry" to RuntimeType.classifyRetry(runtimeConfig),
+                    "Operation" to operationSymbol,
+                    "OperationError" to errorType,
+                    "OperationOutput" to outputType,
+                    "SdkError" to RuntimeType.sdkError(runtimeConfig),
+                    "SdkSuccess" to RuntimeType.sdkSuccess(runtimeConfig),
+                    "send_bounds" to generics.sendBounds(operationSymbol, outputType, errorType, retryClassifier),
+                    "customizable_op_type_params" to rustTypeParameters(
+                        symbolProvider.toSymbol(operation),
+                        retryClassifier,
+                        generics.toRustGenerics(),
+                    ),
+                )
                 rustTemplate(
                     """
-                    /// Sends the request and returns the response.
-                    ///
-                    /// If an error occurs, an `SdkError` will be returned with additional details that
-                    /// can be matched against.
-                    ///
-                    /// By default, any retryable failures will be retried twice. Retry behavior
-                    /// is configurable with the [RetryConfig](aws_smithy_types::retry::RetryConfig), which can be
-                    /// set when configuring the client.
-                    pub async fn send(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}>>
-                    #{send_bounds:W} {
-                        self.send_middleware().await
-                    }
-
-                    /// Consumes this builder, creating a customizable operation that can be modified before being
-                    /// sent. The operation's inner [http::Request] can be modified as well.
-                    pub async fn customize(self) -> #{Result}<
+                    // This function will go away in the near future. Do not rely on it.
+                    ##[doc(hidden)]
+                    pub async fn customize_middleware(self) -> #{Result}<
                         #{CustomizableOperation}#{customizable_op_type_params:W},
                         #{SdkError}<#{OperationError}>
                     > #{send_bounds:W} {
-                        self.customize_middleware().await
+                        let handle = self.handle.clone();
+                        let operation = self.inner.build().map_err(#{SdkError}::construction_failure)?
+                            .make_operation(&handle.conf)
+                            .await
+                            .map_err(#{SdkError}::construction_failure)?;
+                        #{Ok}(#{CustomizableOperation} { handle, operation })
+                    }
+
+                    // This function will go away in the near future. Do not rely on it.
+                    ##[doc(hidden)]
+                    pub async fn send_middleware(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}>>
+                    #{send_bounds:W} {
+                        let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
+                        #{Operation}::orchestrate_with_middleware(input, self.handle, #{None}).await
                     }
                     """,
                     *middlewareScope,
                 )
+                if (smithyRuntimeMode.defaultToMiddleware) {
+                    rustTemplate(
+                        """
+                        /// Sends the request and returns the response.
+                        ///
+                        /// If an error occurs, an `SdkError` will be returned with additional details that
+                        /// can be matched against.
+                        ///
+                        /// By default, any retryable failures will be retried twice. Retry behavior
+                        /// is configurable with the [RetryConfig](aws_smithy_types::retry::RetryConfig), which can be
+                        /// set when configuring the client.
+                        pub async fn send(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}>>
+                        #{send_bounds:W} {
+                            self.send_middleware().await
+                        }
+
+                        /// Consumes this builder, creating a customizable operation that can be modified before being
+                        /// sent. The operation's inner [http::Request] can be modified as well.
+                        pub async fn customize(self) -> #{Result}<
+                            #{CustomizableOperation}#{customizable_op_type_params:W},
+                            #{SdkError}<#{OperationError}>
+                        > #{send_bounds:W} {
+                            self.customize_middleware().await
+                        }
+                        """,
+                        *middlewareScope,
+                    )
+                }
             }
 
             if (smithyRuntimeMode.generateOrchestrator) {
@@ -374,48 +451,17 @@ class FluentClientGenerator(
                         .resolve("CustomizableOperation"),
                     "HttpResponse" to RuntimeType.smithyRuntimeApi(runtimeConfig)
                         .resolve("client::orchestrator::HttpResponse"),
+                    "Operation" to operationSymbol,
                     "OperationError" to errorType,
-                    "Operation" to symbolProvider.toSymbol(operation),
                     "OperationOutput" to outputType,
-                    "RuntimePlugin" to RuntimeType.runtimePlugin(runtimeConfig),
-                    "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig)
-                        .resolve("client::runtime_plugin::RuntimePlugins"),
                     "SdkError" to RuntimeType.sdkError(runtimeConfig),
-                    "TypedBox" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("type_erasure::TypedBox"),
-                    "invoke" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::orchestrator::invoke"),
                 )
                 rustTemplate(
                     """
                     ##[doc(hidden)]
                     pub async fn send_orchestrator(self) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}, #{HttpResponse}>> {
-                        self.send_orchestrator_with_plugin(#{Option}::<Box<dyn #{RuntimePlugin} + #{Send} + #{Sync}>>::None).await
-                    }
-
-                    ##[doc(hidden)]
-                    // TODO(enableNewSmithyRuntime): Delete when unused
-                    /// Equivalent to [`Self::send_orchestrator`] but adds a final runtime plugin to shim missing behavior
-                    pub async fn send_orchestrator_with_plugin(self, final_plugin: #{Option}<impl #{RuntimePlugin} + #{Send} + #{Sync} + 'static>) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}, #{HttpResponse}>> {
-                        let mut runtime_plugins = #{RuntimePlugins}::new()
-                            .with_client_plugin(crate::config::ServiceRuntimePlugin::new(self.handle.clone()));
-                        runtime_plugins = runtime_plugins.with_operation_plugin(#{Operation}::new());
-                        if let Some(config_override) = self.config_override {
-                            runtime_plugins = runtime_plugins.with_operation_plugin(config_override);
-                        }
-                        if let Some(final_plugin) = final_plugin {
-                            runtime_plugins = runtime_plugins.with_client_plugin(final_plugin);
-                        }
                         let input = self.inner.build().map_err(#{SdkError}::construction_failure)?;
-                        let input = #{TypedBox}::new(input).erase();
-                        let output = #{invoke}(input, &runtime_plugins)
-                            .await
-                            .map_err(|err| {
-                                err.map_service_error(|err| {
-                                    #{TypedBox}::<#{OperationError}>::assume_from(err.into())
-                                        .expect("correct error type")
-                                        .unwrap()
-                                })
-                            })?;
-                        #{Ok}(#{TypedBox}::<#{OperationOutput}>::assume_from(output).expect("correct output type").unwrap())
+                        #{Operation}::orchestrate_with_invoke(input, self.handle, self.config_override).await
                     }
 
                     ##[doc(hidden)]

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ClientProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ClientProtocolGenerator.kt
@@ -150,8 +150,9 @@ open class ClientProtocolGenerator(
             if (codegenContext.smithyRuntimeMode.generateMiddleware) {
                 rustTemplate(
                     """
+                    ##[allow(unused_mut)]
                     pub(crate) async fn orchestrate_with_middleware(
-                        input: #{Input},
+                        mut input: #{Input},
                         handle: #{Arc}<crate::client::Handle>,
                         _config_override: #{Option}<crate::config::Builder>,
                     ) -> #{Result}<#{OperationOutput}, #{SdkError}<#{OperationError}>> {

--- a/rust-runtime/aws-smithy-http/src/operation.rs
+++ b/rust-runtime/aws-smithy-http/src/operation.rs
@@ -60,6 +60,7 @@ pub struct Parts<H, R> {
     pub metadata: Option<Metadata>,
 }
 
+// TODO(enableNewSmithyRuntime): Delete `operation::Operation` when cleaning up middleware
 /// An [`Operation`] is a request paired with a response handler, retry classifier,
 /// and metadata that identifies the API being called.
 ///
@@ -159,6 +160,7 @@ impl<H> Operation<H, ()> {
     }
 }
 
+// TODO(enableNewSmithyRuntime): Delete `operation::Request` when cleaning up middleware
 /// Operation request type that associates a property bag with an underlying HTTP request.
 /// This type represents the request in the Tower `Service` in middleware so that middleware
 /// can share information with each other via the properties.
@@ -250,6 +252,7 @@ impl Request {
     }
 }
 
+// TODO(enableNewSmithyRuntime): Delete `operation::Response` when cleaning up middleware
 /// Operation response type that associates a property bag with an underlying HTTP response.
 /// This type represents the response in the Tower `Service` in middleware so that middleware
 /// can share information with each other via the properties.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/runtime_plugin.rs
@@ -39,6 +39,12 @@ impl RuntimePlugins {
         Default::default()
     }
 
+    pub fn for_operation(operation: Box<dyn RuntimePlugin + Send + Sync>) -> Self {
+        let mut plugins = Self::new();
+        plugins.operation_plugins.push(operation);
+        plugins
+    }
+
     pub fn with_client_plugin(
         mut self,
         plugin: impl RuntimePlugin + Send + Sync + 'static,

--- a/tools/ci-scripts/check-aws-sdk-orchestrator-impl
+++ b/tools/ci-scripts/check-aws-sdk-orchestrator-impl
@@ -17,6 +17,7 @@ services_that_fail_compile=(\
     "s3"\
     "s3control"\
     "transcribestreaming"\
+    "polly"\
 )
 
 # TODO(enableNewSmithyRuntime): Move these into `services_that_pass_tests` as more progress is made
@@ -34,7 +35,6 @@ services_that_pass_tests=(\
     "iam"\
     "kms"\
     "lambda"\
-    "polly"\
     "qldbsession"\
     "sso"\
 )
@@ -45,14 +45,14 @@ cd aws/sdk/build/aws-sdk/sdk
 for service in "${services_that_compile[@]}"; do
     pushd "${service}"
     echo -e "${C_YELLOW}# Running 'cargo check --all-features' on '${service}'${C_RESET}"
-    cargo check --all-features
+    RUSTFLAGS="${RUSTFLAGS:-} --cfg aws_sdk_orchestrator_mode" cargo check --all-features
     popd
 done
 
 for service in "${services_that_pass_tests[@]}"; do
     pushd "${service}"
     echo -e "${C_YELLOW}# Running 'cargo test --all-features' on '${service}'${C_RESET}"
-    cargo test --all-features --no-fail-fast
+    RUSTFLAGS="${RUSTFLAGS:-} --cfg aws_sdk_orchestrator_mode" cargo test --all-features --no-fail-fast
     popd
 done
 


### PR DESCRIPTION
## Motivation and Context
This PR removes all the middleware code from generated clients when the `smithy.runtime.mode` flag is set to `orchestrator`. It also changes the `aws-config` crate to use the fluent client instead of the Smithy client for STS and SSO based credential providers.

The `polly` test no longer compiles in orchestrator mode with these changes since presigning directly references middleware code. This will get fixed in a later PR.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
