### PR TITLE
Remove Debug bound from struct definition

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -36,6 +36,7 @@ use aws_smithy_http::result::SdkError;
 use aws_smithy_types::config_bag::ConfigBag;
 use aws_smithy_types::type_erasure::{TypeErasedBox, TypeErasedError};
 use phase::Phase;
+use std::fmt::Debug;
 use std::{fmt, mem};
 use tracing::{debug, error, trace};
 
@@ -53,10 +54,7 @@ type Response = HttpResponse;
 /// context in the [`Phase::BeforeSerialization`] phase won't have a `request` yet since the input hasn't been
 /// serialized at that point. But once it gets into the [`Phase::BeforeTransmit`] phase, the `request` will be set.
 #[derive(Debug)]
-pub struct InterceptorContext<I = Input, O = Output, E = Error>
-where
-    E: fmt::Debug,
-{
+pub struct InterceptorContext<I = Input, O = Output, E = Error> {
     pub(crate) input: Option<I>,
     pub(crate) output_or_error: Option<Result<O, OrchestratorError<E>>>,
     pub(crate) request: Option<Request>,
@@ -81,10 +79,7 @@ impl InterceptorContext<Input, Output, Error> {
     }
 }
 
-impl<I, O, E> InterceptorContext<I, O, E>
-where
-    E: fmt::Debug,
-{
+impl<I, O, E: Debug> InterceptorContext<I, O, E> {
     /// Decomposes the context into its constituent parts.
     #[doc(hidden)]
     #[allow(clippy::type_complexity)]

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context/wrappers.rs
@@ -85,8 +85,7 @@ macro_rules! declare_known_method {
 
 macro_rules! declare_wrapper {
     (($ref_struct_name:ident $mut_struct_name:ident)$($tt:tt)+) => {
-        pub struct $ref_struct_name<'a, I = Input, O = Output, E = Error>
-        where E: Debug {
+        pub struct $ref_struct_name<'a, I = Input, O = Output, E = Error> {
             inner: &'a InterceptorContext<I, O, E>,
         }
 
@@ -101,8 +100,7 @@ macro_rules! declare_wrapper {
             declare_ref_wrapper_methods!($($tt)+);
         }
 
-        pub struct $mut_struct_name<'a, I = Input, O = Output, E = Error>
-        where E: Debug {
+        pub struct $mut_struct_name<'a, I = Input, O = Output, E = Error> {
             inner: &'a mut InterceptorContext<I, O, E>,
         }
 
@@ -170,10 +168,7 @@ declare_wrapper!(
 // time. Consider updating the macros to support these last two if you're looking for a challenge.
 // - Zelda
 
-pub struct FinalizerInterceptorContextRef<'a, I = Input, O = Output, E = Error>
-where
-    E: Debug,
-{
+pub struct FinalizerInterceptorContextRef<'a, I = Input, O = Output, E = Error> {
     inner: &'a InterceptorContext<I, O, E>,
 }
 
@@ -203,10 +198,7 @@ impl<'a, I, O, E: Debug> FinalizerInterceptorContextRef<'a, I, O, E> {
     }
 }
 
-pub struct FinalizerInterceptorContextMut<'a, I = Input, O = Output, E = Error>
-where
-    E: Debug,
-{
+pub struct FinalizerInterceptorContextMut<'a, I = Input, O = Output, E = Error> {
     inner: &'a mut InterceptorContext<I, O, E>,
 }
 

--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator/error.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator/error.rs
@@ -13,7 +13,7 @@ use std::fmt::Debug;
 
 #[derive(Debug)]
 #[non_exhaustive]
-pub enum OrchestratorError<E: Debug> {
+pub enum OrchestratorError<E> {
     /// An error occurred within an interceptor.
     Interceptor { err: InterceptorError },
     /// An error returned by a service.


### PR DESCRIPTION
## Description
the debug bound on the struct definition is redundant and is viral, making the code harder to use

## Testing
code compiles


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
