### PR TITLE
Fix auth failures in codegen-client-tests in orchestrator mode

### DIFF
--- a/buildSrc/src/main/kotlin/CodegenTestCommon.kt
+++ b/buildSrc/src/main/kotlin/CodegenTestCommon.kt
@@ -18,6 +18,7 @@ data class CodegenTest(
     val service: String,
     val module: String,
     val extraConfig: String? = null,
+    val extraCodegenConfig: String? = null,
     val imports: List<String> = emptyList(),
 )
 
@@ -38,6 +39,7 @@ private fun generateSmithyBuild(projectDir: String, pluginName: String, tests: L
                         "relativePath": "$projectDir/rust-runtime"
                     },
                     "codegen": {
+                        ${it.extraCodegenConfig ?: ""}
                     },
                     "service": "${it.service}",
                     "module": "${it.module}",

--- a/codegen-client-test/build.gradle.kts
+++ b/codegen-client-test/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
 val smithyVersion: String by project
 val defaultRustDocFlags: String by project
 val properties = PropertyRetriever(rootProject, project)
+fun getSmithyRuntimeMode(): String = properties.get("smithy.runtime.mode") ?: "middleware"
 
 val pluginName = "rust-client-codegen"
 val workingDirUnderBuildDir = "smithyprojections/codegen-client-test/"
@@ -33,70 +34,81 @@ dependencies {
     implementation("software.amazon.smithy:smithy-aws-traits:$smithyVersion")
 }
 
-val allCodegenTests = "../codegen-core/common-test-models".let { commonModels ->
-    listOf(
-        CodegenTest("com.amazonaws.simple#SimpleService", "simple", imports = listOf("$commonModels/simple.smithy")),
-        CodegenTest("com.amazonaws.dynamodb#DynamoDB_20120810", "dynamo"),
-        CodegenTest("com.amazonaws.ebs#Ebs", "ebs", imports = listOf("$commonModels/ebs.json")),
-        CodegenTest("aws.protocoltests.json10#JsonRpc10", "json_rpc10"),
-        CodegenTest("aws.protocoltests.json#JsonProtocol", "json_rpc11"),
-        CodegenTest("aws.protocoltests.restjson#RestJson", "rest_json"),
-        CodegenTest("aws.protocoltests.restjson#RestJsonExtras", "rest_json_extras", imports = listOf("$commonModels/rest-json-extras.smithy")),
-        CodegenTest("aws.protocoltests.misc#MiscService", "misc", imports = listOf("$commonModels/misc.smithy")),
-        CodegenTest(
-            "aws.protocoltests.restxml#RestXml", "rest_xml",
-            extraConfig = """, "codegen": { "addMessageToErrors": false } """,
-        ),
-
-        CodegenTest(
-            "aws.protocoltests.query#AwsQuery", "aws_query",
-            extraConfig = """, "codegen": { "addMessageToErrors": false } """,
-        ),
-        CodegenTest(
-            "aws.protocoltests.ec2#AwsEc2", "ec2_query",
-            extraConfig = """, "codegen": { "addMessageToErrors": false } """,
-        ),
-        CodegenTest(
-            "aws.protocoltests.restxml.xmlns#RestXmlWithNamespace",
-            "rest_xml_namespace",
-            extraConfig = """, "codegen": { "addMessageToErrors": false } """,
-        ),
-        CodegenTest(
-            "aws.protocoltests.restxml#RestXmlExtras",
-            "rest_xml_extras",
-            extraConfig = """, "codegen": { "addMessageToErrors": false } """,
-        ),
-        CodegenTest(
-            "aws.protocoltests.restxmlunwrapped#RestXmlExtrasUnwrappedErrors",
-            "rest_xml_extras_unwrapped",
-            extraConfig = """, "codegen": { "addMessageToErrors": false } """,
-        ),
-        CodegenTest(
-            "crate#Config",
-            "naming_test_ops",
-            """
-            , "codegen": { "renameErrors": false }
-            """.trimIndent(),
-            imports = listOf("$commonModels/naming-obstacle-course-ops.smithy"),
-        ),
-        CodegenTest(
-            "casing#ACRONYMInside_Service",
-            "naming_test_casing",
-            imports = listOf("$commonModels/naming-obstacle-course-casing.smithy"),
-        ),
-        CodegenTest(
-            "naming_obs_structs#NamingObstacleCourseStructs",
-            "naming_test_structs",
-            """
-            , "codegen": { "renameErrors": false }
-            """.trimIndent(),
-            imports = listOf("$commonModels/naming-obstacle-course-structs.smithy"),
-        ),
-        CodegenTest("aws.protocoltests.json#TestService", "endpoint-rules"),
-        CodegenTest("com.aws.example#PokemonService", "pokemon-service-client", imports = listOf("$commonModels/pokemon.smithy", "$commonModels/pokemon-common.smithy")),
-        CodegenTest("com.aws.example#PokemonService", "pokemon-service-awsjson-client", imports = listOf("$commonModels/pokemon-awsjson.smithy", "$commonModels/pokemon-common.smithy")),
+data class ClientTest(
+    val serviceShapeName: String,
+    val moduleName: String,
+    val dependsOn: List<String> = emptyList(),
+    val addMessageToErrors: Boolean = true,
+    val renameErrors: Boolean = true,
+) {
+    fun toCodegenTest(): CodegenTest = CodegenTest(
+        serviceShapeName,
+        moduleName,
+        extraCodegenConfig = extraCodegenConfig(),
+        imports = imports(),
     )
+
+    private fun extraCodegenConfig(): String = StringBuilder().apply {
+        append("\"addMessageToErrors\": $addMessageToErrors,\n")
+        append("\"renameErrors\": $renameErrors\n,")
+        append("\"enableNewSmithyRuntime\": \"${getSmithyRuntimeMode()}\"")
+    }.toString()
+
+    private fun imports(): List<String> = dependsOn.map { "../codegen-core/common-test-models/$it" }
 }
+
+val allCodegenTests = listOf(
+    ClientTest("com.amazonaws.simple#SimpleService", "simple", dependsOn = listOf("simple.smithy")),
+    ClientTest("com.amazonaws.dynamodb#DynamoDB_20120810", "dynamo"),
+    ClientTest("com.amazonaws.ebs#Ebs", "ebs", dependsOn = listOf("ebs.json")),
+    ClientTest("aws.protocoltests.json10#JsonRpc10", "json_rpc10"),
+    ClientTest("aws.protocoltests.json#JsonProtocol", "json_rpc11"),
+    ClientTest("aws.protocoltests.restjson#RestJson", "rest_json"),
+    ClientTest(
+        "aws.protocoltests.restjson#RestJsonExtras",
+        "rest_json_extras",
+        dependsOn = listOf("rest-json-extras.smithy"),
+    ),
+    ClientTest("aws.protocoltests.misc#MiscService", "misc", dependsOn = listOf("misc.smithy")),
+    ClientTest("aws.protocoltests.restxml#RestXml", "rest_xml", addMessageToErrors = false),
+    ClientTest("aws.protocoltests.query#AwsQuery", "aws_query", addMessageToErrors = false),
+    ClientTest("aws.protocoltests.ec2#AwsEc2", "ec2_query", addMessageToErrors = false),
+    ClientTest("aws.protocoltests.restxml.xmlns#RestXmlWithNamespace", "rest_xml_namespace", addMessageToErrors = false),
+    ClientTest("aws.protocoltests.restxml#RestXmlExtras", "rest_xml_extras", addMessageToErrors = false),
+    ClientTest(
+        "aws.protocoltests.restxmlunwrapped#RestXmlExtrasUnwrappedErrors",
+        "rest_xml_extras_unwrapped",
+        addMessageToErrors = false,
+    ),
+    ClientTest(
+        "crate#Config",
+        "naming_test_ops",
+        dependsOn = listOf("naming-obstacle-course-ops.smithy"),
+        renameErrors = false,
+    ),
+    ClientTest(
+        "casing#ACRONYMInside_Service",
+        "naming_test_casing",
+        dependsOn = listOf("naming-obstacle-course-casing.smithy"),
+    ),
+    ClientTest(
+        "naming_obs_structs#NamingObstacleCourseStructs",
+        "naming_test_structs",
+        dependsOn = listOf("naming-obstacle-course-structs.smithy"),
+        renameErrors = false,
+    ),
+    ClientTest("aws.protocoltests.json#TestService", "endpoint-rules"),
+    ClientTest(
+        "com.aws.example#PokemonService",
+        "pokemon-service-client",
+        dependsOn = listOf("pokemon.smithy", "pokemon-common.smithy"),
+    ),
+    ClientTest(
+        "com.aws.example#PokemonService",
+        "pokemon-service-awsjson-client",
+        dependsOn = listOf("pokemon-awsjson.smithy", "pokemon-common.smithy"),
+    ),
+).map(ClientTest::toCodegenTest)
 
 project.registerGenerateSmithyBuildTask(rootProject, pluginName, allCodegenTests)
 project.registerGenerateCargoWorkspaceTask(rootProject, pluginName, allCodegenTests, workingDirUnderBuildDir)

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/NoAuthDecorator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/customizations/NoAuthDecorator.kt
@@ -7,25 +7,17 @@ package software.amazon.smithy.rust.codegen.client.smithy.customizations
 
 import software.amazon.smithy.model.shapes.OperationShape
 import software.amazon.smithy.model.shapes.ShapeId
-import software.amazon.smithy.model.traits.OptionalAuthTrait
 import software.amazon.smithy.rust.codegen.client.smithy.ClientCodegenContext
 import software.amazon.smithy.rust.codegen.client.smithy.customize.AuthOption
 import software.amazon.smithy.rust.codegen.client.smithy.customize.ClientCodegenDecorator
-import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationCustomization
-import software.amazon.smithy.rust.codegen.client.smithy.generators.OperationSection
 import software.amazon.smithy.rust.codegen.core.rustlang.CargoDependency
-import software.amazon.smithy.rust.codegen.core.rustlang.Writable
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
-import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
-import software.amazon.smithy.rust.codegen.core.util.hasTrait
-import software.amazon.smithy.rust.codegen.core.util.letIf
 
 val noAuthSchemeShapeId: ShapeId = ShapeId.from("aws.smithy.rs#NoAuth")
 
 private fun noAuthModule(codegenContext: ClientCodegenContext): RuntimeType =
     CargoDependency.smithyRuntime(codegenContext.runtimeConfig)
-        .withFeature("no-auth")
         .toType()
         .resolve("client::auth::no_auth")
 
@@ -37,38 +29,11 @@ class NoAuthDecorator : ClientCodegenDecorator {
         codegenContext: ClientCodegenContext,
         operationShape: OperationShape,
         baseAuthOptions: List<AuthOption>,
-    ): List<AuthOption> = baseAuthOptions.letIf(operationShape.hasTrait<OptionalAuthTrait>()) {
-        it + AuthOption.StaticAuthOption(noAuthSchemeShapeId) {
+    ): List<AuthOption> = baseAuthOptions +
+        AuthOption.StaticAuthOption(noAuthSchemeShapeId) {
             rustTemplate(
                 "#{NO_AUTH_SCHEME_ID},",
                 "NO_AUTH_SCHEME_ID" to noAuthModule(codegenContext).resolve("NO_AUTH_SCHEME_ID"),
             )
         }
-    }
-
-    override fun operationCustomizations(
-        codegenContext: ClientCodegenContext,
-        operation: OperationShape,
-        baseCustomizations: List<OperationCustomization>,
-    ): List<OperationCustomization> = baseCustomizations + AnonymousAuthCustomization(codegenContext, operation)
-}
-
-class AnonymousAuthCustomization(
-    private val codegenContext: ClientCodegenContext,
-    private val operationShape: OperationShape,
-) : OperationCustomization() {
-    override fun section(section: OperationSection): Writable = writable {
-        if (
-            codegenContext.smithyRuntimeMode.generateOrchestrator &&
-            section is OperationSection.AdditionalRuntimePlugins &&
-            operationShape.hasTrait<OptionalAuthTrait>()
-        ) {
-            section.addOperationRuntimePlugin(this) {
-                rustTemplate(
-                    "#{NoAuthRuntimePlugin}::new()",
-                    "NoAuthRuntimePlugin" to noAuthModule(codegenContext).resolve("NoAuthRuntimePlugin"),
-                )
-            }
-        }
-    }
 }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsGenerator.kt
@@ -28,6 +28,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.stripOuter
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.isOptional
 import software.amazon.smithy.rust.codegen.core.smithy.makeOptional
 import software.amazon.smithy.rust.codegen.core.smithy.mapRustType
@@ -232,7 +233,8 @@ internal class EndpointParamsGenerator(private val parameters: Parameters) {
         rustWriter.rustBlock("impl ParamsBuilder") {
             docs("Consume this builder, creating [`Params`].")
             rustBlockTemplate(
-                "pub fn build(self) -> Result<#{Params}, #{ParamsError}>",
+                "pub fn build(self) -> #{Result}<#{Params}, #{ParamsError}>",
+                *preludeScope,
                 "Params" to paramsStruct(),
                 "ParamsError" to paramsError(),
             ) {

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/endpoint/generators/EndpointParamsInterceptorGenerator.kt
@@ -27,6 +27,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.withBlockTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.util.PANIC
 import software.amazon.smithy.rust.codegen.core.util.dq
 import software.amazon.smithy.rust.codegen.core.util.inputShape
@@ -45,6 +46,7 @@ class EndpointParamsInterceptorGenerator(
         val orchestrator = runtimeApi.resolve("client::orchestrator")
         val smithyTypes = CargoDependency.smithyTypes(rc).toType()
         arrayOf(
+            *preludeScope,
             "BoxError" to RuntimeType.boxError(rc),
             "ConfigBag" to RuntimeType.configBag(rc),
             "ConfigBagAccessors" to RuntimeType.smithyRuntimeApi(rc)
@@ -78,7 +80,7 @@ class EndpointParamsInterceptorGenerator(
                     &self,
                     context: &#{BeforeSerializationInterceptorContextRef}<'_, #{Input}, #{Output}, #{Error}>,
                     cfg: &mut #{ConfigBag},
-                ) -> Result<(), #{BoxError}> {
+                ) -> #{Result}<(), #{BoxError}> {
                     use #{ConfigBagAccessors};
                     let _input = context.input()
                         .downcast_ref::<${operationInput.name}>()
@@ -91,7 +93,7 @@ class EndpointParamsInterceptorGenerator(
                         .build()
                         .map_err(|err| #{ContextAttachedError}::new("endpoint params could not be built", err))?;
                     cfg.interceptor_state().set_endpoint_resolver_params(#{EndpointResolverParams}::new(params));
-                    Ok(())
+                    #{Ok}(())
                 }
             }
             """,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/OperationGenerator.kt
@@ -59,6 +59,7 @@ open class OperationGenerator(
                         let mut runtime_plugins = runtime_plugins
                             .with_client_plugin(handle.conf.clone())
                             .with_client_plugin(crate::config::ServiceRuntimePlugin::new(handle))
+                            .with_client_plugin(#{NoAuthRuntimePlugin}::new())
                             .with_operation_plugin(operation);
                         if let Some(config_override) = config_override {
                             runtime_plugins = runtime_plugins.with_operation_plugin(config_override);
@@ -71,6 +72,8 @@ open class OperationGenerator(
                     "RuntimePlugin" to RuntimeType.runtimePlugin(runtimeConfig),
                     "RuntimePlugins" to RuntimeType.smithyRuntimeApi(runtimeConfig)
                         .resolve("client::runtime_plugin::RuntimePlugins"),
+                    "NoAuthRuntimePlugin" to RuntimeType.smithyRuntime(runtimeConfig)
+                        .resolve("client::auth::no_auth::NoAuthRuntimePlugin"),
                 )
             }
     }

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/RequestSerializerGenerator.kt
@@ -18,6 +18,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.rust
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.generators.protocol.ProtocolPayloadGenerator
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.HttpLocation
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
@@ -39,6 +40,7 @@ class RequestSerializerGenerator(
         val orchestrator = runtimeApi.resolve("client::orchestrator")
         val smithyTypes = RuntimeType.smithyTypes(codegenContext.runtimeConfig)
         arrayOf(
+            *preludeScope,
             "BoxError" to RuntimeType.boxError(codegenContext.runtimeConfig),
             "config" to ClientRustModule.config,
             "ConfigBag" to RuntimeType.configBag(codegenContext.runtimeConfig),
@@ -70,7 +72,7 @@ class RequestSerializerGenerator(
             struct $serializerName;
             impl #{RequestSerializer} for $serializerName {
                 ##[allow(unused_mut, clippy::let_and_return, clippy::needless_borrow, clippy::useless_conversion)]
-                fn serialize_input(&self, input: #{Input}, _cfg: &mut #{ConfigBag}) -> Result<#{HttpRequest}, #{BoxError}> {
+                fn serialize_input(&self, input: #{Input}, _cfg: &mut #{ConfigBag}) -> #{Result}<#{HttpRequest}, #{BoxError}> {
                     let input = #{TypedBox}::<#{ConcreteInput}>::assume_from(input).expect("correct type").unwrap();
                     let _header_serialization_settings = _cfg.load::<#{HeaderSerializationSettings}>().cloned().unwrap_or_default();
                     let mut request_builder = {
@@ -78,7 +80,7 @@ class RequestSerializerGenerator(
                     };
                     let body = #{generate_body};
                     #{add_content_length}
-                    Ok(request_builder.body(body).expect("valid request"))
+                    #{Ok}(request_builder.body(body).expect("valid request"))
                 }
             }
             """,

--- a/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
+++ b/codegen-client/src/main/kotlin/software/amazon/smithy/rust/codegen/client/smithy/generators/protocol/ResponseDeserializerGenerator.kt
@@ -14,6 +14,7 @@ import software.amazon.smithy.rust.codegen.core.rustlang.RustWriter
 import software.amazon.smithy.rust.codegen.core.rustlang.rustTemplate
 import software.amazon.smithy.rust.codegen.core.rustlang.writable
 import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType
+import software.amazon.smithy.rust.codegen.core.smithy.RuntimeType.Companion.preludeScope
 import software.amazon.smithy.rust.codegen.core.smithy.customize.writeCustomizations
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.Protocol
 import software.amazon.smithy.rust.codegen.core.smithy.protocols.ProtocolFunctions
@@ -36,6 +37,7 @@ class ResponseDeserializerGenerator(
         val orchestrator =
             CargoDependency.smithyRuntimeApi(runtimeConfig).toType().resolve("client::orchestrator")
         arrayOf(
+            *preludeScope,
             "Error" to interceptorContext.resolve("Error"),
             "HttpResponse" to orchestrator.resolve("HttpResponse"),
             "Instrument" to CargoDependency.Tracing.toType().resolve("Instrument"),
@@ -92,14 +94,14 @@ class ResponseDeserializerGenerator(
         val successCode = httpBindingResolver.httpTrait(operationShape).code
         rustTemplate(
             """
-            fn deserialize_streaming(&self, response: &mut #{HttpResponse}) -> Option<#{OutputOrError}> {
+            fn deserialize_streaming(&self, response: &mut #{HttpResponse}) -> #{Option}<#{OutputOrError}> {
                 #{BeforeParseResponse}
 
                 // If this is an error, defer to the non-streaming parser
                 if !response.status().is_success() && response.status().as_u16() != $successCode {
-                    return None;
+                    return #{None};
                 }
-                Some(#{type_erase_result}(#{parse_streaming_response}(response)))
+                #{Some}(#{type_erase_result}(#{parse_streaming_response}(response)))
             }
             """,
             *codegenScope,
@@ -135,7 +137,7 @@ class ResponseDeserializerGenerator(
             let (success, status) = (response.status().is_success(), response.status().as_u16());
             let headers = response.headers();
             let body = response.body().bytes().expect("body loaded");
-             #{BeforeParseResponse}
+            #{BeforeParseResponse}
             let parse_result = if !success && status != $successCode {
                 #{parse_error}(status, headers, body)
             } else {
@@ -155,14 +157,14 @@ class ResponseDeserializerGenerator(
     private fun typeEraseResult(): RuntimeType = ProtocolFunctions.crossOperationFn("type_erase_result") { fnName ->
         rustTemplate(
             """
-            pub(crate) fn $fnName<O, E>(result: Result<O, E>) -> Result<#{Output}, #{OrchestratorError}<#{Error}>>
+            pub(crate) fn $fnName<O, E>(result: #{Result}<O, E>) -> #{Result}<#{Output}, #{OrchestratorError}<#{Error}>>
             where
-                O: std::fmt::Debug + Send + Sync + 'static,
-                E: std::error::Error + std::fmt::Debug + Send + Sync + 'static,
+                O: ::std::fmt::Debug + #{Send} + #{Sync} + 'static,
+                E: ::std::error::Error + std::fmt::Debug + #{Send} + #{Sync} + 'static,
             {
                 result.map(|output| #{TypedBox}::new(output).erase())
                     .map_err(|error| #{TypedBox}::new(error).erase_error())
-                    .map_err(Into::into)
+                    .map_err(#{Into}::into)
             }
             """,
             *codegenScope,

--- a/rust-runtime/aws-smithy-runtime/Cargo.toml
+++ b/rust-runtime/aws-smithy-runtime/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/awslabs/smithy-rs"
 
 [features]
 http-auth = ["aws-smithy-runtime-api/http-auth"]
-no-auth = []
 test-util = ["dep:aws-smithy-protocol-test"]
 
 [dependencies]

--- a/rust-runtime/aws-smithy-runtime/src/client/auth.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/auth.rs
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[cfg(feature = "no-auth")]
 pub mod no_auth;
 
 #[cfg(feature = "http-auth")]

--- a/rust-runtime/aws-smithy-runtime/src/client/identity.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/identity.rs
@@ -3,5 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#[cfg(feature = "no-auth")]
 pub mod no_auth;


### PR DESCRIPTION
## Motivation and Context
In orchestrator mode, most `codegen-client-test` tests were failing due to being unable to find a matching auth scheme, or due to some of the test models referencing the `@sigv4` trait. This PR fixes all of those failures, and adds the `smithy.runtime.mode` flag to `codegen-client-test` as well.

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
