### PR TITLE
Rename `make_token` to `idempotency_token_provider`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -550,3 +550,15 @@ let plugin = plugin_from_operation_fn(map);
 references = ["smithy-rs#2740", "smithy-rs#2759", "smithy-rs#2779"]
 meta = { "breaking" = true, "tada" = false, "bug" = false }
 author = "hlbarber"
+
+[[smithy-rs]]
+message = "The naming `make_token` for fields and the API of `IdempotencyTokenProvider` in service configs and their builders has now been updated to `idempotency_token_provider`."
+references = ["smithy-rs#2783"]
+meta = { "breaking" = true, "tada" = false, "bug" = false, "target" = "client" }
+author = "ysaito1001"
+
+[[aws-sdk-rust]]
+message = "The naming `make_token` for fields and the API of `IdempotencyTokenProvider` in service configs and their builders has now been updated to `idempotency_token_provider`."
+references = ["smithy-rs#2783"]
+meta = { "breaking" = true, "tada" = false, "bug" = false }
+author = "ysaito1001"

--- a/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
+++ b/aws/sdk/integration-tests/timestreamquery/tests/endpoint_disco.rs
@@ -29,7 +29,7 @@ async fn do_endpoint_discovery() {
         .time_source(SharedTimeSource::new(ts.clone()))
         .build();
     let conf = query::config::Builder::from(&config)
-        .make_token("0000-0000-0000")
+        .idempotency_token_provider("0000-0000-0000")
         .build();
     let (client, reloader) = query::Client::from_conf(conf)
         .enable_endpoint_discovery()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/IdempotencyTokenGenerator.kt
@@ -32,7 +32,7 @@ class IdempotencyTokenGenerator(codegenContext: CodegenContext, operationShape: 
                 rustTemplate(
                     """
                     if ${section.input}.$memberName.is_none() {
-                        ${section.input}.$memberName = #{Some}(${section.config}.make_token.make_idempotency_token());
+                        ${section.input}.$memberName = #{Some}(${section.config}.idempotency_token_provider.make_idempotency_token());
                     }
                     """,
                     *preludeScope,


### PR DESCRIPTION
## Motivation and Context
Incorporates suggestion made in https://github.com/awslabs/smithy-rs/pull/2762#discussion_r1231462878

## Description
This PR renames `make_token` to `idempotency_token_provider` for clarity wherever it is referred to in the fields and API in service configs and their builders.

## Testing
Existing tests in CI

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
