### PR TITLE
lazy-load signing region and scope from the ConfigBag

### DIFF
--- a/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
+++ b/aws/rust-runtime/aws-runtime/src/auth/sigv4.rs
@@ -255,12 +255,18 @@ impl SigV4HttpRequestSigner {
             .get::<SigV4OperationSigningConfig>()
             .ok_or(SigV4SigningError::MissingOperationSigningConfig)?;
 
+        let signing_region = config_bag.get::<SigningRegion>();
+        let signing_service = config_bag.get::<SigningService>();
+
         let EndpointAuthSchemeConfig {
             signing_region_override,
             signing_service_override,
         } = Self::extract_endpoint_auth_scheme_config(auth_scheme_endpoint_config)?;
 
-        match (signing_region_override, signing_service_override) {
+        match (
+            signing_region_override.or_else(|| signing_region.cloned()),
+            signing_service_override.or_else(|| signing_service.cloned()),
+        ) {
             (None, None) => Ok(Cow::Borrowed(operation_config)),
             (region, service) => {
                 let mut operation_config = operation_config.clone();

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -131,8 +131,6 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
                     val signingOptional = section.operationShape.hasTrait<OptionalAuthTrait>()
                     rustTemplate(
                         """
-                        let signing_region = cfg.get::<#{SigningRegion}>().cloned();
-                        let signing_service = cfg.get::<#{SigningService}>().cloned();
                         let mut signing_options = #{SigningOptions}::default();
                         signing_options.double_uri_encode = $doubleUriEncode;
                         signing_options.content_sha256_header = $contentSha256Header;
@@ -141,8 +139,8 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
                         signing_options.payload_override = #{payload_override};
 
                         ${section.configBagName}.put(#{SigV4OperationSigningConfig} {
-                            region: signing_region,
-                            service: signing_service,
+                            region: None,
+                            service: None,
                             signing_options,
                         });
                         // TODO(enableNewSmithyRuntime): Make auth options additive in the config bag so that multiple codegen decorators can register them


### PR DESCRIPTION
## Motivation and Context
RuntimePlugins **should not** consider other sources of configuration, instead, if needed, they should demonstrate these behaviors in RuntimePlugins.

## Description
- Set region/signing service to `None` during initialization
- Load region/signing service from the ConfigBag during signing along with loading them from EndpointConfig

## Testing
- CI


----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
