### PR TITLE
Fix tiny_map from_iter where one operation was being dropped

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -12,7 +12,7 @@
 # author = "rcoh"
 
 [[smithy-rs]]
-message = "Fix tiny_map from_iter where one operation was being dropped"
+message = "Fix bug in AWS JSON 1.x routers where, if a service had more than 14 operations, the router was created without the route for the 15th operation."
 author = "thor-bjorgvinsson"
 references = ["smithy-rs#2733"]
 meta = { "breaking" = false, "tada" = false, "bug" = true, "target" ="server" }

--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,6 +11,12 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
+[[smithy-rs]]
+message = "Fix tiny_map from_iter where one operation was being dropped"
+author = "thor-bjorgvinsson"
+references = ["smithy-rs#2733"]
+meta = { "breaking" = false, "tada" = false, "bug" = true, "target" ="server" }
+
 [[aws-sdk-rust]]
 message = "Remove native-tls and add a migration guide."
 author = "82marbag"

--- a/rust-runtime/aws-smithy-http-server/src/routing/tiny_map.rs
+++ b/rust-runtime/aws-smithy-http-server/src/routing/tiny_map.rs
@@ -78,13 +78,13 @@ where
 
         // Populate the `Vec`
         while let Some((index, pair)) = iter.next() {
+            vec.push(pair);
+
             // If overflow `CUTOFF` then return a `HashMap` instead
             if index == CUTOFF {
                 let inner = TinyMapInner::HashMap(vec.into_iter().chain(iter.map(|(_, pair)| pair)).collect());
                 return TinyMap { inner };
             }
-
-            vec.push(pair);
         }
 
         TinyMap {
@@ -158,19 +158,25 @@ mod tests {
     #[test]
     fn get_small_success() {
         let tiny_map: TinyMap<_, _, CUTOFF> = SMALL_VALUES.into_iter().collect();
-        assert_eq!(tiny_map.get("a"), Some(&0))
+        SMALL_VALUES.into_iter().for_each(|(op, val)| {
+            assert_eq!(tiny_map.get(op), Some(&val));
+        });
     }
 
     #[test]
     fn get_medium_success() {
         let tiny_map: TinyMap<_, _, CUTOFF> = MEDIUM_VALUES.into_iter().collect();
-        assert_eq!(tiny_map.get("d"), Some(&3))
+        MEDIUM_VALUES.into_iter().for_each(|(op, val)| {
+            assert_eq!(tiny_map.get(op), Some(&val));
+        });
     }
 
     #[test]
     fn get_large_success() {
         let tiny_map: TinyMap<_, _, CUTOFF> = LARGE_VALUES.into_iter().collect();
-        assert_eq!(tiny_map.get("h"), Some(&7))
+        LARGE_VALUES.into_iter().for_each(|(op, val)| {
+            assert_eq!(tiny_map.get(op), Some(&val));
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Motivation and Context
15th operation was being dropped when iterator was being read into a TinyMap

## Description
The 15th operation was being dropped when the if statement was caught because the operation had been popped of the iterator but hadn't been added to the vec of operations before the two iterators were being chained and collected into a 

## Testing
Added unit tests that reproduced the issue and verified that the issue is fixed

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
