### PR TITLE
Parameterize `Plugin` by service rather than protocol

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/ServerServiceGenerator.kt
@@ -137,22 +137,22 @@ class ServerServiceGenerator(
                     HandlerType: #{SmithyHttpServer}::operation::Handler<crate::operation_shape::$structName, HandlerExtractors>,
 
                     ModelPlugin: #{SmithyHttpServer}::plugin::Plugin<
-                        #{Protocol},
+                        $serviceName,
                         crate::operation_shape::$structName,
                         #{SmithyHttpServer}::operation::IntoService<crate::operation_shape::$structName, HandlerType>
                     >,
                     #{SmithyHttpServer}::operation::UpgradePlugin::<UpgradeExtractors>: #{SmithyHttpServer}::plugin::Plugin<
-                        #{Protocol},
+                        $serviceName,
                         crate::operation_shape::$structName,
                         ModelPlugin::Service
                     >,
                     HttpPlugin: #{SmithyHttpServer}::plugin::Plugin<
-                        #{Protocol},
+                        $serviceName,
                         crate::operation_shape::$structName,
                         <
                             #{SmithyHttpServer}::operation::UpgradePlugin::<UpgradeExtractors>
                             as #{SmithyHttpServer}::plugin::Plugin<
-                                #{Protocol},
+                                $serviceName,
                                 crate::operation_shape::$structName,
                                 ModelPlugin::Service
                             >
@@ -200,22 +200,22 @@ class ServerServiceGenerator(
                     S: #{SmithyHttpServer}::operation::OperationService<crate::operation_shape::$structName, ServiceExtractors>,
 
                     ModelPlugin: #{SmithyHttpServer}::plugin::Plugin<
-                        #{Protocol},
+                        $serviceName,
                         crate::operation_shape::$structName,
                         #{SmithyHttpServer}::operation::Normalize<crate::operation_shape::$structName, S>
                     >,
                     #{SmithyHttpServer}::operation::UpgradePlugin::<UpgradeExtractors>: #{SmithyHttpServer}::plugin::Plugin<
-                        #{Protocol},
+                        $serviceName,
                         crate::operation_shape::$structName,
                         ModelPlugin::Service
                     >,
                     HttpPlugin: #{SmithyHttpServer}::plugin::Plugin<
-                        #{Protocol},
+                        $serviceName,
                         crate::operation_shape::$structName,
                         <
                             #{SmithyHttpServer}::operation::UpgradePlugin::<UpgradeExtractors>
                             as #{SmithyHttpServer}::plugin::Plugin<
-                                #{Protocol},
+                                $serviceName,
                                 crate::operation_shape::$structName,
                                 ModelPlugin::Service
                             >

--- a/design/src/server/anatomy.md
+++ b/design/src/server/anatomy.md
@@ -425,20 +425,20 @@ state in <<fork>>
 <!-- TODO(missing_doc): Link to "Write a Plugin" documentation -->
 
 A [`Plugin`](https://docs.rs/aws-smithy-http-server/latest/aws_smithy_http_server/plugin/trait.Plugin.html) is a
-[`tower::Layer`] with two extra type parameters, `Protocol` and `Operation`. This allows the middleware to be
+[`tower::Layer`] with two extra type parameters, `Service` and `Operation`, corresponding to [Smithy Service](https://awslabs.github.io/smithy/2.0/spec/service-types.html#service) and [Smithy Operation](https://awslabs.github.io/smithy/2.0/spec/service-types.html#operation). This allows the middleware to be
 parameterized them and change behavior depending on the context in which it's applied.
 
 ```rust
 # extern crate aws_smithy_http_server;
-pub trait Plugin<Protocol, Operation, S> {
+pub trait Plugin<Service, Operation, S> {
     type Service;
 
     fn apply(&self, svc: S) -> Self::Service;
 }
 # use aws_smithy_http_server::plugin::Plugin as Pl;
-# impl<P, Op, S, T: Pl<P, Op, S>> Plugin<P, Op, S> for T {
-#   type Service = <T as Pl<P, Op, S>>::Service;
-#   fn apply(&self, svc: S) -> Self::Service { <T as Pl<P, Op, S>>::apply(self, svc) }
+# impl<Ser, Op, S, T: Pl<Ser, Op, S>> Plugin<Ser, Op, S> for T {
+#   type Service = <T as Pl<Ser, Op, S>>::Service;
+#   fn apply(&self, svc: S) -> Self::Service { <T as Pl<Ser, Op, S>>::apply(self, svc) }
 # }
 ```
 
@@ -538,17 +538,17 @@ The builder has two setter methods for each [Smithy Operation](https://awslabs.g
         HandlerType:Handler<GetPokemonSpecies, HandlerExtractors>,
 
         ModelPlugin: Plugin<
-            RestJson1,
+            PokemonService,
             GetPokemonSpecies,
             IntoService<GetPokemonSpecies, HandlerType>
         >,
         UpgradePlugin::<UpgradeExtractors>: Plugin<
-            RestJson1,
+            PokemonService,
             GetPokemonSpecies,
             ModelPlugin::Service
         >,
         HttpPlugin: Plugin<
-            RestJson1,
+            PokemonService,
             GetPokemonSpecies,
             UpgradePlugin::<UpgradeExtractors>::Service
         >,
@@ -566,17 +566,17 @@ The builder has two setter methods for each [Smithy Operation](https://awslabs.g
         S: OperationService<GetPokemonSpecies, ServiceExtractors>,
 
         ModelPlugin: Plugin<
-            RestJson1,
+            PokemonService,
             GetPokemonSpecies,
             Normalize<GetPokemonSpecies, S>
         >,
         UpgradePlugin::<UpgradeExtractors>: Plugin<
-            RestJson1,
+            PokemonService,
             GetPokemonSpecies,
             ModelPlugin::Service
         >,
         HttpPlugin: Plugin<
-            RestJson1,
+            PokemonService,
             GetPokemonSpecies,
             UpgradePlugin::<UpgradeExtractors>::Service
         >,

--- a/design/src/server/middleware.md
+++ b/design/src/server/middleware.md
@@ -275,7 +275,8 @@ use tower::Service;
 /// A [`Service`] that adds a print log.
 pub struct PrintService<S> {
     inner: S,
-    name: &'static str,
+    op_name: &'static str,
+    ser_name: &'static str
 }
 
 impl<R, S> Service<R> for PrintService<S>
@@ -291,7 +292,7 @@ where
     }
 
     fn call(&mut self, req: R) -> Self::Future {
-        println!("Hi {}", self.name);
+        println!("Hi {} in {}", self.op_name, self.ser_name);
         self.inner.call(req)
     }
 }
@@ -304,56 +305,21 @@ An example of a `PrintPlugin` which prints the operation name:
 ```rust
 # extern crate aws_smithy_http_server;
 # pub struct PrintService<S> { inner: S, name: &'static str }
-use aws_smithy_http_server::{plugin::Plugin, operation::OperationShape};
+use aws_smithy_http_server::{plugin::Plugin, operation::OperationShape, service::ServiceShape};
 
 /// A [`Plugin`] for a service builder to add a [`PrintService`] over operations.
 #[derive(Debug)]
 pub struct PrintPlugin;
 
-impl<P, Op, S> Plugin<P, Op, S> for PrintPlugin
+impl<Ser, Op, S> Plugin<Ser, Op, S> for PrintPlugin
 where
+    Ser: ServiceShape,
     Op: OperationShape,
 {
     type Service = PrintService<S>;
 
     fn apply(&self, inner: S) -> Self::Service {
-        PrintService { name: Op::ID.name(), inner }
-    }
-}
-```
-
-An alternative example which prints the protocol name:
-
-```rust
-# extern crate aws_smithy_http_server;
-# pub struct PrintService<S> { name: &'static str, inner: S}
-use aws_smithy_http_server::{
-    plugin::Plugin,
-    proto::{
-        aws_json_10::AwsJson1_0,
-        rest_xml::RestXml,
-    }
-};
-
-/// A [`Plugin`] for a service builder to add a [`PrintService`] over operations.
-#[derive(Debug)]
-pub struct PrintPlugin;
-
-impl<Op, S> Plugin<AwsJson1_0, Op, S> for PrintPlugin
-{
-    type Service = PrintService<S>;
-
-    fn apply(&self, inner: S) -> Self::Service {
-        PrintService { name: "AWS JSON 1.0", inner }
-    }
-}
-
-impl<Op, S> Plugin<RestXml, Op, S> for PrintPlugin
-{
-    type Service = PrintService<S>;
-
-    fn apply(&self, inner: S) -> Self::Service {
-        PrintService { name: "AWS REST XML", inner }
+        PrintService { op_name: Op::ID.name(), ser_name: Ser::ID.name() inner }
     }
 }
 ```
@@ -387,7 +353,7 @@ This allows for:
 # extern crate aws_smithy_http_server;
 # use aws_smithy_http_server::plugin::{PluginStack, Plugin};
 # struct PrintPlugin;
-# impl<P, Op, S> Plugin<P, Op, S> for PrintPlugin { type Service = S; fn apply(&self, svc: S) -> Self::Service { svc }}
+# impl<Ser, Op, S> Plugin<Ser, Op, S> for PrintPlugin { type Service = S; fn apply(&self, svc: S) -> Self::Service { svc }}
 # trait PrintExt<EP> { fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, EP>>; }
 # impl<EP> PrintExt<EP> for PluginPipeline<EP> { fn print(self) -> PluginPipeline<PluginStack<PrintPlugin, EP>> { self.push(PrintPlugin) }}
 # use pokemon_service_server_sdk::{operation_shape::GetPokemonSpecies, input::*, output::*, error::*};

--- a/examples/pokemon-service-common/tests/plugins_execution_order.rs
+++ b/examples/pokemon-service-common/tests/plugins_execution_order.rs
@@ -65,7 +65,7 @@ impl SentinelPlugin {
     }
 }
 
-impl<Protocol, Op, S> Plugin<Protocol, Op, S> for SentinelPlugin {
+impl<Ser, Op, S> Plugin<Ser, Op, S> for SentinelPlugin {
     type Service = SentinelService<S>;
 
     fn apply(&self, inner: S) -> Self::Service {

--- a/rust-runtime/aws-smithy-http-server/src/extension.rs
+++ b/rust-runtime/aws-smithy-http-server/src/extension.rs
@@ -114,7 +114,7 @@ impl fmt::Debug for OperationExtensionPlugin {
     }
 }
 
-impl<P, Op, S> Plugin<P, Op, S> for OperationExtensionPlugin
+impl<Ser, Op, S> Plugin<Ser, Op, S> for OperationExtensionPlugin
 where
     Op: OperationShape,
 {

--- a/rust-runtime/aws-smithy-http-server/src/instrumentation/plugin.rs
+++ b/rust-runtime/aws-smithy-http-server/src/instrumentation/plugin.rs
@@ -13,7 +13,7 @@ use super::InstrumentOperation;
 #[derive(Debug)]
 pub struct InstrumentPlugin;
 
-impl<P, Op, S> Plugin<P, Op, S> for InstrumentPlugin
+impl<Ser, Op, S> Plugin<Ser, Op, S> for InstrumentPlugin
 where
     Op: OperationShape,
     Op: Sensitivity,

--- a/rust-runtime/aws-smithy-http-server/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-server/src/lib.rs
@@ -28,6 +28,7 @@ pub mod response;
 pub mod routing;
 #[doc(hidden)]
 pub mod runtime_error;
+pub mod service;
 pub mod shape_id;
 
 #[doc(inline)]

--- a/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
+++ b/rust-runtime/aws-smithy-http-server/src/operation/upgrade.rs
@@ -18,7 +18,7 @@ use tracing::error;
 
 use crate::{
     body::BoxBody, plugin::Plugin, request::FromRequest, response::IntoResponse,
-    runtime_error::InternalFailureException,
+    runtime_error::InternalFailureException, service::ServiceShape,
 };
 
 use super::OperationShape;
@@ -47,11 +47,12 @@ impl<Extractors> UpgradePlugin<Extractors> {
     }
 }
 
-impl<S, P, Op, Extractors> Plugin<P, Op, S> for UpgradePlugin<Extractors>
+impl<S, Ser, Op, Extractors> Plugin<Ser, Op, S> for UpgradePlugin<Extractors>
 where
+    Ser: ServiceShape,
     Op: OperationShape,
 {
-    type Service = Upgrade<P, (Op::Input, Extractors), S>;
+    type Service = Upgrade<Ser::Protocol, (Op::Input, Extractors), S>;
 
     fn apply(&self, inner: S) -> Self::Service {
         Upgrade {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/closure.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/closure.rs
@@ -13,7 +13,7 @@ pub struct OperationIdFn<F> {
     f: F,
 }
 
-impl<P, Op, S, NewService, F> Plugin<P, Op, S> for OperationIdFn<F>
+impl<Ser, Op, S, NewService, F> Plugin<Ser, Op, S> for OperationIdFn<F>
 where
     F: Fn(ShapeId, S) -> NewService,
     Op: OperationShape,

--- a/rust-runtime/aws-smithy-http-server/src/plugin/either.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/either.rs
@@ -102,10 +102,10 @@ where
     }
 }
 
-impl<P, Op, S, Le, Ri> Plugin<P, Op, S> for Either<Le, Ri>
+impl<Ser, Op, S, Le, Ri> Plugin<Ser, Op, S> for Either<Le, Ri>
 where
-    Le: Plugin<P, Op, S>,
-    Ri: Plugin<P, Op, S>,
+    Le: Plugin<Ser, Op, S>,
+    Ri: Plugin<Ser, Op, S>,
 {
     type Service = Either<Le::Service, Ri::Service>;
 

--- a/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/filter.rs
@@ -51,10 +51,10 @@ impl<Inner, F> FilterByOperationId<Inner, F> {
     }
 }
 
-impl<P, Op, S, Inner, F> Plugin<P, Op, S> for FilterByOperationId<Inner, F>
+impl<Ser, Op, S, Inner, F> Plugin<Ser, Op, S> for FilterByOperationId<Inner, F>
 where
     F: Fn(ShapeId) -> bool,
-    Inner: Plugin<P, Op, S>,
+    Inner: Plugin<Ser, Op, S>,
     Op: OperationShape,
 {
     type Service = Either<Inner::Service, S>;

--- a/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/identity.rs
@@ -8,7 +8,7 @@ use super::Plugin;
 /// A [`Plugin`] that maps a service to itself.
 pub struct IdentityPlugin;
 
-impl<P, Op, S> Plugin<P, Op, S> for IdentityPlugin {
+impl<Ser, Op, S> Plugin<Ser, Op, S> for IdentityPlugin {
     type Service = S;
 
     fn apply(&self, svc: S) -> S {

--- a/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/layer.rs
@@ -12,7 +12,7 @@ use super::Plugin;
 /// A [`Plugin`] which acts as a [`Layer`] `L`.
 pub struct LayerPlugin<L>(pub L);
 
-impl<P, Op, S, L> Plugin<P, Op, S> for LayerPlugin<L>
+impl<Ser, Op, S, L> Plugin<Ser, Op, S> for LayerPlugin<L>
 where
     L: Layer<S>,
 {
@@ -24,15 +24,15 @@ where
 }
 
 /// A [`Layer`] which acts as a [`Plugin`] `Pl` for specific protocol `P` and operation `Op`.
-pub struct PluginLayer<P, Op, Pl> {
+pub struct PluginLayer<Ser, Op, Pl> {
     plugin: Pl,
-    _protocol: PhantomData<P>,
+    _ser: PhantomData<Ser>,
     _op: PhantomData<Op>,
 }
 
-impl<S, P, Op, Pl> Layer<S> for PluginLayer<P, Op, Pl>
+impl<S, Ser, Op, Pl> Layer<S> for PluginLayer<Ser, Op, Pl>
 where
-    Pl: Plugin<P, Op, S>,
+    Pl: Plugin<Ser, Op, S>,
 {
     type Service = Pl::Service;
 
@@ -42,10 +42,10 @@ where
 }
 
 impl<Pl> PluginLayer<(), (), Pl> {
-    pub fn new<P, Op>(plugin: Pl) -> PluginLayer<P, Op, Pl> {
+    pub fn new<Ser, Op>(plugin: Pl) -> PluginLayer<Ser, Op, Pl> {
         PluginLayer {
             plugin,
-            _protocol: PhantomData,
+            _ser: PhantomData,
             _op: PhantomData,
         }
     }

--- a/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/mod.rs
@@ -91,7 +91,7 @@
 //! #[derive(Debug)]
 //! pub struct PrintPlugin;
 //!
-//! impl<P, Op, S> Plugin<P, Op, S> for PrintPlugin
+//! impl<Ser, Op, S> Plugin<Ser, Op, S> for PrintPlugin
 //! where
 //!     Op: OperationShape,
 //! {
@@ -127,7 +127,7 @@ pub use stack::PluginStack;
 /// The generics `Protocol` and `Op` allow the behavior to be parameterized.
 ///
 /// See [module](crate::plugin) documentation for more information.
-pub trait Plugin<Protocol, Op, S> {
+pub trait Plugin<Ser, Op, S> {
     /// The type of the new [`Service`](tower::Service).
     type Service;
 
@@ -135,13 +135,13 @@ pub trait Plugin<Protocol, Op, S> {
     fn apply(&self, svc: S) -> Self::Service;
 }
 
-impl<'a, P, Op, S, Pl> Plugin<P, Op, S> for &'a Pl
+impl<'a, Ser, Op, S, Pl> Plugin<Ser, Op, S> for &'a Pl
 where
-    Pl: Plugin<P, Op, S>,
+    Pl: Plugin<Ser, Op, S>,
 {
     type Service = Pl::Service;
 
     fn apply(&self, inner: S) -> Self::Service {
-        <Pl as Plugin<P, Op, S>>::apply(self, inner)
+        <Pl as Plugin<Ser, Op, S>>::apply(self, inner)
     }
 }

--- a/rust-runtime/aws-smithy-http-server/src/plugin/pipeline.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/pipeline.rs
@@ -150,7 +150,7 @@ impl<P> PluginPipeline<P> {
     /// #[derive(Debug)]
     /// pub struct PrintPlugin;
     ///
-    /// impl<P, Op, S> Plugin<P, Op, S> for PrintPlugin
+    /// impl<Ser, Op, S> Plugin<Ser, Op, S> for PrintPlugin
     /// // [...]
     /// {
     ///     // [...]
@@ -170,9 +170,9 @@ impl<P> PluginPipeline<P> {
     }
 }
 
-impl<P, Op, S, InnerPlugin> Plugin<P, Op, S> for PluginPipeline<InnerPlugin>
+impl<Ser, Op, S, InnerPlugin> Plugin<Ser, Op, S> for PluginPipeline<InnerPlugin>
 where
-    InnerPlugin: Plugin<P, Op, S>,
+    InnerPlugin: Plugin<Ser, Op, S>,
 {
     type Service = InnerPlugin::Service;
 

--- a/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/stack.rs
@@ -22,10 +22,10 @@ impl<Inner, Outer> PluginStack<Inner, Outer> {
     }
 }
 
-impl<P, Op, S, Inner, Outer> Plugin<P, Op, S> for PluginStack<Inner, Outer>
+impl<Ser, Op, S, Inner, Outer> Plugin<Ser, Op, S> for PluginStack<Inner, Outer>
 where
-    Inner: Plugin<P, Op, S>,
-    Outer: Plugin<P, Op, Inner::Service>,
+    Inner: Plugin<Ser, Op, S>,
+    Outer: Plugin<Ser, Op, Inner::Service>,
 {
     type Service = Outer::Service;
 

--- a/rust-runtime/aws-smithy-http-server/src/service.rs
+++ b/rust-runtime/aws-smithy-http-server/src/service.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use crate::shape_id::ShapeId;
+
+/// Models the [Smithy Service shape].
+///
+/// [Smithy Service shape]: https://smithy.io/2.0/spec/service-types.html
+pub trait ServiceShape {
+    /// The [`ShapeId`] of the service.
+    const ID: ShapeId;
+
+    /// The [Protocol] applied to this service.
+    ///
+    /// [Protocol]: https://smithy.io/2.0/spec/protocol-traits.html
+    type Protocol;
+
+    /// An enumeration of all operations contained in this service.
+    type Operations;
+}


### PR DESCRIPTION
## Motivation and Context

Closes https://github.com/awslabs/smithy-rs/issues/1839

Currently, `Plugin` is parameterized by protocol and operation. To improve symmetry, extensibility and uniformity we switch this to be parameterized by service instead. The protocol can still be recovered via a associated type on `ServiceShape`.

## Description

- Add `ServiceShape` trait, encoding the properties of a Smithy service.
- Change `Plugin<Protocol, Operation, S>` to `Plugin<Service, Operation, S>`.
