### PR TITLE
Profile mutation and serialization

### DIFF
--- a/aws/rust-runtime/aws-config/src/profile/parser.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser.rs
@@ -114,6 +114,11 @@ impl ProfileSet {
         self.profiles.get(profile_name)
     }
 
+    /// Set a named profile in the profile set
+    pub fn set_profile(&mut self, profile: Profile) {
+        self.profiles.insert(profile.name().to_string(), profile);
+    }
+
     /// Returns the name of the currently selected profile
     pub fn selected_profile(&self) -> &str {
         self.selected_profile.as_ref()
@@ -170,6 +175,17 @@ impl Profile {
     /// Returns a reference to the property named `name`
     pub fn get(&self, name: &str) -> Option<&str> {
         self.properties.get(name).map(|prop| prop.value())
+    }
+
+    /// Sets the value of the property named `name`
+    pub fn set(&mut self, name: impl Into<String> + Clone, value: impl Into<String>) {
+        self.properties.insert(
+            name.clone().into(),
+            Property {
+                key: name.into(),
+                value: value.into(),
+            },
+        );
     }
 }
 

--- a/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
+++ b/aws/rust-runtime/aws-config/src/profile/parser/normalize.rs
@@ -9,8 +9,8 @@ use crate::profile::{Profile, ProfileSet, Property};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-const DEFAULT: &str = "default";
-const PROFILE_PREFIX: &str = "profile";
+pub(crate) const DEFAULT: &str = "default";
+pub(crate) const PROFILE_PREFIX: &str = "profile";
 
 #[derive(Eq, PartialEq, Hash, Debug)]
 struct ProfileName<'a> {


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Supports mutating `ProfileSet`s, so that applications that fetch STS credentials can update a `ProfileSet` with the new credentials.

Supports serializing `ProfileSet`s, so that those credentials can be written back to disk.

## Description
<!--- Describe your changes in detail -->

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

New test added to `src/profile/parser.rs`

## Checklist
----

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
