### PR TITLE
Configure orchestrator's key components in builder's build method

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/CredentialCaches.kt
@@ -145,11 +145,11 @@ class CredentialCacheConfig(codegenContext: ClientCodegenContext) : ConfigCustom
                 if (runtimeMode.defaultToOrchestrator) {
                     rustTemplate(
                         """
-                        self.inner.store_put(
-                            self.inner.load::<#{CredentialsCache}>()
+                        layer.store_put(
+                            layer.load::<#{CredentialsCache}>()
                                 .cloned()
                                 .unwrap_or_else({
-                                    let sleep = self.inner.load::<#{SharedAsyncSleep}>().cloned();
+                                    let sleep = layer.load::<#{SharedAsyncSleep}>().cloned();
                                     || match sleep {
                                         Some(sleep) => {
                                             #{CredentialsCache}::lazy_builder()
@@ -159,7 +159,7 @@ class CredentialCacheConfig(codegenContext: ClientCodegenContext) : ConfigCustom
                                         None => #{CredentialsCache}::lazy(),
                                     }
                                 })
-                                .create_cache(self.inner.load::<#{SharedCredentialsProvider}>().cloned().unwrap_or_else(|| {
+                                .create_cache(layer.load::<#{SharedCredentialsProvider}>().cloned().unwrap_or_else(|| {
                                     #{SharedCredentialsProvider}::new(#{DefaultProvider})
                                 }))
                         );

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -78,22 +78,6 @@ private class AuthServiceRuntimePluginCustomization(private val codegenContext: 
                     // enable the aws-runtime `sign-eventstream` feature
                     addDependency(AwsCargoDependency.awsRuntime(runtimeConfig).withFeature("event-stream").toType().toSymbol())
                 }
-                section.putConfigValue(this) {
-                    rustTemplate("#{SigningService}::from_static(self.handle.conf.signing_service())", *codegenScope)
-                }
-                rustTemplate(
-                    """
-                    if let Some(region) = self.handle.conf.region() {
-                        #{put_signing_region}
-                    }
-                    """,
-                    *codegenScope,
-                    "put_signing_region" to writable {
-                        section.putConfigValue(this) {
-                            rustTemplate("#{SigningRegion}::from(region.clone())", *codegenScope)
-                        }
-                    },
-                )
             }
 
             else -> {}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -104,12 +104,6 @@ class UserAgentDecorator : ClientCodegenDecorator {
 
         override fun section(section: ServiceRuntimePluginSection): Writable = writable {
             when (section) {
-                is ServiceRuntimePluginSection.AdditionalConfig -> {
-                    section.putConfigValue(this) {
-                        rust("#T.clone()", ClientRustModule.Meta.toType().resolve("API_METADATA"))
-                    }
-                }
-
                 is ServiceRuntimePluginSection.RegisterInterceptor -> {
                     section.registerInterceptor(runtimeConfig, this) {
                         rust("#T::new()", awsRuntime.resolve("user_agent::UserAgentInterceptor"))
@@ -212,7 +206,9 @@ class UserAgentDecorator : ClientCodegenDecorator {
                 }
 
                 is ServiceConfig.BuilderBuild -> writable {
-                    if (runtimeMode.defaultToMiddleware) {
+                    if (runtimeMode.defaultToOrchestrator) {
+                        rust("layer.put(#T.clone());", ClientRustModule.Meta.toType().resolve("API_METADATA"))
+                    } else {
                         rust("app_name: self.app_name,")
                     }
                 }

--- a/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecoratorTest.kt
+++ b/aws/sdk-codegen/src/test/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecoratorTest.kt
@@ -30,6 +30,7 @@ internal class SigV4SigningDecoratorTest {
             codegenContext,
             SigV4SigningConfig(
                 codegenContext.runtimeConfig,
+                codegenContext.smithyRuntimeMode,
                 true,
                 SigV4Trait.builder().name("test-service").build(),
             ),

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpConnectorConfigDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpConnectorConfigDecorator.kt
@@ -192,7 +192,7 @@ private class HttpConnectorConfigCustomization(
                     rustTemplate(
                         """
                         let sleep_impl = layer.load::<#{SharedAsyncSleep}>().cloned();
-                        let timeout_config = layer.load::<#{TimeoutConfig}>().cloned().unwrap_or_else(|| #{TimeoutConfig}::disabled());
+                        let timeout_config = layer.load::<#{TimeoutConfig}>().cloned().unwrap_or_else(#{TimeoutConfig}::disabled);
 
                         let connector_settings = #{ConnectorSettings}::from_timeout_config(&timeout_config);
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/TimeSourceCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/TimeSourceCustomization.kt
@@ -114,7 +114,7 @@ class TimeSourceCustomization(codegenContext: ClientCodegenContext) : ConfigCust
                 ServiceConfig.BuilderBuild -> {
                     if (runtimeMode.defaultToOrchestrator) {
                         rustTemplate(
-                            "self.inner.store_put(self.inner.load::<#{SharedTimeSource}>().cloned().unwrap_or_default());",
+                            "layer.store_put(layer.load::<#{SharedTimeSource}>().cloned().unwrap_or_default());",
                             *codegenScope,
                         )
                     } else {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customize/RequiredCustomizations.kt
@@ -15,11 +15,9 @@ import software.amazon.smithy.rust.codegen.client.smithy.customizations.Idempote
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.InterceptorConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyReExportCustomization
-import software.amazon.smithy.rust.codegen.client.smithy.customizations.ResiliencyServiceRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.TimeSourceCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.customizations.TimeSourceOperationCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCustomization
-import software.amazon.smithy.rust.codegen.client.smithy.generators.ServiceRuntimePluginCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.core.rustlang.Feature
 import software.amazon.smithy.rust.codegen.core.smithy.RustCrate
@@ -92,10 +90,4 @@ class RequiredCustomizations : ClientCodegenDecorator {
             }
         }
     }
-
-    override fun serviceRuntimePluginCustomizations(
-        codegenContext: ClientCodegenContext,
-        baseCustomizations: List<ServiceRuntimePluginCustomization>,
-    ): List<ServiceRuntimePluginCustomization> =
-        baseCustomizations + listOf(ResiliencyServiceRuntimePluginCustomization(codegenContext))
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
@@ -56,6 +56,7 @@ open class OperationGenerator(
                         config_override: #{Option}<crate::config::Builder>,
                     ) -> #{RuntimePlugins} {
                         let mut runtime_plugins = runtime_plugins
+                            .with_client_plugin(handle.conf.clone())
                             .with_client_plugin(crate::config::ServiceRuntimePlugin::new(handle))
                             .with_operation_plugin(operation);
                         if let Some(config_override) = config_override {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceGenerator.kt
@@ -54,6 +54,7 @@ class ServiceGenerator(
                 ServiceRuntimePluginGenerator(codegenContext)
                     .render(this, decorator.serviceRuntimePluginCustomizations(codegenContext, emptyList()))
 
+                serviceConfigGenerator.renderRuntimePluginImplForSelf(this)
                 serviceConfigGenerator.renderRuntimePluginImplForBuilder(this)
             }
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/IdempotencyTokenProviderCustomization.kt
@@ -108,7 +108,7 @@ class IdempotencyTokenProviderCustomization(codegenContext: ClientCodegenContext
             ServiceConfig.BuilderBuild -> writable {
                 if (runtimeMode.defaultToOrchestrator) {
                     rustTemplate(
-                        "self.inner.store_put(self.inner.load::<#{IdempotencyTokenProvider}>().cloned().unwrap_or_else(#{default_provider}));",
+                        "layer.store_put(layer.load::<#{IdempotencyTokenProvider}>().cloned().unwrap_or_else(#{default_provider}));",
                         *codegenScope,
                     )
                 } else {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -12,7 +12,7 @@ use aws_smithy_runtime_api::client::interceptors::InterceptorContext;
 use aws_smithy_runtime_api::client::orchestrator::{
     BoxError, ConfigBagAccessors, EndpointResolver, EndpointResolverParams, HttpRequest,
 };
-use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::endpoint::Endpoint;
 use http::header::HeaderName;
 use http::{HeaderValue, Uri};
@@ -63,6 +63,13 @@ impl From<StaticUriEndpointResolverParams> for EndpointResolverParams {
 #[derive(Debug, Clone)]
 pub struct DefaultEndpointResolver<Params> {
     inner: SharedEndpointResolver<Params>,
+}
+
+impl<Params> Storable for DefaultEndpointResolver<Params>
+where
+    Params: Debug + Send + Sync + 'static,
+{
+    type Storer = StoreReplace<Self>;
 }
 
 impl<Params> DefaultEndpointResolver<Params> {

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -13,7 +13,7 @@ use aws_smithy_runtime_api::client::request_attempts::RequestAttempts;
 use aws_smithy_runtime_api::client::retries::{
     ClassifyRetry, RetryReason, RetryStrategy, ShouldAttempt,
 };
-use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::retry::RetryConfig;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -30,6 +30,10 @@ pub struct StandardRetryStrategy {
     max_attempts: usize,
     max_backoff: Duration,
     retry_permit: Mutex<Option<OwnedSemaphorePermit>>,
+}
+
+impl Storable for StandardRetryStrategy {
+    type Storer = StoreReplace<Self>;
 }
 
 impl StandardRetryStrategy {

--- a/rust-runtime/aws-smithy-types/src/config_bag.rs
+++ b/rust-runtime/aws-smithy-types/src/config_bag.rs
@@ -113,6 +113,12 @@ impl Clone for CloneableLayer {
     }
 }
 
+impl From<CloneableLayer> for Layer {
+    fn from(cloneable_layer: CloneableLayer) -> Layer {
+        cloneable_layer.0
+    }
+}
+
 // We need to "override" the mutable methods to encode the information that an item being stored
 // implements `Clone`. For the immutable methods, they can just be delegated via the `Deref` trait.
 impl CloneableLayer {


### PR DESCRIPTION
## Motivation and Context
Moves setting orchestrator components out of `ServiceRuntimePlugin` and puts it in service config builders' build method.

## Description
This PR is the forth in a series of config refactoring. Here, we move pieces of code out of `ServiceRuntimePlugin::config` method so that key orchestrator components meant for the service-level config should only be constructed once when a service config is created, e.g. during builder's `build` method. Previously, those components were newly created every time an operation is invoked.

Wherever `self.handle.conf...` is used, the PR has moved it from `ServiceRuntimePlugin::config` to the builders' `build` method.

Note that there will be a separate PR to better handle auth resolver & identity resolver in the context of the ongoing config refactoring.

## Testing
- [x] Passed tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
