### PR TITLE
Adjust sSDK error message when using `@range` on floating point shapes

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/ValidateUnsupportedConstraints.kt
@@ -62,10 +62,11 @@ private sealed class UnsupportedConstraintMessageKind {
             shape: Shape,
             constraintTrait: Trait,
             trackingIssue: String,
+            willSupport: Boolean = true,
         ) =
             buildMessage(
                 "The ${shape.type} shape `${shape.id}` has the constraint trait `${constraintTrait.toShapeId()}` attached.",
-                willSupport = true,
+                willSupport,
                 trackingIssue,
             )
 
@@ -105,7 +106,12 @@ private sealed class UnsupportedConstraintMessageKind {
 
             is UnsupportedRangeTraitOnShape -> LogMessage(
                 level,
-                buildMessageShapeHasUnsupportedConstraintTrait(shape, rangeTrait, constraintTraitsUberIssue),
+                buildMessageShapeHasUnsupportedConstraintTrait(
+                    shape,
+                    rangeTrait,
+                    willSupport = false,
+                    trackingIssue = "https://github.com/awslabs/smithy-rs/issues/2007",
+                ),
             )
 
             is UnsupportedUniqueItemsTraitOnShape -> LogMessage(
@@ -253,7 +259,7 @@ fun validateUnsupportedConstraints(
         unsupportedConstraintOnNonErrorShapeReachableViaAnEventStreamSet + unsupportedConstraintErrorShapeReachableViaAnEventStreamSet
 
     // 3. Range trait used on unsupported shapes.
-    // TODO(https://github.com/awslabs/smithy-rs/issues/1401)
+    // TODO(https://github.com/awslabs/smithy-rs/issues/2007)
     val unsupportedRangeTraitOnShapeSet = walker
         .walkShapes(service)
         .asSequence()


### PR DESCRIPTION
To point to a better issue
https://github.com/awslabs/smithy-rs/issues/2007.

Also let users know this is unlikely to ever get implemented.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
