### PR TITLE
Relax bounds on `Scoped`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -405,7 +405,7 @@ let scoped_plugin = Scoped::new::<SomeScope>(plugin);
 ```
 
 """
-references = ["smithy-rs#2740", "smithy-rs#2759"]
+references = ["smithy-rs#2740", "smithy-rs#2759", "smithy-rs#2779"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "hlbarber"
 

--- a/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
+++ b/rust-runtime/aws-smithy-http-server/src/plugin/scoped.rs
@@ -94,7 +94,6 @@ impl<P, Op, S, Scope, Pl> Plugin<P, Op, S> for Scoped<Scope, Pl>
 where
     Scope: Membership<Op>,
     Scope::Contains: ConditionalApply<P, Op, S, Pl>,
-    Pl: Plugin<P, Op, S>,
 {
     type Service = <Scope::Contains as ConditionalApply<P, Op, S, Pl>>::Service;
 


### PR DESCRIPTION
## Motivation and Context

I accidentally added this bound, it is not only redundant but its absence is one of the key benefits of this approach.