### PR TITLE
Remove `get`/`put` methods from `ConfigBag` and `Layer`

### DIFF
--- a/aws/rust-runtime/aws-http/src/user_agent.rs
+++ b/aws/rust-runtime/aws-http/src/user_agent.rs
@@ -5,6 +5,7 @@
 
 use aws_smithy_http::middleware::MapRequest;
 use aws_smithy_http::operation::Request;
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use aws_types::app_name::AppName;
 use aws_types::build_metadata::{OsFamily, BUILD_METADATA};
 use aws_types::os_shim_internal::Env;
@@ -211,6 +212,10 @@ impl AwsUserAgent {
     }
 }
 
+impl Storable for AwsUserAgent {
+    type Storer = StoreReplace<Self>;
+}
+
 #[derive(Clone, Copy, Debug)]
 struct SdkMetadata {
     name: &'static str,
@@ -244,6 +249,10 @@ impl fmt::Display for ApiMetadata {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "api/{}/{}", self.service_id, self.version)
     }
+}
+
+impl Storable for ApiMetadata {
+    type Storer = StoreReplace<Self>;
 }
 
 /// Error for when an user agent metadata doesn't meet character requirements.

--- a/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
+++ b/aws/rust-runtime/aws-inlineable/src/presigning_interceptors.rs
@@ -22,6 +22,7 @@ use aws_smithy_runtime_api::client::interceptors::{
     disable_interceptor, Interceptor, InterceptorRegistrar, SharedInterceptor,
 };
 use aws_smithy_runtime_api::client::orchestrator::ConfigBagAccessors;
+use aws_smithy_runtime_api::client::retries::DynRetryStrategy;
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Layer};
 
@@ -48,11 +49,12 @@ impl Interceptor for SigV4PresigningInterceptor {
         _context: &mut BeforeSerializationInterceptorContextMut<'_>,
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
-        cfg.interceptor_state().put::<HeaderSerializationSettings>(
-            HeaderSerializationSettings::new()
-                .omit_default_content_length()
-                .omit_default_content_type(),
-        );
+        cfg.interceptor_state()
+            .store_put::<HeaderSerializationSettings>(
+                HeaderSerializationSettings::new()
+                    .omit_default_content_length()
+                    .omit_default_content_type(),
+            );
         cfg.interceptor_state()
             .set_request_time(SharedTimeSource::new(StaticTimeSource::new(
                 self.config.start_time(),
@@ -65,12 +67,12 @@ impl Interceptor for SigV4PresigningInterceptor {
         _context: &mut BeforeTransmitInterceptorContextMut<'_>,
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
-        if let Some(mut config) = cfg.get::<SigV4OperationSigningConfig>().cloned() {
+        if let Some(mut config) = cfg.load::<SigV4OperationSigningConfig>().cloned() {
             config.signing_options.expires_in = Some(self.config.expires());
             config.signing_options.signature_type = HttpSignatureType::HttpRequestQueryParams;
             config.signing_options.payload_override = Some(self.payload_override.clone());
             cfg.interceptor_state()
-                .put::<SigV4OperationSigningConfig>(config);
+                .store_put::<SigV4OperationSigningConfig>(config);
             Ok(())
         } else {
             Err(
@@ -101,10 +103,10 @@ impl SigV4PresigningRuntimePlugin {
 impl RuntimePlugin for SigV4PresigningRuntimePlugin {
     fn config(&self) -> Option<FrozenLayer> {
         let mut layer = Layer::new("Presigning");
-        layer.set_retry_strategy(NeverRetryStrategy::new());
-        layer.put(disable_interceptor::<InvocationIdInterceptor>("presigning"));
-        layer.put(disable_interceptor::<RequestInfoInterceptor>("presigning"));
-        layer.put(disable_interceptor::<UserAgentInterceptor>("presigning"));
+        layer.set_retry_strategy(DynRetryStrategy::new(NeverRetryStrategy::new()));
+        layer.store_put(disable_interceptor::<InvocationIdInterceptor>("presigning"));
+        layer.store_put(disable_interceptor::<RequestInfoInterceptor>("presigning"));
+        layer.store_put(disable_interceptor::<UserAgentInterceptor>("presigning"));
         Some(layer.freeze())
     }
 

--- a/aws/rust-runtime/aws-runtime/src/user_agent.rs
+++ b/aws/rust-runtime/aws-runtime/src/user_agent.rs
@@ -77,19 +77,19 @@ impl Interceptor for UserAgentInterceptor {
         cfg: &mut ConfigBag,
     ) -> Result<(), BoxError> {
         let api_metadata = cfg
-            .get::<ApiMetadata>()
+            .load::<ApiMetadata>()
             .ok_or(UserAgentInterceptorError::MissingApiMetadata)?;
 
         // Allow for overriding the user agent by an earlier interceptor (so, for example,
         // tests can use `AwsUserAgent::for_tests()`) by attempting to grab one out of the
         // config bag before creating one.
         let ua: Cow<'_, AwsUserAgent> = cfg
-            .get::<AwsUserAgent>()
+            .load::<AwsUserAgent>()
             .map(Cow::Borrowed)
             .unwrap_or_else(|| {
                 let mut ua = AwsUserAgent::new_from_environment(Env::real(), api_metadata.clone());
 
-                let maybe_app_name = cfg.get::<AppName>();
+                let maybe_app_name = cfg.load::<AppName>();
                 if let Some(app_name) = maybe_app_name {
                     ua.set_app_name(app_name.clone());
                 }
@@ -139,8 +139,8 @@ mod tests {
         let mut context = context();
 
         let mut layer = Layer::new("test");
-        layer.put(AwsUserAgent::for_tests());
-        layer.put(ApiMetadata::new("unused", "unused"));
+        layer.store_put(AwsUserAgent::for_tests());
+        layer.store_put(ApiMetadata::new("unused", "unused"));
         let mut cfg = ConfigBag::of_layers(vec![layer]);
 
         let interceptor = UserAgentInterceptor::new();
@@ -165,7 +165,7 @@ mod tests {
 
         let api_metadata = ApiMetadata::new("some-service", "some-version");
         let mut layer = Layer::new("test");
-        layer.put(api_metadata.clone());
+        layer.store_put(api_metadata.clone());
         let mut config = ConfigBag::of_layers(vec![layer]);
 
         let interceptor = UserAgentInterceptor::new();
@@ -195,8 +195,8 @@ mod tests {
 
         let api_metadata = ApiMetadata::new("some-service", "some-version");
         let mut layer = Layer::new("test");
-        layer.put(api_metadata);
-        layer.put(AppName::new("my_awesome_app").unwrap());
+        layer.store_put(api_metadata);
+        layer.store_put(AppName::new("my_awesome_app").unwrap());
         let mut config = ConfigBag::of_layers(vec![layer]);
 
         let interceptor = UserAgentInterceptor::new();

--- a/aws/rust-runtime/aws-types/src/lib.rs
+++ b/aws/rust-runtime/aws-types/src/lib.rs
@@ -25,6 +25,7 @@ pub mod sdk_config;
 pub use aws_smithy_client::http_connector;
 pub use sdk_config::SdkConfig;
 
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use std::borrow::Cow;
 
 /// The name of the service used to sign this request
@@ -55,4 +56,8 @@ impl From<&'static str> for SigningService {
     fn from(service: &'static str) -> Self {
         Self::from_static(service)
     }
+}
+
+impl Storable for SigningService {
+    type Storer = StoreReplace<Self>;
 }

--- a/aws/rust-runtime/aws-types/src/region.rs
+++ b/aws/rust-runtime/aws-types/src/region.rs
@@ -82,3 +82,7 @@ impl SigningRegion {
         SigningRegion(Cow::Borrowed(region))
     }
 }
+
+impl Storable for SigningRegion {
+    type Storer = StoreReplace<Self>;
+}

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/AwsPresigningDecorator.kt
@@ -363,7 +363,7 @@ class AwsPresignedFluentBuilderMethod(
                             fn config(&self) -> Option<#{FrozenLayer}> {
                                 use #{ConfigBagAccessors};
                                 let mut cfg = #{Layer}::new("presigning_serializer");
-                                cfg.set_request_serializer(#{AlternateSerializer});
+                                cfg.set_request_serializer(#{SharedRequestSerializer}::new(#{AlternateSerializer}));
                                 Some(cfg.freeze())
                             }
                         }
@@ -374,6 +374,8 @@ class AwsPresignedFluentBuilderMethod(
                         "FrozenLayer" to smithyTypes.resolve("config_bag::FrozenLayer"),
                         "Layer" to smithyTypes.resolve("config_bag::Layer"),
                         "RuntimePlugin" to RuntimeType.runtimePlugin(codegenContext.runtimeConfig),
+                        "SharedRequestSerializer" to RuntimeType.smithyRuntimeApi(codegenContext.runtimeConfig)
+                            .resolve("client::orchestrator::SharedRequestSerializer"),
                     )
                 }
             },

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4AuthDecorator.kt
@@ -91,6 +91,7 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
         val runtimeApi = RuntimeType.smithyRuntimeApi(runtimeConfig)
         val awsRuntime = AwsRuntimeType.awsRuntime(runtimeConfig)
         arrayOf(
+            "DynAuthOptionResolver" to runtimeApi.resolve("client::auth::DynAuthOptionResolver"),
             "StaticAuthOptionResolver" to runtimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolver"),
             "HttpSignatureType" to awsRuntime.resolve("auth::sigv4::HttpSignatureType"),
             "SIGV4_SCHEME_ID" to awsRuntime.resolve("auth::sigv4::SCHEME_ID"),
@@ -122,15 +123,15 @@ private class AuthOperationCustomization(private val codegenContext: ClientCodeg
                         signing_options.signing_optional = $signingOptional;
                         signing_options.payload_override = #{payload_override};
 
-                        ${section.newLayerName}.put(#{SigV4OperationSigningConfig} {
+                        ${section.newLayerName}.store_put(#{SigV4OperationSigningConfig} {
                             region: None,
                             service: None,
                             signing_options,
                         });
                         // TODO(enableNewSmithyRuntimeLaunch): Make auth options additive in the config bag so that multiple codegen decorators can register them
-                        let auth_option_resolver = #{StaticAuthOptionResolver}::new(
+                        let auth_option_resolver = #{DynAuthOptionResolver}::new(#{StaticAuthOptionResolver}::new(
                             vec![#{SIGV4_SCHEME_ID}]
-                        );
+                        ));
                         ${section.newLayerName}.set_auth_option_resolver(auth_option_resolver);
                         """,
                         *codegenScope,

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/SigV4SigningDecorator.kt
@@ -113,8 +113,8 @@ class SigV4SigningConfig(
                 if (runtimeMode.defaultToOrchestrator) {
                     rustTemplate(
                         """
-                        layer.put(#{SigningService}::from_static(${sigV4Trait.name.dq()}));
-                        layer.load::<#{Region}>().cloned().map(|r| layer.put(#{SigningRegion}::from(r)));
+                        layer.store_put(#{SigningService}::from_static(${sigV4Trait.name.dq()}));
+                        layer.load::<#{Region}>().cloned().map(|r| layer.store_put(#{SigningRegion}::from(r)));
                         """,
                         *codegenScope,
                     )

--- a/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
+++ b/aws/sdk-codegen/src/main/kotlin/software/amazon/smithy/rustsdk/UserAgentDecorator.kt
@@ -207,7 +207,7 @@ class UserAgentDecorator : ClientCodegenDecorator {
 
                 is ServiceConfig.BuilderBuild -> writable {
                     if (runtimeMode.defaultToOrchestrator) {
-                        rust("layer.put(#T.clone());", ClientRustModule.Meta.toType().resolve("API_METADATA"))
+                        rust("layer.store_put(#T.clone());", ClientRustModule.Meta.toType().resolve("API_METADATA"))
                     } else {
                         rust("app_name: self.app_name,")
                     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpAuthDecorator.kt
@@ -43,6 +43,7 @@ fun codegenScope(runtimeConfig: RuntimeConfig): Array<Pair<String, Any>> {
     return arrayOf(
         "ApiKeyAuthScheme" to authHttp.resolve("ApiKeyAuthScheme"),
         "ApiKeyLocation" to authHttp.resolve("ApiKeyLocation"),
+        "DynAuthOptionResolver" to smithyRuntimeApi.resolve("client::auth::DynAuthOptionResolver"),
         "StaticAuthOptionResolver" to smithyRuntimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolver"),
         "BasicAuthScheme" to authHttp.resolve("BasicAuthScheme"),
         "BearerAuthScheme" to authHttp.resolve("BearerAuthScheme"),
@@ -207,8 +208,8 @@ private class HttpAuthOperationCustomization(codegenContext: ClientCodegenContex
         when (section) {
             is OperationSection.AdditionalRuntimePluginConfig -> {
                 withBlockTemplate(
-                    "let auth_option_resolver = #{StaticAuthOptionResolver}::new(vec![",
-                    "]);",
+                    "let auth_option_resolver = #{DynAuthOptionResolver}::new(#{StaticAuthOptionResolver}::new(vec![",
+                    "]));",
                     *codegenScope,
                 ) {
                     val authTrait: AuthTrait? = section.operationShape.getTrait() ?: serviceShape.getTrait()

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpConnectorConfigDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/HttpConnectorConfigDecorator.kt
@@ -40,6 +40,7 @@ private class HttpConnectorConfigCustomization(
         *preludeScope,
         "Connection" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::orchestrator::Connection"),
         "ConnectorSettings" to RuntimeType.smithyClient(runtimeConfig).resolve("http_connector::ConnectorSettings"),
+        "DynConnection" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::orchestrator::DynConnection"),
         "DynConnectorAdapter" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::connections::adapter::DynConnectorAdapter"),
         "HttpConnector" to RuntimeType.smithyClient(runtimeConfig).resolve("http_connector::HttpConnector"),
         "SharedAsyncSleep" to RuntimeType.smithyAsync(runtimeConfig).resolve("rt::sleep::SharedAsyncSleep"),
@@ -199,10 +200,10 @@ private class HttpConnectorConfigCustomization(
                         if let Some(connection) = layer.load::<#{HttpConnector}>()
                                 .and_then(|c| c.connector(&connector_settings, sleep_impl.clone()))
                                 .or_else(|| #{default_connector}(&connector_settings, sleep_impl)) {
-                            let connection: #{Box}<dyn #{Connection}> = #{Box}::new(#{DynConnectorAdapter}::new(
+                            let connection: #{DynConnection} = #{DynConnection}::new(#{DynConnectorAdapter}::new(
                                 // TODO(enableNewSmithyRuntimeCleanup): Replace the tower-based DynConnector and remove DynConnectorAdapter when deleting the middleware implementation
                                 connection
-                            )) as _;
+                            ));
                             layer.set_connection(connection);
                         }
 

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/ResiliencyConfigCustomization.kt
@@ -9,7 +9,6 @@ import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.ClientRustModule
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ConfigCustomization
 import software.amazon.smithy.rust.codegen.client.smithy.generators.config.ServiceConfig
-import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeConfig
@@ -26,6 +25,7 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
     private val moduleUseName = codegenContext.moduleUseName()
     private val codegenScope = arrayOf(
         *preludeScope,
+        "DynRetryStrategy" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::retries::DynRetryStrategy"),
         "RetryConfig" to retryConfig.resolve("RetryConfig"),
         "SharedAsyncSleep" to sleepModule.resolve("SharedAsyncSleep"),
         "Sleep" to sleepModule.resolve("Sleep"),
@@ -318,7 +318,7 @@ class ResiliencyConfigCustomization(codegenContext: ClientCodegenContext) : Conf
                         rustTemplate(
                             """
                             let retry_config = layer.load::<#{RetryConfig}>().cloned().unwrap_or_else(#{RetryConfig}::disabled);
-                            layer.set_retry_strategy(#{StandardRetryStrategy}::new(&retry_config));
+                            layer.set_retry_strategy(#{DynRetryStrategy}::new(#{StandardRetryStrategy}::new(&retry_config)));
                             """,
                             *codegenScope,
                         )

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
@@ -214,10 +214,12 @@ internal class EndpointConfigCustomization(
                         if (runtimeMode.defaultToOrchestrator) {
                             rustTemplate(
                                 """
-                                let endpoint_resolver = #{DefaultEndpointResolver}::<#{Params}>::new(
-                                    layer.load::<$sharedEndpointResolver>().cloned().unwrap_or_else(||
-                                        #{SharedEndpointResolver}::new(#{FailingResolver})
-                                    ).clone()
+                                let endpoint_resolver = #{DynEndpointResolver}::new(
+                                    #{DefaultEndpointResolver}::<#{Params}>::new(
+                                        layer.load::<$sharedEndpointResolver>().cloned().unwrap_or_else(||
+                                            #{SharedEndpointResolver}::new(#{FailingResolver})
+                                        ).clone()
+                                    )
                                 );
                                 layer.set_endpoint_resolver(endpoint_resolver);
                                 """,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/EndpointConfigCustomization.kt
@@ -35,6 +35,7 @@ internal class EndpointConfigCustomization(
             val codegenScope = arrayOf(
                 *preludeScope,
                 "DefaultEndpointResolver" to RuntimeType.smithyRuntime(runtimeConfig).resolve("client::orchestrator::endpoints::DefaultEndpointResolver"),
+                "DynEndpointResolver" to RuntimeType.smithyRuntimeApi(runtimeConfig).resolve("client::orchestrator::DynEndpointResolver"),
                 "SharedEndpointResolver" to types.sharedEndpointResolver,
                 "SmithyResolver" to types.resolveEndpoint,
                 "Params" to typesGenerator.paramsStruct(),
@@ -165,11 +166,15 @@ internal class EndpointConfigCustomization(
                     if (defaultResolver != null) {
                         if (runtimeMode.defaultToOrchestrator) {
                             rustTemplate(
+                                // TODO(enableNewSmithyRuntimeCleanup): Simplify the endpoint resolvers
                                 """
-                                let endpoint_resolver = #{DefaultEndpointResolver}::<#{Params}>::new(
-                                layer.load::<$sharedEndpointResolver>().cloned().unwrap_or_else(||
-                                    #{SharedEndpointResolver}::new(#{DefaultResolver}::new())
-                                ));
+                                let endpoint_resolver = #{DynEndpointResolver}::new(
+                                    #{DefaultEndpointResolver}::<#{Params}>::new(
+                                        layer.load::<$sharedEndpointResolver>().cloned().unwrap_or_else(||
+                                            #{SharedEndpointResolver}::new(#{DefaultResolver}::new())
+                                        )
+                                    )
+                                );
                                 layer.set_endpoint_resolver(endpoint_resolver);
                                 """,
                                 *codegenScope,
@@ -210,9 +215,10 @@ internal class EndpointConfigCustomization(
                             rustTemplate(
                                 """
                                 let endpoint_resolver = #{DefaultEndpointResolver}::<#{Params}>::new(
-                                layer.load::<$sharedEndpointResolver>().cloned().unwrap_or_else(||
-                                    #{SharedEndpointResolver}::new(#{FailingResolver})
-                                ).clone());
+                                    layer.load::<$sharedEndpointResolver>().cloned().unwrap_or_else(||
+                                        #{SharedEndpointResolver}::new(#{FailingResolver})
+                                    ).clone()
+                                );
                                 layer.set_endpoint_resolver(endpoint_resolver);
                                 """,
                                 *codegenScope,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -173,7 +173,7 @@ class EndpointParamsInterceptorGenerator(
                     codegenContext.smithyRuntimeMode,
                 )
             }
-            rust("cfg.interceptor_state().put(endpoint_prefix);")
+            rust("cfg.interceptor_state().store_put(endpoint_prefix);")
         }
     }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationRuntimePluginGenerator.kt
@@ -27,13 +27,15 @@ class OperationRuntimePluginGenerator(
         arrayOf(
             "AuthOptionResolverParams" to runtimeApi.resolve("client::auth::AuthOptionResolverParams"),
             "BoxError" to RuntimeType.boxError(codegenContext.runtimeConfig),
-            "Layer" to smithyTypes.resolve("config_bag::Layer"),
-            "FrozenLayer" to smithyTypes.resolve("config_bag::FrozenLayer"),
             "ConfigBag" to RuntimeType.configBag(codegenContext.runtimeConfig),
             "ConfigBagAccessors" to runtimeApi.resolve("client::orchestrator::ConfigBagAccessors"),
+            "DynResponseDeserializer" to runtimeApi.resolve("client::orchestrator::DynResponseDeserializer"),
+            "FrozenLayer" to smithyTypes.resolve("config_bag::FrozenLayer"),
             "InterceptorRegistrar" to runtimeApi.resolve("client::interceptors::InterceptorRegistrar"),
+            "Layer" to smithyTypes.resolve("config_bag::Layer"),
             "RetryClassifiers" to runtimeApi.resolve("client::retries::RetryClassifiers"),
             "RuntimePlugin" to runtimeApi.resolve("client::runtime_plugin::RuntimePlugin"),
+            "SharedRequestSerializer" to runtimeApi.resolve("client::orchestrator::SharedRequestSerializer"),
             "StaticAuthOptionResolverParams" to runtimeApi.resolve("client::auth::option_resolver::StaticAuthOptionResolverParams"),
         )
     }
@@ -50,8 +52,8 @@ class OperationRuntimePluginGenerator(
                 fn config(&self) -> #{Option}<#{FrozenLayer}> {
                     let mut cfg = #{Layer}::new(${operationShape.id.name.dq()});
                     use #{ConfigBagAccessors} as _;
-                    cfg.set_request_serializer(${operationStructName}RequestSerializer);
-                    cfg.set_response_deserializer(${operationStructName}ResponseDeserializer);
+                    cfg.set_request_serializer(#{SharedRequestSerializer}::new(${operationStructName}RequestSerializer));
+                    cfg.set_response_deserializer(#{DynResponseDeserializer}::new(${operationStructName}ResponseDeserializer));
 
                     ${"" /* TODO(IdentityAndAuth): Resolve auth parameters from input for services that need this */}
                     cfg.set_auth_option_resolver_params(#{AuthOptionResolverParams}::new(#{StaticAuthOptionResolverParams}::new()));

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -244,6 +244,9 @@ class FluentClientGenerator(
                     }
                     """,
                     *clientScope,
+                    // TODO(enableNewSmithyRuntimeLaunch): Remove the handle config hack
+                    "Storable" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::Storable"),
+                    "StoreReplace" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::StoreReplace"),
                 )
             }
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/client/FluentClientGenerator.kt
@@ -244,9 +244,6 @@ class FluentClientGenerator(
                     }
                     """,
                     *clientScope,
-                    // TODO(enableNewSmithyRuntimeLaunch): Remove the handle config hack
-                    "Storable" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::Storable"),
-                    "StoreReplace" to RuntimeType.smithyTypes(runtimeConfig).resolve("config_bag::StoreReplace"),
                 )
             }
         }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -72,7 +72,7 @@ class RequestSerializerGenerator(
                 ##[allow(unused_mut, clippy::let_and_return, clippy::needless_borrow, clippy::useless_conversion)]
                 fn serialize_input(&self, input: #{Input}, _cfg: &mut #{ConfigBag}) -> Result<#{HttpRequest}, #{BoxError}> {
                     let input = #{TypedBox}::<#{ConcreteInput}>::assume_from(input).expect("correct type").unwrap();
-                    let _header_serialization_settings = _cfg.get::<#{HeaderSerializationSettings}>().cloned().unwrap_or_default();
+                    let _header_serialization_settings = _cfg.load::<#{HeaderSerializationSettings}>().cloned().unwrap_or_default();
                     let mut request_builder = {
                         #{create_http_request}
                     };

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/protocols/HttpBoundProtocolGenerator.kt
@@ -87,7 +87,7 @@ class ClientHttpBoundProtocolPayloadGenerator(
                 if (propertyBagAvailable) {
                     rust("properties.acquire_mut().insert(signer_sender);")
                 } else {
-                    rust("_cfg.interceptor_state().put(signer_sender);")
+                    rust("_cfg.interceptor_state().store_put(signer_sender);")
                 }
             },
         )

--- a/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
+++ b/codegen-core/src/main/kotlin/software/amazon/smithy/rust/codegen/core/rustlang/CargoDependency.kt
@@ -124,6 +124,7 @@ class InlineDependency(
             "serialization_settings",
             CargoDependency.Http,
             CargoDependency.smithyHttp(runtimeConfig),
+            CargoDependency.smithyTypes(runtimeConfig),
         )
 
         fun constrained(): InlineDependency =

--- a/rust-runtime/aws-smithy-eventstream/src/frame.rs
+++ b/rust-runtime/aws-smithy-eventstream/src/frame.rs
@@ -55,6 +55,10 @@ impl DeferredSignerSender {
     }
 }
 
+impl Storable for DeferredSignerSender {
+    type Storer = StoreReplace<Self>;
+}
+
 /// Deferred event stream signer to allow a signer to be wired up later.
 ///
 /// HTTP request signing takes place after serialization, and the event stream
@@ -389,6 +393,7 @@ mod value {
     }
 }
 
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
 pub use value::HeaderValue;
 
 /// Event Stream header.

--- a/rust-runtime/aws-smithy-http/src/endpoint.rs
+++ b/rust-runtime/aws-smithy-http/src/endpoint.rs
@@ -124,6 +124,10 @@ impl EndpointPrefix {
     }
 }
 
+impl Storable for EndpointPrefix {
+    type Storer = StoreReplace<Self>;
+}
+
 /// Apply `endpoint` to `uri`
 ///
 /// This method mutates `uri` by setting the `endpoint` on it

--- a/rust-runtime/aws-smithy-runtime-api/src/client/request_attempts.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/request_attempts.rs
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
+
 #[derive(Debug, Clone, Copy)]
 pub struct RequestAttempts {
     attempts: usize,
@@ -17,6 +19,10 @@ impl RequestAttempts {
     pub fn attempts(&self) -> usize {
         self.attempts
     }
+}
+
+impl Storable for RequestAttempts {
+    type Storer = StoreReplace<Self>;
 }
 
 impl From<usize> for RequestAttempts {

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/endpoints.rs
@@ -100,7 +100,7 @@ pub(super) fn orchestrate_endpoint(
     cfg: &mut ConfigBag,
 ) -> Result<(), BoxError> {
     let params = cfg.endpoint_resolver_params();
-    let endpoint_prefix = cfg.get::<EndpointPrefix>();
+    let endpoint_prefix = cfg.load::<EndpointPrefix>();
     let request = ctx.request_mut().expect("set during serialization");
 
     let endpoint_resolver = cfg.endpoint_resolver();
@@ -108,7 +108,7 @@ pub(super) fn orchestrate_endpoint(
     apply_endpoint(request, &endpoint, endpoint_prefix)?;
 
     // Make the endpoint config available to interceptors
-    cfg.interceptor_state().put(endpoint);
+    cfg.interceptor_state().store_put(endpoint);
     Ok(())
 }
 

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator/interceptors/service_clock_skew.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator/interceptors/service_clock_skew.rs
@@ -6,7 +6,7 @@
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::BeforeDeserializationInterceptorContextMut;
 use aws_smithy_runtime_api::client::interceptors::Interceptor;
-use aws_smithy_types::config_bag::ConfigBag;
+use aws_smithy_types::config_bag::{ConfigBag, Storable, StoreReplace};
 use aws_smithy_types::date_time::Format;
 use aws_smithy_types::DateTime;
 use std::time::{Duration, SystemTime};
@@ -25,6 +25,10 @@ impl ServiceClockSkew {
     pub fn skew(&self) -> Duration {
         self.inner
     }
+}
+
+impl Storable for ServiceClockSkew {
+    type Storer = StoreReplace<Self>;
 }
 
 impl From<ServiceClockSkew> for Duration {
@@ -78,7 +82,7 @@ impl Interceptor for ServiceClockSkewInterceptor {
             }
         };
         let skew = ServiceClockSkew::new(calculate_skew(time_sent, time_received));
-        cfg.interceptor_state().put(skew);
+        cfg.interceptor_state().store_put(skew);
         Ok(())
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/fixed_delay.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/fixed_delay.rs
@@ -53,8 +53,8 @@ impl RetryStrategy for FixedDelayRetryStrategy {
         }
 
         // Check if we're out of attempts
-        let request_attempts: &RequestAttempts = cfg
-            .get()
+        let request_attempts = cfg
+            .load::<RequestAttempts>()
             .expect("at least one request attempt is made before any retry is attempted");
         if request_attempts.attempts() >= self.max_attempts as usize {
             tracing::trace!(
@@ -66,7 +66,7 @@ impl RetryStrategy for FixedDelayRetryStrategy {
         }
 
         let retry_classifiers = cfg
-            .get::<RetryClassifiers>()
+            .load::<RetryClassifiers>()
             .expect("a retry classifier is set");
         let retry_reason = retry_classifiers.classify_retry(ctx);
 

--- a/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/retries/strategy/standard.rs
@@ -119,7 +119,7 @@ impl RetryStrategy for StandardRetryStrategy {
         let output_or_error = ctx.output_or_error().expect(
             "This must never be called without reaching the point where the result exists.",
         );
-        let token_bucket = cfg.get::<TokenBucket>();
+        let token_bucket = cfg.load::<TokenBucket>();
         if output_or_error.is_ok() {
             tracing::debug!("request succeeded, no retry necessary");
             if let Some(tb) = token_bucket {
@@ -138,7 +138,7 @@ impl RetryStrategy for StandardRetryStrategy {
 
         // Check if we're out of attempts
         let request_attempts = cfg
-            .get::<RequestAttempts>()
+            .load::<RequestAttempts>()
             .expect("at least one request attempt is made before any retry is attempted")
             .attempts();
         if request_attempts >= self.max_attempts {
@@ -247,7 +247,7 @@ mod tests {
         layer.set_retry_classifiers(
             RetryClassifiers::new().with_classifier(AlwaysRetry(error_kind)),
         );
-        layer.put(RequestAttempts::new(current_request_attempts));
+        layer.store_put(RequestAttempts::new(current_request_attempts));
         let cfg = ConfigBag::of_layers(vec![layer]);
 
         (ctx, cfg)
@@ -374,16 +374,16 @@ mod tests {
         let strategy = StandardRetryStrategy::default()
             .with_base(|| 1.0)
             .with_max_attempts(5);
-        cfg.interceptor_state().put(TokenBucket::default());
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state().store_put(TokenBucket::default());
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
-        cfg.interceptor_state().put(RequestAttempts::new(1));
+        cfg.interceptor_state().store_put(RequestAttempts::new(1));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
         assert_eq!(token_bucket.available_permits(), 495);
 
-        cfg.interceptor_state().put(RequestAttempts::new(2));
+        cfg.interceptor_state().store_put(RequestAttempts::new(2));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(2));
@@ -391,7 +391,7 @@ mod tests {
 
         ctx.set_output_or_error(Ok(TypeErasedBox::doesnt_matter()));
 
-        cfg.interceptor_state().put(RequestAttempts::new(3));
+        cfg.interceptor_state().store_put(RequestAttempts::new(3));
         let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         assert_eq!(no_retry, ShouldAttempt::No);
         assert_eq!(token_bucket.available_permits(), 495);
@@ -404,22 +404,22 @@ mod tests {
         let strategy = StandardRetryStrategy::default()
             .with_base(|| 1.0)
             .with_max_attempts(3);
-        cfg.interceptor_state().put(TokenBucket::default());
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state().store_put(TokenBucket::default());
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
-        cfg.interceptor_state().put(RequestAttempts::new(1));
+        cfg.interceptor_state().store_put(RequestAttempts::new(1));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
         assert_eq!(token_bucket.available_permits(), 495);
 
-        cfg.interceptor_state().put(RequestAttempts::new(2));
+        cfg.interceptor_state().store_put(RequestAttempts::new(2));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(2));
         assert_eq!(token_bucket.available_permits(), 490);
 
-        cfg.interceptor_state().put(RequestAttempts::new(3));
+        cfg.interceptor_state().store_put(RequestAttempts::new(3));
         let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         assert_eq!(no_retry, ShouldAttempt::No);
         assert_eq!(token_bucket.available_permits(), 490);
@@ -432,16 +432,16 @@ mod tests {
         let strategy = StandardRetryStrategy::default()
             .with_base(|| 1.0)
             .with_max_attempts(5);
-        cfg.interceptor_state().put(TokenBucket::new(5));
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state().store_put(TokenBucket::new(5));
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
-        cfg.interceptor_state().put(RequestAttempts::new(1));
+        cfg.interceptor_state().store_put(RequestAttempts::new(1));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
         assert_eq!(token_bucket.available_permits(), 0);
 
-        cfg.interceptor_state().put(RequestAttempts::new(2));
+        cfg.interceptor_state().store_put(RequestAttempts::new(2));
         let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         assert_eq!(no_retry, ShouldAttempt::No);
         assert_eq!(token_bucket.available_permits(), 0);
@@ -457,16 +457,16 @@ mod tests {
         let strategy = StandardRetryStrategy::default()
             .with_base(|| 1.0)
             .with_max_attempts(5);
-        cfg.interceptor_state().put(TokenBucket::new(100));
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state().store_put(TokenBucket::new(100));
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
-        cfg.interceptor_state().put(RequestAttempts::new(1));
+        cfg.interceptor_state().store_put(RequestAttempts::new(1));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
         assert_eq!(token_bucket.available_permits(), 90);
 
-        cfg.interceptor_state().put(RequestAttempts::new(2));
+        cfg.interceptor_state().store_put(RequestAttempts::new(2));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
@@ -474,7 +474,7 @@ mod tests {
 
         ctx.set_output_or_error(Ok(TypeErasedBox::doesnt_matter()));
 
-        cfg.interceptor_state().put(RequestAttempts::new(3));
+        cfg.interceptor_state().store_put(RequestAttempts::new(3));
         let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         assert_eq!(no_retry, ShouldAttempt::No);
 
@@ -489,8 +489,9 @@ mod tests {
         let strategy = StandardRetryStrategy::default()
             .with_base(|| 1.0)
             .with_max_attempts(usize::MAX);
-        cfg.interceptor_state().put(TokenBucket::new(PERMIT_COUNT));
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state()
+            .store_put(TokenBucket::new(PERMIT_COUNT));
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
         let mut attempt = 1;
 
@@ -501,7 +502,8 @@ mod tests {
                 panic!("This test should have completed by now (drain)");
             }
 
-            cfg.interceptor_state().put(RequestAttempts::new(attempt));
+            cfg.interceptor_state()
+                .store_put(RequestAttempts::new(attempt));
             let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
             assert!(matches!(should_retry, ShouldAttempt::YesAfterDelay(_)));
             attempt += 1;
@@ -519,7 +521,8 @@ mod tests {
                 panic!("This test should have completed by now (fillup)");
             }
 
-            cfg.interceptor_state().put(RequestAttempts::new(attempt));
+            cfg.interceptor_state()
+                .store_put(RequestAttempts::new(attempt));
             let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
             assert_eq!(no_retry, ShouldAttempt::No);
             attempt += 1;
@@ -536,34 +539,34 @@ mod tests {
         let strategy = StandardRetryStrategy::default()
             .with_base(|| 1.0)
             .with_max_attempts(5);
-        cfg.interceptor_state().put(TokenBucket::default());
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state().store_put(TokenBucket::default());
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
-        cfg.interceptor_state().put(RequestAttempts::new(1));
+        cfg.interceptor_state().store_put(RequestAttempts::new(1));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
         assert_eq!(token_bucket.available_permits(), 495);
 
-        cfg.interceptor_state().put(RequestAttempts::new(2));
+        cfg.interceptor_state().store_put(RequestAttempts::new(2));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(2));
         assert_eq!(token_bucket.available_permits(), 490);
 
-        cfg.interceptor_state().put(RequestAttempts::new(3));
+        cfg.interceptor_state().store_put(RequestAttempts::new(3));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(4));
         assert_eq!(token_bucket.available_permits(), 485);
 
-        cfg.interceptor_state().put(RequestAttempts::new(4));
+        cfg.interceptor_state().store_put(RequestAttempts::new(4));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(8));
         assert_eq!(token_bucket.available_permits(), 480);
 
-        cfg.interceptor_state().put(RequestAttempts::new(5));
+        cfg.interceptor_state().store_put(RequestAttempts::new(5));
         let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         assert_eq!(no_retry, ShouldAttempt::No);
         assert_eq!(token_bucket.available_permits(), 480);
@@ -578,34 +581,34 @@ mod tests {
             .with_max_attempts(5)
             .with_initial_backoff(Duration::from_secs(1))
             .with_max_backoff(Duration::from_secs(3));
-        cfg.interceptor_state().put(TokenBucket::default());
-        let token_bucket = cfg.get::<TokenBucket>().unwrap().clone();
+        cfg.interceptor_state().store_put(TokenBucket::default());
+        let token_bucket = cfg.load::<TokenBucket>().unwrap().clone();
 
-        cfg.interceptor_state().put(RequestAttempts::new(1));
+        cfg.interceptor_state().store_put(RequestAttempts::new(1));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(1));
         assert_eq!(token_bucket.available_permits(), 495);
 
-        cfg.interceptor_state().put(RequestAttempts::new(2));
+        cfg.interceptor_state().store_put(RequestAttempts::new(2));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(2));
         assert_eq!(token_bucket.available_permits(), 490);
 
-        cfg.interceptor_state().put(RequestAttempts::new(3));
+        cfg.interceptor_state().store_put(RequestAttempts::new(3));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(3));
         assert_eq!(token_bucket.available_permits(), 485);
 
-        cfg.interceptor_state().put(RequestAttempts::new(4));
+        cfg.interceptor_state().store_put(RequestAttempts::new(4));
         let should_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         let dur = should_retry.expect_delay();
         assert_eq!(dur, Duration::from_secs(3));
         assert_eq!(token_bucket.available_permits(), 480);
 
-        cfg.interceptor_state().put(RequestAttempts::new(5));
+        cfg.interceptor_state().store_put(RequestAttempts::new(5));
         let no_retry = strategy.should_attempt_retry(&ctx, &cfg).unwrap();
         assert_eq!(no_retry, ShouldAttempt::No);
         assert_eq!(token_bucket.available_permits(), 480);

--- a/rust-runtime/aws-smithy-runtime/src/client/runtime_plugin/anonymous_auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/runtime_plugin/anonymous_auth.rs
@@ -11,7 +11,8 @@ use aws_smithy_runtime_api::client::auth::option_resolver::{
     StaticAuthOptionResolver, StaticAuthOptionResolverParams,
 };
 use aws_smithy_runtime_api::client::auth::{
-    AuthSchemeEndpointConfig, AuthSchemeId, HttpAuthScheme, HttpAuthSchemes, HttpRequestSigner,
+    AuthSchemeEndpointConfig, AuthSchemeId, DynAuthOptionResolver, HttpAuthScheme, HttpAuthSchemes,
+    HttpRequestSigner,
 };
 use aws_smithy_runtime_api::client::identity::{Identity, IdentityResolver, IdentityResolvers};
 use aws_smithy_runtime_api::client::orchestrator::{ConfigBagAccessors, HttpRequest};
@@ -43,9 +44,9 @@ impl AnonymousAuthRuntimePlugin {
     pub fn new() -> Self {
         let mut cfg = Layer::new("AnonymousAuth");
         cfg.set_auth_option_resolver_params(StaticAuthOptionResolverParams::new().into());
-        cfg.set_auth_option_resolver(StaticAuthOptionResolver::new(vec![
-            ANONYMOUS_AUTH_SCHEME_ID,
-        ]));
+        cfg.set_auth_option_resolver(DynAuthOptionResolver::new(StaticAuthOptionResolver::new(
+            vec![ANONYMOUS_AUTH_SCHEME_ID],
+        )));
         cfg.set_identity_resolvers(
             IdentityResolvers::builder()
                 .identity_resolver(ANONYMOUS_AUTH_SCHEME_ID, AnonymousIdentityResolver::new())

--- a/rust-runtime/aws-smithy-runtime/src/client/test_util/deserializer.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/test_util/deserializer.rs
@@ -5,7 +5,8 @@
 
 use aws_smithy_runtime_api::client::interceptors::context::{Error, Output};
 use aws_smithy_runtime_api::client::orchestrator::{
-    ConfigBagAccessors, HttpResponse, OrchestratorError, ResponseDeserializer,
+    ConfigBagAccessors, DynResponseDeserializer, HttpResponse, OrchestratorError,
+    ResponseDeserializer,
 };
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_types::config_bag::{FrozenLayer, Layer};
@@ -45,10 +46,9 @@ impl ResponseDeserializer for CannedResponseDeserializer {
 impl RuntimePlugin for CannedResponseDeserializer {
     fn config(&self) -> Option<FrozenLayer> {
         let mut cfg = Layer::new("CannedResponse");
-        cfg.set_response_deserializer(Self {
+        cfg.set_response_deserializer(DynResponseDeserializer::new(Self {
             inner: Mutex::new(self.take()),
-        });
-
+        }));
         Some(cfg.freeze())
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/test_util/serializer.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/test_util/serializer.rs
@@ -6,7 +6,7 @@
 use aws_smithy_runtime_api::box_error::BoxError;
 use aws_smithy_runtime_api::client::interceptors::context::Input;
 use aws_smithy_runtime_api::client::orchestrator::{
-    ConfigBagAccessors, HttpRequest, RequestSerializer,
+    ConfigBagAccessors, HttpRequest, RequestSerializer, SharedRequestSerializer,
 };
 use aws_smithy_runtime_api::client::runtime_plugin::RuntimePlugin;
 use aws_smithy_types::config_bag::{ConfigBag, FrozenLayer, Layer};
@@ -52,9 +52,9 @@ impl RequestSerializer for CannedRequestSerializer {
 impl RuntimePlugin for CannedRequestSerializer {
     fn config(&self) -> Option<FrozenLayer> {
         let mut cfg = Layer::new("CannedRequest");
-        cfg.set_request_serializer(Self {
+        cfg.set_request_serializer(SharedRequestSerializer::new(Self {
             inner: Mutex::new(self.take()),
-        });
+        }));
         Some(cfg.freeze())
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/timeout.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/timeout.rs
@@ -114,7 +114,7 @@ pub(super) trait ProvideMaybeTimeoutConfig {
 
 impl ProvideMaybeTimeoutConfig for ConfigBag {
     fn maybe_timeout_config(&self, timeout_kind: TimeoutKind) -> MaybeTimeoutConfig {
-        if let Some(timeout_config) = self.get::<TimeoutConfig>() {
+        if let Some(timeout_config) = self.load::<TimeoutConfig>() {
             let sleep_impl = self.sleep_impl();
             let timeout = match (sleep_impl.as_ref(), timeout_kind) {
                 (None, _) => None,
@@ -199,7 +199,7 @@ mod tests {
 
         let mut cfg = ConfigBag::base();
         let mut timeout_config = Layer::new("timeout");
-        timeout_config.put(TimeoutConfig::builder().build());
+        timeout_config.store_put(TimeoutConfig::builder().build());
         timeout_config.set_sleep_impl(Some(sleep_impl));
         cfg.push_layer(timeout_config);
 
@@ -225,7 +225,7 @@ mod tests {
 
         let mut cfg = ConfigBag::base();
         let mut timeout_config = Layer::new("timeout");
-        timeout_config.put(
+        timeout_config.store_put(
             TimeoutConfig::builder()
                 .operation_timeout(Duration::from_millis(250))
                 .build(),

--- a/rust-runtime/aws-smithy-types/src/endpoint.rs
+++ b/rust-runtime/aws-smithy-types/src/endpoint.rs
@@ -4,6 +4,7 @@
  */
 //! Smithy Endpoint Types
 
+use crate::config_bag::{Storable, StoreReplace};
 use crate::Document;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -51,6 +52,10 @@ impl Endpoint {
     pub fn builder() -> Builder {
         Builder::new()
     }
+}
+
+impl Storable for Endpoint {
+    type Storer = StoreReplace<Self>;
 }
 
 #[derive(Debug, Clone)]

--- a/rust-runtime/inlineable/src/serialization_settings.rs
+++ b/rust-runtime/inlineable/src/serialization_settings.rs
@@ -6,6 +6,7 @@
 #![allow(dead_code)]
 
 use aws_smithy_http::header::set_request_header_if_absent;
+use aws_smithy_types::config_bag::{Storable, StoreReplace};
 use http::header::{HeaderName, CONTENT_LENGTH, CONTENT_TYPE};
 
 /// Configuration for how default protocol headers are serialized
@@ -55,6 +56,10 @@ impl HeaderSerializationSettings {
         }
         request
     }
+}
+
+impl Storable for HeaderSerializationSettings {
+    type Storer = StoreReplace<Self>;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR removes the non-storable `get`/`put` methods from `ConfigBag` and `Layer`.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
