### PR TITLE
Categorize orchestrator TODO comments into `Launch` and `Cleanup`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         test:
         - action: check-aws-sdk-adhoc-tests
           runner: ubuntu-latest
-        # TODO(enableNewSmithyRuntime): Remove `check-aws-sdk-orchestrator-impl` when cleaning up middleware
+        # TODO(enableNewSmithyRuntimeCleanup): Remove `check-aws-sdk-orchestrator-impl` when cleaning up middleware
         - action: check-aws-sdk-orchestrator-impl
           runner: smithy_ubuntu-latest_8-core
         - action: check-client-codegen-integration-tests

--- a/aws/rust-runtime/aws-config/src/sso.rs
+++ b/aws/rust-runtime/aws-config/src/sso.rs
@@ -217,7 +217,7 @@ async fn load_sso_credentials(
         .region(sso_provider_config.region.clone())
         .credentials_cache(CredentialsCache::no_caching())
         .build();
-    // TODO(enableNewSmithyRuntime): Use `customize().config_override()` to set the region instead of creating a new client once middleware is removed
+    // TODO(enableNewSmithyRuntimeCleanup): Use `customize().config_override()` to set the region instead of creating a new client once middleware is removed
     let client = SsoClient::from_conf(config);
     let resp = client
         .get_role_credentials()

--- a/aws/rust-runtime/aws-http/src/recursion_detection.rs
+++ b/aws/rust-runtime/aws-http/src/recursion_detection.rs
@@ -11,7 +11,7 @@ use http::HeaderValue;
 use percent_encoding::{percent_encode, CONTROLS};
 use std::borrow::Cow;
 
-// TODO(enableNewSmithyRuntime): Delete this module
+// TODO(enableNewSmithyRuntimeCleanup): Delete this module
 
 /// Recursion Detection Middleware
 ///

--- a/aws/rust-runtime/aws-http/src/user_agent.rs
+++ b/aws/rust-runtime/aws-http/src/user_agent.rs
@@ -513,7 +513,7 @@ impl fmt::Display for ExecEnvMetadata {
     }
 }
 
-// TODO(enableNewSmithyRuntime): Delete the user agent Tower middleware and consider moving all the remaining code into aws-runtime
+// TODO(enableNewSmithyRuntimeCleanup): Delete the user agent Tower middleware and consider moving all the remaining code into aws-runtime
 
 /// User agent middleware
 #[non_exhaustive]

--- a/aws/rust-runtime/aws-inlineable/src/glacier_checksums.rs
+++ b/aws/rust-runtime/aws-inlineable/src/glacier_checksums.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TODO(enableNewSmithyRuntime): Delete this file when cleaning up middleware
+// TODO(enableNewSmithyRuntimeCleanup): Delete this file when cleaning up middleware
 
 use aws_sig_auth::signer::SignableBody;
 use aws_smithy_http::body::SdkBody;

--- a/aws/rust-runtime/aws-runtime/src/request_info.rs
+++ b/aws/rust-runtime/aws-runtime/src/request_info.rs
@@ -54,7 +54,6 @@ impl RequestInfoInterceptor {
         &self,
         cfg: &ConfigBag,
     ) -> Option<(Cow<'static, str>, Cow<'static, str>)> {
-        // TODO(enableNewSmithyRuntime) What config will we actually store in the bag? Will it be a whole config or just the max_attempts part?
         if let Some(retry_config) = cfg.get::<RetryConfig>() {
             let max_attempts = retry_config.max_attempts().to_string();
             Some((Cow::Borrowed("max"), Cow::Owned(max_attempts)))

--- a/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/event_stream.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TODO(enableNewSmithyRuntime): Remove this blanket allow once the old implementations are deleted
+// TODO(enableNewSmithyRuntimeCleanup): Remove this blanket allow once the old implementations are deleted
 #![allow(deprecated)]
 
 use crate::middleware::Signature;
@@ -123,7 +123,7 @@ mod tests {
     }
 }
 
-// TODO(enableNewSmithyRuntime): Delete this old implementation that was kept around to support patch releases.
+// TODO(enableNewSmithyRuntimeCleanup): Delete this old implementation that was kept around to support patch releases.
 #[deprecated = "use aws_sig_auth::event_stream::SigV4MessageSigner instead (this may require upgrading the smithy-rs code generator)"]
 #[derive(Debug)]
 /// Event Stream SigV4 signing implementation.
@@ -199,7 +199,7 @@ impl SignMessage for SigV4Signer {
     }
 }
 
-// TODO(enableNewSmithyRuntime): Delete this old implementation that was kept around to support patch releases.
+// TODO(enableNewSmithyRuntimeCleanup): Delete this old implementation that was kept around to support patch releases.
 #[cfg(test)]
 mod old_tests {
     use crate::event_stream::SigV4Signer;

--- a/aws/rust-runtime/aws-sig-auth/src/middleware.rs
+++ b/aws/rust-runtime/aws-sig-auth/src/middleware.rs
@@ -25,7 +25,7 @@ use crate::event_stream::SigV4MessageSigner as EventStreamSigV4Signer;
 #[cfg(feature = "sign-eventstream")]
 use aws_smithy_eventstream::frame::DeferredSignerSender;
 
-// TODO(enableNewSmithyRuntime): Delete `Signature` when switching to the orchestrator
+// TODO(enableNewSmithyRuntimeCleanup): Delete `Signature` when switching to the orchestrator
 /// Container for the request signature for use in the property bag.
 #[non_exhaustive]
 #[derive(Debug, Clone)]
@@ -151,7 +151,7 @@ fn signing_config(
         request_ts: config
             .get::<SharedTimeSource>()
             .map(|t| t.now())
-            // TODO(enableNewSmithyRuntime): Remove this fallback
+            // TODO(enableNewSmithyRuntimeLaunch): Remove this fallback
             .unwrap_or_else(|| SharedTimeSource::default().now()),
         region,
         payload_override,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCustomizableOperationDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsCustomizableOperationDecorator.kt
@@ -85,7 +85,7 @@ class CustomizableOperationTestHelpers(runtimeConfig: RuntimeConfig) :
                         *codegenScope,
                     )
                 } else {
-                    // TODO(enableNewSmithyRuntime): Delete this branch when middleware is no longer used
+                    // TODO(enableNewSmithyRuntimeCleanup): Delete this branch when middleware is no longer used
                     rustTemplate(
                         """
                         ##[doc(hidden)]

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -137,7 +137,7 @@ class AwsPresigningDecorator internal constructor(
     }
 }
 
-// TODO(enableNewSmithyRuntime): Delete this class when cleaning up middleware
+// TODO(enableNewSmithyRuntimeCleanup): Delete this class when cleaning up middleware
 class AwsInputPresignedMethod(
     private val codegenContext: ClientCodegenContext,
     private val operationShape: OperationShape,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeType.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsRuntimeType.kt
@@ -53,11 +53,11 @@ object AwsRuntimeType {
             ),
         )
 
-    // TODO(enableNewSmithyRuntime): Delete the `presigning_service.rs` inlineable when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete the `presigning_service.rs` inlineable when cleaning up middleware
     fun presigningService(): RuntimeType =
         RuntimeType.forInlineDependency(InlineAwsDependency.forRustFile("presigning_service", visibility = Visibility.PUBCRATE))
 
-    // TODO(enableNewSmithyRuntime): Delete defaultMiddleware and middleware.rs, and remove tower dependency from inlinables, when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete defaultMiddleware and middleware.rs, and remove tower dependency from inlinables, when cleaning up middleware
     fun RuntimeConfig.defaultMiddleware() = RuntimeType.forInlineDependency(
         InlineAwsDependency.forRustFile(
             "middleware", visibility = Visibility.PUBLIC,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpConnectorConfigCustomization.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpConnectorConfigCustomization.kt
@@ -17,7 +17,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.CodegenContext
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.util.letIf
 
-// TODO(enableNewSmithyRuntime): Delete this decorator since it's now in `codegen-client`
+// TODO(enableNewSmithyRuntimeCleanup): Delete this decorator since it's now in `codegen-client`
 class HttpConnectorDecorator : ClientCodegenDecorator {
     override val name: String = "HttpConnectorDecorator"
     override val order: Byte = 0

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpRequestChecksumDecorator.kt
@@ -42,7 +42,7 @@ class HttpRequestChecksumDecorator : ClientCodegenDecorator {
     override val name: String = "HttpRequestChecksum"
     override val order: Byte = 0
 
-    // TODO(enableNewSmithyRuntime): Implement checksumming via interceptor and delete this decorator upon launching the orchestrator
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this decorator upon launching the orchestrator
     private fun applies(codegenContext: ClientCodegenContext): Boolean =
         codegenContext.smithyRuntimeMode.generateMiddleware
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/HttpResponseChecksumDecorator.kt
@@ -33,7 +33,7 @@ class HttpResponseChecksumDecorator : ClientCodegenDecorator {
     override val name: String = "HttpResponseChecksum"
     override val order: Byte = 0
 
-    // TODO(enableNewSmithyRuntime): Implement checksumming via interceptor and delete this decorator
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this decorator
     private fun applies(codegenContext: ClientCodegenContext, operationShape: OperationShape): Boolean =
         codegenContext.smithyRuntimeMode.generateMiddleware && operationShape.outputShape != ShapeId.from("com.amazonaws.s3#GetObjectOutput")
 

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/IntegrationTestDependencies.kt
@@ -129,7 +129,7 @@ class S3TestDependencies(private val codegenContext: ClientCodegenContext) : Lib
             addDependency(TracingAppender)
             addDependency(TracingTest)
 
-            // TODO(enableNewSmithyRuntime): These additional dependencies may not be needed anymore when removing this flag
+            // TODO(enableNewSmithyRuntimeCleanup): These additional dependencies may not be needed anymore when removing this flag
             // depending on if the sra-test is kept around or not.
             if (codegenContext.smithyRuntimeMode.generateOrchestrator) {
                 addDependency(CargoDependency.smithyRuntime(codegenContext.runtimeConfig).toDevDependency())

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -143,7 +143,7 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
                             service: None,
                             signing_options,
                         });
-                        // TODO(enableNewSmithyRuntime): Make auth options additive in the config bag so that multiple codegen decorators can register them
+                        // TODO(enableNewSmithyRuntimeLaunch): Make auth options additive in the config bag so that multiple codegen decorators can register them
                         let auth_option_resolver = #{StaticAuthOptionResolver}::new(
                             vec![#{SIGV4_SCHEME_ID}]
                         );

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -32,7 +32,7 @@ import software.amazon.smithy.rust.codegen.core.util.hasEventStreamOperations
 import software.amazon.smithy.rust.codegen.core.util.hasTrait
 import software.amazon.smithy.rust.codegen.core.util.isInputEventStream
 
-// TODO(enableNewSmithyRuntime): Remove this decorator (superseded by SigV4AuthDecorator)
+// TODO(enableNewSmithyRuntimeCleanup): Remove this decorator (superseded by SigV4AuthDecorator)
 /**
  * The SigV4SigningDecorator:
  * - adds a `signing_service()` method to `config` to return the default signing service

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -120,7 +120,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
         }
     }
 
-    // TODO(enableNewSmithyRuntime): Remove this customization class
+    // TODO(enableNewSmithyRuntimeCleanup): Remove this customization class
     private class UserAgentMutateOpRequest(
         codegenContext: ClientCodegenContext,
     ) : OperationCustomization() {

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/apigateway/ApiGatewayDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/apigateway/ApiGatewayDecorator.kt
@@ -25,7 +25,7 @@ class ApiGatewayDecorator : ClientCodegenDecorator {
     override val name: String = "ApiGateway"
     override val order: Byte = 0
 
-    // TODO(enableNewSmithyRuntime): Delete when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete when cleaning up middleware
     override fun operationCustomizations(
         codegenContext: ClientCodegenContext,
         operation: OperationShape,
@@ -44,7 +44,7 @@ class ApiGatewayDecorator : ClientCodegenDecorator {
         }
 }
 
-// TODO(enableNewSmithyRuntime): Delete when cleaning up middleware
+// TODO(enableNewSmithyRuntimeCleanup): Delete when cleaning up middleware
 private class ApiGatewayAddAcceptHeader : OperationCustomization() {
     override fun section(section: OperationSection): Writable = when (section) {
         is OperationSection.FinalizeOperation -> emptySection

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/AccountIdAutofill.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/AccountIdAutofill.kt
@@ -14,7 +14,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 
-// TODO(enableNewSmithyRuntime): Delete this file when cleaning up middleware.
+// TODO(enableNewSmithyRuntimeCleanup): Delete this file when cleaning up middleware.
 
 class AccountIdAutofill : OperationCustomization() {
     override fun mutSelf(): Boolean = true

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/ApiVersionHeader.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/ApiVersionHeader.kt
@@ -13,7 +13,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.util.dq
 
-// TODO(enableNewSmithyRuntime): Delete this file when cleaning up middleware.
+// TODO(enableNewSmithyRuntimeCleanup): Delete this file when cleaning up middleware.
 
 class ApiVersionHeader(
     /**

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/GlacierDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/GlacierDecorator.kt
@@ -97,7 +97,7 @@ private class GlacierAccountIdCustomization(private val codegenContext: ClientCo
     }
 }
 
-// TODO(enableNewSmithyRuntime): Install the glacier customizations as a single additional runtime plugin instead
+// TODO(enableNewSmithyRuntimeLaunch): Install the glacier customizations as a single additional runtime plugin instead
 // of wiring up the interceptors individually
 
 /** Adds the `x-amz-glacier-version` header to all requests */

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/TreeHashHeader.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/customize/glacier/TreeHashHeader.kt
@@ -18,7 +18,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.generators.operationBuildError
 import software.amazon.smithy.rustsdk.InlineAwsDependency
 
-// TODO(enableNewSmithyRuntime): Delete this file when cleaning up middleware.
+// TODO(enableNewSmithyRuntimeCleanup): Delete this file when cleaning up middleware.
 
 val TreeHashDependencies = listOf(
     CargoDependency.Ring,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/ClientRustSettings.kt
@@ -72,7 +72,7 @@ data class ClientRustSettings(
     }
 }
 
-// TODO(enableNewSmithyRuntime): Remove this mode after switching to the orchestrator
+// TODO(enableNewSmithyRuntimeCleanup): Remove this mode after switching to the orchestrator
 enum class SmithyRuntimeMode {
     Middleware,
     BothDefaultMiddleware,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ApiKeyAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ApiKeyAuthDecorator.kt
@@ -28,7 +28,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.util.letIf
 
-// TODO(enableNewSmithyRuntime): Delete this decorator when switching to the orchestrator
+// TODO(enableNewSmithyRuntimeCleanup): Delete this decorator when switching to the orchestrator
 
 /**
  * Inserts a ApiKeyAuth configuration into the operation

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
@@ -223,7 +223,7 @@ private class HttpAuthOperationCustomization(codegenContext: ClientCodegenContex
                     }
                 }
 
-                // TODO(enableNewSmithyRuntime): Make auth options additive in the config bag so that multiple codegen decorators can register them
+                // TODO(enableNewSmithyRuntimeLaunch): Make auth options additive in the config bag so that multiple codegen decorators can register them
                 rustTemplate("${section.newLayerName}.set_auth_option_resolver(auth_option_resolver);", *codegenScope)
             }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/InterceptorConfigCustomization.kt
@@ -42,7 +42,7 @@ class InterceptorConfigCustomization(codegenContext: CodegenContext) : ConfigCus
 
                 ServiceConfig.ConfigImpl -> rustTemplate(
                     """
-                    // TODO(enableNewSmithyRuntime): Remove this doc hidden upon launch
+                    // TODO(enableNewSmithyRuntimeLaunch): Remove this doc hidden upon launch
                     ##[doc(hidden)]
                     /// Returns interceptors currently registered by the user.
                     pub fn interceptors(&self) -> impl Iterator<Item = &#{SharedInterceptor}> + '_ {
@@ -55,7 +55,7 @@ class InterceptorConfigCustomization(codegenContext: CodegenContext) : ConfigCus
                 ServiceConfig.BuilderImpl ->
                     rustTemplate(
                         """
-                        // TODO(enableNewSmithyRuntime): Remove this doc hidden upon launch
+                        // TODO(enableNewSmithyRuntimeLaunch): Remove this doc hidden upon launch
                         ##[doc(hidden)]
                         /// Add an [`Interceptor`](#{Interceptor}) that runs at specific stages of the request execution pipeline.
                         ///
@@ -106,7 +106,7 @@ class InterceptorConfigCustomization(codegenContext: CodegenContext) : ConfigCus
                             self
                         }
 
-                        // TODO(enableNewSmithyRuntime): Remove this doc hidden upon launch
+                        // TODO(enableNewSmithyRuntimeLaunch): Remove this doc hidden upon launch
                         ##[doc(hidden)]
                         /// Add a [`SharedInterceptor`](#{SharedInterceptor}) that runs at specific stages of the request execution pipeline.
                         ///
@@ -160,7 +160,7 @@ class InterceptorConfigCustomization(codegenContext: CodegenContext) : ConfigCus
                             self
                         }
 
-                        // TODO(enableNewSmithyRuntime): Remove this doc hidden upon launch
+                        // TODO(enableNewSmithyRuntimeLaunch): Remove this doc hidden upon launch
                         ##[doc(hidden)]
                         /// Set [`SharedInterceptor`](#{SharedInterceptor})s for the builder.
                         pub fn set_interceptors(&mut self, interceptors: impl IntoIterator<Item = #{SharedInterceptor}>) -> &mut Self {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -56,7 +56,6 @@ class RequiredCustomizations : ClientCodegenDecorator {
         codegenContext: ClientCodegenContext,
         baseCustomizations: List<ConfigCustomization>,
     ): List<ConfigCustomization> =
-        // TODO(enableNewSmithyRuntime): Keep only then branch once we switch to orchestrator
         if (codegenContext.smithyRuntimeMode.generateOrchestrator) {
             baseCustomizations + ResiliencyConfigCustomization(codegenContext) + InterceptorConfigCustomization(
                 codegenContext,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointsDecorator.kt
@@ -102,7 +102,6 @@ class EndpointsDecorator : ClientCodegenDecorator {
     override val name: String = "Endpoints"
     override val order: Byte = 0
 
-    // TODO(enableNewSmithyRuntime): Remove `operationCustomizations` and `InjectEndpointInMakeOperation`
     override fun operationCustomizations(
         codegenContext: ClientCodegenContext,
         operation: OperationShape,
@@ -155,6 +154,7 @@ class EndpointsDecorator : ClientCodegenDecorator {
      *     .build();
      * ```
      */
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this customization
     class InjectEndpointInMakeOperation(
         private val ctx: ClientCodegenContext,
         private val typesGenerator: EndpointTypesGenerator,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/EndpointTraitBindingGenerator.kt
@@ -75,7 +75,7 @@ class EndpointTraitBindings(
                     }
                     if (generateValidation) {
                         val contents = if (smithyRuntimeMode.generateOrchestrator) {
-                            // TODO(enableNewSmithyRuntime): Remove the allow attribute once all places need .into method
+                            // TODO(enableNewSmithyRuntimeCleanup): Remove the allow attribute once all places need .into method
                             """
                             if $field.is_empty() {
                                 ##[allow(clippy::useless_conversion)]

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationCustomization.kt
@@ -23,7 +23,7 @@ sealed class OperationSection(name: String) : Section(name) {
     data class OperationImplBlock(override val customizations: List<OperationCustomization>) :
         OperationSection("OperationImplBlock")
 
-    // TODO(enableNewSmithyRuntime): Delete this customization hook when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this customization hook when cleaning up middleware
     /** Write additional functions inside the Input's impl block */
     @Deprecated("customization for middleware; won't be used in the orchestrator impl")
     data class InputImpl(
@@ -33,7 +33,7 @@ sealed class OperationSection(name: String) : Section(name) {
         val protocol: Protocol,
     ) : OperationSection("InputImpl")
 
-    // TODO(enableNewSmithyRuntime): Delete this customization hook when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this customization hook when cleaning up middleware
     @Deprecated("customization for middleware; won't be used in the orchestrator impl")
     data class MutateInput(
         override val customizations: List<OperationCustomization>,
@@ -41,7 +41,7 @@ sealed class OperationSection(name: String) : Section(name) {
         val config: String,
     ) : OperationSection("MutateInput")
 
-    // TODO(enableNewSmithyRuntime): Delete this customization hook when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this customization hook when cleaning up middleware
     /** Write custom code into the block that builds an operation
      *
      * [request]: Name of the variable holding the `aws_smithy_http::Request`
@@ -55,7 +55,7 @@ sealed class OperationSection(name: String) : Section(name) {
         val config: String,
     ) : OperationSection("Feature")
 
-    // TODO(enableNewSmithyRuntime): Delete this customization hook when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this customization hook when cleaning up middleware
     @Deprecated("customization for middleware; won't be used in the orchestrator impl")
     data class FinalizeOperation(
         override val customizations: List<OperationCustomization>,
@@ -69,7 +69,7 @@ sealed class OperationSection(name: String) : Section(name) {
         /** Name of the response headers map (for referring to it in Rust code) */
         val responseHeadersName: String,
 
-        // TODO(enableNewSmithyRuntime): Remove this flag when switching to the orchestrator
+        // TODO(enableNewSmithyRuntimeCleanup): Remove this flag when switching to the orchestrator
         /** Whether the property bag exists in this context */
         val propertyBagAvailable: Boolean,
     ) : OperationSection("MutateOutput")
@@ -165,11 +165,11 @@ sealed class OperationSection(name: String) : Section(name) {
 }
 
 abstract class OperationCustomization : NamedCustomization<OperationSection>() {
-    // TODO(enableNewSmithyRuntime): Delete this when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when cleaning up middleware
     @Deprecated("property for middleware; won't be used in the orchestrator impl")
     open fun retryType(): RuntimeType? = null
 
-    // TODO(enableNewSmithyRuntime): Delete this when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when cleaning up middleware
     /**
      * Does `make_operation` consume the self parameter?
      *
@@ -179,7 +179,7 @@ abstract class OperationCustomization : NamedCustomization<OperationSection>() {
     @Deprecated("property for middleware; won't be used in the orchestrator impl")
     open fun consumesSelf(): Boolean = false
 
-    // TODO(enableNewSmithyRuntime): Delete this when cleaning up middleware
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when cleaning up middleware
     /**
      * Does `make_operation` mutate the self parameter?
      */

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
@@ -38,10 +38,10 @@ open class OperationGenerator(
      * Operations generate a `make_operation(&config)` method to build a `aws_smithy_http::Operation` that can be dispatched
      * This is the serializer side of request dispatch
      */
-    // TODO(enableNewSmithyRuntime): Remove the `makeOperationGenerator`
+    // TODO(enableNewSmithyRuntimeCleanup): Remove the `makeOperationGenerator`
     private val makeOperationGenerator: MakeOperationGenerator,
     private val bodyGenerator: ProtocolPayloadGenerator,
-    // TODO(enableNewSmithyRuntime): Remove the `traitGenerator`
+    // TODO(enableNewSmithyRuntimeCleanup): Remove the `traitGenerator`
     private val traitGenerator: HttpBoundProtocolTraitImplGenerator,
 ) {
     companion object {
@@ -82,7 +82,7 @@ open class OperationGenerator(
      */
     fun renderOperation(
         operationWriter: RustWriter,
-        // TODO(enableNewSmithyRuntime): Remove the `inputWriter` since `make_operation` generation is going away
+        // TODO(enableNewSmithyRuntimeCleanup): Remove the `inputWriter` since `make_operation` generation is going away
         inputWriter: RustWriter,
         operationShape: OperationShape,
         codegenDecorator: ClientCodegenDecorator,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -144,7 +144,7 @@ class ServiceRuntimePluginGenerator(
                         self.handle.conf.endpoint_resolver());
                     cfg.set_endpoint_resolver(endpoint_resolver);
 
-                    // TODO(enableNewSmithyRuntime): Make it possible to set retry classifiers at the service level.
+                    // TODO(enableNewSmithyRuntimeLaunch): Make it possible to set retry classifiers at the service level.
                     //     Retry classifiers can also be set at the operation level and those should be added to the
                     //     list of classifiers defined here, rather than replacing them.
 
@@ -159,7 +159,7 @@ class ServiceRuntimePluginGenerator(
                             .and_then(|c| c.connector(&connector_settings, sleep_impl.clone()))
                             .or_else(|| #{default_connector}(&connector_settings, sleep_impl)) {
                         let connection: #{Box}<dyn #{Connection}> = #{Box}::new(#{DynConnectorAdapter}::new(
-                            // TODO(enableNewSmithyRuntime): Replace the tower-based DynConnector and remove DynConnectorAdapter when deleting the middleware implementation
+                            // TODO(enableNewSmithyRuntimeCleanup): Replace the tower-based DynConnector and remove DynConnectorAdapter when deleting the middleware implementation
                             connection
                         )) as _;
                         cfg.set_connection(connection);

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/CustomizableOperationGenerator.kt
@@ -36,8 +36,8 @@ class CustomizableOperationGenerator(
     fun render(crate: RustCrate) {
         crate.withModule(ClientRustModule.Client.customize) {
             rustTemplate(
-                // TODO(enableNewSmithyRuntime): Stop exporting `Operation` when removing middleware
-                // TODO(enableNewSmithyRuntime): Re-export orchestrator equivalents for retry types when removing middleware
+                // TODO(enableNewSmithyRuntimeCleanup): Stop exporting `Operation` when removing middleware
+                // TODO(enableNewSmithyRuntimeLaunch): Re-export orchestrator equivalents for retry types when defaulting to orchestrator
                 """
                 pub use #{Operation};
                 pub use #{Request};
@@ -171,7 +171,7 @@ class CustomizableOperationGenerator(
         crate.withModule(customizeModule) {
             renderConvenienceAliases(customizeModule, this)
 
-            // TODO(enableNewSmithyRuntime): Render it directly under the customize module when CustomizableOperation
+            // TODO(enableNewSmithyRuntimeCleanup): Render it directly under the customize module when CustomizableOperation
             //  in the middleware has been removed.
             withInlineModule(
                 RustModule.new(
@@ -332,12 +332,12 @@ fun renderCustomizableOperationSend(codegenContext: ClientCodegenContext, generi
         *preludeScope,
         "SdkSuccess" to RuntimeType.sdkSuccess(runtimeConfig),
         "SdkError" to RuntimeType.sdkError(runtimeConfig),
-        // TODO(enableNewSmithyRuntime): Delete the trait bounds when cleaning up middleware
+        // TODO(enableNewSmithyRuntimeCleanup): Delete the trait bounds when cleaning up middleware
         "ParseHttpResponse" to smithyHttp.resolve("response::ParseHttpResponse"),
         "NewRequestPolicy" to smithyClient.resolve("retry::NewRequestPolicy"),
         "SmithyRetryPolicy" to smithyClient.resolve("bounds::SmithyRetryPolicy"),
         "ClassifyRetry" to RuntimeType.classifyRetry(runtimeConfig),
-        // TODO(enableNewSmithyRuntime): Delete the generics when cleaning up middleware
+        // TODO(enableNewSmithyRuntimeCleanup): Delete the generics when cleaning up middleware
         "combined_generics_decl" to combinedGenerics.declaration(),
         "handle_generics_bounds" to handleGenerics.bounds(),
     )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -125,7 +125,7 @@ class FluentClientGenerator(
                     },
                 "RetryConfig" to RuntimeType.smithyTypes(runtimeConfig).resolve("retry::RetryConfig"),
                 "TimeoutConfig" to RuntimeType.smithyTypes(runtimeConfig).resolve("timeout::TimeoutConfig"),
-                // TODO(enableNewSmithyRuntime): Delete the generics when cleaning up middleware
+                // TODO(enableNewSmithyRuntimeCleanup): Delete the generics when cleaning up middleware
                 "generics_decl" to generics.decl,
                 "smithy_inst" to generics.smithyInst,
             )
@@ -224,7 +224,7 @@ class FluentClientGenerator(
                         }
 
                         ##[doc(hidden)]
-                        // TODO(enableNewSmithyRuntime): Delete this function when cleaning up middleware
+                        // TODO(enableNewSmithyRuntimeCleanup): Delete this function when cleaning up middleware
                         // This is currently kept around so the tests still compile in both modes
                         /// Creates a client with the given service configuration.
                         pub fn with_config<C, M, R>(_client: #{client}::Client<C, M, R>, conf: crate::Config) -> Self {
@@ -234,7 +234,7 @@ class FluentClientGenerator(
                         }
 
                         ##[doc(hidden)]
-                        // TODO(enableNewSmithyRuntime): Delete this function when cleaning up middleware
+                        // TODO(enableNewSmithyRuntimeCleanup): Delete this function when cleaning up middleware
                         // This is currently kept around so the tests still compile in both modes
                         /// Returns the client's configuration.
                         pub fn conf(&self) -> &crate::Config {
@@ -510,7 +510,7 @@ class FluentClientGenerator(
                     }
 
                     ##[doc(hidden)]
-                    // TODO(enableNewSmithyRuntime): Remove `async` once we switch to orchestrator
+                    // TODO(enableNewSmithyRuntimeCleanup): Remove `async` once we switch to orchestrator
                     pub async fn customize_orchestrator(
                         self,
                     ) -> #{CustomizableOperation}<
@@ -550,7 +550,7 @@ class FluentClientGenerator(
 
                         /// Consumes this builder, creating a customizable operation that can be modified before being
                         /// sent.
-                        // TODO(enableNewSmithyRuntime): Remove `async` and `Result` once we switch to orchestrator
+                        // TODO(enableNewSmithyRuntimeCleanup): Remove `async` and `Result` once we switch to orchestrator
                         pub async fn customize(
                             self,
                         ) -> #{Result}<

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerics.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerics.kt
@@ -15,7 +15,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 
-// TODO(enableNewSmithyRuntime): Delete this client generics on/off switch headache
+// TODO(enableNewSmithyRuntimeCleanup): Delete this client generics on/off switch headache
 interface FluentClientGenerics {
     /** Declaration with defaults set */
     val decl: Writable

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -329,7 +329,7 @@ class ServiceConfigGenerator(
             """
             impl #{RuntimePlugin} for Builder {
                 fn config(&self) -> #{Option}<#{FrozenLayer}> {
-                    // TODO(enableNewSmithyRuntime): Put into `cfg` the fields in `self.config_override` that are not `None`
+                    // TODO(enableNewSmithyRuntimeLaunch): Put into `cfg` the fields in `self.config_override` that are not `None`
                     ##[allow(unused_mut)]
                     let mut cfg = #{Layer}::new("service config");
                     #{config}

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/MakeOperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/MakeOperationGenerator.kt
@@ -35,7 +35,7 @@ import software.amazon.smithy.rust.codegen.core.util.getTrait
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.letIf
 
-// TODO(enableNewSmithyRuntime): Delete this class when cleaning up `enableNewSmithyRuntime`
+// TODO(enableNewSmithyRuntimeCleanup): Delete this class when cleaning up `enableNewSmithyRuntime`
 /** Generates the `make_operation` function on input structs */
 open class MakeOperationGenerator(
     protected val codegenContext: CodegenContext,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ProtocolParserGenerator.kt
@@ -55,13 +55,13 @@ class ProtocolParserGenerator(
         "operation" to RuntimeType.operationModule(codegenContext.runtimeConfig),
         "Bytes" to RuntimeType.Bytes,
         "SdkBody" to RuntimeType.sdkBody(codegenContext.runtimeConfig),
-        // TODO(enableNewSmithyRuntime): Remove the `PropertyBag` below
+        // TODO(enableNewSmithyRuntimeCleanup): Remove the `PropertyBag` below
         "PropertyBag" to RuntimeType.smithyHttp(codegenContext.runtimeConfig).resolve("property_bag::PropertyBag"),
     )
 
     fun parseResponseFn(
         operationShape: OperationShape,
-        // TODO(enableNewSmithyRuntime): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
+        // TODO(enableNewSmithyRuntimeCleanup): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
         propertyBagAvailable: Boolean,
         customizations: List<OperationCustomization>,
     ): RuntimeType {
@@ -189,7 +189,7 @@ class ProtocolParserGenerator(
 
     fun parseStreamingResponseFn(
         operationShape: OperationShape,
-        // TODO(enableNewSmithyRuntime): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
+        // TODO(enableNewSmithyRuntimeCleanup): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
         propertyBagAvailable: Boolean,
         customizations: List<OperationCustomization>,
     ): RuntimeType {
@@ -241,7 +241,7 @@ class ProtocolParserGenerator(
         outputShape: StructureShape,
         bindings: List<HttpBindingDescriptor>,
         errorSymbol: Symbol,
-        // TODO(enableNewSmithyRuntime): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
+        // TODO(enableNewSmithyRuntimeCleanup): Remove the `propertyBagAvailable` flag as if it were always set to `false` when switching to the orchestrator
         propertyBagAvailable: Boolean,
         customizations: List<OperationCustomization>,
     ) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -33,7 +33,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctio
 import software.amazon.smithy.rust.codegen.core.util.hasStreamingMember
 import software.amazon.smithy.rust.codegen.core.util.outputShape
 
-// TODO(enableNewSmithyRuntime): Delete this class when cleaning up `enableNewSmithyRuntime` (replace with ClientProtocolGenerator)
+// TODO(enableNewSmithyRuntimeCleanup): Delete this class when cleaning up `enableNewSmithyRuntime` (replace with ClientProtocolGenerator)
 class HttpBoundProtocolGenerator(
     codegenContext: ClientCodegenContext,
     protocol: Protocol,
@@ -52,7 +52,7 @@ class HttpBoundProtocolGenerator(
     HttpBoundProtocolTraitImplGenerator(codegenContext, protocol),
 )
 
-// TODO(enableNewSmithyRuntime): Completely delete `AdditionalPayloadContext` when switching to the orchestrator
+// TODO(enableNewSmithyRuntimeCleanup): Completely delete `AdditionalPayloadContext` when switching to the orchestrator
 data class ClientAdditionalPayloadContext(
     val propertyBagAvailable: Boolean,
 ) : AdditionalPayloadContext
@@ -94,7 +94,7 @@ class ClientHttpBoundProtocolPayloadGenerator(
     },
 )
 
-// TODO(enableNewSmithyRuntime): Delete this class when cleaning up `enableNewSmithyRuntime`
+// TODO(enableNewSmithyRuntimeCleanup): Delete this class when cleaning up `enableNewSmithyRuntime`
 open class HttpBoundProtocolTraitImplGenerator(
     codegenContext: ClientCodegenContext,
     protocol: Protocol,

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/PaginatorGeneratorTest.kt
@@ -70,7 +70,7 @@ internal class PaginatorGeneratorTest {
         }
     """.asSmithyModel()
 
-    // TODO(enableNewSmithyRuntime): Remove this middleware test when launching
+    // TODO(enableNewSmithyRuntimeCleanup): Remove this middleware test when launching
     @Test
     fun `generate paginators that compile with middleware`() {
         clientIntegrationTest(model) { clientCodegenContext, rustCrate ->

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestCodegenSettings.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestCodegenSettings.kt
@@ -10,7 +10,7 @@ import software.amazon.smithy.model.node.StringNode
 import software.amazon.smithy.rust.codegen.core.testutil.IntegrationTestParams
 
 object TestCodegenSettings {
-    // TODO(enableNewSmithyRuntime): Delete this when removing `enableNewSmithyRuntime` feature gate
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when removing `enableNewSmithyRuntime` feature gate
     fun middlewareMode(): ObjectNode = ObjectNode.objectNodeBuilder()
         .withMember(
             "codegen",
@@ -19,7 +19,7 @@ object TestCodegenSettings {
         )
         .build()
 
-    // TODO(enableNewSmithyRuntime): Delete this when removing `enableNewSmithyRuntime` feature gate
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when removing `enableNewSmithyRuntime` feature gate
     fun orchestratorMode(): ObjectNode = ObjectNode.objectNodeBuilder()
         .withMember(
             "codegen",
@@ -28,11 +28,11 @@ object TestCodegenSettings {
         )
         .build()
 
-    // TODO(enableNewSmithyRuntime): Delete this when removing `enableNewSmithyRuntime` feature gate
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when removing `enableNewSmithyRuntime` feature gate
     val middlewareModeTestParams get(): IntegrationTestParams =
         IntegrationTestParams(additionalSettings = middlewareMode())
 
-    // TODO(enableNewSmithyRuntime): Delete this when removing `enableNewSmithyRuntime` feature gate
+    // TODO(enableNewSmithyRuntimeCleanup): Delete this when removing `enableNewSmithyRuntime` feature gate
     val orchestratorModeTestParams get(): IntegrationTestParams =
         IntegrationTestParams(additionalSettings = orchestratorMode())
 }

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -101,7 +101,7 @@ impl DeferredSigner {
                     .unwrap()
                     .try_recv()
                     .ok()
-                    // TODO(enableNewSmithyRuntime): When the middleware implementation is removed,
+                    // TODO(enableNewSmithyRuntimeCleanup): When the middleware implementation is removed,
                     // this should panic rather than default to the `NoOpSigner`. The reason it defaults
                     // is because middleware-based generic clients don't have any default middleware,
                     // so there is no way to send a `NoOpSigner` by default when there is no other

--- a/rust-runtime/aws-smithy-http-auth/src/lib.rs
+++ b/rust-runtime/aws-smithy-http-auth/src/lib.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TODO(enableNewSmithyRuntime): The contents of this crate are moving into aws-smithy-runtime.
+// TODO(enableNewSmithyRuntimeCleanup): The contents of this crate are moving into aws-smithy-runtime.
 // This crate is kept to continue sorting the middleware implementation until it is removed.
 // When removing the old implementation, clear out this crate and deprecate it.
 

--- a/rust-runtime/aws-smithy-http/src/endpoint/middleware.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint/middleware.rs
@@ -13,7 +13,7 @@ use http::header::HeaderName;
 use http::{HeaderValue, Uri};
 use std::str::FromStr;
 
-// TODO(enableNewSmithyRuntime): Delete this module
+// TODO(enableNewSmithyRuntimeCleanup): Delete this module
 
 /// Middleware to apply an HTTP endpoint to the request
 ///

--- a/rust-runtime/aws-smithy-http/src/operation.rs
+++ b/rust-runtime/aws-smithy-http/src/operation.rs
@@ -60,7 +60,7 @@ pub struct Parts<H, R> {
     pub metadata: Option<Metadata>,
 }
 
-// TODO(enableNewSmithyRuntime): Delete `operation::Operation` when cleaning up middleware
+// TODO(enableNewSmithyRuntimeCleanup): Delete `operation::Operation` when cleaning up middleware
 /// An [`Operation`] is a request paired with a response handler, retry classifier,
 /// and metadata that identifies the API being called.
 ///
@@ -160,7 +160,7 @@ impl<H> Operation<H, ()> {
     }
 }
 
-// TODO(enableNewSmithyRuntime): Delete `operation::Request` when cleaning up middleware
+// TODO(enableNewSmithyRuntimeCleanup): Delete `operation::Request` when cleaning up middleware
 /// Operation request type that associates a property bag with an underlying HTTP request.
 /// This type represents the request in the Tower `Service` in middleware so that middleware
 /// can share information with each other via the properties.
@@ -252,7 +252,7 @@ impl Request {
     }
 }
 
-// TODO(enableNewSmithyRuntime): Delete `operation::Response` when cleaning up middleware
+// TODO(enableNewSmithyRuntimeCleanup): Delete `operation::Response` when cleaning up middleware
 /// Operation response type that associates a property bag with an underlying HTTP response.
 /// This type represents the response in the Tower `Service` in middleware so that middleware
 /// can share information with each other via the properties.

--- a/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/interceptors/context.rs
@@ -294,7 +294,6 @@ impl<I, O, E: Debug> InterceptorContext<I, O, E> {
         }
 
         // Otherwise, rewind to the saved request checkpoint
-        // TODO(enableNewSmithyRuntime): Also rewind the ConfigBag
         self.phase = Phase::BeforeTransmit;
         self.request = try_clone(self.request_checkpoint.as_ref().expect("checked above"));
         assert!(

--- a/rust-runtime/aws-smithy-runtime/src/client/connections/test_connection.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/connections/test_connection.rs
@@ -225,7 +225,6 @@ impl TestConnection {
 
 impl Connection for TestConnection {
     fn call(&self, request: HttpRequest) -> BoxFuture<HttpResponse> {
-        // TODO(enableNewSmithyRuntime) Validate request
         let (res, simulated_latency) = if let Some(event) = self.data.lock().unwrap().pop() {
             self.requests.lock().unwrap().push(ValidateRequest {
                 expected: event.req,

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -34,7 +34,7 @@ pub struct StandardRetryStrategy {
 
 impl StandardRetryStrategy {
     pub fn new(retry_config: &RetryConfig) -> Self {
-        // TODO(enableNewSmithyRuntime) add support for `retry_config.reconnect_mode()` here or in the orchestrator flow.
+        // TODO(enableNewSmithyRuntimeLaunch) add support for `retry_config.reconnect_mode()` here or in the orchestrator flow.
         Self::default()
             .with_max_attempts(retry_config.max_attempts() as usize)
             .with_initial_backoff(retry_config.initial_backoff())

--- a/rust-runtime/aws-smithy-runtime/src/client/test_util/interceptors.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/test_util/interceptors.rs
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// TODO(enableNewSmithyRuntime): Delete this file once test helpers on `CustomizableOperation` have been removed
+// TODO(enableNewSmithyRuntimeCleanup): Delete this file once test helpers on `CustomizableOperation` have been removed
 
 use aws_smithy_runtime_api::client::interceptors::{
     BeforeTransmitInterceptorContextMut, BoxError, Interceptor,

--- a/rust-runtime/aws-smithy-types/src/lib.rs
+++ b/rust-runtime/aws-smithy-types/src/lib.rs
@@ -14,7 +14,7 @@
     unreachable_pub
 )]
 pub mod base64;
-//TODO(enableNewSmithyRuntime): Unhide this module when switching to the orchestrator
+//TODO(enableNewSmithyRuntimeLaunch): Unhide this module when switching to the orchestrator
 #[doc(hidden)]
 /// A typemap for storing configuration.
 pub mod config_bag;
@@ -25,7 +25,7 @@ pub mod primitive;
 pub mod retry;
 pub mod timeout;
 
-//TODO(enableNewSmithyRuntime): Unhide this module when switching to the orchestrator
+//TODO(enableNewSmithyRuntimeLaunch): Unhide this module when switching to the orchestrator
 #[doc(hidden)]
 /// Utilities for type erasure.
 pub mod type_erasure;

--- a/tools/ci-scripts/check-aws-sdk-adhoc-tests
+++ b/tools/ci-scripts/check-aws-sdk-adhoc-tests
@@ -10,7 +10,7 @@ C_RESET='\033[0m'
 set -eu
 cd smithy-rs
 
-# TODO(enableNewSmithyRuntime): Remove the middleware test run when cleaning up middleware
+# TODO(enableNewSmithyRuntimeCleanup): Remove the middleware test run when cleaning up middleware
 echo -e "## ${C_YELLOW}Running SDK adhoc tests against the middleware implementation...${C_RESET}"
 ./gradlew aws:sdk-adhoc-test:clean
 ./gradlew aws:sdk-adhoc-test:check -Psmithy.runtime.mode=middleware

--- a/tools/ci-scripts/check-aws-sdk-orchestrator-impl
+++ b/tools/ci-scripts/check-aws-sdk-orchestrator-impl
@@ -12,7 +12,7 @@ C_RESET='\033[0m'
 set -eu
 cd smithy-rs
 
-# TODO(enableNewSmithyRuntime): Move these into `services_that_pass_tests` as more progress is made
+# TODO(enableNewSmithyRuntimeLaunch): Move these into `services_that_pass_tests` as more progress is made
 services_that_compile=(\
     "aws-config"\
     "dynamodb"\

--- a/tools/ci-scripts/codegen-diff/semver-checks.py
+++ b/tools/ci-scripts/codegen-diff/semver-checks.py
@@ -34,7 +34,7 @@ def main(skip_generation=False):
     os.chdir(sdk_directory)
 
     failed = False
-    # TODO(enableNewSmithyRuntime): Remove the deny list below
+    # TODO(enableNewSmithyRuntimeLaunch): Remove the deny list below
     deny_list = [
         "aws-runtime",
         "aws-runtime-api",


### PR DESCRIPTION
This PR categorizes orchestrator TODO comments into `Launch` and `Cleanup`:

- `enableNewSmithyRuntimeLaunch`: Comment needs to be addressed before orchestrator launch
- `enableNewSmithyRuntimeCleanup`: Comment needs to be addressed after launch when removing middleware

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
