### PR TITLE
Add tests to ensure that `serde` attributes are not added to error types

### DIFF
--- a/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
+++ b/codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt
@@ -18,6 +18,8 @@ import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.compileAndTest
 import software.amazon.smithy.rust.codegen.core.testutil.testSymbolProvider
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
+import kotlin.io.path.extension
+import kotlin.io.path.readText
 
 internal class BuilderGeneratorTest {
     private val model = StructureGeneratorTest.model
@@ -25,6 +27,7 @@ internal class BuilderGeneratorTest {
     private val struct = StructureGeneratorTest.struct
     private val credentials = StructureGeneratorTest.credentials
     private val secretStructure = StructureGeneratorTest.secretStructure
+    private val errorStruct = StructureGeneratorTest.error
 
     @Test
     fun `generate builders`() {
@@ -136,5 +139,31 @@ internal class BuilderGeneratorTest {
             BuilderGenerator(model, provider, secretStructure, emptyList()).render(this)
         }
         project.compileAndTest()
+    }
+
+    @Test
+    fun `don't add serde to error types`() {
+        val provider = testSymbolProvider(model)
+        val project = TestWorkspace.testProject(provider)
+        project.moduleFor(errorStruct) {
+            rust("##![allow(deprecated)]")
+            StructureGenerator(model, provider, this, errorStruct, emptyList()).render()
+            implBlock(provider.toSymbol(errorStruct)) {
+                BuilderGenerator.renderConvenienceMethod(this, provider, errorStruct)
+            }
+        }
+        project.withModule(provider.moduleForBuilder(errorStruct)) {
+            BuilderGenerator(model, provider, errorStruct, emptyList()).render(this)
+        }
+        project.compileAndTest()
+
+        // checks if there is a serde derive in the code
+        project.generatedFiles().forEach {
+            if (it.extension == "rs") {
+                val file = project.baseDir.resolve(it).toFile().readText()
+                val check = file.contains("derive(serde::Deserialize)") || file.contains("derive(serde::Serialize)")
+                assert(!check)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Motivation and Context
This is a sub-PR of https://github.com/awslabs/smithy-rs/pull/2615

During the development, I mistakenly added `serde` attributes to `error` related data types.

This tests ensures that error types are not added.

Test that this PR adds will pass without the `serde` attributes.
## Description
Adds test on `codegen-core/src/test/kotlin/software/amazon/smithy/rust/codegen/core/smithy/generators/BuilderGeneratorTest.kt`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist
<!--- If a checkbox below is not applicable, then please DELETE it rather than leaving it unchecked -->
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the smithy-rs codegen or runtime crates
- [ ] I have updated `CHANGELOG.next.toml` if I made changes to the AWS SDK, generated SDK code, or SDK runtime crates

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
