### PR TITLE
Add get_foo() -> &Option<Foo> accessors for builders and fluent builders.

### DIFF
--- a/CHANGELOG.next.toml
+++ b/CHANGELOG.next.toml
@@ -11,6 +11,18 @@
 # meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client | server | all"}
 # author = "rcoh"
 
+ [[aws-sdk-rust]]
+ message = "Add accessors to Builders"
+ references = ["smithy-rs#2791"]
+ meta = { "breaking" = false, "tada" = false, "bug" = false }
+ author = "davidsouther"
+
+ [[smithy-rs]]
+ message = "Add accessors to Builders"
+ references = ["smithy-rs#2791"]
+ meta = { "breaking" = false, "tada" = false, "bug" = false, "target" = "client"}
+ author = "davidsouther"
+
 [[smithy-rs]]
 message = "Avoid intermediate vec allocations in AggregatedBytes::to_vec."
 author = "yotamofek"

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientCore.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientCore.kt
@@ -15,6 +15,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.documentShape
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustBlock
+import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 
 class FluentClientCore(private val model: Model) {
@@ -65,6 +66,17 @@ class FluentClientCore(private val model: Model) {
         rustBlock("pub fn $memberName(mut self, ${functionInput.argument}) -> Self") {
             write("self.inner = self.inner.$memberName(${functionInput.value});")
             write("self")
+        }
+    }
+
+    /**
+     * Generate and write Rust code for a getter method that returns a reference to the inner data.
+     */
+    fun RustWriter.renderGetterHelper(member: MemberShape, memberName: String, coreType: RustType) {
+        documentShape(member, model)
+        deprecatedShape(member)
+        withBlockTemplate("pub fn $memberName(&self) -> &#{CoreType} {", "}", "CoreType" to coreType) {
+            write("self.inner.$memberName()")
         }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -48,6 +48,7 @@ import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
 import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
 import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
+import software.amazon.smithy.rust.codegen.core.smithy.generators.getterName
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.orNull
@@ -409,6 +410,14 @@ class FluentClientGenerator(
                 }
             }
 
+            rust("/// Access the inner ${operationSymbol.name} builder as a reference.\n")
+            withBlockTemplate(
+                "pub fn inner(&self) -> &#{Inner} {", "}",
+                "Inner" to symbolProvider.symbolForBuilder(input),
+            ) {
+                write("&self.inner")
+            }
+
             if (smithyRuntimeMode.generateMiddleware) {
                 val middlewareScope = arrayOf(
                     *preludeScope,
@@ -630,6 +639,9 @@ class FluentClientGenerator(
                 val setterName = member.setterName()
                 val optionalInputType = outerType.asOptional()
                 with(core) { renderInputHelper(member, setterName, optionalInputType) }
+
+                val getterName = member.getterName()
+                with(core) { renderGetterHelper(member, getterName, optionalInputType) }
             }
         }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -410,9 +410,9 @@ class FluentClientGenerator(
                 }
             }
 
-            rust("/// Access the inner ${operationSymbol.name} builder as a reference.\n")
+            rust("/// Access the ${operationSymbol.name} as a reference.\n")
             withBlockTemplate(
-                "pub fn inner(&self) -> &#{Inner} {", "}",
+                "pub fn as_input(&self) -> &#{Inner} {", "}",
                 "Inner" to symbolProvider.symbolForBuilder(input),
             ) {
                 write("&self.inner")

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -47,8 +47,8 @@ import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
 import software.amazon.smithy.rust.codegen.core.smithy.RustSymbolProvider
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
 import software.amazon.smithy.rust.codegen.core.smithy.expectRustMetadata
-import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.core.smithy.generators.getterName
+import software.amazon.smithy.rust.codegen.core.smithy.generators.setterName
 import software.amazon.smithy.rust.codegen.core.smithy.rustType
 import software.amazon.smithy.rust.codegen.core.util.inputShape
 import software.amazon.smithy.rust.codegen.core.util.orNull

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
@@ -6,26 +6,17 @@
 package software.amazon.smithy.rust.codegen.client.smithy.generators.client
 
 import org.junit.jupiter.api.Test
-import software.amazon.smithy.model.shapes.StructureShape
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.testutil.TestCodegenSettings
 import software.amazon.smithy.rust.codegen.client.testutil.clientIntegrationTest
-import software.amazon.smithy.rust.codegen.client.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
-import software.amazon.smithy.rust.codegen.core.rustlang.implBlock
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
-import software.amazon.smithy.rust.codegen.core.smithy.generators.BuilderGenerator
-import software.amazon.smithy.rust.codegen.core.smithy.generators.StructureGenerator
-import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
-import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.integrationTest
-import software.amazon.smithy.rust.codegen.core.testutil.unitTest
-import software.amazon.smithy.rust.codegen.core.util.lookup
 
 class FluentClientGeneratorTest {
     val model = """

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
@@ -114,7 +114,7 @@ class FluentClientGeneratorTest {
                         if (codegenContext.smithyRuntimeMode.generateOrchestrator) {
                             rust(".http_connector(connector.clone())")
                         }
-                    }
+                    },
                 )
             }
         }

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
@@ -100,10 +100,10 @@ class FluentClientGeneratorTest {
                             .build_dyn();
                         let client = $moduleName::Client::with_config(smithy_client, config); 
                     
-                        let say_hello_input_builder = client.say_hello().byte_value(4).foo("hello!");
-                        assert_eq!(*say_hello_input_builder.get_foo(), Some("hello!".to_string()));
-                        let inner = say_hello_input_builder.inner();
-                        assert_eq!(*inner.get_byte_value(), Some(4));
+                        let say_hello_fluent_builder = client.say_hello().byte_value(4).foo("hello!");
+                        assert_eq!(*say_hello_fluent_builder.get_foo(), Some("hello!".to_string()));
+                        let input = say_hello_fluent_builder.as_input();
+                        assert_eq!(*input.get_byte_value(), Some(4));
                     }
                     """,
                     "TestConnection" to CargoDependency.smithyClient(codegenContext.runtimeConfig)

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGeneratorTest.kt
@@ -98,8 +98,8 @@ class FluentClientGeneratorTest {
                             .connector(connector.clone())
                             .middleware_fn(|r| r)
                             .build_dyn();
-                        let client = $moduleName::Client::with_config(smithy_client, config); 
-                    
+                        let client = $moduleName::Client::with_config(smithy_client, config);
+
                         let say_hello_fluent_builder = client.say_hello().byte_value(4).foo("hello!");
                         assert_eq!(*say_hello_fluent_builder.get_foo(), Some("hello!".to_string()));
                         let input = say_hello_fluent_builder.as_input();

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -93,7 +93,7 @@ class OperationBuildError(private val runtimeConfig: RuntimeConfig) {
 // Setter names will never hit a reserved word and therefore never need escaping.
 fun MemberShape.setterName() = "set_${this.memberName.toSnakeCase()}"
 
-// Setter names will never hit a reserved word and therefore never need escaping.
+// Getter names will never hit a reserved word and therefore never need escaping.
 fun MemberShape.getterName() = "get_${this.memberName.toSnakeCase()}"
 
 class BuilderGenerator(

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGenerator.kt
@@ -92,6 +92,7 @@ class OperationBuildError(private val runtimeConfig: RuntimeConfig) {
 
 // Setter names will never hit a reserved word and therefore never need escaping.
 fun MemberShape.setterName() = "set_${this.memberName.toSnakeCase()}"
+
 // Setter names will never hit a reserved word and therefore never need escaping.
 fun MemberShape.getterName() = "get_${this.memberName.toSnakeCase()}"
 

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
@@ -40,7 +40,10 @@ internal class BuilderGeneratorTest {
             unitTest("generate_builders") {
                 rust(
                     """
-                    let my_struct = MyStruct::builder().byte_value(4).foo("hello!").build();
+                    let my_struct_builder = MyStruct::builder().byte_value(4).foo("hello!");
+                    assert_eq!(*my_struct_builder.get_byte_value(), Some(4));
+                    
+                    let my_struct = my_struct_builder.build();
                     assert_eq!(my_struct.foo.unwrap(), "hello!");
                     assert_eq!(my_struct.bar, 0);
                     """,

--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
@@ -42,7 +42,7 @@ internal class BuilderGeneratorTest {
                     """
                     let my_struct_builder = MyStruct::builder().byte_value(4).foo("hello!");
                     assert_eq!(*my_struct_builder.get_byte_value(), Some(4));
-                    
+
                     let my_struct = my_struct_builder.build();
                     assert_eq!(my_struct.foo.unwrap(), "hello!");
                     assert_eq!(my_struct.bar, 0);

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedCollectionGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedCollectionGeneratorTest.kt
@@ -18,22 +18,22 @@ class UnconstrainedCollectionGeneratorTest {
         val model =
             """
             namespace test
-            
+
             use aws.protocols#restJson1
             use smithy.framework#ValidationException
-            
+
             @restJson1
             service TestService {
                 operations: ["Operation"]
             }
-            
+
             @http(uri: "/operation", method: "POST")
             operation Operation {
                 input: OperationInputOutput
                 output: OperationInputOutput
                 errors: [ValidationException]
             }
-            
+
             structure OperationInputOutput {
                 list: ListA
             }
@@ -103,7 +103,7 @@ class UnconstrainedCollectionGeneratorTest {
                         let c_builder = crate::model::StructureC::builder();
                         let list_b_unconstrained = crate::unconstrained::list_b_unconstrained::ListBUnconstrained(vec![c_builder]);
                         let list_a_unconstrained = crate::unconstrained::list_a_unconstrained::ListAUnconstrained(vec![list_b_unconstrained]);
-  
+
                         let _list_a: crate::constrained::MaybeConstrained<crate::constrained::list_a_constrained::ListAConstrained> = list_a_unconstrained.into();
                         """,
                     )

--- a/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedMapGeneratorTest.kt
+++ b/codegen-server/src/test/kotlin/software/amazon/smithy/rust/codegen/server/smithy/generators/UnconstrainedMapGeneratorTest.kt
@@ -23,22 +23,22 @@ class UnconstrainedMapGeneratorTest {
         val model =
             """
             namespace test
-            
+
             use aws.protocols#restJson1
             use smithy.framework#ValidationException
-            
+
             @restJson1
             service TestService {
                 operations: ["Operation"]
             }
-            
+
             @http(uri: "/operation", method: "POST")
             operation Operation {
                 input: OperationInputOutput
                 output: OperationInputOutput
                 errors: [ValidationException]
             }
-            
+
             structure OperationInputOutput {
                 map: MapA
             }


### PR DESCRIPTION
This allows testing, as well as making decisions while creating builders. The references are not mutable, so these props remain read only keeping the Builder invariants.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some operations are built up using various logic (for instance, choosing an S3 bucket based on a logged in user). It is a lot of overhead to test at the mock level, and the Debug formatting is typically not stable.
<!--- If it fixes an open issue, please link to the issue here -->
Closes #2791 

## Description
<!--- Describe your changes in detail -->
1. Add `get_foo(&self) -> &Option<Foo>` to Builders
2. Add `as_input(&self) -> &OperationInputBuilder` to Fluent Builders
3. Add `get_foo(&self) -> &Option<Foo>` to FluentBuilder which delegates to Builders


## Testing
<!--- Please describe in detail how you tested your changes -->
Included unit tests, as well as [proof of concept tests](https://github.com/DavidSouther/aws-doc-sdk-examples/commit/017e8a2e407eba6a4c259bca0334f1356ab822d9)
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [X] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
