### PR TITLE
Fix server SDK bug with directly constrained list/map shapes in operation output

### DIFF
--- a/codegen-core/common-test-models/constraints.smithy
+++ b/codegen-core/common-test-models/constraints.smithy
@@ -11,6 +11,9 @@ use smithy.framework#ValidationException
 service ConstraintsService {
     operations: [
         ConstrainedShapesOperation,
+        // See https://github.com/awslabs/smithy-rs/issues/2760 for why testing operations reaching
+        // constrained shapes that only lie in the output is important.
+        ConstrainedShapesOnlyInOutputOperation,
         ConstrainedHttpBoundShapesOperation,
         ConstrainedHttpPayloadBoundShapeOperation,
         ConstrainedRecursiveShapesOperation,
@@ -49,6 +52,11 @@ operation ConstrainedShapesOperation {
     input: ConstrainedShapesOperationInputOutput,
     output: ConstrainedShapesOperationInputOutput,
     errors: [ValidationException]
+}
+
+@http(uri: "/constrained-shapes-only-in-output-operation", method: "POST")
+operation ConstrainedShapesOnlyInOutputOperation {
+    output: ConstrainedShapesOnlyInOutputOperationOutput,
 }
 
 @http(
@@ -934,4 +942,32 @@ map MapOfMapOfListOfListOfConB {
 map MapOfListOfListOfConB {
     key: String,
     value: ConBList
+}
+
+structure ConstrainedShapesOnlyInOutputOperationOutput {
+    list: ConstrainedListInOutput
+    map: ConstrainedMapInOutput
+    // Unions were not affected by
+    // https://github.com/awslabs/smithy-rs/issues/2760, but testing anyway for
+    // good measure.
+    union: ConstrainedUnionInOutput
+}
+
+@length(min: 69)
+list ConstrainedListInOutput {
+    member: ConstrainedUnionInOutput
+}
+
+@length(min: 69)
+map ConstrainedMapInOutput {
+    key: String
+    value: TransitivelyConstrainedStructureInOutput
+}
+
+union ConstrainedUnionInOutput {
+    structure: TransitivelyConstrainedStructureInOutput
+}
+
+structure TransitivelyConstrainedStructureInOutput {
+    lengthString: LengthString
 }

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/CollectionConstraintViolationGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/CollectionConstraintViolationGenerator.kt
@@ -48,7 +48,7 @@ class CollectionConstraintViolationGenerator(
 
         inlineModuleCreator(constraintViolationSymbol) {
             val constraintViolationVariants = constraintsInfo.map { it.constraintViolationVariant }.toMutableList()
-            if (isMemberConstrained) {
+            if (shape.isReachableFromOperationInput() && isMemberConstrained) {
                 constraintViolationVariants += {
                     val memberConstraintViolationSymbol =
                         constraintViolationSymbolProvider.toSymbol(targetShape).letIf(


### PR DESCRIPTION
Fixes https://github.com/awslabs/smithy-rs/issues/2760.

## Testing

I verified that the updated `constraints.smithy` integration test does not compile without the fix applied.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
