### PR TITLE
Add `sdk_ua_app_id` in addition to sdk-ua-app-id in profile file support

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -652,3 +652,9 @@ message = "Public fields in structs are no longer marked as `#[doc(hidden)]`, an
 references = ["smithy-rs#2854"]
 meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client" }
 author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "The AppName property can now be set with `sdk_ua_app_id` in profile files. The old field, `sdk-ua-app-id`, is maintained for backwards compatibility."
+references = ["smithy-rs#2724"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+author = "rcoh"

--- a/aws/rust-runtime/aws-config/src/environment/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/environment/app_name.rs
@@ -9,10 +9,12 @@ use aws_types::os_shim_internal::Env;
 
 /// Load an app name from the `AWS_SDK_UA_APP_ID` environment variable.
 #[derive(Debug, Default)]
+#[deprecated(note = "This is unused and will be removed in a future release.")]
 pub struct EnvironmentVariableAppNameProvider {
     env: Env,
 }
 
+#[allow(deprecated)]
 impl EnvironmentVariableAppNameProvider {
     /// Create a new `EnvironmentVariableAppNameProvider`
     pub fn new() -> Self {
@@ -40,32 +42,5 @@ impl EnvironmentVariableAppNameProvider {
         } else {
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::environment::EnvironmentVariableAppNameProvider;
-    use aws_types::app_name::AppName;
-    use aws_types::os_shim_internal::Env;
-    use std::collections::HashMap;
-
-    #[test]
-    fn env_var_not_set() {
-        let provider = EnvironmentVariableAppNameProvider::new_with_env(Env::from(HashMap::new()));
-        assert_eq!(None, provider.app_name());
-    }
-
-    #[test]
-    fn env_var_set() {
-        let provider = EnvironmentVariableAppNameProvider::new_with_env(Env::from(
-            vec![("AWS_SDK_UA_APP_ID".to_string(), "something".to_string())]
-                .into_iter()
-                .collect::<HashMap<String, String>>(),
-        ));
-        assert_eq!(
-            Some(AppName::new("something").unwrap()),
-            provider.app_name()
-        );
     }
 }

--- a/aws/rust-runtime/aws-config/src/environment/mod.rs
+++ b/aws/rust-runtime/aws-config/src/environment/mod.rs
@@ -8,7 +8,6 @@
 /// Load app name from the environment
 pub mod app_name;
 
-pub use app_name::EnvironmentVariableAppNameProvider;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 

--- a/aws/rust-runtime/aws-config/src/profile/app_name.rs
+++ b/aws/rust-runtime/aws-config/src/profile/app_name.rs
@@ -33,10 +33,14 @@ use aws_types::app_name::AppName;
 ///
 /// This provider is part of the [default app name provider chain](crate::default_provider::app_name).
 #[derive(Debug, Default)]
+#[deprecated(
+    note = "This is unused and is deprecated for backwards compatibility. It will be removed in a future release."
+)]
 pub struct ProfileFileAppNameProvider {
     provider_config: ProviderConfig,
 }
 
+#[allow(deprecated)]
 impl ProfileFileAppNameProvider {
     /// Create a new [ProfileFileAppNameProvider}
     ///
@@ -67,12 +71,14 @@ impl ProfileFileAppNameProvider {
 
 /// Builder for [ProfileFileAppNameProvider]
 #[derive(Debug, Default)]
+#[allow(deprecated)]
 pub struct Builder {
     config: Option<ProviderConfig>,
     profile_override: Option<String>,
     profile_files: Option<ProfileFiles>,
 }
 
+#[allow(deprecated)]
 impl Builder {
     /// Override the configuration for this provider
     pub fn configure(mut self, config: &ProviderConfig) -> Self {
@@ -87,6 +93,7 @@ impl Builder {
     }
 
     /// Build a [ProfileFileAppNameProvider] from this builder
+    #[allow(deprecated)]
     pub fn build(self) -> ProfileFileAppNameProvider {
         let conf = self
             .config
@@ -95,79 +102,5 @@ impl Builder {
         ProfileFileAppNameProvider {
             provider_config: conf,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::ProfileFileAppNameProvider;
-    use crate::provider_config::ProviderConfig;
-    use crate::test_case::no_traffic_connector;
-    use aws_sdk_sts::config::AppName;
-    use aws_types::os_shim_internal::{Env, Fs};
-    use tracing_test::traced_test;
-
-    fn provider_config(config_contents: &str) -> ProviderConfig {
-        let fs = Fs::from_slice(&[("test_config", config_contents)]);
-        let env = Env::from_slice(&[("AWS_CONFIG_FILE", "test_config")]);
-        ProviderConfig::empty()
-            .with_fs(fs)
-            .with_env(env)
-            .with_http_connector(no_traffic_connector())
-    }
-
-    fn default_provider(config_contents: &str) -> ProfileFileAppNameProvider {
-        ProfileFileAppNameProvider::builder()
-            .configure(&provider_config(config_contents))
-            .build()
-    }
-
-    #[tokio::test]
-    async fn no_app_name() {
-        assert_eq!(None, default_provider("[default]\n").app_name().await);
-    }
-
-    #[tokio::test]
-    async fn app_name_default_profile() {
-        assert_eq!(
-            Some(AppName::new("test").unwrap()),
-            default_provider("[default]\nsdk-ua-app-id = test")
-                .app_name()
-                .await
-        );
-    }
-
-    #[tokio::test]
-    async fn app_name_other_profiles() {
-        let config = "\
-            [default]\n\
-            sdk-ua-app-id = test\n\
-            \n\
-            [profile other]\n\
-            sdk-ua-app-id = bar\n
-        ";
-        assert_eq!(
-            Some(AppName::new("bar").unwrap()),
-            ProfileFileAppNameProvider::builder()
-                .profile_name("other")
-                .configure(&provider_config(config))
-                .build()
-                .app_name()
-                .await
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn invalid_app_name() {
-        assert_eq!(
-            None,
-            default_provider("[default]\nsdk-ua-app-id = definitely invalid")
-                .app_name()
-                .await
-        );
-        assert!(logs_contain(
-            "`sdk-ua-app-id` property `definitely invalid` was invalid"
-        ));
     }
 }


### PR DESCRIPTION
## Motivation and Context
The field name is being changed, but we need to maintain support for customers already using this feature

## Description
<!--- Describe your changes in detail -->

## Testing
- existing tests

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
