### PR TITLE
Optimize `AggregatedBytes::to_vec`

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -12,6 +12,12 @@
 # author = "rcoh"
 
 [[smithy-rs]]
+message = "Avoid intermediate vec allocations in AggregatedBytes::to_vec."
+author = "yotamofek"
+references = ["smithy-rs#2786"]
+meta = { "breaking" = false, "tada" = false, "bug" = false }
+
+[[smithy-rs]]
 message = "Fix bug in AWS JSON 1.x routers where, if a service had more than 14 operations, the router was created without the route for the 15th operation."
 author = "thor-bjorgvinsson"
 references = ["smithy-rs#2733"]

--- a/rust-runtime/aws-smithy-http/src/byte_stream.rs
+++ b/rust-runtime/aws-smithy-http/src/byte_stream.rs
@@ -484,11 +484,7 @@ impl AggregatedBytes {
 
     /// Convert this buffer into a `Vec<u8>`
     pub fn to_vec(self) -> Vec<u8> {
-        self.0
-            .into_inner()
-            .into_iter()
-            .flat_map(|b| b.to_vec())
-            .collect()
+        self.0.into_inner().into_iter().flatten().collect()
     }
 }
 


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
Avoid intermediate vec allocations in `AggregatedBytes::to_vec`.

## Description
<!--- Describe your changes in detail -->
Calling `slice::to_vec` on every segment is wasteful, the segments can be just flattened into an iterator over `u8`s and collected directly. Also makes the code a bit simpler.

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [x] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
