### PR TITLE
Invert `seen_${var}` to `${var}_seen`

### DIFF
--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -971,7 +971,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
             val (queryBindingsTargetingCollection, queryBindingsTargetingSimple) =
                 queryBindings.partition { model.expectShape(it.member.target) is CollectionShape }
             queryBindingsTargetingSimple.forEach {
-                rust("let mut seen_${symbolProvider.toMemberName(it.member)} = false;")
+                rust("let mut ${symbolProvider.toMemberName(it.member)}_seen = false;")
             }
             queryBindingsTargetingCollection.forEach {
                 rust("let mut ${symbolProvider.toMemberName(it.member)} = Vec::new();")
@@ -983,7 +983,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                     val memberName = symbolProvider.toMemberName(it.member)
                     rustTemplate(
                         """
-                        if !seen_$memberName && k == "${it.locationName}" {
+                        if !${memberName}_seen && k == "${it.locationName}" {
                             input = input.${it.member.setterName()}(
                                 #{deserializer}(&v)?
                             );

--- a/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
+++ b/codegen-server/src/main/kotlin/software/amazon/smithy/rust/codegen/server/smithy/protocols/ServerHttpBoundProtocolGenerator.kt
@@ -987,7 +987,7 @@ class ServerHttpBoundProtocolTraitImplGenerator(
                             input = input.${it.member.setterName()}(
                                 #{deserializer}(&v)?
                             );
-                            seen_$memberName = true;
+                            ${memberName}_seen = true;
                         }
                         """.trimIndent(),
                         "deserializer" to deserializer,


### PR DESCRIPTION
## Motivation and Context

When `var` is a reserved word, `seen_${var}` becomes `seen_r#var` which is invalid Rust.

## Description

Invert `seen_${var}` to `${var}_seen`. This is a least effort fix.
