### PR TITLE
Unpin the `arbitrary` and `derive-arbitrary` dependencies

### DIFF
--- a/aws/rust-runtime/aws-config/Cargo.toml
+++ b/aws/rust-runtime/aws-config/Cargo.toml
@@ -55,7 +55,7 @@ tracing-subscriber = { version = "0.3.16", features = ["fmt", "json"] }
 tokio = { version = "1.23.1", features = ["full", "test-util"] }
 
 # used for fuzzing profile parsing
-arbitrary = "=1.1.3" # 1.1.4 requires Rust 1.63 to compile
+arbitrary = "1.3"
 
 # used for test case deserialization
 serde = { version = "1", features = ["derive"] }

--- a/rust-runtime/aws-smithy-eventstream/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/awslabs/smithy-rs"
 derive-arbitrary = ["arbitrary", "derive_arbitrary"]
 
 [dependencies]
-arbitrary = { version = "=1.1.3", optional = true } # 1.1.4 requires Rust 1.63 to compile
+arbitrary = { version = "1.3", optional = true }
 aws-smithy-types = { path = "../aws-smithy-types" }
 bytes = "1"
 crc32fast = "1.3"
-derive_arbitrary = { version = "=1.1.6", optional = true } # 1.2.0 requires Rust 1.63 to compile
+derive_arbitrary = { version = "1.3", optional = true }
 
 [dev-dependencies]
 bytes-utils = "0.1"

--- a/rust-runtime/aws-smithy-eventstream/fuzz/Cargo.toml
+++ b/rust-runtime/aws-smithy-eventstream/fuzz/Cargo.toml
@@ -9,11 +9,11 @@ edition = "2021"
 cargo-fuzz = true
 
 [dependencies]
-arbitrary = "=1.1.3" # 1.1.4 requires Rust 1.63 to compile
+arbitrary = "1.3"
 aws-smithy-types = { path = "../../aws-smithy-types" }
 bytes = "1"
 crc32fast = "1"
-derive_arbitrary = "=1.1.6" # 1.2.0 requires Rust 1.63 to compile
+derive_arbitrary = "1.3"
 libfuzzer-sys = "0.4"
 
 [dependencies.aws-smithy-eventstream]


### PR DESCRIPTION
These no longer need to be pinned since the current MSRV is compatible with their latest versions.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
