### PR TITLE
Make endpoint resolution async

### DIFF
--- a/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime-api/src/client/orchestrator.rs
@@ -135,7 +135,7 @@ impl Storable for EndpointResolverParams {
 }
 
 pub trait EndpointResolver: Send + Sync + fmt::Debug {
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> Result<Endpoint, BoxError>;
+    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> Future<Endpoint>;
 }
 
 #[derive(Debug)]
@@ -148,7 +148,7 @@ impl DynEndpointResolver {
 }
 
 impl EndpointResolver for DynEndpointResolver {
-    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> Result<Endpoint, BoxError> {
+    fn resolve_endpoint(&self, params: &EndpointResolverParams) -> Future<Endpoint> {
         self.0.resolve_endpoint(params)
     }
 }

--- a/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
+++ b/rust-runtime/aws-smithy-runtime/src/client/orchestrator.rs
@@ -251,7 +251,7 @@ async fn try_attempt(
     stop_point: StopPoint,
 ) {
     halt_on_err!([ctx] => interceptors.read_before_attempt(ctx, cfg));
-    halt_on_err!([ctx] => orchestrate_endpoint(ctx, cfg).map_err(OrchestratorError::other));
+    halt_on_err!([ctx] => orchestrate_endpoint(ctx, cfg).await.map_err(OrchestratorError::other));
     halt_on_err!([ctx] => interceptors.modify_before_signing(ctx, cfg));
     halt_on_err!([ctx] => interceptors.read_before_signing(ctx, cfg));
 


### PR DESCRIPTION
## Motivation and Context
Make endpoint resolution async from the perspective of the orchestrator.
- #2608 

## Description
Change the endpoint trait in the orchestrator to be asynchronous

## Testing
- compiled code

----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
