### PR TITLE
Remove HACK that used to put `Handle` in config bag

### DIFF
--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/EndpointBuiltInsDecorator.kt
@@ -20,18 +20,23 @@ import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegen
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.EndpointRulesetIndex
 import software.amazon.smithy.rust.codegen.client.smithy.endpoint.rustName
+import software.amazon.smithy.rust.codegen.client.smithy.endpoint.symbol
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigParam
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.configParamNewtype
+import software.amazon.smithy.rust.codegen.client.smithy.generators.config.loadFromConfigBag
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.standardConfigParam
+import software.amazon.smithy.rust.codegen.core.rustlang.RustType
 import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.docs
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.smithy.customize.AdHocCustomization
+import software.amazon.smithy.rust.codegen.core.smithy.mapRustType
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.extendIf
@@ -54,22 +59,20 @@ fun ClientCodegenContext.getBuiltIn(builtIn: String): Parameter? {
 private fun promotedBuiltins(parameter: Parameter) =
     parameter == Builtins.FIPS || parameter == Builtins.DUALSTACK || parameter == Builtins.SDK_ENDPOINT
 
+private fun configParamNewtype(parameter: Parameter, name: String, runtimeConfig: RuntimeConfig): RuntimeType {
+    val type = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
+    return when (promotedBuiltins(parameter)) {
+        true -> AwsRuntimeType.awsTypes(runtimeConfig)
+            .resolve("endpoint_config::${name.toPascalCase()}")
+
+        false -> configParamNewtype(name.toPascalCase(), type, runtimeConfig)
+    }
+}
+
 private fun ConfigParam.Builder.toConfigParam(parameter: Parameter, runtimeConfig: RuntimeConfig): ConfigParam =
     this.name(this.name ?: parameter.name.rustName())
-        .type(
-            when (parameter.type!!) {
-                ParameterType.STRING -> RuntimeType.String.toSymbol()
-                ParameterType.BOOLEAN -> RuntimeType.Bool.toSymbol()
-            },
-        )
-        .newtype(
-            when (promotedBuiltins(parameter)) {
-                true -> AwsRuntimeType.awsTypes(runtimeConfig)
-                    .resolve("endpoint_config::${this.name!!.toPascalCase()}")
-
-                false -> configParamNewtype(this.name!!.toPascalCase(), this.type!!, runtimeConfig)
-            },
-        )
+        .type(parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() })
+        .newtype(configParamNewtype(parameter, this.name!!, runtimeConfig))
         .setterDocs(this.setterDocs ?: parameter.documentation.orNull()?.let { writable { docs(it) } })
         .build()
 
@@ -139,7 +142,12 @@ fun decoratorForBuiltIn(
                     when (parameter.builtIn) {
                         builtIn.builtIn -> writable {
                             if (codegenContext.smithyRuntimeMode.defaultToOrchestrator) {
-                                rust("$configRef.$name()")
+                                val newtype = configParamNewtype(parameter, name, codegenContext.runtimeConfig)
+                                val symbol = parameter.symbol().mapRustType { t -> t.stripOuter<RustType.Option>() }
+                                rustTemplate(
+                                    """$configRef.#{load_from_service_config_layer}""",
+                                    "load_from_service_config_layer" to loadFromConfigBag(symbol.name, newtype),
+                                )
                             } else {
                                 rust("$configRef.$name")
                             }

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/RegionDecorator.kt
@@ -132,7 +132,10 @@ class RegionDecorator : ClientCodegenDecorator {
                     return when (parameter.builtIn) {
                         Builtins.REGION.builtIn -> writable {
                             if (codegenContext.smithyRuntimeMode.defaultToOrchestrator) {
-                                rust("$configRef.region().as_ref().map(|r|r.as_ref().to_owned())")
+                                rustTemplate(
+                                    "$configRef.load::<#{Region}>().map(|r|r.as_ref().to_owned())",
+                                    "Region" to region(codegenContext.runtimeConfig).resolve("Region"),
+                                )
                             } else {
                                 rust("$configRef.region.as_ref().map(|r|r.as_ref().to_owned())")
                             }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -111,6 +111,9 @@ class ServiceRuntimePluginGenerator(
     fun render(writer: RustWriter, customizations: List<ServiceRuntimePluginCustomization>) {
         writer.rustTemplate(
             """
+            // TODO(enableNewSmithyRuntimeLaunch) Remove `allow(dead_code)` as well as a field `handle` when
+            //  the field is no longer used.
+            ##[allow(dead_code)]
             ##[derive(Debug)]
             pub(crate) struct ServiceRuntimePlugin {
                 handle: #{Arc}<crate::client::Handle>,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/ServiceRuntimePluginGenerator.kt
@@ -127,9 +127,6 @@ class ServiceRuntimePluginGenerator(
                     use #{ConfigBagAccessors};
                     let mut cfg = #{Layer}::new(${codegenContext.serviceShape.id.name.dq()});
 
-                    // HACK: Put the handle into the config bag to work around config not being fully implemented yet
-                    cfg.put(self.handle.clone());
-
                     let http_auth_schemes = #{HttpAuthSchemes}::builder()
                         #{http_auth_scheme_customizations}
                         .build();

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/config/ServiceConfigGenerator.kt
@@ -428,6 +428,7 @@ class ServiceConfigGenerator(
                 rustBlock("pub fn build(mut self) -> Config") {
                     rustTemplate(
                         """
+                        ##[allow(unused_imports)]
                         use #{ConfigBagAccessors};
                         // The builder is being turned into a service config. While doing so, we'd like to avoid
                         // requiring that items created and stored _during_ the build method be `Clone`, since they
@@ -470,14 +471,17 @@ class ServiceConfigGenerator(
                     #{Some}(self.inner.clone())
                 }
 
-                fn interceptors(&self, interceptors: &mut #{InterceptorRegistrar}) {
-                    interceptors.extend(self.interceptors.iter().cloned());
+                fn interceptors(&self, _interceptors: &mut #{InterceptorRegistrar}) {
+                    #{interceptors}
                 }
             }
 
             """,
             *codegenScope,
             "config" to writable { writeCustomizations(customizations, ServiceConfig.RuntimePluginConfig("cfg")) },
+            "interceptors" to writable {
+                writeCustomizations(customizations, ServiceConfig.RuntimePluginInterceptors("_interceptors"))
+            },
         )
     }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/testutil/TestConfigCustomization.kt
@@ -129,6 +129,9 @@ fun stubConfigProject(codegenContext: ClientCodegenContext, customization: Confi
     val generator = ServiceConfigGenerator(codegenContext, customizations = customizations.toList())
     project.withModule(ClientRustModule.Config) {
         generator.render(this)
+        if (codegenContext.smithyRuntimeMode.defaultToOrchestrator) {
+            generator.renderRuntimePluginImplForSelf(this)
+        }
         unitTest(
             "config_send_sync",
             """

--- a/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextConfigCustomizationTest.kt
+++ b/codegen-client/src/test/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/ClientContextConfigCustomizationTest.kt
@@ -12,6 +12,8 @@ import software.amazon.smithy.rust.codegen.client.testutil.testClientCodegenCont
 import software.amazon.smithy.rust.codegen.client.testutil.validateConfigCustomizations
 import software.amazon.smithy.rust.codegen.client.testutil.withSmithyRuntimeMode
 import software.amazon.smithy.rust.codegen.core.rustlang.rust
+import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
 import software.amazon.smithy.rust.codegen.core.testutil.TestWorkspace
 import software.amazon.smithy.rust.codegen.core.testutil.asSmithyModel
 import software.amazon.smithy.rust.codegen.core.testutil.unitTest
@@ -37,14 +39,30 @@ class ClientContextConfigCustomizationTest {
     fun `client params generate a valid customization`(smithyRuntimeModeStr: String) {
         val project = TestWorkspace.testProject()
         val smithyRuntimeMode = SmithyRuntimeMode.fromString(smithyRuntimeModeStr)
+        val context = testClientCodegenContext(model).withSmithyRuntimeMode(smithyRuntimeMode)
         project.unitTest {
             if (smithyRuntimeMode.defaultToOrchestrator) {
-                rust(
+                rustTemplate(
                     """
+                    use #{RuntimePlugin};
                     let conf = crate::Config::builder().a_string_param("hello!").a_bool_param(true).build();
-                    assert_eq!(conf.a_string_param().unwrap(), "hello!");
-                    assert_eq!(conf.a_bool_param(), Some(true));
+                    assert_eq!(
+                        conf.config()
+                            .unwrap()
+                            .load::<crate::config::AStringParam>()
+                            .map(|u| u.0.clone())
+                            .unwrap(),
+                        "hello!"
+                    );
+                    assert_eq!(
+                        conf.config()
+                            .unwrap()
+                            .load::<crate::config::ABoolParam>()
+                            .map(|u| u.0),
+                        Some(true)
+                    );
                     """,
+                    "RuntimePlugin" to RuntimeType.runtimePlugin(context.runtimeConfig),
                 )
             } else {
                 rust(
@@ -59,12 +77,27 @@ class ClientContextConfigCustomizationTest {
         // unset fields
         project.unitTest {
             if (smithyRuntimeMode.defaultToOrchestrator) {
-                rust(
+                rustTemplate(
                     """
+                    use #{RuntimePlugin};
                     let conf = crate::Config::builder().a_string_param("hello!").build();
-                    assert_eq!(conf.a_string_param().unwrap(), "hello!");
-                    assert_eq!(conf.a_bool_param(), None);
+                    assert_eq!(
+                        conf.config()
+                            .unwrap()
+                            .load::<crate::config::AStringParam>()
+                            .map(|u| u.0.clone())
+                            .unwrap(),
+                        "hello!"
+                    );
+                    assert_eq!(
+                        conf.config()
+                            .unwrap()
+                            .load::<crate::config::ABoolParam>()
+                            .map(|u| u.0),
+                        None,
+                    );
                     """,
+                    "RuntimePlugin" to RuntimeType.runtimePlugin(context.runtimeConfig),
                 )
             } else {
                 rust(
@@ -76,7 +109,6 @@ class ClientContextConfigCustomizationTest {
                 )
             }
         }
-        val context = testClientCodegenContext(model).withSmithyRuntimeMode(smithyRuntimeMode)
         validateConfigCustomizations(context, ClientContextConfigCustomization(context), project)
     }
 }


### PR DESCRIPTION
## Motivation and Context
Removes `HACK` that used to put `Handle` in config bag.

## Description
The `HACK` was previously placed in `ServiceRuntimePlugin::config` because later in the orchestrator execution, we needed to access service config fields (through `Handle`) to build endpoint `Params` within `EndpointParamsInterceptor`. Now that service config fields are baked into a frozen layer, `EndpointParamsInterceptor` can load those fields directly from the config bag (to which the frozen layer has been added) when constructing endpoint `Params`. We can therefore remove `HACK` at this point.

## Testing
- [x] Passed tests in CI

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
